### PR TITLE
Fix authentication issues

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -535,6 +535,7 @@ namespace microsoftTeams
             }
 
             delete handlers["initialize"];
+            delete handlers["navigateCrossDomain"];
         }
 
         function startAuthenticationWindowMonitor(): void
@@ -572,6 +573,15 @@ namespace microsoftTeams
             handlers["initialize"] = () =>
             {
                 return [ frameContexts.authentication, hostClientType ];
+            };
+
+            // Set up a navigateCrossDomain message handlers that will block cross-domain re-navigation attempts
+            // in the authentication window. We could at some point choose to implement this method via a call to
+            // authenticationWindow.location.href = url; however, we would first need to figure out how to
+            // validate the url against the tab's list of valid domains.
+            handlers["navigateCrossDomain"] = (url: string) =>
+            {
+                return false;
             };
         }
 

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -550,7 +550,7 @@ namespace microsoftTeams
                 {
                     handleFailure("CancelledByUser");
                 }
-                else if (!childOrigin)
+                else
                 {
                     try
                     {

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -525,7 +525,10 @@ namespace microsoftTeams
             }
 
             // Start monitoring the authentication window so that we can detect if it gets closed before the flow completes
-            startAuthenticationWindowMonitor();
+            if (childWindow)
+            {
+                startAuthenticationWindowMonitor();
+            }
         }
 
         function stopAuthenticationWindowMonitor(): void

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -89,7 +89,8 @@ namespace microsoftTeams
         let messageListener = (evt: MessageEvent) => processMessage(evt);
         currentWindow.addEventListener("message", messageListener, false);
 
-        // If we are in an iframe then our parent window is the one hosting us (i.e. window.parent)
+        // If we are in an iframe then our parent window is the one hosting us (i.e. window.parent); otherwise,
+        // it's the window that opened us (i.e. window.opener)
         parentWindow = (currentWindow.parent !== currentWindow.self) ? currentWindow.parent : currentWindow.opener;
 
         try
@@ -477,8 +478,8 @@ namespace microsoftTeams
             height = height || 400;
 
             // Ensure that the new window is always smaller than our app's window so that it never fully covers up our app
-            width = Math.min(width, (currentWindow.innerWidth - 400));
-            height = Math.min(height, (currentWindow.innerHeight - 200));
+            width = Math.min(width, (currentWindow.outerWidth - 400));
+            height = Math.min(height, (currentWindow.outerHeight - 200));
 
             // Convert any relative URLs into absolute ones before sending them over to our parent window
             let link = document.createElement("a");
@@ -508,8 +509,8 @@ namespace microsoftTeams
                 // We are running in the browser so we need to center the new window ourselves
                 let left: number = (typeof currentWindow.screenLeft !== undefined) ? currentWindow.screenLeft : currentWindow.screenX;
                 let top: number = (typeof currentWindow.screenTop !== undefined) ? currentWindow.screenTop : currentWindow.screenY;
-                left += (currentWindow.innerWidth / 2) - (width / 2);
-                top += (currentWindow.innerHeight / 2) - (height / 2);
+                left += (currentWindow.outerWidth / 2) - (width / 2);
+                top += (currentWindow.outerHeight / 2) - (height / 2);
 
                 // Open the window with a desired set of standard browser features
                 childWindow = currentWindow.open(link.href, "_blank", "toolbar=no, location=yes, status=no, menubar=no, top=" + top + ", left=" + left + ", width=" + width + ", height=" + height);

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -461,7 +461,6 @@ namespace microsoftTeams
                 if (result || reason)
                 {
                     clearInterval(interval);
-                    authWindow.close();
 
                     // Notify caller of the authentication result
                     if (result)
@@ -491,6 +490,7 @@ namespace microsoftTeams
             ensureInitialized(frameContexts.authentication);
 
             localStorage.setItem("authentication.success", result);
+            self.close();
         }
 
         /**
@@ -504,6 +504,7 @@ namespace microsoftTeams
             ensureInitialized(frameContexts.authentication);
 
             localStorage.setItem("authentication.failure", reason);
+            self.close();
         }
 
         export interface AuthenticateParameters

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -542,8 +542,10 @@ namespace microsoftTeams
             stopAuthenticationWindowMonitor();
 
             // Create an interval loop that:
-            // - Notifies the caller of failure if it detects that the authentication window was closed
-            // - Keeps pinging the authentication window until it establishes contact
+            // - Notifies the caller of failure if it detects that the authentication window is closed
+            // - Keeps pinging the authentication window while its open in order to re-establish
+            //   contact with any pages along the authentication flow that need to communicate
+            //   with us
             authWindowMonitor = setInterval(() =>
             {
                 if (!childWindow || childWindow.closed)
@@ -552,6 +554,7 @@ namespace microsoftTeams
                 }
                 else
                 {
+                    let savedChildOrigin = childOrigin;
                     try
                     {
                         childOrigin = "*";
@@ -559,7 +562,7 @@ namespace microsoftTeams
                     }
                     finally
                     {
-                        childOrigin = null;
+                        childOrigin = savedChildOrigin;
                     }
                 }
             }, 100);

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -47,8 +47,8 @@ describe("MicrosoftTeams", () =>
         messages = [];
         let mockWindow =
         {
-            innerWidth: 1024,
-            innerHeight: 768,
+            outerWidth: 1024,
+            outerHeight: 768,
             screenLeft: 0,
             screenTop: 0,
             addEventListener: function(type: string, listener: (ev: MessageEvent) => void, useCapture?: boolean): void

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -588,16 +588,7 @@ describe("MicrosoftTeams", () =>
             expect(specs.indexOf("width = 100")).not.toBe(-1);
             expect(specs.indexOf("height = 200")).not.toBe(-1);
             windowOpenCalled = true;
-
-            let openedWindow =
-            {
-                close: function (): void
-                {
-                    return;
-                },
-            } as Window;
-
-            return openedWindow;
+            return {} as Window;
         });
 
         let authenticationParams =
@@ -613,15 +604,6 @@ describe("MicrosoftTeams", () =>
     it("should successfully handle auth success", () =>
     {
         initializeWithContext("content");
-
-        let windowCloseCalled = false;
-        spyOn(microsoftTeams._window, "open").and.returnValue(
-        {
-            close: function (): void
-            {
-                windowCloseCalled = true;
-            },
-        } as Window);
 
         let successResult: string;
         let failureReason: string;
@@ -645,15 +627,6 @@ describe("MicrosoftTeams", () =>
     it("should successfully handle auth failure", () =>
     {
         initializeWithContext("content");
-
-        let windowCloseCalled = false;
-        spyOn(microsoftTeams._window, "open").and.returnValue(
-        {
-            close: function (): void
-            {
-                windowCloseCalled = true;
-            },
-        } as Window);
 
         let successResult: string;
         let failureReason: string;

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -33,12 +33,24 @@ describe("MicrosoftTeams", () =>
     // A list of messages the library sends to the app.
     let messages: MessageRequest[];
 
+    let childWindow =
+    {
+        close: function (): void
+        {
+            return;
+        },
+    };
+
     beforeEach(() =>
     {
         processMessage = null;
         messages = [];
         let mockWindow =
         {
+            innerWidth: 1024,
+            innerHeight: 768,
+            screenLeft: 0,
+            screenTop: 0,
             addEventListener: function(type: string, listener: (ev: MessageEvent) => void, useCapture?: boolean): void
             {
                 if (type === "message")
@@ -76,15 +88,7 @@ describe("MicrosoftTeams", () =>
             self: null as Window,
             open: function (url: string, name: string, specs: string): Window
             {
-                let openedWindow =
-                {
-                    close: function (): void
-                    {
-                        return;
-                    },
-                } as Window;
-
-                return openedWindow;
+                return childWindow as Window;
             },
         };
         microsoftTeams._window = mockWindow.self = mockWindow as Window;
@@ -591,9 +595,9 @@ describe("MicrosoftTeams", () =>
         spyOn(microsoftTeams._window, "open").and.callFake((url: string, name: string, specs: string): Window =>
         {
             expect(url).toEqual("https://someurl/");
-            expect(name).toEqual("Microsoft Teams");
-            expect(specs.indexOf("width = 100")).not.toBe(-1);
-            expect(specs.indexOf("height = 200")).not.toBe(-1);
+            expect(name).toEqual("_blank");
+            expect(specs.indexOf("width=100")).not.toBe(-1);
+            expect(specs.indexOf("height=200")).not.toBe(-1);
             windowOpenCalled = true;
             return {} as Window;
         });
@@ -627,9 +631,10 @@ describe("MicrosoftTeams", () =>
         processMessage(
         {
             origin: tabOrigin,
-            source: {} as Window,
+            source: childWindow,
             data:
             {
+                id: 0,
                 func: "authentication.authenticate.success",
                 args: ["someResult"],
             },
@@ -658,9 +663,10 @@ describe("MicrosoftTeams", () =>
         processMessage(
         {
             origin: tabOrigin,
-            source: {} as Window,
+            source: childWindow,
             data:
             {
+                id: 0,
                 func: "authentication.authenticate.failure",
                 args: ["someReason"],
             },


### PR DESCRIPTION
This change addresses two major issues we've seen with the current implementation of the authentication APIs:
1. The call to microsoftTeams.authentication.authenticate is often triggering the browser's popup blocker because we are calling window.open from the Microsoft Teams window in response to a posted message as opposed to the click handler of the element responsible for kicking off the authentication flow.
2. Authentication is failing in Edge and IE11 for certain tabs that trigger redirects in the authentication popup across different security zones.

The change fixes these issues as follows:
1. The call to window.open will now happen inside the iframe and as long as microsoftTeams.authentication.authenticate is called from a click handler browsers will not block the popup.
2. Instead of relying on window.opener the authentication flow now uses localStorage to communicate success/failure as well as flow completion between the popup and the iframe. Additionally, the authentication popup now closes itself at the end of the flow instead of relying on its opener to do so.