### PR TITLE
Send the SDK version with the initialize call

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -12,6 +12,8 @@ namespace microsoftTeams
 {
     "use strict";
 
+    const version = "0.2";
+
     const validOrigins = [
         "https://teams.microsoft.com",
         "https://teams.skype.com",
@@ -98,7 +100,7 @@ namespace microsoftTeams
             // Send the initialized message to any origin since at this point we most likely don't know what our
             // parent window's origin is yet and this message contains no data that could pose a security risk.
             parentOrigin = "*";
-            let messageId = sendMessageRequest(parentWindow, "initialize");
+            let messageId = sendMessageRequest(parentWindow, "initialize", [ version ]);
             callbacks[messageId] = (context: string, clientType: string) =>
             {
                 frameContext = context;

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -127,7 +127,7 @@ describe("MicrosoftTeams", () =>
         expect(initMessage).not.toBeNull();
         expect(initMessage.id).toBe(0);
         expect(initMessage.func).toBe("initialize");
-        expect(initMessage.args).toEqual([]);
+        expect(initMessage.args).toEqual(["0.2"]);
     });
 
     it("should not allow multiple initialize calls", () =>


### PR DESCRIPTION
In the short term this is mainly for instrumentation so we can easily see how many tabs are using which version. Longer term we might have breaking changes which we'll need to hand back-compat support for, so this proactively helps with that if we can't just infer the version by the way the call looks.