### PR TITLE
Allow multiple initialize calls

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -79,7 +79,9 @@ namespace microsoftTeams
     {
         if (initializeCalled)
         {
-            throw new Error("initialize must not be called more than once.");
+            // Independent components may not know whether the SDK is initialized so may call it to be safe.
+            // Just no-op if that happens to make it easier to use.
+            return;
         }
 
         initializeCalled = true;

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -130,11 +130,16 @@ describe("MicrosoftTeams", () =>
         expect(initMessage.args).toEqual(["0.2"]);
     });
 
-    it("should not allow multiple initialize calls", () =>
+    it("should allow multiple initialize calls", () =>
     {
-        microsoftTeams.initialize();
+        for (let i = 0; i < 100; i++)
+        {
+            microsoftTeams.initialize();
+        }
 
-        expect(() => microsoftTeams.initialize()).toThrowError("initialize must not be called more than once.");
+        // Still only one message actually sent, the extra calls just no-op'ed
+        expect(processMessage).toBeDefined();
+        expect(messages.length).toBe(1);
     });
 
     it("should not allow calls before initialization", () =>


### PR DESCRIPTION
This is based on feedback from @WrathOfZombies. I would still imagine that most users would want to call initialize onready, but I can imagine scenarios where there is a valid reason to potentially call it more than once. In any case I'd rather err on the side of flexibility for the developer.