### PR TITLE
Enable extension tab scenario tests

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -19,6 +19,7 @@ namespace microsoftTeams
         "https://teams.skype.com",
         "https://ppespaces.skype.com",
         "https://devspaces.skype.com",
+        "https://ssauth.skype.com",
         "http://dev.local", // local development
     ];
 


### PR DESCRIPTION
This change whitelists the https://ssauth.skype.com domain so that extension tabs work in our scenario test environment.