### PR TITLE
Don't close the authentication window until it has finished sending the notifySuccess or notifyFailure message to its parent

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -606,7 +606,14 @@ namespace microsoftTeams
 
             sendMessageRequest(parentWindow, "authentication.authenticate.success", [result]);
 
-            window.close();
+            // Wait for the message to be sent before closing the window
+            setInterval(() =>
+            {
+                if (getTargetMessageQueue(parentWindow).length === 0)
+                {
+                    window.close();
+                }
+            }, 100);
         }
 
         /**
@@ -621,7 +628,14 @@ namespace microsoftTeams
 
             sendMessageRequest(parentWindow, "authentication.authenticate.failure", [ reason ]);
 
-            window.close();
+            // Wait for the message to be sent before closing the window
+            setInterval(() =>
+            {
+                if (getTargetMessageQueue(parentWindow).length === 0)
+                {
+                    window.close();
+                }
+            }, 100);
         }
 
         function handleSuccess(result?: string): void

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -607,13 +607,7 @@ namespace microsoftTeams
             sendMessageRequest(parentWindow, "authentication.authenticate.success", [result]);
 
             // Wait for the message to be sent before closing the window
-            setInterval(() =>
-            {
-                if (getTargetMessageQueue(parentWindow).length === 0)
-                {
-                    window.close();
-                }
-            }, 100);
+            waitForMessageQueue(parentWindow, () => currentWindow.close());
         }
 
         /**
@@ -629,13 +623,7 @@ namespace microsoftTeams
             sendMessageRequest(parentWindow, "authentication.authenticate.failure", [ reason ]);
 
             // Wait for the message to be sent before closing the window
-            setInterval(() =>
-            {
-                if (getTargetMessageQueue(parentWindow).length === 0)
-                {
-                    window.close();
-                }
-            }, 100);
+            waitForMessageQueue(parentWindow, () => currentWindow.close());
         }
 
         function handleSuccess(result?: string): void
@@ -904,6 +892,18 @@ namespace microsoftTeams
         {
             targetWindow.postMessage(targetMessageQueue.shift(), targetOrigin);
         }
+    }
+
+    function waitForMessageQueue(targetWindow: Window, callback: () => void): void
+    {
+        let messageQueueMonitor = setInterval(() =>
+        {
+            if (getTargetMessageQueue(targetWindow).length === 0)
+            {
+                clearInterval(messageQueueMonitor);
+                callback();
+            }
+        }, 100);
     }
 
     // tslint:disable-next-line:no-any:The args here are a passthrough to postMessage where we do allow any[]


### PR DESCRIPTION
In cases where the initialize response or parent ping haven't come in before notifySuccess/notifyFailure are called, the authentication window will close itself before it has managed to post the message to its parent. This is a common scenario since code in the authentication window will typically call notifySuccess/notifyFailure immediately after initialize.

This change fixes the issue by ensuring that the authentication window waits for the parent message queue to be empty (i.e. all messages sent) before closing itself.