### PR TITLE
Add new authentication APIs in order to enable AAD SSO for Teams Apps

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -475,6 +475,47 @@ namespace microsoftTeams
             authParams = authenticateParameters;
         }
 
+        /**
+         * Requests an AAD token to be issued on behalf of the app. The token is acquired token from the
+         * cache if it is not expired. Otherwise a request will be sent to AAD to obtain a new token.
+         * @param authTokenRequest A set pf values that configure the token request.
+         */
+        export function getAuthToken(authTokenRequest: AuthTokenRequest): void
+        {
+            ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove);
+
+            let messageId = sendMessageRequest(parentWindow, "authentication.getAuthToken", [ authTokenRequest.resources ]);
+            callbacks[messageId] = (error: string, token: string) =>
+            {
+                if (error)
+                {
+                    authTokenRequest.failureCallback(error);
+                }
+                else
+                {
+                    authTokenRequest.successCallback(token);
+                }
+            };
+        }
+
+        /**
+         * Requests the decoded AAD user identity on behalf of the app.
+         */
+        export function getUser(userRequest: UserRequest): void
+        {
+            ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove);
+
+            let messageId = sendMessageRequest(parentWindow, "authentication.getUser");
+            callbacks[messageId] = (error: string, user: UserProfile) => {
+                if (error) {
+                    userRequest.failureCallback(error);
+                }
+                else {
+                    userRequest.successCallback(user);
+                }
+            };
+        }
+
         function closeAuthenticationWindow(): void
         {
             // Stop monitoring the authentication window
@@ -699,6 +740,119 @@ namespace microsoftTeams
              * A function which is called if the authentication fails with the reason for the failure returned from the authentication popup.
              */
             failureCallback?: (reason?: string) => void;
+        }
+
+        export interface AuthTokenRequest
+        {
+            /**
+             * An array of resource URIs identifying the target resources for which the token should be requested.
+             */
+            resources: string[];
+
+            /**
+             * A function which is called if the token request succeeds with the resulting token.
+             */
+            successCallback?: (token: string) => void;
+
+            /**
+             * A function which is called if the token request fails with the reason for the failure.
+             */
+            failureCallback?: (reason: string) => void;
+        }
+
+        export interface UserRequest
+        {
+            /**
+             * A function which is called if the token request succeeds with the resulting token.
+             */
+            successCallback?: (user: UserProfile) => void;
+
+            /**
+             * A function which is called if the token request fails with the reason for the failure.
+             */
+            failureCallback?: (reason: string) => void;
+        }
+
+        export interface UserProfile
+        {
+            /**
+             * The intended recipient of the token. The application that receives the token must verify that the audience
+             * value is correct and reject any tokens intended for a different audience.
+             */
+            aud: string;
+
+            /**
+             * Identifies how the subject of the token was authenticated.
+             */
+            amr: string[];
+
+            /**
+             * Stores the time at which the token was issued. It is often used to measure token freshness.
+             */
+            iat: number;
+
+            /**
+             * Identifies the security token service (STS) that constructs and returns the token. In the tokens that Azure AD
+             * returns, the issuer is sts.windows.net. The GUID in the Issuer claim value is the tenant ID of the Azure AD
+             * directory. The tenant ID is an immutable and reliable identifier of the directory.
+             */
+            iss: string;
+
+            /**
+             * Provides the last name, surname, or family name of the user as defined in the Azure AD user object.
+             */
+            family_name: string;
+
+            /**
+             * Provides the first or "given" name of the user, as set on the Azure AD user object.
+             */
+            given_name: string;
+
+            /**
+             * Provides a human readable value that identifies the subject of the token. This value is not guaranteed to
+             * be unique within a tenant and is designed to be used only for display purposes.
+             */
+            unique_name: string;
+
+            /**
+             * Contains a unique identifier of an object in Azure AD. This value is immutable and cannot be reassigned or
+             * reused. Use the object ID to identify an object in queries to Azure AD.
+             */
+            oid: string;
+
+            /**
+             * Identifies the principal about which the token asserts information, such as the user of an application.
+             * This value is immutable and cannot be reassigned or reused, so it can be used to perform authorization
+             * checks safely. Because the subject is always present in the tokens the Azure AD issues, we recommended
+             * using this value in a general purpose authorization system.
+             */
+            sub: string;
+
+            /**
+             * An immutable, non-reusable identifier that identifies the directory tenant that issued the token. You can
+             * use this value to access tenant-specific directory resources in a multi-tenant application. For example,
+             * you can use this value to identify the tenant in a call to the Graph API.
+             */
+            tid: string;
+
+            /**
+             * Defines the time interval within which a token is valid. The service that validates the token should verify
+             * that the current date is within the token lifetime, else it should reject the token. The service might allow
+             * for up to five minutes beyond the token lifetime range to account for any differences in clock time ("time
+             * skew") between Azure AD and the service.
+             */
+            exp: number;
+            nbf: number;
+
+            /**
+             * Stores the user name of the user principal.
+             */
+            upn: string;
+
+            /**
+             * Stores the version number of the token.
+             */
+            ver: string;
         }
     }
 

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -485,15 +485,15 @@ namespace microsoftTeams
             ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove);
 
             let messageId = sendMessageRequest(parentWindow, "authentication.getAuthToken", [ authTokenRequest.resources ]);
-            callbacks[messageId] = (error: string, token: string) =>
+            callbacks[messageId] = (success: boolean, result: string) =>
             {
-                if (error)
+                if (success)
                 {
-                    authTokenRequest.failureCallback(error);
+                    authTokenRequest.successCallback(result);
                 }
                 else
                 {
-                    authTokenRequest.successCallback(token);
+                    authTokenRequest.failureCallback(result);
                 }
             };
         }
@@ -506,12 +506,15 @@ namespace microsoftTeams
             ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove);
 
             let messageId = sendMessageRequest(parentWindow, "authentication.getUser");
-            callbacks[messageId] = (error: string, user: UserProfile) => {
-                if (error) {
-                    userRequest.failureCallback(error);
+            callbacks[messageId] = (success: boolean, result: UserProfile | string) =>
+            {
+                if (success && typeof(result) === "UserProfile")
+                {
+                    userRequest.successCallback(result);
                 }
-                else {
-                    userRequest.successCallback(user);
+                else if (typeof(result) === "string")
+                {
+                    userRequest.failureCallback(result);
                 }
             };
         }

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -476,13 +476,13 @@ namespace microsoftTeams
         }
 
         /**
-         * Requests an AAD token to be issued on behalf of the app. The token is acquired token from the
-         * cache if it is not expired. Otherwise a request will be sent to AAD to obtain a new token.
-         * @param authTokenRequest A set pf values that configure the token request.
+         * Requests an AAD token to be issued on behalf of the app. The token is acquired from the cache
+         * if it is not expired. Otherwise a request will be sent to AAD to obtain a new token.
+         * @param authTokenRequest A set of values that configure the token request.
          */
         export function getAuthToken(authTokenRequest: AuthTokenRequest): void
         {
-            ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove);
+            ensureInitialized();
 
             let messageId = sendMessageRequest(parentWindow, "authentication.getAuthToken", [ authTokenRequest.resources ]);
             callbacks[messageId] = (success: boolean, result: string) =>
@@ -503,18 +503,18 @@ namespace microsoftTeams
          */
         export function getUser(userRequest: UserRequest): void
         {
-            ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove);
+            ensureInitialized();
 
             let messageId = sendMessageRequest(parentWindow, "authentication.getUser");
             callbacks[messageId] = (success: boolean, result: UserProfile | string) =>
             {
-                if (success && typeof(result) === "UserProfile")
+                if (success)
                 {
-                    userRequest.successCallback(result);
+                    userRequest.successCallback(result as UserProfile);
                 }
-                else if (typeof(result) === "string")
+                else
                 {
-                    userRequest.failureCallback(result);
+                    userRequest.failureCallback(result as string);
                 }
             };
         }


### PR DESCRIPTION
This is the initial proposal for the API surface needed to enable AAD single sign on for Teams Apps. I've tried to closely mirror the corresponding APIs in the AuthenticationService of Microsoft Teams and underlying ADAL library:
https://github.com/AzureAD/azure-activedirectory-library-for-js

The AAD user object definition is based on the spec found here:
https://docs.microsoft.com/en-us/azure/active-directory/active-directory-token-and-claims