### PR TITLE
Clean up callbacks once they're called

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -1019,6 +1019,9 @@ namespace microsoftTeams
             if (callback)
             {
                 callback.apply(null, message.args);
+
+                // Remove the callback to only let the callback get called once and to free up memory.
+                delete callbacks[message.id];
             }
         }
         else if ("func" in evt.data)

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -285,6 +285,35 @@ describe("MicrosoftTeams", () =>
         expect(actualContext3).toBe(expectedContext3);
     });
 
+    it("should only call callbacks once", () =>
+    {
+        initializeWithContext("content");
+
+        let callbackCalled = 0;
+        microsoftTeams.getContext((context) =>
+        {
+            callbackCalled++;
+        });
+
+        let getContextMessage = findMessageByFunc("getContext");
+        expect(getContextMessage).not.toBeNull();
+
+        let expectedContext: microsoftTeams.Context =
+        {
+            locale: "someLocale",
+            groupId: "someGroupId",
+        };
+
+        // Get many responses to the same message
+        for (let i = 0; i < 100; i++)
+        {
+            respondToMessage(getContextMessage, expectedContext);
+        }
+
+        // Still only called the callback once.
+        expect(callbackCalled).toBe(1);
+    });
+
     it("should successfully get context", () =>
     {
         initializeWithContext("content");


### PR DESCRIPTION
This is fixing a minor memory leak where the callbacks map just grows forever the more calls that are made. It also prevents a callback from getting called multiple times, although in practice that shouldn't really happen.