### PR TITLE
Allow developers to provide their own entity id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ typings/
 # build output
 build/
 dist/
+
+# Visual Studio cache/options directory
+.vs/

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -210,7 +210,8 @@ namespace microsoftTeams
         ensureInitialized(frameContexts.content);
 
         sendMessageRequest(parentWindow, "shareDeepLink", [
-            deepLinkParameters.deepLinkContext,
+            deepLinkParameters.entityId,
+            deepLinkParameters.subEntityId,
             deepLinkParameters.label,
             deepLinkParameters.webUrl,
         ]);
@@ -330,18 +331,9 @@ namespace microsoftTeams
             websiteUrl?: string;
 
             /**
-             * The custom settings for this content instance.
-             * The developer may use this for generic storage specific to this instance,
-             * for example a JSON blob describing the previously selected options used to pre-populate the UI.
-             * The string must be less than 1kb.
-             */
-            customSettings?: string;
-
-            /**
              * The developer-defined unique id for the entity this content points to.
-             * If not provided, one will be generated from the contentUrl.
              */
-            entityId?: string;
+            entityId: string;
         }
 
         export interface SaveEvent
@@ -878,13 +870,18 @@ namespace microsoftTeams
         /**
          * The Microsoft Teams id for the channel with which the content is associated.
          */
-        channelId?: string;
+        channelId: string;
 
         /**
          * The developer-defined unique id for the entity this content points to.
-         * If none was provided, this value is generated from the contentUrl.
          */
         entityId: string;
+
+        /**
+         * The developer-defined unique id for the sub-entity this content points to.
+         * This field should be used to restore to a specific state within an entity, for example scrolling to or activating a specific piece of content.
+         */
+        subEntityId?: string;
 
         /**
          * The current locale that the user has configured for the app formatted as
@@ -912,31 +909,25 @@ namespace microsoftTeams
          * The current UI theme the user is using.
          */
         theme?: string;
-
-        /**
-         * The context passed in as part of a deep link navigation to this page which should be used
-         * to restore a specific page state.
-         */
-        deepLinkContext?: string;
     }
 
     export interface DeepLinkParameters
     {
         /**
-         * Any context the page might need to restore a specific state for the user.
+         * The developer-defined unique id for the entity this deep link points to.
          */
-        deepLinkContext?: string;
+        entityId: string;
 
         /**
-         * The developer-defined unique id for the entity this deep link points to.
-         * If not provided, one will be generated from the contentUrl.
+         * The developer-defined unique id for the sub-entity this deep link points to.
+         * This field may be used to restore to a specific state within an entity, for example scrolling to or activating a specific piece of content.
          */
-        entityId?: string;
+        subEntityId?: string;
 
         /**
          * The label which should be displayed for this deep link when the link is rendered in a client.
          */
-        label?: string;
+        label: string;
 
         /**
          * The fallback url to navigate the user to if there is no support for rendering the page inside the client.

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -336,6 +336,12 @@ namespace microsoftTeams
              * The string must be less than 1kb.
              */
             customSettings?: string;
+
+            /**
+             * The developer-defined unique id for the entity this content points to.
+             * If not provided, one will be generated from the contentUrl.
+             */
+            entityId?: string;
         }
 
         export interface SaveEvent
@@ -875,6 +881,12 @@ namespace microsoftTeams
         channelId?: string;
 
         /**
+         * The developer-defined unique id for the entity this content points to.
+         * If none was provided, this value is generated from the contentUrl.
+         */
+        entityId: string;
+
+        /**
          * The current locale that the user has configured for the app formatted as
          * languageId-countryId (e.g. en-us).
          */
@@ -914,6 +926,12 @@ namespace microsoftTeams
          * Any context the page might need to restore a specific state for the user.
          */
         deepLinkContext?: string;
+
+        /**
+         * The developer-defined unique id for the entity this deep link points to.
+         * If not provided, one will be generated from the contentUrl.
+         */
+        entityId?: string;
 
         /**
          * The label which should be displayed for this deep link when the link is rendered in a client.

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -210,7 +210,6 @@ namespace microsoftTeams
         ensureInitialized(frameContexts.content);
 
         sendMessageRequest(parentWindow, "shareDeepLink", [
-            deepLinkParameters.entityId,
             deepLinkParameters.subEntityId,
             deepLinkParameters.label,
             deepLinkParameters.webUrl,
@@ -914,13 +913,8 @@ namespace microsoftTeams
     export interface DeepLinkParameters
     {
         /**
-         * The developer-defined unique id for the entity this deep link points to.
-         */
-        entityId: string;
-
-        /**
-         * The developer-defined unique id for the sub-entity this deep link points to.
-         * This field may be used to restore to a specific state within an entity, for example scrolling to or activating a specific piece of content.
+         * The developer-defined unique id for the sub-entity this deep link points to. The entityId of this content will automatically be included
+         * so this field may be used to restore to a specific state within an entity, for example scrolling to or activating a specific piece of content.
          */
         subEntityId?: string;
 

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -425,12 +425,12 @@ describe("MicrosoftTeams", () =>
         let message = findMessageByFunc("settings.getSettings");
         expect(message).not.toBeNull();
 
-        let expectedSettings =
+        let expectedSettings: microsoftTeams.settings.Settings =
         {
             suggestedDisplayName: "someSuggestedDisplayName",
             contentUrl: "someContentUrl",
             websiteUrl: "someWebsiteUrl",
-            customSettings: "someCustomSettings",
+            entityId: "someEntityId",
         };
 
         respondToMessage(message, expectedSettings);
@@ -442,12 +442,11 @@ describe("MicrosoftTeams", () =>
     {
         initializeWithContext("settings");
 
-        let settings =
+        let settings: microsoftTeams.settings.Settings =
         {
             suggestedDisplayName: "someSuggestedDisplayName",
             contentUrl: "someContentUrl",
             websiteUrl: "someWebsiteUrl",
-            customSettings: "someCustomSettings",
             entityId: "someEntityId",
         };
         microsoftTeams.settings.setSettings(settings);

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -270,9 +270,9 @@ describe("MicrosoftTeams", () =>
         expect(getContextMessage2).not.toBe(getContextMessage1);
         expect(getContextMessage3).not.toBe(getContextMessage2);
 
-        let expectedContext1: microsoftTeams.Context = { locale: "someLocale1", groupId: "someGroupId1" };
-        let expectedContext2: microsoftTeams.Context = { locale: "someLocale2", groupId: "someGroupId2" };
-        let expectedContext3: microsoftTeams.Context = { locale: "someLocale3", groupId: "someGroupId3" };
+        let expectedContext1: microsoftTeams.Context = { locale: "someLocale1", groupId: "someGroupId1", entityId: "someEntityId1" };
+        let expectedContext2: microsoftTeams.Context = { locale: "someLocale2", groupId: "someGroupId2", entityId: "someEntityId2" };
+        let expectedContext3: microsoftTeams.Context = { locale: "someLocale3", groupId: "someGroupId3", entityId: "someEntityId3" };
 
         // respond in the wrong order
         respondToMessage(getContextMessage3, expectedContext3);
@@ -302,6 +302,7 @@ describe("MicrosoftTeams", () =>
         {
             locale: "someLocale",
             groupId: "someGroupId",
+            entityId: "someEntityId",
         };
 
         // Get many responses to the same message
@@ -331,6 +332,7 @@ describe("MicrosoftTeams", () =>
         {
             locale: "someLocale",
             groupId: "someGroupId",
+            entityId: "someEntityId",
         };
 
         respondToMessage(getContextMessage, expectedContext);

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -446,6 +446,7 @@ describe("MicrosoftTeams", () =>
             contentUrl: "someContentUrl",
             websiteUrl: "someWebsiteUrl",
             customSettings: "someCustomSettings",
+            entityId: "someEntityId",
         };
         microsoftTeams.settings.setSettings(settings);
 
@@ -857,17 +858,19 @@ describe("MicrosoftTeams", () =>
         initializeWithContext("content");
 
         microsoftTeams.shareDeepLink({
-            deepLinkContext: "someDeepLinkContext",
+            entityId: "someEntityId",
+            subEntityId: "someSubEntityId",
             label: "someLabel",
             webUrl: "someWebUrl",
         });
 
         let message = findMessageByFunc("shareDeepLink");
         expect(message).not.toBeNull();
-        expect(message.args.length).toBe(3);
-        expect(message.args[0]).toBe("someDeepLinkContext");
-        expect(message.args[1]).toBe("someLabel");
-        expect(message.args[2]).toBe("someWebUrl");
+        expect(message.args.length).toBe(4);
+        expect(message.args[0]).toBe("someEntityId");
+        expect(message.args[1]).toBe("someSubEntityId");
+        expect(message.args[2]).toBe("someLabel");
+        expect(message.args[3]).toBe("someWebUrl");
     });
 
     function initializeWithContext(frameContext: string, hostClientType?: string): void

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -270,9 +270,9 @@ describe("MicrosoftTeams", () =>
         expect(getContextMessage2).not.toBe(getContextMessage1);
         expect(getContextMessage3).not.toBe(getContextMessage2);
 
-        let expectedContext1: microsoftTeams.Context = { locale: "someLocale1", groupId: "someGroupId1", entityId: "someEntityId1" };
-        let expectedContext2: microsoftTeams.Context = { locale: "someLocale2", groupId: "someGroupId2", entityId: "someEntityId2" };
-        let expectedContext3: microsoftTeams.Context = { locale: "someLocale3", groupId: "someGroupId3", entityId: "someEntityId3" };
+        let expectedContext1: microsoftTeams.Context = { locale: "someLocale1", groupId: "someGroupId1", channelId: "someChannelId1", entityId: "someEntityId1" };
+        let expectedContext2: microsoftTeams.Context = { locale: "someLocale2", groupId: "someGroupId2", channelId: "someChannelId2", entityId: "someEntityId2" };
+        let expectedContext3: microsoftTeams.Context = { locale: "someLocale3", groupId: "someGroupId3", channelId: "someChannelId3", entityId: "someEntityId3" };
 
         // respond in the wrong order
         respondToMessage(getContextMessage3, expectedContext3);
@@ -302,6 +302,7 @@ describe("MicrosoftTeams", () =>
         {
             locale: "someLocale",
             groupId: "someGroupId",
+            channelId: "someChannelId",
             entityId: "someEntityId",
         };
 
@@ -332,6 +333,7 @@ describe("MicrosoftTeams", () =>
         {
             locale: "someLocale",
             groupId: "someGroupId",
+            channelId: "someChannelId",
             entityId: "someEntityId",
         };
 

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -859,7 +859,6 @@ describe("MicrosoftTeams", () =>
         initializeWithContext("content");
 
         microsoftTeams.shareDeepLink({
-            entityId: "someEntityId",
             subEntityId: "someSubEntityId",
             label: "someLabel",
             webUrl: "someWebUrl",
@@ -867,11 +866,10 @@ describe("MicrosoftTeams", () =>
 
         let message = findMessageByFunc("shareDeepLink");
         expect(message).not.toBeNull();
-        expect(message.args.length).toBe(4);
-        expect(message.args[0]).toBe("someEntityId");
-        expect(message.args[1]).toBe("someSubEntityId");
-        expect(message.args[2]).toBe("someLabel");
-        expect(message.args[3]).toBe("someWebUrl");
+        expect(message.args.length).toBe(3);
+        expect(message.args[0]).toBe("someSubEntityId");
+        expect(message.args[1]).toBe("someLabel");
+        expect(message.args[2]).toBe("someWebUrl");
     });
 
     function initializeWithContext(frameContext: string, hostClientType?: string): void


### PR DESCRIPTION
This change allows developers to provide their own entity id as opposed to just always using the content url as the unique identifier.

This allows developers to use multiple urls which may have minor differences (param ordering, presentation-related query params, etc.) which all should be considered to point to the same underlying entity. This also makes it easier for things like bots to create deep links to existing tabs without knowing the exact content url for example.

As a reminder, we had originally decided that we wouldn't need an entity id since we could generate it from the content url, and if we had the content url we wouldn't need an entity id, but this makes assumptions about a url exactly and uniquely identifying an entity, which as described above isn't necessarily a good assumption.