### PR TITLE
Prepare to release v0.4 of the SDK

### DIFF
--- a/src/MicrosoftTeams.schema.json
+++ b/src/MicrosoftTeams.schema.json
@@ -8,14 +8,19 @@
         },
         "version": {
             "type": "string",
-            "description": "The extension version. Changes to the extension should cause a version change. This version string must follow the semver standard."
+            "description": "The app version. Changes to the app should cause a version change. This version string must follow the semver standard."
+        },
+        "id": {
+            "type": "string",
+            "description": "A unique identifier for this app. The id must use reverse domain name notation.",
+            "maxLength": 64
         },
         "developer": {
             "type": "object",
             "properties": {
                 "name": {
                     "type": "string",
-                    "description": "The display name for the developer",
+                    "description": "The display name for the developer.",
                     "maxLength": 32
                 },
                 "websiteUrl": {

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -12,7 +12,7 @@ namespace microsoftTeams
 {
     "use strict";
 
-    const version = "0.3";
+    const version = "0.4";
 
     const validOrigins = [
         "https://teams.microsoft.com",

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -131,7 +131,7 @@ describe("MicrosoftTeams", () =>
         expect(initMessage).not.toBeNull();
         expect(initMessage.id).toBe(0);
         expect(initMessage.func).toBe("initialize");
-        expect(initMessage.args).toEqual(["0.3"]);
+        expect(initMessage.args).toEqual(["0.4"]);
     });
 
     it("should allow multiple initialize calls", () =>


### PR DESCRIPTION
This change gets us ready to release v0.4 of the MicrosoftTeams SDK.
I also snuck an id field into the app manifest schema because I already know we will need it.