### PR TITLE
Schema changes to rationalize gallery tabs, static tabs, and scopes

### DIFF
--- a/src/MicrosoftTeams.schema.json
+++ b/src/MicrosoftTeams.schema.json
@@ -182,7 +182,6 @@
                                 "personal"
                             ],
                         "description": "Specifies whether the bot offers an experience in the context of a channel in a team, a chat between one or more people, or an experience scoped to an individual user alone. These options are non-exclusive"
-
                         }
                     }
                 },

--- a/src/MicrosoftTeams.schema.json
+++ b/src/MicrosoftTeams.schema.json
@@ -106,18 +106,13 @@
                     "scope": {
                         "type": "array",
                         "items": {
-                            "teams": {
-                                "type": "string",
-                                "description": "A value of 'teams' indicates the tab offers an experience in the context of a channel in a team"
-                            },
-                            "people": {
-                                "type": "string",
-                                "description": "A value of 'people' indicates the tab offers an experience in the context of a chat between one or more people"
-                            },
-                            "personal": {
-                                "type": "string",
-                                "description": "A value of 'personal' indicates the tab offers an experience scoped to an individual user alone"
-                            }
+                            "enum": [
+                                "team",
+                                "people",
+                                "personal"
+                            ],
+                        "description": "Specifies whether the tab offers an experience in the context of a channel in a team, a chat between one or more people, or an experience scoped to an individual user alone. These options are non-exclusive"
+
                         }
                     }
                 },
@@ -134,44 +129,37 @@
                 "properties": {
                     "entityId": {
                         "type": "string",
-                        "description": "A unique identifier for the entity which the tab displays. The id must use reverse domain name notation.",
-                        "maxLength": 64
+                        "description": "A unique identifier for the entity which the tab displays."
                     },
                     "name": {
                         "type": "string",
-                        "description": "The display name of the tab.",
-                        "maxLength": 16
+                        "description": "The display name of the tab."
                     },
-                    "canvasUrl": {
+                    "contentUrl": {
                         "type": "string",
                         "description": "The url which points to the entity UI to be displayed in the Teams canvas."
                     },
                     "websiteUrl": {
                         "type": "string",
-                        "description": "The url to point at if a user opts to view in a browser. If this is not supplied the browswer will be pointed at the canvasUrl"
+                        "description": "The url to point at if a user opts to view in a browser."
                     },
                     "scope": {
                         "type": "array",
                         "items": {
-                            "teams": {
-                                "type": "string",
-                                "description": "A value of 'teams' indicates the tab offers an experience in the context of a channel in a team"
-                            },
-                            "people": {
-                                "type": "string",
-                                "description": "A value of 'people' indicates the tab offers an experience in the context of a chat between one or more people"
-                            },
-                            "personal": {
-                                "type": "string",
-                                "description": "A value of 'personal' indicates the tab offers an experience scoped to an individual user alone"
-                            }
+                            "enum": [
+                                "team",
+                                "people",
+                                "personal"
+                            ],
+                        "description": "Specifies whether the tab offers an experience in the context of a channel in a team, a chat between one or more people, or an experience scoped to an individual user alone. These options are non-exclusive"
+
                         }
                     }
                 },
                 "required": [
                     "entityId",
                     "name",
-                    "canvasUrl",
+                    "contentUrl",
                     "scope"
                 ]
             }
@@ -189,18 +177,13 @@
                     "scope": {
                         "type": "array",
                         "items": {
-                            "teams": {
-                                "type": "string",
-                                "description": "A value of 'teams' indicates the bot offers an experience in the context of a channel in a team"
-                            },
-                            "people": {
-                                "type": "string",
-                                "description": "A value of 'people' indicates the bot offers an experience in the context of a chat between one or more people"
-                            },
-                            "personal": {
-                                "type": "string",
-                                "description": "A value of 'personal' indicates the bot offers an experience scoped to an individual user alone"
-                            }
+                            "enum": [
+                                "team",
+                                "people",
+                                "personal"
+                            ],
+                        "description": "Specifies whether the bot offers an experience in the context of a channel in a team, a chat between one or more people, or an experience scoped to an individual user alone. These options are non-exclusive"
+
                         }
                     }
                 },

--- a/src/MicrosoftTeams.schema.json
+++ b/src/MicrosoftTeams.schema.json
@@ -152,7 +152,6 @@
                                 "personal"
                             ],
                         "description": "Specifies whether the tab offers an experience in the context of a channel in a team, a chat between one or more people, or an experience scoped to an individual user alone. These options are non-exclusive"
-
                         }
                     }
                 },

--- a/src/MicrosoftTeams.schema.json
+++ b/src/MicrosoftTeams.schema.json
@@ -198,7 +198,7 @@
                     "identity"
                 ]
             },
-            "description": "Specifies which permissions that app requests"
+            "description": "Specifies which permissions the app requests"
         },
         "validDomains": {
             "type": "array",

--- a/src/MicrosoftTeams.schema.json
+++ b/src/MicrosoftTeams.schema.json
@@ -94,13 +94,13 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "configUrl": {
+                    "configurationUrl": {
                         "type": "string",
                         "description": "The url to use when configuring the tab."
                     },
-                    "canUpdateConfig": {
+                    "canUpdateConfiguration": {
                         "type": "boolean",
-                        "description": "A value indicating whether an instance of the tab's config can be updated by the user after creation.",
+                        "description": "A value indicating whether an instance of the tab's configuration can be updated by the user after creation.",
                         "default": true
                     },
                     "scope": {
@@ -117,7 +117,7 @@
                     }
                 },
                 "required": [
-                    "configUrl",
+                    "configurationUrl",
                     "scope"
                 ]
             }
@@ -168,7 +168,7 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "mri": {
+                    "botId": {
                         "type": "string",
                         "description": "A unique identifier for the bot that matches its ID in the bot framework.",
                         "maxLength": 64
@@ -186,14 +186,19 @@
                     }
                 },
                 "required": [
-                    "mri",
+                    "botId",
                     "scope"
                 ]
             }
         },
-        "needsIdentity": {
-            "type": "boolean",
-            "description": "A value indicating whether the app is requesting access to identity information"
+        "permissions": {
+            "type": "array",
+            "items": {
+                "enum": [
+                    "identity"
+                ]
+            },
+            "description": "Specifies which permissions that app requests"
         },
         "validDomains": {
             "type": "array",

--- a/src/MicrosoftTeams.schema.json
+++ b/src/MicrosoftTeams.schema.json
@@ -43,79 +43,136 @@
                 "termsOfUseUrl"
             ]
         },
-        "tabs": {
+        "name": {
+            "type": "string",
+            "description": "The display name of the app.",
+            "maxLength": 16
+        },
+        "description": {
+            "type": "object",
+            "properties": {
+                "short": {
+                    "type": "string",
+                    "description": "A short description of the app used when space is limited. Maximum length is 80 characters.",
+                    "maxLength": 80
+                },
+                "full": {
+                    "type": "string",
+                    "description": "The full description of the app. Maximum length is 256 characters.",
+                    "maxLength": 256
+                }
+            },
+            "required": [
+                "short",
+                "full"
+            ]
+        },
+        "icons": {
+            "type": "object",
+            "description": "Each icon image file must be a transparent PNG, with a white or light-colored background.",
+            "properties": {
+                "44": {
+                    "type": "string",
+                    "description": "An icon for the app sized to 44x44."
+                },
+                "88": {
+                    "type": "string",
+                    "description": "An icon for the app sized to 88x88."
+                }
+            },
+            "required": [
+                "44",
+                "88"
+            ]
+        },
+        "accentColor": {
+            "type": "string",
+            "description": "A color to use in conjunction with the app's icons. The value must be a valid HTML color code starting with '#', for example `#4464ee`."
+        },
+        "galleryTabs": {
             "type": "array",
             "items": {
                 "type": "object",
                 "properties": {
-                    "id": {
+                    "configUrl": {
                         "type": "string",
-                        "description": "A unique identifier for this extension. The id must use reverse domain name notation.",
+                        "description": "The url to use when configuring the tab."
+                    },
+                    "canUpdateConfig": {
+                        "type": "boolean",
+                        "description": "A value indicating whether an instance of the tab's config can be updated by the user after creation.",
+                        "default": true
+                    },
+                    "scope": {
+                        "type": "array",
+                        "items": {
+                            "teams": {
+                                "type": "string",
+                                "description": "A value of 'teams' indicates the tab offers an experience in the context of a channel in a team"
+                            },
+                            "people": {
+                                "type": "string",
+                                "description": "A value of 'people' indicates the tab offers an experience in the context of a chat between one or more people"
+                            },
+                            "personal": {
+                                "type": "string",
+                                "description": "A value of 'personal' indicates the tab offers an experience scoped to an individual user alone"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "configUrl",
+                    "scope"
+                ]
+            }
+        },
+        "staticTabs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "entityId": {
+                        "type": "string",
+                        "description": "A unique identifier for the entity which the tab displays. The id must use reverse domain name notation.",
                         "maxLength": 64
                     },
                     "name": {
                         "type": "string",
-                        "description": "The display name of the extension.",
+                        "description": "The display name of the tab.",
                         "maxLength": 16
                     },
-                    "description": {
-                        "type": "object",
-                        "properties": {
-                            "short": {
-                                "type": "string",
-                                "description": "A short description of the extension used when space is limited. Maximum length is 80 characters.",
-                                "maxLength": 80
-                            },
-                            "full": {
-                                "type": "string",
-                                "description": "The full description of the extension. Maximum length is 256 characters.",
-                                "maxLength": 256
-                            }
-                        },
-                        "required": [
-                            "short",
-                            "full"
-                        ]
-                    },
-                    "icons": {
-                        "type": "object",
-                        "description": "Each icon image file must be a transparent PNG, with a white or light-colored background.",
-                        "properties": {
-                            "44": {
-                                "type": "string",
-                                "description": "An icon for the extension sized to 44x44."
-                            },
-                            "88": {
-                                "type": "string",
-                                "description": "An icon for the extension sized to 88x88."
-                            }
-                        },
-                        "required": [
-                            "44",
-                            "88"
-                        ]
-                    },
-                    "accentColor": {
+                    "canvasUrl": {
                         "type": "string",
-                        "description": "A color to use in conjunction with the extension's icons. The value must be a valid HTML color code starting with '#', for example `#4464ee`."
+                        "description": "The url which points to the entity UI to be displayed in the Teams canvas."
                     },
-                    "configUrl": {
+                    "websiteUrl": {
                         "type": "string",
-                        "description": "The url to use when configuring the extension."
+                        "description": "The url to point at if a user opts to view in a browser. If this is not supplied the browswer will be pointed at the canvasUrl"
                     },
-                    "canUpdateConfig": {
-                        "type": "boolean",
-                        "description": "A value indicating whether an instance of the extension's config can be updated by the user after creation.",
-                        "default": true
+                    "scope": {
+                        "type": "array",
+                        "items": {
+                            "teams": {
+                                "type": "string",
+                                "description": "A value of 'teams' indicates the tab offers an experience in the context of a channel in a team"
+                            },
+                            "people": {
+                                "type": "string",
+                                "description": "A value of 'people' indicates the tab offers an experience in the context of a chat between one or more people"
+                            },
+                            "personal": {
+                                "type": "string",
+                                "description": "A value of 'personal' indicates the tab offers an experience scoped to an individual user alone"
+                            }
+                        }
                     }
                 },
                 "required": [
-                    "id",
+                    "entityId",
                     "name",
-                    "description",
-                    "icons",
-                    "accentColor",
-                    "configUrl"
+                    "canvasUrl",
+                    "scope"
                 ]
             }
         },
@@ -129,56 +186,37 @@
                         "description": "A unique identifier for the bot that matches its ID in the bot framework.",
                         "maxLength": 64
                     },
-                    "pinnedTabs": {
+                    "scope": {
                         "type": "array",
                         "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string",
-                                    "description": "A unique identifier for this tab instance.",
-                                    "maxLength": 64
-                                },
-                                "definitionId": {
-                                    "type": "string",
-                                    "description": "The id of the tab definition this tab is an instance of.",
-                                    "maxLength": 64
-                                },
-                                "displayName": {
-                                    "type": "string",
-                                    "description": "The display name of this tab instance.",
-                                    "maxLength": 16
-                                },
-                                "url": {
-                                    "type": "string",
-                                    "description": "The content url for this tab instance"
-                                },
-                                "websiteUrl": {
-                                    "type": "string",
-                                    "description": "The website url of the content displayed in this tab instance"
-                                }
+                            "teams": {
+                                "type": "string",
+                                "description": "A value of 'teams' indicates the bot offers an experience in the context of a channel in a team"
                             },
-                            "required": [
-                                "id",
-                                "definitionId",
-                                "displayName",
-                                "url"
-                            ]
+                            "people": {
+                                "type": "string",
+                                "description": "A value of 'people' indicates the bot offers an experience in the context of a chat between one or more people"
+                            },
+                            "personal": {
+                                "type": "string",
+                                "description": "A value of 'personal' indicates the bot offers an experience scoped to an individual user alone"
+                            }
                         }
                     }
                 },
                 "required": [
-                    "mri"
+                    "mri",
+                    "scope"
                 ]
             }
         },
         "needsIdentity": {
             "type": "boolean",
-            "description": "A value indicating whether the extension is requesting access to identity information"
-         },
+            "description": "A value indicating whether the app is requesting access to identity information"
+        },
         "validDomains": {
             "type": "array",
-            "description": "A list of valid domains from which the extension expects to load any content. Domain listings can include wildcards, for example `*.example.com`. If your tab configuration or content UI needs to navigate to any other domain besides the one use for tab configuration, that domain must be specified here.",
+            "description": "A list of valid domains from which the app expects to load any content. Domain listings can include wildcards, for example `*.example.com`. If your tab configuration or content UI needs to navigate to any other domain besides the one use for tab configuration, that domain must be specified here.",
             "items": {
                 "type": "string"
             }
@@ -187,6 +225,9 @@
     "required": [
         "manifestVersion",
         "version",
-        "developer"
+        "id",
+        "developer",
+        "icons",
+        "accentColor"
     ]
 }


### PR DESCRIPTION
Refactored to make gallery tabs, static tabs and bots as top level app properties, each of which also have a defined scope. 