### PR TITLE
Fix intermittent build errors caused by conflicting definitions for setInterval

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -615,7 +615,7 @@ namespace microsoftTeams
             // - Keeps pinging the authentication window while its open in order to re-establish
             //   contact with any pages along the authentication flow that need to communicate
             //   with us
-            authWindowMonitor = window.setInterval(() =>
+            authWindowMonitor = currentWindow.setInterval(() =>
             {
                 if (!childWindow || childWindow.closed)
                 {
@@ -1111,7 +1111,7 @@ namespace microsoftTeams
 
     function waitForMessageQueue(targetWindow: Window, callback: () => void): void
     {
-        let messageQueueMonitor = window.setInterval(() =>
+        let messageQueueMonitor = currentWindow.setInterval(() =>
         {
             if (getTargetMessageQueue(targetWindow).length === 0)
             {

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -615,7 +615,7 @@ namespace microsoftTeams
             // - Keeps pinging the authentication window while its open in order to re-establish
             //   contact with any pages along the authentication flow that need to communicate
             //   with us
-            authWindowMonitor = setInterval(() =>
+            authWindowMonitor = window.setInterval(() =>
             {
                 if (!childWindow || childWindow.closed)
                 {
@@ -1111,7 +1111,7 @@ namespace microsoftTeams
 
     function waitForMessageQueue(targetWindow: Window, callback: () => void): void
     {
-        let messageQueueMonitor = setInterval(() =>
+        let messageQueueMonitor = window.setInterval(() =>
         {
             if (getTargetMessageQueue(targetWindow).length === 0)
             {

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -94,6 +94,7 @@ describe("MicrosoftTeams", () =>
             {
                 return;
             },
+            setInterval: (handler: Function, timeout: number): number => setInterval(handler, timeout),
         };
         microsoftTeams._window = mockWindow.self = mockWindow as Window;
 


### PR DESCRIPTION
In @types/node which is auto-installed in the CI builds, `setInterval` returns a `NodeJS.Timer` object instead of just a number.

I'm not clear on why this is just now suddenly manifesting and only in the CI build, or why the node typings are being downloaded for a web project (based on logs I suspect it has something to do with the gulp-typings install; we should move to use the @types pattern instead in the future), but being explicit about using the `setInterval` on the window object should disambiguate properly.

See details here: https://github.com/Microsoft/TypeScript/issues/842