### PR TITLE
Prevent navigateCrossDomain calls from authentication popup

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -190,7 +190,7 @@ namespace microsoftTeams
      */
     export function navigateCrossDomain(url: string): void
     {
-        ensureInitialized();
+        ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove);
 
         let messageId = sendMessageRequest(parentWindow, "navigateCrossDomain", [ url ]);
         callbacks[messageId] = (success: boolean) =>


### PR DESCRIPTION
This change prevents calls to navigateCrossDomain from the authentication popup since that's not a supported API from that context.