### PR TITLE
Remove optional parameter for teamTabs. Reason is that without it, th…

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -54,7 +54,7 @@ namespace microsoftTeams
     }
 
     export interface TabInformation {
-        teamTabs?: TabInstance[];
+        teamTabs: TabInstance[];
     }
 
     export interface TabInstance {


### PR DESCRIPTION
Remove optional parameter for teamTabs. Reason is that without it, the type of teamTabs is "TabInformation[] | undefined", which is cumbersome for callers to deal with.  Seeing the impact of this as I look at the DefinitelyTyped updates.