### PR TITLE
Add support for connectors inline configuration experience

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -230,7 +230,7 @@ namespace microsoftTeams {
      * thrown. This function needs to be used only when navigating the frame to a URL in a different domain 
      * than the current one in a way that keeps the app informed of the change and allows the SDK to 
      * continue working.
-     * @param {string} url The URL to navigate the frame to.
+     * @param url The URL to navigate the frame to.
      */
     export function navigateCrossDomain(url: string): void {
         ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove);
@@ -247,7 +247,7 @@ namespace microsoftTeams {
      * Allows an app to retrieve for this user tabs that are owned by this app.
      * If no TabInstanceParameters are passed, the app defaults to favorite teams and favorite channels.
      * @param callback The callback to invoke when the {@link TabInstanceParameters} object is retrieved.
-     * @param {TabInstanceParameters} tabInstanceParameters OPTIONAL Flags that specify whether to scope call to favorite teams or channels.
+     * @param tabInstanceParameters OPTIONAL Flags that specify whether to scope call to favorite teams or channels.
      */
     export function getTabInstances(callback: (tabInfo: TabInformation) => void, tabInstanceParameters?: TabInstanceParameters): void {
         ensureInitialized();
@@ -259,7 +259,7 @@ namespace microsoftTeams {
     /**
      * Allows an app to retrieve the most recently used tabs for this user.
      * @param callback The callback to invoke when the {@link TabInformation} object is retrieved.
-     * @param {TabInstanceParameters} tabInstanceParameters OPTIONAL Ignored, kept for future use
+     * @param tabInstanceParameters OPTIONAL Ignored, kept for future use
      */
     export function getMruTabInstances(callback: (tabInfo: TabInformation) => void, tabInstanceParameters?: TabInstanceParameters): void {
         ensureInitialized();
@@ -270,7 +270,7 @@ namespace microsoftTeams {
 
     /**
      * Shares a deep link that a user can use to navigate back to a specific state in this page.
-     * @param {DeepLinkParameters} deepLinkParameters ID and label for the link and fallback URL.
+     * @param deepLinkParameters ID and label for the link and fallback URL.
      */
     export function shareDeepLink(deepLinkParameters: DeepLinkParameters): void {
         ensureInitialized(frameContexts.content);
@@ -284,7 +284,7 @@ namespace microsoftTeams {
 
     /**
      * Navigates the Microsoft Teams app to the specified tab instance.
-     * @param {TabInstance} tabInstance The tab instance to navigate to.
+     * @param tabInstance The tab instance to navigate to.
      */
     export function navigateToTab(tabInstance: TabInstance): void {
         ensureInitialized();
@@ -310,7 +310,7 @@ namespace microsoftTeams {
         /**
          * Sets the validity state for the settings.
          * The initial value is false, so the user cannot save the settings until this is called with true.
-         * @param {boolean} validityState Indicates whether the save or remove button is enabled for the user.
+         * @param validityState Indicates whether the save or remove button is enabled for the user.
          */
         export function setValidityState(validityState: boolean): void {
             ensureInitialized(frameContexts.settings, frameContexts.remove);
@@ -332,7 +332,7 @@ namespace microsoftTeams {
         /**
          * Sets the settings for the current instance.
          * This is an asynchronous operation; calls to getSettings are not guaranteed to reflect the changed state.
-         * @param {Settings} settings The desired settings for this instance.
+         * @param settings The desired settings for this instance.
          */
         export function setSettings(settings: Settings): void {
             ensureInitialized(frameContexts.settings);
@@ -413,7 +413,7 @@ namespace microsoftTeams {
 
             /**
              * Indicates that creation of the underlying resource failed and that the settings cannot be saved.
-             * @param {string} reason Specifies a reason for the failure. If provided, this string is displayed to the user; otherwise a generic error is displayed.
+             * @param reason Specifies a reason for the failure. If provided, this string is displayed to the user; otherwise a generic error is displayed.
              */
             notifyFailure(reason?: string): void;
         }
@@ -426,7 +426,7 @@ namespace microsoftTeams {
 
             /**
              * Indicates that removal of the underlying resource failed and that the content cannot be removed.
-             * @param {string} reason Specifies a reason for the failure. If provided, this string is displayed to the user; otherwise a generic error is displayed.
+             * @param reason Specifies a reason for the failure. If provided, this string is displayed to the user; otherwise a generic error is displayed.
              */
             notifyFailure(reason?: string): void;
         }
@@ -507,7 +507,7 @@ namespace microsoftTeams {
 
         /**
          * Initiates an authentication request, which opens a new window with the specified settings.
-         * @param {AuthenticateParameters} authenticateParameters A set of values that configure the authentication pop-up.
+         * @param authenticateParameters A set of values that configure the authentication pop-up.
          */
         export function authenticate(authenticateParameters: AuthenticateParameters): void {
             ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove);
@@ -541,7 +541,7 @@ namespace microsoftTeams {
         /**
          * Requests an Azure AD token to be issued on behalf of the app. The token is acquired from the cache
          * if it is not expired. Otherwise a request is sent to Azure AD to obtain a new token.
-         * @param {AuthTokenRequest} authTokenRequest A set of values that configure the token request.
+         * @param authTokenRequest A set of values that configure the token request.
          */
         export function getAuthToken(authTokenRequest: AuthTokenRequest): void {
             ensureInitialized();
@@ -679,7 +679,7 @@ namespace microsoftTeams {
          * Notifies the frame that initiated this authentication request that the request was successful.
          * This function is usable only on the authentication window.
          * This call causes the authentication window to be closed.
-         * @param {string} result Specifies a result for the authentication. If specified, the frame that initiated the authentication pop-up receives this value in its callback.
+         * @param result Specifies a result for the authentication. If specified, the frame that initiated the authentication pop-up receives this value in its callback.
          */
         export function notifySuccess(result?: string): void {
             ensureInitialized(frameContexts.authentication);

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -247,9 +247,9 @@ namespace microsoftTeams {
      * Allows an app to retrieve for this user tabs that are owned by this app.
      * If no TabInstanceParameters are passed, the app defaults to favorite teams and favorite channels.
      * @param callback The callback to invoke when the {@link TabInstanceParameters} object is retrieved.
-     * @param {TabInstanceParameters} tabInstanceParameters Flags that specify whether to scope call to favorite teams or channels.
+     * @param {TabInstanceParameters} tabInstanceParameters OPTIONAL Flags that specify whether to scope call to favorite teams or channels.
      */
-    export function getTabInstances(callback: (tabInfo: TabInformation) => void, tabInstanceParameters: TabInstanceParameters): void {
+    export function getTabInstances(callback: (tabInfo: TabInformation) => void, tabInstanceParameters?: TabInstanceParameters): void {
         ensureInitialized();
 
         let messageId = sendMessageRequest(parentWindow, "getTabInstances", [tabInstanceParameters]);
@@ -259,9 +259,9 @@ namespace microsoftTeams {
     /**
      * Allows an app to retrieve the most recently used tabs for this user.
      * @param callback The callback to invoke when the {@link TabInformation} object is retrieved.
-     * @param {TabInstanceParameters} tabInstanceParameters Flags that specify whether to scope call to favorite teams or channels.
+     * @param {TabInstanceParameters} tabInstanceParameters OPTIONAL Ignored, kept for future use
      */
-    export function getMruTabInstances(callback: (tabInfo: TabInformation) => void, tabInstanceParameters: TabInstanceParameters): void {
+    export function getMruTabInstances(callback: (tabInfo: TabInformation) => void, tabInstanceParameters?: TabInstanceParameters): void {
         ensureInitialized();
 
         let messageId = sendMessageRequest(parentWindow, "getMruTabInstances", [tabInstanceParameters]);

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -10,7 +10,7 @@ interface MessageEvent {
 namespace microsoftTeams {
     "use strict";
 
-    const version = "1.1-prerel";
+    const version = "1.1";
 
     const validOrigins = [
         "https://teams.microsoft.com",

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -50,15 +50,15 @@ namespace microsoftTeams {
     }
 
     /**
-   * Represents information about tabs for an app
-   */
+    * Represents information about tabs for an app
+    */
     export interface TabInformation {
         teamTabs: TabInstance[];
     }
 
     /**
-      * Represents information about a tab instance
-      */
+     * Represents information about a tab instance
+     */
     export interface TabInstance {
         /**
          * The name of the tab
@@ -496,6 +496,10 @@ namespace microsoftTeams {
             webhookUrl?: string;
         }
 
+         /**
+         * @private
+         * Hide from docs, since this class is not directly used.
+         */
         class SaveEventImpl implements SaveEvent {
             public notified: boolean = false;
             public result: SaveResult = {};
@@ -537,9 +541,9 @@ namespace microsoftTeams {
         }
 
         /**
-      * @private
-      * Hide from docs, since this class is not directly used.
-      */
+         * @private
+         * Hide from docs, since this class is not directly used.
+         */
         class RemoveEventImpl implements RemoveEvent {
             public notified: boolean = false;
 
@@ -577,7 +581,10 @@ namespace microsoftTeams {
         handlers["authentication.authenticate.success"] = handleSuccess;
         handlers["authentication.authenticate.failure"] = handleFailure;
 
-
+        /**
+         * Registers the authentication parameters
+         * @param authenticateParameters A set of values that configure the authentication pop-up.
+         */
         export function registerAuthenticationParameters(authenticateParameters: AuthenticateParameters): void {
             authParams = authenticateParameters;
         }
@@ -822,8 +829,9 @@ namespace microsoftTeams {
             }
         }
 
-        /**
-        * Validates that the state param is a url with host as outlook.office.com and client_type correctly set to Outlook Desktop
+        /*
+        * Validates that the state param is a valid url with host as outlook.office.com and client_type correctly set to Outlook Desktop
+        * @param uri - the url to validate
         */
         function isValidState(state) {
             var link = document.createElement('a');

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -424,7 +424,7 @@ namespace microsoftTeams {
             removeHandler = handler;
         }
 
-        function handleSave(result): void {
+        function handleSave(result: SaveResult): void {
             let saveEvent = new SaveEventImpl(result);
             if (saveHandler) {
                 saveHandler(saveEvent);
@@ -593,7 +593,7 @@ namespace microsoftTeams {
          * Initiates an authentication request, which opens a new window with the specified settings.
          */
         export function authenticate(): void {
-            var authenticateParameters = authParams;
+            let authenticateParameters = authParams;
             ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove);
 
             if (hostClientType === hostClientTypes.desktop) {
@@ -767,9 +767,9 @@ namespace microsoftTeams {
          */
         export function notifySuccess(authenticationResultParams: AuthenticationResultParameters): void {
             if (authenticationResultParams.state) {
-                var decodedUrl = decodeURIComponent(authenticationResultParams.state);
+                let decodedUrl = decodeURIComponent(authenticationResultParams.state);
                 if (isValidState(decodedUrl)) {
-                    var link = document.createElement('a');
+                    let link = document.createElement("a");
                     link.href = updateUrlParameter(decodedUrl, "result", authenticationResultParams.result);
                     window.location.href = link.href;
                 }
@@ -790,9 +790,9 @@ namespace microsoftTeams {
          */
         export function notifyFailure(authenticationResultParams: AuthenticationResultParameters): void {
             if (authenticationResultParams.state) {
-                var decodedUrl = decodeURIComponent(authenticationResultParams.state);
+                let decodedUrl = decodeURIComponent(authenticationResultParams.state);
                 if (isValidState(decodedUrl)) {
-                    var link = document.createElement('a');
+                    let link = document.createElement("a");
                     link.href = updateUrlParameter(decodedUrl, "reason", authenticationResultParams.reason);
                     window.location.href = link.href;
                 }
@@ -833,10 +833,10 @@ namespace microsoftTeams {
         * Validates that the state param is a valid url with host as outlook.office.com and client_type correctly set to Outlook Desktop
         * @param uri - the url to validate
         */
-        function isValidState(state) {
-            var link = document.createElement('a');
+        function isValidState(state: string): boolean {
+            let link = document.createElement("a");
             link.href = state;
-            if (link.host && link.host != window.location.host && link.host === "outlook.office.com" && link.search.indexOf('client_type=Win32_Outlook') > -1) {
+            if (link.host && link.host !== window.location.host && link.host === "outlook.office.com" && link.search.indexOf("client_type=Win32_Outlook") > -1) {
                 return true;
             }
             return false;
@@ -848,14 +848,13 @@ namespace microsoftTeams {
          * @param key - the QSP key
          * @param value - the QSP value
          */
-        function updateUrlParameter(uri, key, value) {
-            var i = uri.indexOf('#');
-            var hash = i === -1 ? '' : uri.substr(i);
+        function updateUrlParameter(uri: string, key: string, value: string): string {
+            let i = uri.indexOf("#");
+            let hash = i === -1 ? "" : uri.substr(i);
             hash = hash + "&" + key + "=" + value;
             uri = i === -1 ? uri : uri.substr(0, i);
             return uri + hash;  // append the updated hash
         }
-
 
         export interface AuthenticateParameters {
             /**

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -527,7 +527,7 @@ namespace microsoftTeams {
 
         export interface SaveEvent {
             /**
-             * Object containing properties passed as arguments to the settings.save event. 
+             * Object containing properties passed as arguments to the settings.save event.
              */
             result: SaveResult;
 
@@ -843,7 +843,7 @@ namespace microsoftTeams {
          */
         export function notifySuccess(result?: string, callbackUrl?: string): void {
             redirectIfWin32Outlook(callbackUrl, "result", result);
-            
+
             ensureInitialized(frameContexts.authentication);
 
             sendMessageRequest(parentWindow, "authentication.authenticate.success", [result]);
@@ -861,7 +861,7 @@ namespace microsoftTeams {
          */
         export function notifyFailure(reason?: string, callbackUrl?: string): void {
             redirectIfWin32Outlook(callbackUrl, "reason", reason);
-            
+
             ensureInitialized(frameContexts.authentication);
 
             sendMessageRequest(parentWindow, "authentication.authenticate.failure", [reason]);
@@ -903,14 +903,18 @@ namespace microsoftTeams {
         function redirectIfWin32Outlook(callbackUrl?: string, key?: string, value?: string): void {
             if (callbackUrl) {
                 let link = document.createElement("a");
-                link.href = decodeURIComponent(callbackUrl);;
+                link.href = decodeURIComponent(callbackUrl);
                 if (link.host && link.host !== window.location.host && link.host === "outlook.office.com" && link.search.indexOf("client_type=Win32_Outlook") > -1) {
-                    if (key && key === "result" && value) {
-                        link.href = updateUrlParameter(link.href, "result", value);
+                    if (key && key === "result") {
+                        if (value) {
+                            link.href = updateUrlParameter(link.href, "result", value);
+                        }
                         currentWindow.location.assign(updateUrlParameter(link.href, "authSuccess", ""));
                     }
-                    if (key && key === "reason" && value) {
-                        link.href = updateUrlParameter(link.href, "reason", value);
+                    if (key && key === "reason") {
+                        if (value) {
+                            link.href = updateUrlParameter(link.href, "reason", value);
+                        }
                         currentWindow.location.assign(updateUrlParameter(link.href, "authFailure", ""));
                     }
                 }
@@ -918,10 +922,10 @@ namespace microsoftTeams {
         }
 
         /**
-         * Appends either result or reason as a hash param to the 'state' url 
+         * Appends either result or reason as a fragment to the 'callbackUrl'
          * @param uri - the url to modify
-         * @param key - the QSP key
-         * @param value - the QSP value
+         * @param key - the fragment key
+         * @param value - the fragment value
          */
         function updateUrlParameter(uri: string, key: string, value: string): string {
             let i = uri.indexOf("#");
@@ -957,7 +961,7 @@ namespace microsoftTeams {
              */
             failureCallback?: (reason?: string) => void;
         }
-      
+
         /**
         * @private
         * Hide from docs.

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -465,6 +465,11 @@ namespace microsoftTeams {
 
         export interface SaveEvent {
             /**
+             * Object containing properties passed as arguments to the settings.save event. 
+             */
+            result: SaveResult;
+
+            /**
              * Indicates that the underlying resource has been created and the settings can be saved.
              */
             notifySuccess(): void;
@@ -503,9 +508,11 @@ namespace microsoftTeams {
         class SaveEventImpl implements SaveEvent {
             public notified: boolean = false;
             public result: SaveResult = {};
+
             constructor(result: SaveResult) {
                 this.result = result;
             }
+
             public notifySuccess(): void {
                 this.ensureNotNotified();
 
@@ -592,33 +599,33 @@ namespace microsoftTeams {
         /**
          * Initiates an authentication request, which opens a new window with the specified settings.
          */
-        export function authenticate(): void {
-            let authenticateParameters = authParams;
+        export function authenticate(authenticateParameters?: AuthenticateParameters): void {
+            let authenticateParams = authenticateParameters !== undefined ? authenticateParameters : authParams;
             ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove);
 
             if (hostClientType === hostClientTypes.desktop) {
                 // Convert any relative URLs into absolute URLs before sending them over to the parent window.
                 let link = document.createElement("a");
-                link.href = authenticateParameters.url;
+                link.href = authenticateParams.url;
 
                 // Ask the parent window to open an authentication window with the parameters provided by the caller.
                 let messageId = sendMessageRequest(parentWindow, "authentication.authenticate", [
                     link.href,
-                    authenticateParameters.width,
-                    authenticateParameters.height,
+                    authenticateParams.width,
+                    authenticateParams.height,
                 ]);
                 callbacks[messageId] = (success: boolean, response: string) => {
                     if (success) {
-                        authenticateParameters.successCallback(response);
+                        authenticateParams.successCallback(response);
                     }
                     else {
-                        authenticateParameters.failureCallback(response);
+                        authenticateParams.failureCallback(response);
                     }
                 };
             }
             else {
                 // Open an authentication window with the parameters provided by the caller.
-                openAuthenticationWindow(authenticateParameters);
+                openAuthenticationWindow(authenticateParams);
             }
         }
 

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -10,7 +10,7 @@ interface MessageEvent {
 namespace microsoftTeams {
     "use strict";
 
-    const version = "1.1";
+    const version = "1.2";
 
     const validOrigins = [
         "https://teams.microsoft.com",

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -366,8 +366,8 @@ namespace microsoftTeams {
             removeHandler = handler;
         }
 
-        function handleSave(): void {
-            let saveEvent = new SaveEventImpl();
+        function handleSave(result): void {
+            let saveEvent = new SaveEventImpl(result);
             if (saveHandler) {
                 saveHandler(saveEvent);
             }
@@ -433,6 +433,10 @@ namespace microsoftTeams {
 
         class SaveEventImpl implements SaveEvent {
             public notified: boolean = false;
+            public result: Object = {};
+            constructor(result: Object) {
+                this.result = result;
+            }
 
             public notifySuccess(): void {
                 this.ensureNotNotified();

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -50,8 +50,8 @@ namespace microsoftTeams {
     }
 
     /**
-    * Represents information about tabs for an app
-    */
+     * Represents information about tabs for an app
+     */
     export interface TabInformation {
         teamTabs: TabInstance[];
     }
@@ -778,7 +778,8 @@ namespace microsoftTeams {
                 if (isValidState(decodedUrl)) {
                     let link = document.createElement("a");
                     link.href = updateUrlParameter(decodedUrl, "result", authenticationResultParams.result);
-                    window.location.href = link.href;
+                    currentWindow.location.assign(link.href);
+                    return;
                 }
             }
             ensureInitialized(frameContexts.authentication);
@@ -801,7 +802,8 @@ namespace microsoftTeams {
                 if (isValidState(decodedUrl)) {
                     let link = document.createElement("a");
                     link.href = updateUrlParameter(decodedUrl, "reason", authenticationResultParams.reason);
-                    window.location.href = link.href;
+                    currentWindow.location.assign(link.href);
+                    return;
                 }
             }
             ensureInitialized(frameContexts.authentication);
@@ -838,7 +840,7 @@ namespace microsoftTeams {
 
         /*
         * Validates that the state param is a valid url with host as outlook.office.com and client_type correctly set to Outlook Desktop
-        * @param uri - the url to validate
+        * @param state - the url to validate
         */
         function isValidState(state: string): boolean {
             let link = document.createElement("a");
@@ -857,10 +859,10 @@ namespace microsoftTeams {
          */
         function updateUrlParameter(uri: string, key: string, value: string): string {
             let i = uri.indexOf("#");
-            let hash = i === -1 ? "" : uri.substr(i);
+            let hash = i === -1 ? "#" : uri.substr(i);
             hash = hash + "&" + key + "=" + value;
             uri = i === -1 ? uri : uri.substr(0, i);
-            return uri + hash;  // append the updated hash
+            return uri + hash;
         }
 
         export interface AuthenticateParameters {
@@ -891,13 +893,19 @@ namespace microsoftTeams {
         }
 
         export interface AuthenticationResultParameters {
-            /* reason Specifies a reason for the authentication failure.If specified, the frame that initiated the authentication pop- up receives this value in its callback*/
+            /**
+             * Specifies a reason for the authentication failure.If specified, the frame that initiated the authentication pop- up receives this value in its callback
+             */
             reason?: string;
 
-            /* result Specifies a result for the authentication.If specified, the frame that initiated the authentication pop- up receives this value in its callback.*/
+            /**
+             * Specifies a result for the authentication.If specified, the frame that initiated the authentication pop- up receives this value in its callback. 
+             */
             result?: string;
 
-            /* state Specifies a return url for the authentication applicable in case of Outlook Desktop client. If specified, the frame that initiated the authentication redirects back to the specified URL after authentication success/failure.*/
+            /**
+             * Specifies a return url for the authentication applicable in case of Outlook Desktop client. If specified, the frame that initiated the authentication redirects back to the specified URL after authentication success/failure
+             */
             state?: string;
         }
 

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -486,7 +486,7 @@ namespace microsoftTeams {
             removeHandler = handler;
         }
 
-        function handleSave(result: SaveResult): void {
+        function handleSave(result?: SaveParameters): void {
             let saveEvent = new SaveEventImpl(result);
             if (saveHandler) {
                 saveHandler(saveEvent);
@@ -529,7 +529,7 @@ namespace microsoftTeams {
             /**
              * Object containing properties passed as arguments to the settings.save event.
              */
-            result: SaveResult;
+            result: SaveParameters;
 
             /**
              * Indicates that the underlying resource has been created and the settings can be saved.
@@ -556,7 +556,7 @@ namespace microsoftTeams {
             notifyFailure(reason?: string): void;
         }
 
-        export interface SaveResult {
+        export interface SaveParameters {
             /**
              * Connector's webhook Url returned as arguments to settings.save event as part of user clicking on Save
              */
@@ -569,10 +569,10 @@ namespace microsoftTeams {
          */
         class SaveEventImpl implements SaveEvent {
             public notified: boolean = false;
-            public result: SaveResult = {};
+            public result: SaveParameters;
 
-            constructor(result: SaveResult) {
-                this.result = result;
+            constructor(result?: SaveParameters) {
+                this.result = result ? result : {};
             }
 
             public notifySuccess(): void {
@@ -651,10 +651,10 @@ namespace microsoftTeams {
         handlers["authentication.authenticate.failure"] = handleFailure;
 
         /**
-         * Registers the authentication parameters
+         * Registers the authentication handlers
          * @param authenticateParameters A set of values that configure the authentication pop-up.
 	     */
-        export function registerAuthenticationParameters(authenticateParameters: AuthenticateParameters): void {
+        export function registerAuthenticationHandlers(authenticateParameters: AuthenticateParameters): void {
             authParams = authenticateParameters;
         }
 

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -876,6 +876,24 @@ describe("MicrosoftTeams", () =>
         expect(message.args[2]).toBe("someSubEntityWebUrl");
     });
 
+    describe("getTabInstances", () => {
+        it("should allow a missing and valid optional parameter", () => {
+            initializeWithContext("getTabInstances");
+
+            microsoftTeams.getTabInstances(tabInfo => tabInfo);
+            microsoftTeams.getTabInstances(tabInfo => tabInfo, {} as microsoftTeams.TabInstanceParameters);
+        });
+    });
+
+    describe("getMruTabInstances", () => {
+        it("should allow a missing and valid optional parameter", () => {
+            initializeWithContext("getMruTabInstances");
+
+            microsoftTeams.getMruTabInstances(tabInfo => tabInfo);
+            microsoftTeams.getMruTabInstances(tabInfo => tabInfo, {} as microsoftTeams.TabInstanceParameters);
+        });
+    });
+
     function initializeWithContext(frameContext: string, hostClientType?: string): void
     {
         microsoftTeams.initialize();

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -132,7 +132,7 @@ describe("MicrosoftTeams", () =>
         expect(initMessage).not.toBeNull();
         expect(initMessage.id).toBe(0);
         expect(initMessage.func).toBe("initialize");
-        expect(initMessage.args).toEqual(["1.1"]);
+        expect(initMessage.args).toEqual(["1.2"]);
     });
 
     it("should allow multiple initialize calls", () =>

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -476,6 +476,22 @@ describe("MicrosoftTeams", () =>
         expect(handlerCalled).toBe(true);
     });
 
+    it("should successfully get webhook URL in the save handler", () => {
+        initializeWithContext("settings");
+
+        let handlerCalled = false;
+        microsoftTeams.settings.registerOnSaveHandler((saveEvent) => {
+            handlerCalled = true;
+            expect(saveEvent.result["webhookUrl"]).not.toBeNull();
+        });
+
+        sendMessage("settings.save", [{
+            webhookUrl: "someWebhookUrl",
+        }]);
+
+        expect(handlerCalled).toBe(true);
+    });
+
     it("should successfully register a remove handler", () =>
     {
         initializeWithContext("remove");
@@ -658,6 +674,30 @@ describe("MicrosoftTeams", () =>
         expect(windowOpenCalled).toBe(true);
     });
 
+    it("should successfully pop up the auth window when registerAuthenticationParameters is called", () => {
+        initializeWithContext("content");
+
+        let windowOpenCalled = false;
+        spyOn(microsoftTeams._window, "open").and.callFake((url: string, name: string, specs: string): Window => {
+            expect(url).toEqual("https://someurl/");
+            expect(name).toEqual("_blank");
+            expect(specs.indexOf("width=100")).not.toBe(-1);
+            expect(specs.indexOf("height=200")).not.toBe(-1);
+            windowOpenCalled = true;
+            return childWindow as Window;
+        });
+
+        let authenticationParams =
+            {
+                url: "https://someurl/",
+                width: 100,
+                height: 200,
+            };
+        microsoftTeams.authentication.registerAuthenticationParameters(authenticationParams);
+        microsoftTeams.authentication.authenticate();
+        expect(windowOpenCalled).toBe(true);
+    });
+
     it("should successfully handle auth success", () =>
     {
         initializeWithContext("content");
@@ -795,8 +835,11 @@ describe("MicrosoftTeams", () =>
     it("should successfully notify auth success", () =>
     {
         initializeWithContext("authentication");
-
-        microsoftTeams.authentication.notifySuccess("someResult");
+        let authenticationResultParams =
+        {
+            result: "someResult",
+        };
+        microsoftTeams.authentication.notifySuccess(authenticationResultParams);
 
         let message = findMessageByFunc("authentication.authenticate.success");
         expect(message).not.toBeNull();
@@ -807,8 +850,11 @@ describe("MicrosoftTeams", () =>
     it("should successfully notify auth failure", () =>
     {
         initializeWithContext("authentication");
-
-        microsoftTeams.authentication.notifyFailure("someReason");
+        let authenticationResultParams =
+        {
+            reason: "someReason",
+        };
+        microsoftTeams.authentication.notifyFailure(authenticationResultParams);
 
         let message = findMessageByFunc("authentication.authenticate.failure");
         expect(message).not.toBeNull();
@@ -823,8 +869,11 @@ describe("MicrosoftTeams", () =>
         microsoftTeams.initialize();
         let initMessage = findMessageByFunc("initialize");
         expect(initMessage).not.toBeNull();
-
-        microsoftTeams.authentication.notifySuccess("someResult");
+        let authenticationResultParams =
+        {
+            result: "someResult",
+        };
+        microsoftTeams.authentication.notifySuccess(authenticationResultParams);
         let message = findMessageByFunc("authentication.authenticate.success");
         expect(message).toBeNull();
         expect(closeWindowSpy).not.toHaveBeenCalled();
@@ -844,8 +893,11 @@ describe("MicrosoftTeams", () =>
         microsoftTeams.initialize();
         let initMessage = findMessageByFunc("initialize");
         expect(initMessage).not.toBeNull();
-
-        microsoftTeams.authentication.notifyFailure("someReason");
+        let authenticationResultParams =
+        {
+            reason: "someReason",
+        };
+        microsoftTeams.authentication.notifyFailure(authenticationResultParams);
         let message = findMessageByFunc("authentication.authenticate.failure");
         expect(message).toBeNull();
         expect(closeWindowSpy).not.toHaveBeenCalled();

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -795,7 +795,7 @@ describe("MicrosoftTeams", () => {
         expect(message.args[0]).toBe("someResult");
     });
 
-    it("should do window redirect if state is valid", () => {
+    it("should do window redirect if callbackUrl is for win32 Outlook", () => {
         let windowAssignSpyCalled = false;
         spyOn(microsoftTeams._window.location, "assign").and.callFake((url: string): void => {
             windowAssignSpyCalled = true;
@@ -805,12 +805,23 @@ describe("MicrosoftTeams", () => {
         initializeWithContext("authentication");
 
         microsoftTeams.authentication.notifySuccess("someResult", "https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook%23%2Fconfigurations");
-        let message = findMessageByFunc("authentication.authenticate.success");
-        expect(message).toBeNull();
         expect(windowAssignSpyCalled).toBe(true);
     });
 
-    it("should do window redirect if state is valid but does not have URL fragments", () => {
+    it("should do window redirect if callbackUrl is for win32 Outlook and no result param specified", () => {
+        let windowAssignSpyCalled = false;
+        spyOn(microsoftTeams._window.location, "assign").and.callFake((url: string): void => {
+            windowAssignSpyCalled = true;
+            expect(url).toEqual("https://outlook.office.com/connectors?client_type=Win32_Outlook#/configurations&authSuccess");
+        });
+
+        initializeWithContext("authentication");
+
+        microsoftTeams.authentication.notifySuccess(null, "https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook%23%2Fconfigurations");
+        expect(windowAssignSpyCalled).toBe(true);
+    });
+
+    it("should do window redirect if callbackUrl is for win32 Outlook but does not have URL fragments", () => {
         let windowAssignSpyCalled = false;
         spyOn(microsoftTeams._window.location, "assign").and.callFake((url: string): void => {
             windowAssignSpyCalled = true;
@@ -820,15 +831,13 @@ describe("MicrosoftTeams", () => {
         initializeWithContext("authentication");
 
         microsoftTeams.authentication.notifySuccess("someResult", "https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook");
-        let message = findMessageByFunc("authentication.authenticate.success");
-        expect(message).toBeNull();
         expect(windowAssignSpyCalled).toBe(true);
     });
 
-    it("should successfully notify auth success if state is invalid", () => {
+    it("should successfully notify auth success if callbackUrl is not for win32 Outlook", () => {
         initializeWithContext("authentication");
 
-        microsoftTeams.authentication.notifySuccess("someResult", "https%3A%2F%2Fsomeinvalidurl.com%3Fstate%3Dtest%23%2Fconfiguration");
+        microsoftTeams.authentication.notifySuccess("someResult", "https%3A%2F%2Fsomeinvalidurl.com%3FcallbackUrlstate%3Dtest%23%2Fconfiguration");
         let message = findMessageByFunc("authentication.authenticate.success");
         expect(message).not.toBeNull();
         expect(message.args.length).toBe(1);
@@ -837,7 +846,7 @@ describe("MicrosoftTeams", () => {
 
     it("should successfully notify auth failure", () => {
         initializeWithContext("authentication");
-        
+
         microsoftTeams.authentication.notifyFailure("someReason");
 
         let message = findMessageByFunc("authentication.authenticate.failure");
@@ -846,7 +855,7 @@ describe("MicrosoftTeams", () => {
         expect(message.args[0]).toBe("someReason");
     });
 
-    it("should do window redirect if state is valid and auth failure happens", () => {
+    it("should do window redirect if callbackUrl is for win32 Outlook and auth failure happens", () => {
         let windowAssignSpyCalled = false;
         spyOn(microsoftTeams._window.location, "assign").and.callFake((url: string): void => {
             windowAssignSpyCalled = true;
@@ -856,19 +865,17 @@ describe("MicrosoftTeams", () => {
         initializeWithContext("authentication");
 
         microsoftTeams.authentication.notifyFailure("someReason", "https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook%23%2Fconfigurations");
-        let message = findMessageByFunc("authentication.authenticate.failure");
-        expect(message).toBeNull();
         expect(windowAssignSpyCalled).toBe(true);
     });
 
-    it("should successfully notify auth failure if state is invalid", () => {
+    it("should successfully notify auth failure if callbackUrl is not for win32 Outlook", () => {
         spyOn(microsoftTeams._window.location, "assign").and.callFake((url: string): void => {
-            expect(url).toEqual("https://someinvalidurl.com?state=test#/configuration&reason=someReason&authFailure");
+            expect(url).toEqual("https://someinvalidurl.com?callbackUrl=test#/configuration&reason=someReason&authFailure");
         });
 
         initializeWithContext("authentication");
-        
-        microsoftTeams.authentication.notifyFailure("someReason", "https%3A%2F%2Fsomeinvalidurl.com%3Fstate%3Dtest%23%2Fconfiguration");
+
+        microsoftTeams.authentication.notifyFailure("someReason", "https%3A%2F%2Fsomeinvalidurl.com%3FcallbackUrl%3Dtest%23%2Fconfiguration");
         let message = findMessageByFunc("authentication.authenticate.failure");
         expect(message).not.toBeNull();
         expect(message.args.length).toBe(1);
@@ -881,7 +888,7 @@ describe("MicrosoftTeams", () => {
         microsoftTeams.initialize();
         let initMessage = findMessageByFunc("initialize");
         expect(initMessage).not.toBeNull();
-        
+
         microsoftTeams.authentication.notifySuccess("someResult");
         let message = findMessageByFunc("authentication.authenticate.success");
         expect(message).toBeNull();
@@ -901,7 +908,7 @@ describe("MicrosoftTeams", () => {
         microsoftTeams.initialize();
         let initMessage = findMessageByFunc("initialize");
         expect(initMessage).not.toBeNull();
-        
+
         microsoftTeams.authentication.notifyFailure("someReason");
         let message = findMessageByFunc("authentication.authenticate.failure");
         expect(message).toBeNull();

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -132,7 +132,7 @@ describe("MicrosoftTeams", () =>
         expect(initMessage).not.toBeNull();
         expect(initMessage.id).toBe(0);
         expect(initMessage.func).toBe("initialize");
-        expect(initMessage.args).toEqual(["1.1-prerel"]);
+        expect(initMessage.args).toEqual(["1.1"]);
     });
 
     it("should allow multiple initialize calls", () =>

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -787,11 +787,8 @@ describe("MicrosoftTeams", () => {
 
     it("should successfully notify auth success", () => {
         initializeWithContext("authentication");
-        let authenticationResultParams = {
-            result: "someResult",
-        };
-        microsoftTeams.authentication.notifySuccess(authenticationResultParams);
 
+        microsoftTeams.authentication.notifySuccess("someResult");
         let message = findMessageByFunc("authentication.authenticate.success");
         expect(message).not.toBeNull();
         expect(message.args.length).toBe(1);
@@ -802,17 +799,12 @@ describe("MicrosoftTeams", () => {
         let windowAssignSpyCalled = false;
         spyOn(microsoftTeams._window.location, "assign").and.callFake((url: string): void => {
             windowAssignSpyCalled = true;
-            expect(url).toEqual("https://outlook.office.com/connectors?MailboxAddress=test%40service.microsoft.com&client_type=Win32_Outlook#/configurations&result=someResult&authSuccess");
+            expect(url).toEqual("https://outlook.office.com/connectors?client_type=Win32_Outlook#/configurations&result=someResult&authSuccess");
         });
 
         initializeWithContext("authentication");
-        let authenticationResultParams =
-        {
-            result: "someResult",
-            state: "https%3A%2F%2Foutlook.office.com%2Fconnectors%3FMailboxAddress%3Dtest%2540service.microsoft.com%26client_type%3DWin32_Outlook%23%2Fconfigurations",
-        };
 
-        microsoftTeams.authentication.notifySuccess(authenticationResultParams);
+        microsoftTeams.authentication.notifySuccess("someResult", "https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook%23%2Fconfigurations");
         let message = findMessageByFunc("authentication.authenticate.success");
         expect(message).toBeNull();
         expect(windowAssignSpyCalled).toBe(true);
@@ -822,35 +814,21 @@ describe("MicrosoftTeams", () => {
         let windowAssignSpyCalled = false;
         spyOn(microsoftTeams._window.location, "assign").and.callFake((url: string): void => {
             windowAssignSpyCalled = true;
-            expect(url).toEqual("https://outlook.office.com/connectors?MailboxAddress=test%40service.microsoft.com&client_type=Win32_Outlook#&result=someResult&authSuccess");
+            expect(url).toEqual("https://outlook.office.com/connectors?client_type=Win32_Outlook#&result=someResult&authSuccess");
         });
 
         initializeWithContext("authentication");
-        let authenticationResultParams =
-        {
-            result: "someResult",
-            state: "https%3A%2F%2Foutlook.office.com%2Fconnectors%3FMailboxAddress%3Dtest%2540service.microsoft.com%26client_type%3DWin32_Outlook",
-        };
 
-        microsoftTeams.authentication.notifySuccess(authenticationResultParams);
+        microsoftTeams.authentication.notifySuccess("someResult", "https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook");
         let message = findMessageByFunc("authentication.authenticate.success");
         expect(message).toBeNull();
         expect(windowAssignSpyCalled).toBe(true);
     });
 
     it("should successfully notify auth success if state is invalid", () => {
-        spyOn(microsoftTeams._window.location, "assign").and.callFake((url: string): void => {
-            expect(url).toEqual("https://outlook.office.com/connectors?MailboxAddress=test%40service.microsoft.com&client_type=Win32_Outlook#/configurations&result=someResult");
-        });
-
         initializeWithContext("authentication");
-        let authenticationResultParams =
-        {
-            result: "someResult",
-            state: "https%3A%2F%2Fsomeinvalidurl.com%3Fstate%3Dtest%23%2Fconfiguration",
-        };
 
-        microsoftTeams.authentication.notifySuccess(authenticationResultParams);
+        microsoftTeams.authentication.notifySuccess("someResult", "https%3A%2F%2Fsomeinvalidurl.com%3Fstate%3Dtest%23%2Fconfiguration");
         let message = findMessageByFunc("authentication.authenticate.success");
         expect(message).not.toBeNull();
         expect(message.args.length).toBe(1);
@@ -859,10 +837,8 @@ describe("MicrosoftTeams", () => {
 
     it("should successfully notify auth failure", () => {
         initializeWithContext("authentication");
-        let authenticationResultParams = {
-            reason: "someReason",
-        };
-        microsoftTeams.authentication.notifyFailure(authenticationResultParams);
+        
+        microsoftTeams.authentication.notifyFailure("someReason");
 
         let message = findMessageByFunc("authentication.authenticate.failure");
         expect(message).not.toBeNull();
@@ -874,17 +850,12 @@ describe("MicrosoftTeams", () => {
         let windowAssignSpyCalled = false;
         spyOn(microsoftTeams._window.location, "assign").and.callFake((url: string): void => {
             windowAssignSpyCalled = true;
-            expect(url).toEqual("https://outlook.office.com/connectors?MailboxAddress=test%40service.microsoft.com&client_type=Win32_Outlook#/configurations&reason=someReason&authFailure");
+            expect(url).toEqual("https://outlook.office.com/connectors?client_type=Win32_Outlook#/configurations&reason=someReason&authFailure");
         });
 
         initializeWithContext("authentication");
-        let authenticationResultParams =
-        {
-            reason: "someReason",
-            state: "https%3A%2F%2Foutlook.office.com%2Fconnectors%3FMailboxAddress%3Dtest%2540service.microsoft.com%26client_type%3DWin32_Outlook%23%2Fconfigurations",
-        };
 
-        microsoftTeams.authentication.notifyFailure(authenticationResultParams);
+        microsoftTeams.authentication.notifyFailure("someReason", "https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook%23%2Fconfigurations");
         let message = findMessageByFunc("authentication.authenticate.failure");
         expect(message).toBeNull();
         expect(windowAssignSpyCalled).toBe(true);
@@ -896,13 +867,8 @@ describe("MicrosoftTeams", () => {
         });
 
         initializeWithContext("authentication");
-        let authenticationResultParams =
-        {
-            reason: "someReason",
-            state: "https%3A%2F%2Fsomeinvalidurl.com%3Fstate%3Dtest%23%2Fconfiguration",
-        };
-
-        microsoftTeams.authentication.notifyFailure(authenticationResultParams);
+        
+        microsoftTeams.authentication.notifyFailure("someReason", "https%3A%2F%2Fsomeinvalidurl.com%3Fstate%3Dtest%23%2Fconfiguration");
         let message = findMessageByFunc("authentication.authenticate.failure");
         expect(message).not.toBeNull();
         expect(message.args.length).toBe(1);
@@ -915,11 +881,8 @@ describe("MicrosoftTeams", () => {
         microsoftTeams.initialize();
         let initMessage = findMessageByFunc("initialize");
         expect(initMessage).not.toBeNull();
-        let authenticationResultParams = {
-            result: "someResult",
-        };
-        microsoftTeams.authentication.notifySuccess(authenticationResultParams);
-
+        
+        microsoftTeams.authentication.notifySuccess("someResult");
         let message = findMessageByFunc("authentication.authenticate.success");
         expect(message).toBeNull();
         expect(closeWindowSpy).not.toHaveBeenCalled();
@@ -938,10 +901,8 @@ describe("MicrosoftTeams", () => {
         microsoftTeams.initialize();
         let initMessage = findMessageByFunc("initialize");
         expect(initMessage).not.toBeNull();
-        let authenticationResultParams = {
-            reason: "someReason",
-        };
-        microsoftTeams.authentication.notifyFailure(authenticationResultParams);
+        
+        microsoftTeams.authentication.notifyFailure("someReason");
         let message = findMessageByFunc("authentication.authenticate.failure");
         expect(message).toBeNull();
         expect(closeWindowSpy).not.toHaveBeenCalled();

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -660,7 +660,7 @@ describe("MicrosoftTeams", () => {
                 width: 100,
                 height: 200,
             };
-        microsoftTeams.authentication.registerAuthenticationParameters(authenticationParams);
+        microsoftTeams.authentication.registerAuthenticationHandlers(authenticationParams);
         microsoftTeams.authentication.authenticate();
         expect(windowOpenCalled).toBe(true);
     });
@@ -837,7 +837,7 @@ describe("MicrosoftTeams", () => {
     it("should successfully notify auth success if callbackUrl is not for win32 Outlook", () => {
         initializeWithContext("authentication");
 
-        microsoftTeams.authentication.notifySuccess("someResult", "https%3A%2F%2Fsomeinvalidurl.com%3FcallbackUrlstate%3Dtest%23%2Fconfiguration");
+        microsoftTeams.authentication.notifySuccess("someResult", "https%3A%2F%2Fsomeinvalidurl.com%3FcallbackUrl%3Dtest%23%2Fconfiguration");
         let message = findMessageByFunc("authentication.authenticate.success");
         expect(message).not.toBeNull();
         expect(message.args.length).toBe(1);


### PR DESCRIPTION
**Align the configuration experience of 3rd party developed connectors with the existing configuration experience of Tabs across all connector clients.**

**Changes:**
Connectors will return a newly added `SaveResult` object as argument to `settings.save` event which will contain the `webhookUrl` that can be accessed by the 3rd party in their `registerOnSaveHandler` like such: 
```
microsoftTeams.settings.registerOnSaveHandler(function (saveEvent) {
 var webhookUrl = saveEvent.result["webhookUrl"];
...... 
}
```

For **Outlook Desktop**, the authentication flow does not contain a pop up because of technical limitations of the client itself. The user experience would be:

> 1. User clicks on Authenticate/Login button on the 3rd party iframed page
> 2. Instead of a pop up, the complete connector's page hosting the iframe redirects to the 3rd party authentication url
> 3. The user completes the authentication
> 4. The window redirects back to the connector's url and now the post-login configuration page loads in the iframe.

**The changes to support this experience are:**

> 1. Similar to Teams desktop, the SDK calls `authentication.authenticate` on it's parent (connector's page)
> 2. The connector's page figures out the client as **Outlook Desktop** and instead of opening a pop up, redirects the complete window to the authentication url after appending a `callbackUrl` query string parameter (with value being the url of the connector's page hosting the iframe).
> 3. Since authentication url is a page hosted on the 3rd party, they will preserve the value of this QSP on their end and the user will complete the authentication process.
> 4. In their post-consent page where today they call `authentication.notifySuccess()/authentication.notifyFailure()` with an optional string `result/reason` param, they will now pass an additional string param `callbackUrl` containing the preserved value from above.
> 5. The SDK will look at the `callbackUrl` param(if present), validate it and redirect the (post-consent)page back to the connector's page by appending the `result/reason` (if supplied) along with `authSuccess/authFailure` as fragments to the connector's URL. 
> 6. When we redirect to the connector's page(which would reload the 3rd party iframe as well), the authentication parameters(success and failure callback methods) need to be registered in the SDK again. To solve this,
> 7. We introduce a `registerAuthenticationParameters()` method to be called on page load which would save the authentication parameters in a global variable in the SDK . This method needs to be called on the configuration page alongside `initialize()`.  So when the configuration page reloads in the iframe, this method would register the callback methods again with the SDK.
> 8. The connector's page will then read the `authSuccess/authFailure` and `result/reason` from URL fragments and call the `authentication.authenticate.success/authentication.authenticate.failure` events with the corresponding values of `result/reason`. 
> 9. The `authentication.authenticate()` no longer needs to pass the authentication parameters if `registerAuthenticationParameters` is called.  

**To summarize, with the new flow developers need to:**

> 1. Call `initialize()` as before
> 2. Call `authentication.registerAuthenticationParameters({url: <auth URL>, width: <width>, height: <height>, successCallback: <successCallback>, failureCallback: <failureCallback>})`
> 3. Call `authentication.authenticate()` as before but without the need to pass authentication parameters.
> 4. Preserve the `callbackUrl` QSP appended to the authentication url when loaded.
> 5. In their post-consent page, instead of `authentication.notifySuccess(result)`, call
```
authentication.notifySucess(result,callbackUrl)
```
> Or, instead of `authentication.notifyFailure(reason)`, call
```
authentication.notifyFailure(reason,callbackUrl))
```
