### PR TITLE
Add openFilePreview API

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -341,6 +341,25 @@ namespace microsoftTeams {
     }
 
     /**
+     * Opens a client-friendly preview of the specified file.
+     * @param file The file to preview.
+     */
+    export function openFilePreview(filePreviewParameters: FilePreviewParameters): void {
+        ensureInitialized(frameContexts.content);
+
+        sendMessageRequest(parentWindow, "openFilePreview", [
+            filePreviewParameters.entityId,
+            filePreviewParameters.title,
+            filePreviewParameters.description,
+            filePreviewParameters.type,
+            filePreviewParameters.objectUrl,
+            filePreviewParameters.downloadUrl,
+            filePreviewParameters.webPreviewUrl,
+            filePreviewParameters.webEditUrl,
+        ]);
+    }
+
+    /**
      * Navigates the Microsoft Teams app to the specified tab instance.
      * @param tabInstance The tab instance to navigate to.
      */
@@ -1026,6 +1045,48 @@ namespace microsoftTeams {
          * This URL should lead directly to the sub-entity.
          */
         subEntityWebUrl?: string;
+    }
+
+    export interface FilePreviewParameters {
+        /**
+         * The developer-defined unique ID for the file.
+         */
+        entityId: string;
+
+        /**
+         * The display name of the file.
+         */
+        title: string;
+
+        /**
+         * An optional description of the file.
+         */
+        description?: string;
+
+        /**
+         * The file extension; e.g. pptx, docx, etc.
+         */
+        type: string;
+
+        /**
+         * A url to the source of the file, used to open the content in the user's default browser
+         */
+        objectUrl: string;
+
+        /**
+         * Optional; an alternate self-authenticating url used to preview the file in Mobile clients and offer it for download by the user
+         */
+        downloadUrl?: string;
+
+        /**
+         * Optional; an alternate url optimized for previewing the file in Teams web and desktop clients
+         */
+        webPreviewUrl?: string;
+
+        /**
+         * Optional; an alternate url that allows editing of the file in Teams web and desktop clients
+         */
+        webEditUrl?: string;
     }
 
     function ensureInitialized(...expectedFrameContexts: string[]): void {

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -876,6 +876,33 @@ describe("MicrosoftTeams", () =>
         expect(message.args[2]).toBe("someSubEntityWebUrl");
     });
 
+    it("should successfully open a file preview", () => {
+        initializeWithContext("content");
+
+        microsoftTeams.openFilePreview({
+            entityId: "someEntityId",
+            title: "someTitle",
+            description: "someDescription",
+            type: "someType",
+            objectUrl: "someObjectUrl",
+            downloadUrl: "someDownloadUrl",
+            webPreviewUrl: "someWebPreviewUrl",
+            webEditUrl: "someWebEditUrl",
+        });
+
+        let message = findMessageByFunc("openFilePreview");
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(8);
+        expect(message.args[0]).toBe("someEntityId");
+        expect(message.args[1]).toBe("someTitle");
+        expect(message.args[2]).toBe("someDescription");
+        expect(message.args[3]).toBe("someType");
+        expect(message.args[4]).toBe("someObjectUrl");
+        expect(message.args[5]).toBe("someDownloadUrl");
+        expect(message.args[6]).toBe("someWebPreviewUrl");
+        expect(message.args[7]).toBe("someWebEditUrl");
+    });
+
     describe("getTabInstances", () => {
         it("should allow a missing and valid optional parameter", () => {
             initializeWithContext("getTabInstances");


### PR DESCRIPTION
This new API will allow apps to request a file be opened in the most appropriate Teams client preview mechanism available.