### PR TITLE
Add a new teamSiteUrl Context field

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -1162,6 +1162,11 @@ namespace microsoftTeams {
          * The type of the team.
          */
         teamType?: TeamType;
+
+        /**
+         * The root ShatePoint folder associated with the team.
+         */
+        teamSiteUrl?: string;
     }
 
     export interface DeepLinkParameters {

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -270,6 +270,7 @@ describe("MicrosoftTeams", () => {
             channelId: "someChannelId",
             entityId: "someEntityId",
             teamType: microsoftTeams.TeamType.Edu,
+            teamSiteUrl: "someSiteUrl",
         };
 
         // Get many responses to the same message
@@ -299,6 +300,7 @@ describe("MicrosoftTeams", () => {
             entityId: "someEntityId",
             isFullScreen: true,
             teamType: microsoftTeams.TeamType.Staff,
+            teamSiteUrl: "someSiteUrl",
         };
 
         respondToMessage(getContextMessage, expectedContext);


### PR DESCRIPTION
Add a new teamSiteUrl Context field that provides a quick pointer to the root SharePoint folder associated with the current team.