### PR TITLE
Add close delay to notifySuccess/notifyFailure calls

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -849,7 +849,7 @@ namespace microsoftTeams {
             sendMessageRequest(parentWindow, "authentication.authenticate.success", [result]);
 
             // Wait for the message to be sent before closing the window
-            waitForMessageQueue(parentWindow, () => currentWindow.close());
+            waitForMessageQueue(parentWindow, () => setTimeout(() => currentWindow.close(), 200));
         }
 
         /**
@@ -867,7 +867,7 @@ namespace microsoftTeams {
             sendMessageRequest(parentWindow, "authentication.authenticate.failure", [reason]);
 
             // Wait for the message to be sent before closing the window
-            waitForMessageQueue(parentWindow, () => currentWindow.close());
+            waitForMessageQueue(parentWindow, () => setTimeout(() => currentWindow.close(), 200));
         }
 
         function handleSuccess(result?: string): void {

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -900,7 +900,8 @@ describe("MicrosoftTeams", () => {
         message = findMessageByFunc("authentication.authenticate.success");
         expect(message).not.toBeNull();
 
-        jasmine.clock().tick(101);
+        // Wait 100ms for the message queue and 200ms for the close delay
+        jasmine.clock().tick(301);
         expect(closeWindowSpy).toHaveBeenCalled();
     });
 
@@ -920,7 +921,8 @@ describe("MicrosoftTeams", () => {
         message = findMessageByFunc("authentication.authenticate.failure");
         expect(message).not.toBeNull();
 
-        jasmine.clock().tick(101);
+        // Wait 100ms for the message queue and 200ms for the close delay
+        jasmine.clock().tick(301);
         expect(closeWindowSpy).toHaveBeenCalled();
     });
 

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -32,7 +32,13 @@ describe("MicrosoftTeams", () => {
     // A list of messages the library sends to the app.
     let messages: MessageRequest[];
 
+    // A list of messages the library sends to the auth popup.
+    let childMessages: MessageRequest[];
+
     let childWindow = {
+        postMessage: function(message: MessageRequest, targetOrigin: string): void {
+            childMessages.push(message);
+        },
         close: function (): void {
             return;
         },
@@ -42,6 +48,8 @@ describe("MicrosoftTeams", () => {
     beforeEach(() => {
         processMessage = null;
         messages = [];
+        childMessages = [];
+        childWindow.closed = false;
         let mockWindow = {
             outerWidth: 1024,
             outerHeight: 768,
@@ -95,10 +103,6 @@ describe("MicrosoftTeams", () => {
         if (microsoftTeams._uninitialize) {
             microsoftTeams._uninitialize();
         }
-
-        // Clear local storage values
-        localStorage.removeItem("authentication.success");
-        localStorage.removeItem("authentication.failure");
 
         jasmine.clock().uninstall();
     });


### PR DESCRIPTION
This is my first attempt to fix #49, which is caused by a race condition that exists between the notifySuccess/notifyFailure logic running in the authentication window and the code monitoring its lifetime in the parent window. We have two options here:
1. Add an arbitrary wait in the authentication flow after sending the success/failure message before closing the window; this should give the parent window more time to handle the message and complete the flow.
2. Don't call window.close() in the authentication flow at all and always let the parent take care of closing the child window. In the past this has occasionally resulted in child windows failing to close so I would rather avoid this fix for now.