### PR TITLE
Add sessionId to SDK context to allow for better correlation of telemetry events between Teams and tabs

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -200,7 +200,6 @@ namespace microsoftTeams {
             // Send the initialized message to any origin, because at this point we most likely don't know the origin
             // of the parent window, and this message contains no data that could pose a security risk.
             parentOrigin = "*";
-
             let messageId = sendMessageRequest(parentWindow, "initialize", [version]);
             callbacks[messageId] = (context: string, clientType: string) => {
                 frameContext = context;
@@ -241,14 +240,6 @@ namespace microsoftTeams {
 
             currentWindow.removeEventListener("message", messageListener, false);
         };
-    }
-
-    function getGuid(): string {
-        let rd = (): string => {
-            return Math.floor((1 + Math.random()) * 0x10000)
-                .toString(16).substring(1, 5);
-        };
-        return [rd(), rd(), "-", rd(), "-", rd(), "-", rd(), "-", rd(), rd(), rd()].join("");
     }
 
     /**

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -250,9 +250,7 @@ namespace microsoftTeams {
         ensureInitialized();
 
         let messageId = sendMessageRequest(parentWindow, "getContext");
-        callbacks[messageId] = (context: Context): void => {
-            callback(context);
-        };
+        callbacks[messageId] = callback;
     }
 
     /**

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -116,10 +116,8 @@ describe("MicrosoftTeams", () => {
         expect(initMessage).not.toBeNull();
         expect(initMessage.id).toBe(0);
         expect(initMessage.func).toBe("initialize");
-        expect(initMessage.args.length).toEqual(2);
+        expect(initMessage.args.length).toEqual(1);
         expect(initMessage.args[0]).toEqual("1.2");
-        expect(initMessage.args[1]).toEqual(jasmine.any(String));
-        expect(initMessage.args[1].length).toEqual(36);
     });
 
     it("should allow multiple initialize calls", () => {
@@ -274,6 +272,7 @@ describe("MicrosoftTeams", () => {
             entityId: "someEntityId",
             teamType: microsoftTeams.TeamType.Edu,
             teamSiteUrl: "someSiteUrl",
+            sessionId: "someSessionId",
         };
 
         // Get many responses to the same message
@@ -304,6 +303,7 @@ describe("MicrosoftTeams", () => {
             isFullScreen: true,
             teamType: microsoftTeams.TeamType.Staff,
             teamSiteUrl: "someSiteUrl",
+            sessionId: "someSessionId",
         };
 
         respondToMessage(getContextMessage, expectedContext);

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -116,7 +116,10 @@ describe("MicrosoftTeams", () => {
         expect(initMessage).not.toBeNull();
         expect(initMessage.id).toBe(0);
         expect(initMessage.func).toBe("initialize");
-        expect(initMessage.args).toEqual(["1.2"]);
+        expect(initMessage.args.length).toEqual(2);
+        expect(initMessage.args[0]).toEqual("1.2");
+        expect(initMessage.args[1]).toEqual(jasmine.any(String));
+        expect(initMessage.args[1].length).toEqual(36);
     });
 
     it("should allow multiple initialize calls", () => {


### PR DESCRIPTION
In order to debug various issues our developers have encountered with their apps we have found the need to correlate events between the Teams telemetry and that of the app. We plan to implement this by sharing the Teams sessionId with the tabs we host via the getContext API of our SDK.