### PR TITLE
Changes to the sdk to support the launch and dismissal of the task module

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -151,6 +151,12 @@ namespace microsoftTeams {
     favoriteTeamsOnly?: boolean;
   }
 
+  export const enum TaskModuleDimension {
+    Large = "80px",
+    Medium = "60px",
+    Small = "40px"
+  }
+
   // This indicates whether initialize was called (started).
   // It does not indicate whether initialization is complete. That can be inferred by whether parentOrigin is set.
   let initializeCalled = false;
@@ -1585,12 +1591,12 @@ namespace microsoftTeams {
     /**
      * The requested height of the webview/iframe in pixels.
      */
-    height?: string;
+    height?: TaskModuleDimension | Number;
 
     /**
      * The requested width of the webview/iframe in pixels.
      */
-    width?: string;
+    width?: TaskModuleDimension | Number;
 
     /**
      * Title of the task module.
@@ -1620,7 +1626,9 @@ namespace microsoftTeams {
       // Ensure that the tab content is initialized
       ensureInitialized(frameContexts.content);
 
-      let messageId = sendMessageRequest(parentWindow, "tasks.startTask", [taskInfo]);
+      let messageId = sendMessageRequest(parentWindow, "tasks.startTask", [
+        taskInfo
+      ]);
       callbacks[messageId] = completionHandler;
     }
 

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -1607,13 +1607,13 @@ namespace microsoftTeams {
    * Namespace to interact with the task module-specific part of the SDK.
    * This object is usable only on the content frame.
    */
-  export namespace task {
+  export namespace tasks {
     /**
      * Allows an app to open the task module.
      * @param taskInfo An object containing the parameters of the task module
      * @param completionHandler Handler to call when the task module is completed
      */
-    export function start(
+    export function startTask(
       taskInfo: TaskInfo,
       completionHandler?: (err: string, result: string) => void
     ): void {
@@ -1629,7 +1629,7 @@ namespace microsoftTeams {
      * @param result Contains the result to be sent to the bot or teh app. Typically a JSON object or a serialized version of it
      * @param appId Helps to validate that the call originates from the same appId as the one that invoked the task module
      */
-    export function complete(
+    export function completeTask(
       result?: string | object,
       appIds?: string[]
     ): void {

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -152,9 +152,9 @@ namespace microsoftTeams {
   }
 
   export const enum TaskModuleDimension {
-    Large = "80px",
-    Medium = "60px",
-    Small = "40px"
+    Large = "large",
+    Medium = "medium",
+    Small = "small"
   }
 
   // This indicates whether initialize was called (started).
@@ -856,13 +856,13 @@ namespace microsoftTeams {
         link.href,
         "_blank",
         "toolbar=no, location=yes, status=no, menubar=no, scrollbars=yes, top=" +
-          top +
-          ", left=" +
-          left +
-          ", width=" +
-          width +
-          ", height=" +
-          height
+        top +
+        ", left=" +
+        left +
+        ", width=" +
+        width +
+        ", height=" +
+        height
       );
       if (childWindow) {
         // Start monitoring the authentication window so that we can detect if it gets closed before the flow completes
@@ -1589,12 +1589,12 @@ namespace microsoftTeams {
     card?: string;
 
     /**
-     * The requested height of the webview/iframe in pixels.
+     * The requested height of the webview/iframe.
      */
     height?: TaskModuleDimension | Number;
 
     /**
-     * The requested width of the webview/iframe in pixels.
+     * The requested width of the webview/iframe.
      */
     width?: TaskModuleDimension | Number;
 

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -1573,11 +1573,6 @@ namespace microsoftTeams {
 
   export interface TaskInfo {
     /**
-     * The app Id from which the task module should be invoked.
-     */
-    appId: string;
-
-    /**
      * The url to be rendered in the webview/iframe.
      */
     url?: string;
@@ -1586,11 +1581,6 @@ namespace microsoftTeams {
      * JSON defining an adaptive card.
      */
     card?: string;
-
-    /**
-     * Invoke message sent to the bot to fect the URL or Adaptive card body dynamically.
-     */
-    fetchtask?: boolean;
 
     /**
      * The requested height of the webview/iframe in pixels.
@@ -1611,11 +1601,6 @@ namespace microsoftTeams {
      * If client doesnt support the URL, the URL that needs to be opened in the browser.
      */
     fallbackUrl?: string;
-
-    /**
-     * Used to identify the BotId to send the task/complete invoke message to.
-     */
-    completionBotId?: string;
   }
 
   /**
@@ -1623,14 +1608,15 @@ namespace microsoftTeams {
    * This object is usable only on the content frame.
    */
   export namespace task {
-
     /**
-    * Allows an app to open the task module.
-    * @param taskInfo An object containing the parameters of the task module
-    * @param completionHandler Handler to call when the task module is completed
-    */
-    export function start(taskInfo: TaskInfo, completionHandler?: (err: string, result: string) => void): void {
-
+     * Allows an app to open the task module.
+     * @param taskInfo An object containing the parameters of the task module
+     * @param completionHandler Handler to call when the task module is completed
+     */
+    export function start(
+      taskInfo: TaskInfo,
+      completionHandler?: (err: string, result: string) => void
+    ): void {
       // Ensure that the tab content is initialized
       ensureInitialized(frameContexts.content);
 
@@ -1639,20 +1625,18 @@ namespace microsoftTeams {
     }
 
     /**
-    * Complete the task module.
-    * @param result Contains the result to be sent to the bot or teh app. Typically a JSON object or a serialized version of it
-    * @param appId Helps to validate that the call originates from the same appId as the one that invoked the task module
-    */
-    export function complete(result?: string|object, appId?: string): void {
-
+     * Complete the task module.
+     * @param result Contains the result to be sent to the bot or teh app. Typically a JSON object or a serialized version of it
+     * @param appId Helps to validate that the call originates from the same appId as the one that invoked the task module
+     */
+    export function complete(
+      result?: string | object,
+      appIds?: string[]
+    ): void {
       // Ensure that the tab content is initialized
       ensureInitialized(frameContexts.content);
 
-      sendMessageRequest(parentWindow, "complete", [
-        result,
-        appId
-      ]);
+      sendMessageRequest(parentWindow, "complete", [result, appIds]);
     }
-
   }
 }

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -1620,14 +1620,14 @@ namespace microsoftTeams {
       // Ensure that the tab content is initialized
       ensureInitialized(frameContexts.content);
 
-      let messageId = sendMessageRequest(parentWindow, "start", [taskInfo]);
+      let messageId = sendMessageRequest(parentWindow, "tasks.startTask", [taskInfo]);
       callbacks[messageId] = completionHandler;
     }
 
     /**
      * Complete the task module.
-     * @param result Contains the result to be sent to the bot or teh app. Typically a JSON object or a serialized version of it
-     * @param appId Helps to validate that the call originates from the same appId as the one that invoked the task module
+     * @param result Contains the result to be sent to the bot or the app. Typically a JSON object or a serialized version of it
+     * @param appIds Helps to validate that the call originates from the same appId as the one that invoked the task module
      */
     export function completeTask(
       result?: string | object,
@@ -1636,7 +1636,7 @@ namespace microsoftTeams {
       // Ensure that the tab content is initialized
       ensureInitialized(frameContexts.content);
 
-      sendMessageRequest(parentWindow, "complete", [result, appIds]);
+      sendMessageRequest(parentWindow, "tasks.completeTask", [result, appIds]);
     }
   }
 }


### PR DESCRIPTION
Adding a new namespace under microsoftTeams.task. 
Adding a couple of functions: start() to launch the task module and complete() when the task is done