### PR TITLE
Add support for file editing and return context in openFilePreview API

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -638,13 +638,10 @@ namespace microsoftTeams {
       filePreviewParameters.downloadUrl,
       filePreviewParameters.webPreviewUrl,
       filePreviewParameters.webEditUrl,
+      filePreviewParameters.baseUrl,
       filePreviewParameters.editFile,
       filePreviewParameters.subEntityId
     ];
-
-    if (filePreviewParameters.baseUrl) {
-      params.push(filePreviewParameters.baseUrl);
-    }
 
     sendMessageRequest(parentWindow, "openFilePreview", params);
   }
@@ -1065,13 +1062,13 @@ namespace microsoftTeams {
         link.href,
         "_blank",
         "toolbar=no, location=yes, status=no, menubar=no, scrollbars=yes, top=" +
-        top +
-        ", left=" +
-        left +
-        ", width=" +
-        width +
-        ", height=" +
-        height
+          top +
+          ", left=" +
+          left +
+          ", width=" +
+          width +
+          ", height=" +
+          height
       );
       if (childWindow) {
         // Start monitoring the authentication window so that we can detect if it gets closed before the flow completes

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -637,7 +637,9 @@ namespace microsoftTeams {
       filePreviewParameters.objectUrl,
       filePreviewParameters.downloadUrl,
       filePreviewParameters.webPreviewUrl,
-      filePreviewParameters.webEditUrl
+      filePreviewParameters.webEditUrl,
+      filePreviewParameters.editFile,
+      filePreviewParameters.subEntityId
     ];
 
     if (filePreviewParameters.baseUrl) {
@@ -1597,6 +1599,17 @@ namespace microsoftTeams {
      * Optional; the base url of the site where the file is hosted
      */
     baseUrl?: string;
+
+    /**
+     * Optional; indicates whether the file should be opened in edit mode
+     */
+    editFile?: true;
+
+    /**
+     * Optional; the developer-defined unique ID for the sub-entity to return to when the file stage closes.
+     * This field should be used to restore to a specific state within an entity, such as scrolling to or activating a specific piece of content.
+     */
+    subEntityId?: string;
   }
 
   function ensureInitialized(...expectedFrameContexts: string[]): void {

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -1600,7 +1600,7 @@ namespace microsoftTeams {
     /**
      * Optional; indicates whether the file should be opened in edit mode
      */
-    editFile?: true;
+    editFile?: boolean;
 
     /**
      * Optional; the developer-defined unique ID for the sub-entity to return to when the file stage closes.

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -32,10 +32,10 @@ describe("MicrosoftTeams", () => {
   let childMessages: MessageRequest[];
 
   let childWindow = {
-    postMessage: function(message: MessageRequest, targetOrigin: string): void {
+    postMessage: function (message: MessageRequest, targetOrigin: string): void {
       childMessages.push(message);
     },
-    close: function(): void {
+    close: function (): void {
       return;
     },
     closed: false
@@ -51,7 +51,7 @@ describe("MicrosoftTeams", () => {
       outerHeight: 768,
       screenLeft: 0,
       screenTop: 0,
-      addEventListener: function(
+      addEventListener: function (
         type: string,
         listener: (ev: MessageEvent) => void,
         useCapture?: boolean
@@ -60,7 +60,7 @@ describe("MicrosoftTeams", () => {
           processMessage = listener;
         }
       },
-      removeEventListener: function(
+      removeEventListener: function (
         type: string,
         listener: (ev: MessageEvent) => void,
         useCapture?: boolean
@@ -72,12 +72,12 @@ describe("MicrosoftTeams", () => {
       location: {
         origin: tabOrigin,
         href: validOrigin,
-        assign: function(url: string): void {
+        assign: function (url: string): void {
           return;
         }
       },
       parent: {
-        postMessage: function(
+        postMessage: function (
           message: MessageRequest,
           targetOrigin: string
         ): void {
@@ -91,10 +91,10 @@ describe("MicrosoftTeams", () => {
         }
       } as Window,
       self: null as Window,
-      open: function(url: string, name: string, specs: string): Window {
+      open: function (url: string, name: string, specs: string): Window {
         return childWindow as Window;
       },
-      close: function(): void {
+      close: function (): void {
         return;
       },
       setInterval: (handler: Function, timeout: number): number =>
@@ -1087,7 +1087,9 @@ describe("MicrosoftTeams", () => {
       downloadUrl: "someDownloadUrl",
       webPreviewUrl: "someWebPreviewUrl",
       webEditUrl: "someWebEditUrl",
-      baseUrl: "someBaseUrl"
+      baseUrl: "someBaseUrl",
+      editFile: true,
+      subEntityId: "someSubEntityId"
     });
 
     let message = findMessageByFunc("openFilePreview");
@@ -1102,6 +1104,8 @@ describe("MicrosoftTeams", () => {
     expect(message.args[6]).toBe("someWebPreviewUrl");
     expect(message.args[7]).toBe("someWebEditUrl");
     expect(message.args[8]).toBe("someBaseUrl");
+    expect(message.args[9]).toBe(true);
+    expect(message.args[10]).toBe("someSubEntityId");
   });
 
   describe("getTabInstances", () => {

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -32,10 +32,10 @@ describe("MicrosoftTeams", () => {
   let childMessages: MessageRequest[];
 
   let childWindow = {
-    postMessage: function (message: MessageRequest, targetOrigin: string): void {
+    postMessage: function(message: MessageRequest, targetOrigin: string): void {
       childMessages.push(message);
     },
-    close: function (): void {
+    close: function(): void {
       return;
     },
     closed: false
@@ -51,7 +51,7 @@ describe("MicrosoftTeams", () => {
       outerHeight: 768,
       screenLeft: 0,
       screenTop: 0,
-      addEventListener: function (
+      addEventListener: function(
         type: string,
         listener: (ev: MessageEvent) => void,
         useCapture?: boolean
@@ -60,7 +60,7 @@ describe("MicrosoftTeams", () => {
           processMessage = listener;
         }
       },
-      removeEventListener: function (
+      removeEventListener: function(
         type: string,
         listener: (ev: MessageEvent) => void,
         useCapture?: boolean
@@ -72,12 +72,12 @@ describe("MicrosoftTeams", () => {
       location: {
         origin: tabOrigin,
         href: validOrigin,
-        assign: function (url: string): void {
+        assign: function(url: string): void {
           return;
         }
       },
       parent: {
-        postMessage: function (
+        postMessage: function(
           message: MessageRequest,
           targetOrigin: string
         ): void {
@@ -91,10 +91,10 @@ describe("MicrosoftTeams", () => {
         }
       } as Window,
       self: null as Window,
-      open: function (url: string, name: string, specs: string): Window {
+      open: function(url: string, name: string, specs: string): Window {
         return childWindow as Window;
       },
-      close: function (): void {
+      close: function(): void {
         return;
       },
       setInterval: (handler: Function, timeout: number): number =>
@@ -1094,7 +1094,7 @@ describe("MicrosoftTeams", () => {
 
     let message = findMessageByFunc("openFilePreview");
     expect(message).not.toBeNull();
-    expect(message.args.length).toBe(9);
+    expect(message.args.length).toBe(11);
     expect(message.args[0]).toBe("someEntityId");
     expect(message.args[1]).toBe("someTitle");
     expect(message.args[2]).toBe("someDescription");


### PR DESCRIPTION
This change adds two more parameters to openFilePreview:
- editFile - a boolean value indicating whether to open the file directly in edit mode or not
- subEntityId - the ID of the sub-entity to return to after the file file preview is closed