### PR TITLE
fixing null exception in sendMessageRequest

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -1100,13 +1100,13 @@ namespace microsoftTeams {
         link.href,
         "_blank",
         "toolbar=no, location=yes, status=no, menubar=no, scrollbars=yes, top=" +
-          top +
-          ", left=" +
-          left +
-          ", width=" +
-          width +
-          ", height=" +
-          height
+        top +
+        ", left=" +
+        left +
+        ", width=" +
+        width +
+        ", height=" +
+        height
       );
       if (childWindow) {
         // Start monitoring the authentication window so that we can detect if it gets closed before the flow completes
@@ -1833,9 +1833,11 @@ namespace microsoftTeams {
   ): number {
     let request = createMessageRequest(actionName, args);
     if (isFramelessWindow) {
-      currentWindow.nativeInterface.framelessPostMessage(
-        JSON.stringify(request)
-      );
+      if (currentWindow && currentWindow.nativeInterface) {
+        currentWindow.nativeInterface.framelessPostMessage(
+          JSON.stringify(request)
+        );
+      }
     } else {
       let targetOrigin = getTargetOrigin(targetWindow);
 


### PR DESCRIPTION
Exception happen when developer open app config URL(that is calling sendMessageRequest) in browser and they haven't implement nativeInterface. Adding a null check before callings its function.