### PR TITLE
Fix HostClientType enum and prepare to release v1.3.3 of the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To install the stable version:
 
 #### Production
 
-You can access [these files on unpkg](https://unpkg.com/@microsoft/teams-js@1.2.5/dist/MicrosoftTeams.min.js), download them, or point your package manager to them.
+You can access [these files on unpkg](https://unpkg.com/@microsoft/teams-js@1.3.3/dist/MicrosoftTeams.min.js), download them, or point your package manager to them.
 
 ## Usage
 
@@ -46,7 +46,7 @@ Reference the library inside of your `.html` page using:
 
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
-<script src="https://unpkg.com/@microsoft/teams-js@1.3.3/dist/MicrosoftTeams.min.js" integrity="sha384-fTjWNTelhUDsOG+6Xvsly5BVO8estmdrfVmaRQuTGRTtcjHYA3oQANo805/kHXvJ" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@microsoft/teams-js@1.3.3/dist/MicrosoftTeams.min.js" integrity="sha384-g1iQyAjC6TaAEj70a8TEV96chNDvgDxIjqEdppo/wph3gPqZ60d7lA1mxDUkAETe" crossorigin="anonymous"></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
 <script src="node_modules/@microsoft/teams-js@1.3.3/dist/MicrosoftTeams.min.js"></script>

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ This JavaScript library is part of the [Microsoft Teams developer platform](http
 [![Coverage Status](https://coveralls.io/repos/github/OfficeDev/microsoft-teams-library-js/badge.svg?branch=master)](https://coveralls.io/github/OfficeDev/microsoft-teams-library-js?branch=master)
 
 ## Getting Started
-1. Clone the repo
-2. Navigate to the repo root
-3. `yarn install`
-4. `gulp`
+
+1.  Clone the repo
+2.  Navigate to the repo root
+3.  `yarn install`
+4.  `gulp`
 
 ### Installation
+
 To install the stable version:
 
 #### npm
@@ -35,26 +37,28 @@ Install either using npm or yarn
 **If you are using any dependency loader** such as [RequireJS](http://requirejs.org/) or [SystemJS](https://github.com/systemjs/systemjs) or module bundler such as [browserify](http://browserify.org/), [webpack](https://webpack.github.io/), you can use `import` syntax to import specific modules. For e.g.
 
 ```typescript
-import * as microsoftTeams from '@microsoft/teams-js';
+import * as microsoftTeams from "@microsoft/teams-js";
 ```
 
 ### As a Script Tag
 
 Reference the library inside of your `.html` page using:
+
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
-<script src="https://unpkg.com/@microsoft/teams-js@1.2.5/dist/MicrosoftTeams.min.js" integrity="sha384-fTjWNTelhUDsOG+6Xvsly5BVO8estmdrfVmaRQuTGRTtcjHYA3oQANo805/kHXvJ" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@microsoft/teams-js@1.3.3/dist/MicrosoftTeams.min.js" integrity="sha384-fTjWNTelhUDsOG+6Xvsly5BVO8estmdrfVmaRQuTGRTtcjHYA3oQANo805/kHXvJ" crossorigin="anonymous"></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@1.2.5/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@1.3.3/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>
 ```
 
 ## Contributing
+
 We strongly welcome and encourage contributions to this project. Please read the [contributor's guide](CONTRIBUTING.md).
 
-- - -
+---
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ var options = {
   connectionString: ""
 };
 
-gulp.task("tslint", function () {
+gulp.task("tslint", function() {
   return gulp
     .src(["./src/**/*.ts", "./test/**/*.ts"])
     .pipe(
@@ -62,7 +62,7 @@ var tsProject = typescript.createProject("./tsconfig.json", {
   typescript: require("typescript")
 });
 
-gulp.task("ts", ["tslint"], function () {
+gulp.task("ts", ["tslint"], function() {
   var tsResult = tsProject.src().pipe(tsProject());
 
   return merge([
@@ -70,10 +70,10 @@ gulp.task("ts", ["tslint"], function () {
     tsResult.js
       .pipe(
         umd({
-          exports: function (file) {
+          exports: function(file) {
             return libName;
           },
-          namespace: function (file) {
+          namespace: function(file) {
             return libName;
           }
         })
@@ -85,22 +85,22 @@ gulp.task("ts", ["tslint"], function () {
   ]);
 });
 
-gulp.task("test", ["ts"], function (done) {
+gulp.task("test", ["ts"], function(done) {
   new karma({ configFile: __dirname + "/karma.conf.js" }, done).start();
 });
 
-gulp.task("doc", function (done) {
+gulp.task("doc", function(done) {
   var parse = require("json-schema-to-markdown");
   var schema = require("./src/MicrosoftTeams.schema.json");
   var markdown = parse(schema);
-  fs.mkdir(buildDir, function () {
-    fs.mkdir(buildDir + "/doc", function () {
+  fs.mkdir(buildDir, function() {
+    fs.mkdir(buildDir + "/doc", function() {
       fs.writeFile(buildDir + "/doc/MicrosoftTeams.schema.md", markdown, done);
     });
   });
 });
 
-gulp.task("dist", ["ts", "doc"], function () {
+gulp.task("dist", ["ts", "doc"], function() {
   var distFiles = [
     buildDir + "/src/**/*.js",
     buildDir + "/src/**/*.d.ts",
@@ -112,12 +112,12 @@ gulp.task("dist", ["ts", "doc"], function () {
 
 gulp.task("default", ["prettier", "ts", "test", "doc", "dist"]);
 
-gulp.task("clean", function () {
+gulp.task("clean", function() {
   return del([buildDir, distDir]);
 });
 
 /// tasks for uploading dist assets to CDN
-gulp.task("get-connectionstring-from-secret", function (done) {
+gulp.task("get-connectionstring-from-secret", function(done) {
   var clientId = argv.clientId;
   var clientSecret = argv.clientSecret;
   var vaultUri = argv.vaultUri;
@@ -132,13 +132,13 @@ gulp.task("get-connectionstring-from-secret", function (done) {
   }
 
   // Authenticator - retrieves the access token
-  var authenticator = function (challenge, callback) {
+  var authenticator = function(challenge, callback) {
     var context = new AuthenticationContext(challenge.authorization);
     return context.acquireTokenWithClientCredentials(
       challenge.resource,
       clientId,
       clientSecret,
-      function (err, tokenResponse) {
+      function(err, tokenResponse) {
         if (err) throw err;
         var authorizationValue =
           tokenResponse.tokenType + " " + tokenResponse.accessToken;
@@ -150,7 +150,7 @@ gulp.task("get-connectionstring-from-secret", function (done) {
   var credentials = new KeyVault.KeyVaultCredentials(authenticator);
   var keyVaultClient = new KeyVault.KeyVaultClient(credentials);
 
-  keyVaultClient.getSecret(secretIdentifier, function (err, secretBundle) {
+  keyVaultClient.getSecret(secretIdentifier, function(err, secretBundle) {
     if (err) throw err;
     options.connectionString = secretBundle.value;
     done();
@@ -160,7 +160,7 @@ gulp.task("get-connectionstring-from-secret", function (done) {
 gulp.task(
   "upload",
   ["get-connectionstring-from-secret", "dist", "test"],
-  function () {
+  function() {
     var buildVer = argv.version || "";
     if (!buildVer) {
       console.error("missing build version argument (--version)!");
@@ -182,7 +182,7 @@ gulp.task(
       }
     ];
 
-    var uploadTasks = assetBundles.map(function (assetBundle) {
+    var uploadTasks = assetBundles.map(function(assetBundle) {
       return gulp.src(assetBundle.glob).pipe(
         deployCdn({
           containerName: "sdk", // container name in blob

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "1.2.6",
+  "version": "1.3.3",
   "description": "Microsoft Client SDK for building app for Microsoft teams",
   "main": "./dist/MicrosoftTeams.min.js",
   "typings": "./dist/MicrosoftTeams.d.ts",
@@ -43,9 +43,5 @@
     "typescript": "2.5.0",
     "yargs": "^8.0.1"
   },
-  "files": [
-    "dist/**",
-    "README.md",
-    "LICENSE"
-  ]
+  "files": ["dist/**", "README.md", "LICENSE"]
 }

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -3,7 +3,10 @@ declare interface String {
 }
 
 if (!String.prototype.startsWith) {
-  String.prototype.startsWith = function (search: string, pos?: number): boolean {
+  String.prototype.startsWith = function(
+    search: string,
+    pos?: number
+  ): boolean {
     return this.substr(!pos || pos < 0 ? 0 : +pos, search.length) === search;
   };
 }
@@ -49,7 +52,8 @@ namespace microsoftTeams {
     let urlRegExpPart = "^";
     let urlParts = url.split(".");
     for (let j = 0; j < urlParts.length; j++) {
-      urlRegExpPart += (j > 0 ? "[.]" : "") + urlParts[j].replace("*", "[^\/^.]+");
+      urlRegExpPart +=
+        (j > 0 ? "[.]" : "") + urlParts[j].replace("*", "[^/^.]+");
     }
     urlRegExpPart += "$";
     return urlRegExpPart;
@@ -730,7 +734,7 @@ namespace microsoftTeams {
     sendMessageRequest(parentWindow, "shareDeepLink", [
       deepLinkParameters.subEntityId,
       deepLinkParameters.subEntityLabel,
-      deepLinkParameters.subEntityWebUrl
+      deepLinkParameters.subEntityWeUrl
     ]);
   }
 
@@ -1199,13 +1203,13 @@ namespace microsoftTeams {
         link.href,
         "_blank",
         "toolbar=no, location=yes, status=no, menubar=no, scrollbars=yes, top=" +
-        top +
-        ", left=" +
-        left +
-        ", width=" +
-        width +
-        ", height=" +
-        height
+          top +
+          ", left=" +
+          left +
+          ", width=" +
+          width +
+          ", height=" +
+          height
       );
       if (childWindow) {
         // Start monitoring the authentication window so that we can detect if it gets closed before the flow completes

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -734,7 +734,7 @@ namespace microsoftTeams {
     sendMessageRequest(parentWindow, "shareDeepLink", [
       deepLinkParameters.subEntityId,
       deepLinkParameters.subEntityLabel,
-      deepLinkParameters.subEntityWeUrl
+      deepLinkParameters.subEntityWebUrl
     ]);
   }
 

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -32,7 +32,7 @@ interface Window {
 namespace microsoftTeams {
   "use strict";
 
-  const version = "1.2";
+  const version = "1.3.3";
 
   const validOrigins = [
     "https://teams.microsoft.com",

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -76,7 +76,7 @@ namespace microsoftTeams {
     remove: "remove"
   };
 
-  export enum HostClientTypes {
+  export const enum HostClientType {
     desktop = "desktop",
     web = "web",
     android = "android",
@@ -1073,7 +1073,7 @@ namespace microsoftTeams {
         frameContexts.remove
       );
 
-      if (hostClientType === HostClientTypes.desktop) {
+      if (hostClientType === HostClientType.desktop) {
         // Convert any relative URLs into absolute URLs before sending them over to the parent window.
         let link = document.createElement("a");
         link.href = authenticateParams.url;
@@ -1676,7 +1676,7 @@ namespace microsoftTeams {
     /**
      * The type of the host client. Possible values are : android, ios, web, desktop
      */
-    hostClientType?: HostClientTypes;
+    hostClientType?: HostClientType;
   }
 
   export interface DeepLinkParameters {

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -400,7 +400,8 @@ describe("MicrosoftTeams", () => {
       teamSiteUrl: "someSiteUrl",
       sessionId: "someSessionId",
       userTeamRole: microsoftTeams.UserTeamRole.Admin,
-      chatId: "someChatId"
+      chatId: "someChatId",
+      hostClientType: microsoftTeams.HostClientType.web
     };
 
     respondToMessage(getContextMessage, expectedContext);

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -129,7 +129,7 @@ describe("MicrosoftTeams", () => {
     expect(initMessage.id).toBe(0);
     expect(initMessage.func).toBe("initialize");
     expect(initMessage.args.length).toEqual(1);
-    expect(initMessage.args[0]).toEqual("1.2");
+    expect(initMessage.args[0]).toEqual("1.3.3");
   });
 
   it("should allow multiple initialize calls", () => {

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -32,10 +32,10 @@ describe("MicrosoftTeams", () => {
   let childMessages: MessageRequest[];
 
   let childWindow = {
-    postMessage: function (message: MessageRequest, targetOrigin: string): void {
+    postMessage: function(message: MessageRequest, targetOrigin: string): void {
       childMessages.push(message);
     },
-    close: function (): void {
+    close: function(): void {
       return;
     },
     closed: false
@@ -51,7 +51,7 @@ describe("MicrosoftTeams", () => {
       outerHeight: 768,
       screenLeft: 0,
       screenTop: 0,
-      addEventListener: function (
+      addEventListener: function(
         type: string,
         listener: (ev: MessageEvent) => void,
         useCapture?: boolean
@@ -60,7 +60,7 @@ describe("MicrosoftTeams", () => {
           processMessage = listener;
         }
       },
-      removeEventListener: function (
+      removeEventListener: function(
         type: string,
         listener: (ev: MessageEvent) => void,
         useCapture?: boolean
@@ -72,12 +72,12 @@ describe("MicrosoftTeams", () => {
       location: {
         origin: tabOrigin,
         href: validOrigin,
-        assign: function (url: string): void {
+        assign: function(url: string): void {
           return;
         }
       },
       parent: {
-        postMessage: function (
+        postMessage: function(
           message: MessageRequest,
           targetOrigin: string
         ): void {
@@ -91,10 +91,10 @@ describe("MicrosoftTeams", () => {
         }
       } as Window,
       self: null as Window,
-      open: function (url: string, name: string, specs: string): Window {
+      open: function(url: string, name: string, specs: string): Window {
         return childWindow as Window;
       },
-      close: function (): void {
+      close: function(): void {
         return;
       },
       setInterval: (handler: Function, timeout: number): number =>
@@ -174,32 +174,35 @@ describe("MicrosoftTeams", () => {
   ];
 
   unSupportedDomains.forEach(unSupportedDomain => {
-    it("should reject messages from unsupported domain: " + unSupportedDomain, () => {
-      initializeWithContext("content");
-      let callbackCalled = false;
-      microsoftTeams.getContext(() => {
-        callbackCalled = true;
-      });
+    it(
+      "should reject messages from unsupported domain: " + unSupportedDomain,
+      () => {
+        initializeWithContext("content");
+        let callbackCalled = false;
+        microsoftTeams.getContext(() => {
+          callbackCalled = true;
+        });
 
-      let getContextMessage = findMessageByFunc("getContext");
-      expect(getContextMessage).not.toBeNull();
+        let getContextMessage = findMessageByFunc("getContext");
+        expect(getContextMessage).not.toBeNull();
 
-      callbackCalled = false;
-      processMessage({
-        origin: unSupportedDomain,
-        source: microsoftTeams._window.parent,
-        data: {
-          id: getContextMessage.id,
-          args: [
-            {
-              groupId: "someMaliciousValue"
-            }
-          ]
-        } as MessageResponse
-      } as MessageEvent);
+        callbackCalled = false;
+        processMessage({
+          origin: unSupportedDomain,
+          source: microsoftTeams._window.parent,
+          data: {
+            id: getContextMessage.id,
+            args: [
+              {
+                groupId: "someMaliciousValue"
+              }
+            ]
+          } as MessageResponse
+        } as MessageEvent);
 
-      expect(callbackCalled).toBe(false);
-    });
+        expect(callbackCalled).toBe(false);
+      }
+    );
   });
 
   const supportedDomains = [
@@ -1189,7 +1192,6 @@ describe("MicrosoftTeams", () => {
   });
 
   describe("getUserJoinedTeams", () => {
-
     it("should not allow calls before initialization", () => {
       expect(() =>
         microsoftTeams.getUserJoinedTeams(() => {
@@ -1202,7 +1204,9 @@ describe("MicrosoftTeams", () => {
       let callbackCalled: boolean = false;
       initializeWithContext("getUserJoinedTeams");
       microsoftTeams.getUserJoinedTeams(
-        userJoinedTeamsInformation => { callbackCalled = true; },
+        userJoinedTeamsInformation => {
+          callbackCalled = true;
+        },
         { favoriteTeamsOnly: true } as microsoftTeams.TeamInstanceParameters
       );
 
@@ -1216,7 +1220,9 @@ describe("MicrosoftTeams", () => {
       let callbackCalled: boolean = false;
       initializeWithContext("getUserJoinedTeams");
       microsoftTeams.getUserJoinedTeams(
-        userJoinedTeamsInformation => { callbackCalled = true; },
+        userJoinedTeamsInformation => {
+          callbackCalled = true;
+        },
         { favoriteTeamsOnly: false } as microsoftTeams.TeamInstanceParameters
       );
 
@@ -1229,9 +1235,9 @@ describe("MicrosoftTeams", () => {
     it("should allow a missing optional parameter", () => {
       let callbackCalled: boolean = false;
       initializeWithContext("getUserJoinedTeams");
-      microsoftTeams.getUserJoinedTeams(
-        userJoinedTeamsInformation => { callbackCalled = true; }
-      );
+      microsoftTeams.getUserJoinedTeams(userJoinedTeamsInformation => {
+        callbackCalled = true;
+      });
 
       let getUserJoinedTeamsMessage = findMessageByFunc("getUserJoinedTeams");
       expect(getUserJoinedTeamsMessage).not.toBeNull();
@@ -1243,7 +1249,9 @@ describe("MicrosoftTeams", () => {
       let callbackCalled: boolean = false;
       initializeWithContext("getUserJoinedTeams");
       microsoftTeams.getUserJoinedTeams(
-        userJoinedTeamsInformation => { callbackCalled = true; },
+        userJoinedTeamsInformation => {
+          callbackCalled = true;
+        },
         {} as microsoftTeams.TeamInstanceParameters
       );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2620,7 +2620,7 @@ karma-coverage@1.1.2:
     minimatch "^3.0.0"
     source-map "^0.5.1"
 
-karma-coveralls@^2.0.0:
+karma-coveralls@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/karma-coveralls/-/karma-coveralls-2.0.0.tgz#7511cf16efa4f46953c55451c676633f5e058c6f"
   dependencies:


### PR DESCRIPTION
The HostClientType must be exported as a const enum so that it gets compiled down to vanilla strings.