### PR TITLE
Added sendCustomMessage function for sending custom messages to Teams

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -1997,12 +1997,14 @@ namespace microsoftTeams {
   }
 
   /**
+   * @private
+   * Internal use only
    * Sends a custom action message to Teams.
    * @param actionName Specifies name of the custom action to be sent
    * @param args Specifies additional arguments passed to the action
    * @returns id of sent message
    */
-  export function sendMessage(
+  export function sendCustomMessage(
     actionName: string,
     // tslint:disable-next-line:no-any
     args?: any[]

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -1996,6 +1996,21 @@ namespace microsoftTeams {
     return request.id;
   }
 
+  /**
+   * Sends a custom action message to Teams.
+   * @param actionName Specifies name of the custom action to be sent
+   * @param args Specifies additional arguments passed to the action
+   * @returns id of sent message
+   */
+  export function sendMessage(
+    actionName: string,
+    // tslint:disable-next-line:no-any
+    args?: any[]
+  ): number {
+    ensureInitialized();
+    return sendMessageRequest(parentWindow, actionName, args);
+  }
+
   function sendMessageResponse(
     targetWindow: Window,
     id: number,

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -1263,6 +1263,24 @@ describe("MicrosoftTeams", () => {
     });
   });
 
+  describe("sendMessage", () => {
+    it("should successfully pass message and provided arguments", () => {
+      initializeWithContext("content");
+
+      const id = microsoftTeams.sendMessage("customMessage", [
+        "arg1",
+        2,
+        3.0,
+        true
+      ]);
+
+      let message = findMessageByFunc("customMessage");
+      expect(message).not.toBeNull();
+      expect(message.args).toEqual(["arg1", 2, 3.0, true]);
+      expect(id).toBe(message.id);
+    });
+  });
+
   function initializeWithContext(
     frameContext: string,
     hostClientType?: string

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -1263,11 +1263,11 @@ describe("MicrosoftTeams", () => {
     });
   });
 
-  describe("sendMessage", () => {
+  describe("sendCustomMessage", () => {
     it("should successfully pass message and provided arguments", () => {
       initializeWithContext("content");
 
-      const id = microsoftTeams.sendMessage("customMessage", [
+      const id = microsoftTeams.sendCustomMessage("customMessage", [
         "arg1",
         2,
         3.0,


### PR DESCRIPTION
This PR adds a new exported function `sendMessage` which allows tabs to send custom messages to Teams.