### PR TITLE
Make tasks.submitTask backwards compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To install the stable version:
 
 #### Production
 
-You can access [these files on unpkg](https://unpkg.com/@microsoft/teams-js@1.3.4/dist/MicrosoftTeams.min.js), download them, or point your package manager to them.
+You can access [these files on unpkg](https://unpkg.com/@microsoft/teams-js@1.3.5/dist/MicrosoftTeams.min.js), download them, or point your package manager to them.
 
 ## Usage
 
@@ -46,10 +46,10 @@ Reference the library inside of your `.html` page using:
 
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
-<script src="https://unpkg.com/@microsoft/teams-js@1.3.4/dist/MicrosoftTeams.min.js" integrity="sha384-3zTjxw3msc6gKx3DseSU0lfRM129YrFjr2xgocfMIN/kBCdzJ88d+FSB1n3scUku" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@microsoft/teams-js@1.3.5/dist/MicrosoftTeams.min.js" integrity="sha384-t1ID2NmMGB5huCWZdo2EV4RXQ9H/+VDaxxWeUfWuuVuYIc62+Xj7M5re4yqbpbDt" crossorigin="anonymous"></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@1.3.4/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@1.3.5/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Microsoft Client SDK for building app for Microsoft teams",
   "main": "./dist/MicrosoftTeams.min.js",
   "typings": "./dist/MicrosoftTeams.d.ts",

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -44,7 +44,7 @@ interface Window {
 namespace microsoftTeams {
   "use strict";
 
-  const version = "1.3.4";
+  const version = "1.3.5";
 
   const validOrigins = [
     "https://teams.microsoft.com",
@@ -2110,7 +2110,8 @@ namespace microsoftTeams {
     ): void {
       ensureInitialized(frameContexts.content, frameContexts.task);
 
-      sendMessageRequest(parentWindow, "tasks.submitTask", [
+      // Send tasks.completeTask instead of tasks.submitTask message for backward compatibility with Mobile clients
+      sendMessageRequest(parentWindow, "tasks.completeTask", [
         result,
         Array.isArray(appIds) ? appIds : [appIds]
       ]);

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -129,7 +129,7 @@ describe("MicrosoftTeams", () => {
     expect(initMessage.id).toBe(0);
     expect(initMessage.func).toBe("initialize");
     expect(initMessage.args.length).toEqual(1);
-    expect(initMessage.args[0]).toEqual("1.3.4");
+    expect(initMessage.args[0]).toEqual("1.3.5");
   });
 
   it("should allow multiple initialize calls", () => {
@@ -1406,7 +1406,7 @@ describe("MicrosoftTeams", () => {
         "someOtherAppId"
       ]);
 
-      const submitTaskMessage = findMessageByFunc("tasks.submitTask");
+      const submitTaskMessage = findMessageByFunc("tasks.completeTask");
       expect(submitTaskMessage).not.toBeNull();
       expect(submitTaskMessage.args).toEqual([
         "someResult",
@@ -1419,7 +1419,7 @@ describe("MicrosoftTeams", () => {
 
       microsoftTeams.tasks.submitTask("someResult", "someAppId");
 
-      const submitTaskMessage = findMessageByFunc("tasks.submitTask");
+      const submitTaskMessage = findMessageByFunc("tasks.completeTask");
       expect(submitTaskMessage).not.toBeNull();
       expect(submitTaskMessage.args).toEqual(["someResult", ["someAppId"]]);
     });


### PR DESCRIPTION
This change renames the underlying serialized function name of the tasks.submitTask API to tasks.completeTask so that the SDK library can remain backward compatible with the Teams Mobile clients. This change will be released as v1.3.5 of the SDK.