### PR TITLE
#135 - Allow authenticate and navigateCrossDomain calls from the task module frame context

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -687,7 +687,8 @@ namespace microsoftTeams {
     ensureInitialized(
       frameContexts.content,
       frameContexts.settings,
-      frameContexts.remove
+      frameContexts.remove,
+      frameContexts.task
     );
 
     let messageId = sendMessageRequest(parentWindow, "navigateCrossDomain", [
@@ -1107,7 +1108,8 @@ namespace microsoftTeams {
       ensureInitialized(
         frameContexts.content,
         frameContexts.settings,
-        frameContexts.remove
+        frameContexts.remove,
+        frameContexts.task
       );
 
       if (hostClientType === HostClientType.desktop) {


### PR DESCRIPTION
This change allows the authentication.authenticate and navigateCrossDomain calls to be invoked from the task task modules. Currently they are blocked because the frame context for task modules is set to "task" and these APIs only allow calls in the "content", "settings", or "remove" frame contexts.