### PR TITLE
adding print capability to client sdk, App can register custom print handler.

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -610,27 +610,12 @@ namespace microsoftTeams {
   }
 
   /**
-   * Registers a handler for print.
    * default print handler
    */
   export function print(): void {
     if (printCapabilityEnabled) {
-      if (customPrintHandler) {
-        customPrintHandler();
-      } else {
-        window.print();
-      }
+      window.print();
     }
-  }
-
-  /**
-   * Registers a custom handler for print.
-   * @param handler The handler to invoke when printHandler is called.
-   */
-  export function registerCustomPrintHandler(handler: () => void): void {
-    ensureInitialized();
-
-    customPrintHandler = handler;
   }
 
   /**

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -39,18 +39,6 @@ interface Window {
 }
 
 /**
- * adding ctrl+P and cmd+P handler
- */
-document.addEventListener("keydown", function(event: KeyboardEvent): void {
-  if ((event.ctrlKey || event.metaKey) && event.keyCode === 80) {
-    microsoftTeams.print();
-    event.cancelBubble = true;
-    event.preventDefault();
-    event.stopImmediatePropagation();
-  }
-});
-
-/**
  * This is the root namespace for the JavaScript SDK.
  */
 namespace microsoftTeams {
@@ -606,7 +594,19 @@ namespace microsoftTeams {
    * enable print capability
    */
   export function enablePrintCapability(): void {
+    ensureInitialized();
     printCapabilityEnabled = true;
+    /**
+     * adding ctrl+P and cmd+P handler
+     */
+    document.addEventListener("keydown", function(event: KeyboardEvent): void {
+      if ((event.ctrlKey || event.metaKey) && event.keyCode === 80) {
+        microsoftTeams.print();
+        event.cancelBubble = true;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+      }
+    });
   }
 
   /**
@@ -615,7 +615,6 @@ namespace microsoftTeams {
    */
   export function print(): void {
     if (printCapabilityEnabled) {
-      ensureInitialized();
       if (customPrintHandler) {
         customPrintHandler();
       } else {

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -40,7 +40,7 @@ interface Window {
 
 document.addEventListener("keydown", function(event: KeyboardEvent): void {
   if ((event.ctrlKey || event.metaKey) && event.keyCode === 80) {
-    print();
+    microsoftTeams.printHandler();
     event.cancelBubble = true;
     event.preventDefault();
     event.stopImmediatePropagation();
@@ -507,7 +507,7 @@ namespace microsoftTeams {
   let hostClientType: string;
 
   let themeChangeHandler: (theme: string) => void;
-  let printHandler: () => void;
+  let customPrintHandler: () => void;
   handlers["themeChange"] = handleThemeChange;
 
   let fullScreenChangeHandler: (isFullScreen: boolean) => void;
@@ -602,10 +602,10 @@ namespace microsoftTeams {
    * Registers a handler for print.
    * default print handler
    */
-  export function print(handler: () => void): void {
+  export function printHandler(): void {
     ensureInitialized();
-    if (printHandler) {
-      printHandler();
+    if (customPrintHandler) {
+      customPrintHandler();
     } else {
       window.print();
     }
@@ -619,7 +619,7 @@ namespace microsoftTeams {
   export function registerOnPrintHandler(handler: () => void): void {
     ensureInitialized();
 
-    printHandler = handler;
+    customPrintHandler = handler;
   }
 
   /**

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -38,6 +38,15 @@ interface Window {
   onNativeMessage(evt: MessageEvent): void;
 }
 
+document.addEventListener("keydown", function(event: KeyboardEvent): void {
+  if ((event.ctrlKey || event.metaKey) && event.keyCode === 80) {
+    print();
+    event.cancelBubble = true;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }
+});
+
 /**
  * This is the root namespace for the JavaScript SDK.
  */
@@ -498,6 +507,7 @@ namespace microsoftTeams {
   let hostClientType: string;
 
   let themeChangeHandler: (theme: string) => void;
+  let printHandler: () => void;
   handlers["themeChange"] = handleThemeChange;
 
   let fullScreenChangeHandler: (isFullScreen: boolean) => void;
@@ -586,6 +596,30 @@ namespace microsoftTeams {
       hostClientType = null;
       isFramelessWindow = false;
     };
+  }
+
+  /**
+   * Registers a handler for print.
+   * default print handler
+   */
+  export function print(handler: () => void): void {
+    ensureInitialized();
+    if (printHandler) {
+      printHandler();
+    } else {
+      window.print();
+    }
+  }
+
+  /**
+   * Registers a handler for print.
+   * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
+   * @param handler The handler to invoke when the user changes their theme.
+   */
+  export function registerOnPrintHandler(handler: () => void): void {
+    ensureInitialized();
+
+    printHandler = handler;
   }
 
   /**

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -38,9 +38,12 @@ interface Window {
   onNativeMessage(evt: MessageEvent): void;
 }
 
+/**
+ * adding ctrl+P and cmd+P handler
+ */
 document.addEventListener("keydown", function(event: KeyboardEvent): void {
   if ((event.ctrlKey || event.metaKey) && event.keyCode === 80) {
-    microsoftTeams.printHandler();
+    microsoftTeams.print();
     event.cancelBubble = true;
     event.preventDefault();
     event.stopImmediatePropagation();
@@ -508,6 +511,7 @@ namespace microsoftTeams {
 
   let themeChangeHandler: (theme: string) => void;
   let customPrintHandler: () => void;
+  let printCapabilityEnabled: boolean = false;
   handlers["themeChange"] = handleThemeChange;
 
   let fullScreenChangeHandler: (isFullScreen: boolean) => void;
@@ -599,22 +603,30 @@ namespace microsoftTeams {
   }
 
   /**
-   * Registers a handler for print.
-   * default print handler
+   * enable print capability
    */
-  export function printHandler(): void {
-    ensureInitialized();
-    if (customPrintHandler) {
-      customPrintHandler();
-    } else {
-      window.print();
-    }
+  export function enablePrintCapability(): void {
+    printCapabilityEnabled = true;
   }
 
   /**
    * Registers a handler for print.
-   * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
-   * @param handler The handler to invoke when the user changes their theme.
+   * default print handler
+   */
+  export function print(): void {
+    if (printCapabilityEnabled) {
+      ensureInitialized();
+      if (customPrintHandler) {
+        customPrintHandler();
+      } else {
+        window.print();
+      }
+    }
+  }
+
+  /**
+   * Registers a custom handler for print.
+   * @param handler The handler to invoke when printHandler is called.
    */
   export function registerCustomPrintHandler(handler: () => void): void {
     ensureInitialized();

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -498,8 +498,6 @@ namespace microsoftTeams {
   let hostClientType: string;
 
   let themeChangeHandler: (theme: string) => void;
-  let customPrintHandler: () => void;
-  let printCapabilityEnabled: boolean = false;
   handlers["themeChange"] = handleThemeChange;
 
   let fullScreenChangeHandler: (isFullScreen: boolean) => void;
@@ -595,7 +593,6 @@ namespace microsoftTeams {
    */
   export function enablePrintCapability(): void {
     ensureInitialized();
-    printCapabilityEnabled = true;
     /**
      * adding ctrl+P and cmd+P handler
      */
@@ -613,9 +610,7 @@ namespace microsoftTeams {
    * default print handler
    */
   export function print(): void {
-    if (printCapabilityEnabled) {
-      window.print();
-    }
+    window.print();
   }
 
   /**

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -496,6 +496,7 @@ namespace microsoftTeams {
   let callbacks: { [id: number]: Function } = {};
   let frameContext: string;
   let hostClientType: string;
+  let printCapabilityEnabled: boolean = false;
 
   let themeChangeHandler: (theme: string) => void;
   handlers["themeChange"] = handleThemeChange;
@@ -589,21 +590,22 @@ namespace microsoftTeams {
   }
 
   /**
-   * enable print capability
+   * Enable print capability to support printing page using Ctrl+P and cmd+P
    */
   export function enablePrintCapability(): void {
-    ensureInitialized();
-    /**
-     * adding ctrl+P and cmd+P handler
-     */
-    document.addEventListener("keydown", function(event: KeyboardEvent): void {
-      if ((event.ctrlKey || event.metaKey) && event.keyCode === 80) {
-        microsoftTeams.print();
-        event.cancelBubble = true;
-        event.preventDefault();
-        event.stopImmediatePropagation();
-      }
-    });
+    if (!printCapabilityEnabled) {
+      printCapabilityEnabled = true;
+      ensureInitialized();
+      // adding ctrl+P and cmd+P handler
+      document.addEventListener("keydown", (event: KeyboardEvent) => {
+        if ((event.ctrlKey || event.metaKey) && event.keyCode === 80) {
+          microsoftTeams.print();
+          event.cancelBubble = true;
+          event.preventDefault();
+          event.stopImmediatePropagation();
+        }
+      });
+    }
   }
 
   /**

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -616,7 +616,7 @@ namespace microsoftTeams {
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    * @param handler The handler to invoke when the user changes their theme.
    */
-  export function registerOnPrintHandler(handler: () => void): void {
+  export function registerCustomPrintHandler(handler: () => void): void {
     ensureInitialized();
 
     customPrintHandler = handler;

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -628,19 +628,6 @@ describe("MicrosoftTeams", () => {
     expect(handlerCalled).toBe(true);
   });
 
-  it("should successfully register a print handler", () => {
-    let handlerCalled = false;
-    microsoftTeams.initialize();
-    microsoftTeams.enablePrintCapability();
-    microsoftTeams.registerCustomPrintHandler(() => {
-      handlerCalled = true;
-    });
-
-    microsoftTeams.print();
-
-    expect(handlerCalled).toBe(true);
-  });
-
   it("should successfully override a save handler with another", () => {
     initializeWithContext("settings");
 

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -599,14 +599,27 @@ describe("MicrosoftTeams", () => {
     expect(handlerCalled).toBe(true);
   });
 
-  it("print handler should successfully call default print handler", () => {
+  it("print handler should not called if print capability is disabled", () => {
     let handlerCalled = false;
     microsoftTeams.initialize();
     spyOn(window, "print").and.callFake((): void => {
       handlerCalled = true;
     });
 
-    microsoftTeams.printHandler();
+    microsoftTeams.print();
+
+    expect(handlerCalled).toBe(false);
+  });
+
+  it("print handler should successfully call default print handler", () => {
+    let handlerCalled = false;
+    microsoftTeams.initialize();
+    microsoftTeams.enablePrintCapability();
+    spyOn(window, "print").and.callFake((): void => {
+      handlerCalled = true;
+    });
+
+    microsoftTeams.print();
 
     expect(handlerCalled).toBe(true);
   });
@@ -614,7 +627,8 @@ describe("MicrosoftTeams", () => {
   it("Ctrl+P should successfully call print handler", () => {
     let handlerCalled = false;
     microsoftTeams.initialize();
-    spyOn(microsoftTeams, "printHandler").and.callFake((): void => {
+    microsoftTeams.enablePrintCapability();
+    spyOn(microsoftTeams, "print").and.callFake((): void => {
       handlerCalled = true;
     });
     let printEvent = new Event("keydown");
@@ -630,7 +644,8 @@ describe("MicrosoftTeams", () => {
   it("Cmd+P should successfully call print handler", () => {
     let handlerCalled = false;
     microsoftTeams.initialize();
-    spyOn(microsoftTeams, "printHandler").and.callFake((): void => {
+    microsoftTeams.enablePrintCapability();
+    spyOn(microsoftTeams, "print").and.callFake((): void => {
       handlerCalled = true;
     });
     let printEvent = new Event("keydown");
@@ -646,11 +661,12 @@ describe("MicrosoftTeams", () => {
   it("should successfully register a print handler", () => {
     let handlerCalled = false;
     microsoftTeams.initialize();
+    microsoftTeams.enablePrintCapability();
     microsoftTeams.registerCustomPrintHandler(() => {
       handlerCalled = true;
     });
 
-    microsoftTeams.printHandler();
+    microsoftTeams.print();
 
     expect(handlerCalled).toBe(true);
   });

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -566,19 +566,39 @@ describe("MicrosoftTeams", () => {
 
     sendMessage("settings.remove");
 
-    expect(handlerCalled).toBe(true);
+    expect(handlerCalled).toBeTruthy();
   });
 
-  it("print handler should not called if print capability is disabled", () => {
+  it("Ctrl+P shouldn't call print handler if printCapabilty is disabled", () => {
     let handlerCalled = false;
     microsoftTeams.initialize();
-    spyOn(window, "print").and.callFake((): void => {
+    spyOn(microsoftTeams, "print").and.callFake((): void => {
       handlerCalled = true;
     });
+    let printEvent = new Event("keydown");
+    // tslint:disable:no-any
+    (printEvent as any).keyCode = 80;
+    (printEvent as any).ctrlKey = true;
+    // tslint:enable:no-any
 
-    microsoftTeams.print();
+    document.dispatchEvent(printEvent);
+    expect(handlerCalled).toBeFalsy();
+  });
 
-    expect(handlerCalled).toBe(false);
+  it("Cmd+P shouldn't call print handler if printCapabilty is disabled", () => {
+    let handlerCalled = false;
+    microsoftTeams.initialize();
+    spyOn(microsoftTeams, "print").and.callFake((): void => {
+      handlerCalled = true;
+    });
+    let printEvent = new Event("keydown");
+    // tslint:disable:no-any
+    (printEvent as any).keyCode = 80;
+    (printEvent as any).metaKey = true;
+    // tslint:enable:no-any
+
+    document.dispatchEvent(printEvent);
+    expect(handlerCalled).toBeFalsy();
   });
 
   it("print handler should successfully call default print handler", () => {
@@ -591,7 +611,7 @@ describe("MicrosoftTeams", () => {
 
     microsoftTeams.print();
 
-    expect(handlerCalled).toBe(true);
+    expect(handlerCalled).toBeTruthy();
   });
 
   it("Ctrl+P should successfully call print handler", () => {
@@ -608,7 +628,7 @@ describe("MicrosoftTeams", () => {
     // tslint:enable:no-any
 
     document.dispatchEvent(printEvent);
-    expect(handlerCalled).toBe(true);
+    expect(handlerCalled).toBeTruthy();
   });
 
   it("Cmd+P should successfully call print handler", () => {

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -599,6 +599,62 @@ describe("MicrosoftTeams", () => {
     expect(handlerCalled).toBe(true);
   });
 
+  it("print handler should successfully call default print handler", () => {
+    let handlerCalled = false;
+    microsoftTeams.initialize();
+    spyOn(window, "print").and.callFake((): void => {
+      handlerCalled = true;
+    });
+
+    microsoftTeams.printHandler();
+
+    expect(handlerCalled).toBe(true);
+  });
+
+  it("Ctrl+P should successfully call print handler", () => {
+    let handlerCalled = false;
+    microsoftTeams.initialize();
+    spyOn(microsoftTeams, "printHandler").and.callFake((): void => {
+      handlerCalled = true;
+    });
+    let printEvent = new Event("keydown");
+    // tslint:disable:no-any
+    (printEvent as any).keyCode = 80;
+    (printEvent as any).ctrlKey = true;
+    // tslint:enable:no-any
+
+    document.dispatchEvent(printEvent);
+    expect(handlerCalled).toBe(true);
+  });
+
+  it("Cmd+P should successfully call print handler", () => {
+    let handlerCalled = false;
+    microsoftTeams.initialize();
+    spyOn(microsoftTeams, "printHandler").and.callFake((): void => {
+      handlerCalled = true;
+    });
+    let printEvent = new Event("keydown");
+    // tslint:disable:no-any
+    (printEvent as any).keyCode = 80;
+    (printEvent as any).metaKey = true;
+    // tslint:enable:no-any
+
+    document.dispatchEvent(printEvent);
+    expect(handlerCalled).toBe(true);
+  });
+
+  it("should successfully register a print handler", () => {
+    let handlerCalled = false;
+    microsoftTeams.initialize();
+    microsoftTeams.registerCustomPrintHandler(() => {
+      handlerCalled = true;
+    });
+
+    microsoftTeams.printHandler();
+
+    expect(handlerCalled).toBe(true);
+  });
+
   it("should successfully override a save handler with another", () => {
     initializeWithContext("settings");
 


### PR DESCRIPTION
adding print capability to client sdk, 
1. By default we it will be disabled App need to call microsoftTeams.enablePrintCapability()

2. microsoftTeams.printHandler: 
App can register custom print handler otherwise by default it will call window.print.
It support
2.1. Ctrl+P 
2.2. Cmd+P (mac)
and 2.3. by calling explicit microsoftTeams.printHandler 