### PR TITLE
#133 - Need to add completionBotId as a member of TaskInfo

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -2079,6 +2079,13 @@ namespace microsoftTeams {
      * If client doesnt support the URL, the URL that needs to be opened in the browser.
      */
     fallbackUrl?: string;
+
+    /**
+     * Specifies a bot ID to send the result of the user's interaction with the task module.
+     * If specified, the bot will receive a task/complete invoke event with a JSON object
+     * in the event payload.
+     */
+    completionBotId?: string;
   }
 
   /**

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -1441,7 +1441,8 @@ describe("MicrosoftTeams", () => {
         height: microsoftTeams.TaskModuleDimension.Large,
         width: microsoftTeams.TaskModuleDimension.Large,
         title: "someTitle",
-        url: "someUrl"
+        url: "someUrl",
+        completionBotId: "someCompletionBotId"
       };
 
       microsoftTeams.tasks.startTask(taskInfo, (err, result) => {


### PR DESCRIPTION
This change adds the completionBotId field to the TaskInfo structure. This filed allows the developer to specify a bot ID to send the result of the user's interaction with the task module. If specified, the bot will receive a task/complete invoke event with a JSON object in the event payload.

This matches the documentation for our TaskInfo structure here:
https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/task-modules/task-modules-overview#the-taskinfo-object