### PR TITLE
adding SharePoint context to teams client sdk context

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
       "tsx",
       "js"
     ]
+  },
+  "dependencies": {
+    "@microsoft/sp-page-context": "^1.6.0"
   }
 }

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -1,4 +1,7 @@
 "use strict";
+
+import { PageContext } from "@microsoft/sp-page-context";
+
 declare interface String {
   startsWith(search: string, pos?: number): boolean;
 }
@@ -1766,6 +1769,11 @@ export interface Context {
    * The type of the host client. Possible values are : android, ios, web, desktop
    */
   hostClientType?: HostClientType;
+
+  /**
+   * SharePoint context
+   */
+  sharePointContext?: PageContext;
 }
 
 export interface DeepLinkParameters {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,93 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@microsoft/sp-core-library@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/sp-core-library/-/sp-core-library-1.6.0.tgz#0a6c1f4608312f715c71961e8912bef987b0752e"
+  dependencies:
+    "@microsoft/sp-lodash-subset" "1.6.0"
+    "@microsoft/sp-module-interfaces" "1.6.0"
+    "@types/es6-promise" "0.0.33"
+    "@types/webpack-env" "1.13.1"
+
+"@microsoft/sp-diagnostics@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/sp-diagnostics/-/sp-diagnostics-1.6.0.tgz#243ea05c7d4a0001251c6aa6a34034df8ca6bbc8"
+  dependencies:
+    "@microsoft/sp-core-library" "1.6.0"
+    "@microsoft/sp-lodash-subset" "1.6.0"
+
+"@microsoft/sp-dynamic-data@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.6.0.tgz#1b198b23239cb5c385b700f0f7547feba0098508"
+  dependencies:
+    "@microsoft/sp-core-library" "1.6.0"
+    "@types/webpack-env" "1.13.1"
+    tslib "~1.8.0"
+
+"@microsoft/sp-lodash-subset@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.6.0.tgz#5aadd8dec446f17c3519bc4bd35960e17c064b83"
+  dependencies:
+    "@types/lodash" "4.14.74"
+    "@types/webpack-env" "1.13.1"
+    tslib "~1.8.0"
+
+"@microsoft/sp-module-interfaces@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.6.0.tgz#3c291f78766e2314473c94a35349860a62bfc4f2"
+  dependencies:
+    "@types/node" "8.5.8"
+    "@types/z-schema" "3.16.31"
+    z-schema "~3.18.3"
+
+"@microsoft/sp-odata-types@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/sp-odata-types/-/sp-odata-types-1.6.0.tgz#f07b1aef340c97a507de1317db87db2cc6abafe1"
+  dependencies:
+    tslib "~1.8.0"
+
+"@microsoft/sp-page-context@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/sp-page-context/-/sp-page-context-1.6.0.tgz#ddd9d8ff023e4568d53f250437c43bf294fa6a0e"
+  dependencies:
+    "@microsoft/sp-core-library" "1.6.0"
+    "@microsoft/sp-diagnostics" "1.6.0"
+    "@microsoft/sp-dynamic-data" "1.6.0"
+    "@microsoft/sp-lodash-subset" "1.6.0"
+    "@microsoft/sp-odata-types" "1.6.0"
+    "@microsoft/teams-js" "1.3.0-beta.4"
+    "@types/es6-promise" "0.0.33"
+    "@types/webpack-env" "1.13.1"
+    tslib "~1.8.0"
+
+"@microsoft/teams-js@1.3.0-beta.4":
+  version "1.3.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/teams-js/-/teams-js-1.3.0-beta.4.tgz#c7e214f8b4412bef715b46bdc46ae04bfda8c18e"
+
+"@types/es6-promise@0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@types/es6-promise/-/es6-promise-0.0.33.tgz#280a707e62b1b6bef1a86cc0861ec63cd06c7ff3"
+
 "@types/jest@^23.3.5":
   version "23.3.7"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.7.tgz#77f9a4332ccf8db680a31818ade3ee454c831a79"
+
+"@types/lodash@4.14.74":
+  version "4.14.74"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.74.tgz#ac3bd8db988e7f7038e5d22bd76a7ba13f876168"
+
+"@types/node@8.5.8":
+  version "8.5.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.8.tgz#92509422653f10e9c0ac18d87e0610b39f9821c7"
+
+"@types/webpack-env@1.13.1":
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.13.1.tgz#b45c222e24301bd006e3edfc762cc6b51bda236a"
+
+"@types/z-schema@3.16.31":
+  version "3.16.31"
+  resolved "https://registry.yarnpkg.com/@types/z-schema/-/z-schema-3.16.31.tgz#2eb1d00a5e4ec3fa58c76afde12e182b66dc5c1c"
 
 "@webassemblyjs/ast@1.7.10":
   version "1.7.10"
@@ -850,7 +934,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.1:
+commander@^2.12.1, commander@^2.7.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
 
@@ -2635,6 +2719,14 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
+lodash.get@^4.0.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
+lodash.isequal@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -4114,6 +4206,10 @@ tslib@^1.0.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
+tslib@~1.8.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
+
 tslint-eslint-rules@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-4.1.1.tgz#7c30e7882f26bc276bff91d2384975c69daf88ba"
@@ -4294,6 +4390,10 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validator@^8.0.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-8.2.0.tgz#3c1237290e37092355344fef78c231249dab77b9"
 
 verror@1.10.0:
   version "1.10.0"
@@ -4569,3 +4669,13 @@ yargs@^8.0.1:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
+
+z-schema@~3.18.3:
+  version "3.18.4"
+  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-3.18.4.tgz#ea8132b279533ee60be2485a02f7e3e42541a9a2"
+  dependencies:
+    lodash.get "^4.0.0"
+    lodash.isequal "^4.0.0"
+    validator "^8.0.0"
+  optionalDependencies:
+    commander "^2.7.1"


### PR DESCRIPTION
adding SharePoint context to teams client sdk context

- adding optional 'sharePointContext' to client sdk Context interface will be use by teams apps in SharePoint context