### PR TITLE
Update the Teams context to include SKU / license properties

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -1804,14 +1804,14 @@ export interface Context {
   sharepoint?: any;
 
   /**
-   * The type of license for the current user.
+   * The type of license for the current users tenant.
    */
-  licenseType?: string;
+  tenantSKU?: string;
 
   /**
-   * The license category type for the current user.
+   * The license type for the current user.
    */
-  licenseCategoryType?: string;
+  userLicenseType?: string;
 }
 
 export interface DeepLinkParameters {

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -4,7 +4,7 @@ declare interface String {
 }
 
 if (!(String.prototype as any).startsWith) {
-  (String.prototype as any).startsWith = function(
+  (String.prototype as any).startsWith = function (
     search: string,
     pos?: number
   ): boolean {
@@ -590,7 +590,7 @@ export function initialize(hostWindow: any = window): void {
  * Initializes the library. This must be called before any other SDK calls
  * but after the frame is loaded successfully.
  */
-export function _uninitialize(): void {}
+export function _uninitialize(): void { }
 /**
  * Enable print capability to support printing page using Ctrl+P and cmd+P
  */
@@ -1323,13 +1323,13 @@ export namespace authentication {
       link.href,
       "_blank",
       "toolbar=no, location=yes, status=no, menubar=no, scrollbars=yes, top=" +
-        top +
-        ", left=" +
-        left +
-        ", width=" +
-        width +
-        ", height=" +
-        height
+      top +
+      ", left=" +
+      left +
+      ", width=" +
+      width +
+      ", height=" +
+      height
     );
     if (childWindow) {
       // Start monitoring the authentication window so that we can detect if it gets closed before the flow completes
@@ -1802,6 +1802,16 @@ export interface Context {
    * SharePoint context
    */
   sharepoint?: any;
+
+  /**
+   * The type of license for the current user.
+   */
+  licenseType?: string;
+
+  /**
+   * The license category type for the current user.
+   */
+  licenseCategoryType?: string;
 }
 
 export interface DeepLinkParameters {


### PR DESCRIPTION
Adding two new properties to the teams context to expose the SKU / Azure licenses the user currently has.  Example like EDU license type with either teacher or student category.