### PR TITLE
Saching/inline configuration handler

### DIFF
--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -564,7 +564,6 @@ export function initialize(hostWindow: any = window): void {
       registerFullScreenHandler(null);
       registerBackButtonHandler(null);
       registerBeforeUnloadHandler(null);
-      registerChangeSettingsHandler(null);
     }
 
     if (frameContext === frameContexts.settings) {

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -4,7 +4,7 @@ declare interface String {
 }
 
 if (!(String.prototype as any).startsWith) {
-  (String.prototype as any).startsWith = function(
+  (String.prototype as any).startsWith = function (
     search: string,
     pos?: number
   ): boolean {
@@ -594,7 +594,7 @@ export function initialize(hostWindow: any = window): void {
  * Initializes the library. This must be called before any other SDK calls
  * but after the frame is loaded successfully.
  */
-export function _uninitialize(): void {}
+export function _uninitialize(): void { }
 /**
  * Enable print capability to support printing page using Ctrl+P and cmd+P
  */
@@ -959,10 +959,12 @@ export function navigateToTab(tabInstance: TabInstance): void {
  * This object is usable only on the settings frame.
  */
 export namespace settings {
+  let settingsHandler: () => void;
   let saveHandler: (evt: SaveEvent) => void;
   let removeHandler: (evt: RemoveEvent) => void;
   handlers["settings.save"] = handleSave;
   handlers["settings.remove"] = handleRemove;
+  handlers["settings.settings"] = settingsHandler;
 
   /**
    * Sets the validity state for the settings.
@@ -1042,6 +1044,20 @@ export namespace settings {
 
     removeHandler = handler;
     handler && sendMessageRequest(parentWindow, "registerHandler", ["remove"]);
+  }
+
+  /**
+   * Registers a handler for when the user reconfigurated tab
+   * to create or update the underlying resource powering the content.
+   * @param handler The handler to invoke when the user click on Settings.
+   */
+  export function registerOnSettingsHandler(
+    handler: () => void
+  ): void {
+    ensureInitialized(frameContexts.content);
+
+    settingsHandler = handler;
+    handler && sendMessageRequest(parentWindow, "registerHandler", ["settings"]);
   }
 
   function handleSave(result?: SaveParameters): void {
@@ -1364,13 +1380,13 @@ export namespace authentication {
       link.href,
       "_blank",
       "toolbar=no, location=yes, status=no, menubar=no, scrollbars=yes, top=" +
-        top +
-        ", left=" +
-        left +
-        ", width=" +
-        width +
-        ", height=" +
-        height
+      top +
+      ", left=" +
+      left +
+      ", width=" +
+      width +
+      ", height=" +
+      height
     );
     if (childWindow) {
       // Start monitoring the authentication window so that we can detect if it gets closed before the flow completes

--- a/src/MicrosoftTeams.ts
+++ b/src/MicrosoftTeams.ts
@@ -507,8 +507,8 @@ handlers["backButtonPress"] = handleBackButtonPress;
 let beforeUnloadHandler: (readyToUnload: () => void) => boolean;
 handlers["beforeUnload"] = handleBeforeUnload;
 
-let settingsChangeHandler: () => void;
-handlers["settingsChange"] = handleSettingsChange;
+let changeSettingsHandler: () => void;
+handlers["changeSettings"] = handleChangeSettings;
 
 /**
  * Initializes the library. This must be called before any other SDK calls
@@ -564,7 +564,7 @@ export function initialize(hostWindow: any = window): void {
       registerFullScreenHandler(null);
       registerBackButtonHandler(null);
       registerBeforeUnloadHandler(null);
-      registerOnSettingsChangeHandler(null);
+      registerChangeSettingsHandler(null);
     }
 
     if (frameContext === frameContexts.settings) {
@@ -749,19 +749,19 @@ function handleBeforeUnload(): void {
  * Registers a handler for when the user reconfigurated tab
  * @param handler The handler to invoke when the user click on Settings.
  */
-export function registerOnSettingsChangeHandler(
+export function registerChangeSettingsHandler(
   handler: () => void
 ): void {
   ensureInitialized(frameContexts.content);
 
-  settingsChangeHandler = handler;
-  handler && sendMessageRequest(parentWindow, "registerHandler", ["settingsChange"]);
+  changeSettingsHandler = handler;
+  handler && sendMessageRequest(parentWindow, "registerHandler", ["changeSettings"]);
 }
 
 
-function handleSettingsChange(): void {
-  if (settingsChangeHandler) {
-    settingsChangeHandler();
+function handleChangeSettings(): void {
+  if (changeSettingsHandler) {
+    changeSettingsHandler();
   }
 }
 

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -25,10 +25,10 @@ describe("MicrosoftTeams", () => {
   let childMessages: MessageRequest[];
 
   let childWindow = {
-    postMessage: function(message: MessageRequest, targetOrigin: string): void {
+    postMessage: function (message: MessageRequest, targetOrigin: string): void {
       childMessages.push(message);
     },
-    close: function(): void {
+    close: function (): void {
       return;
     },
     closed: false
@@ -39,7 +39,7 @@ describe("MicrosoftTeams", () => {
     outerHeight: 768,
     screenLeft: 0,
     screenTop: 0,
-    addEventListener: function(
+    addEventListener: function (
       type: string,
       listener: (ev: MessageEvent) => void,
       useCapture?: boolean
@@ -48,7 +48,7 @@ describe("MicrosoftTeams", () => {
         processMessage = listener;
       }
     },
-    removeEventListener: function(
+    removeEventListener: function (
       type: string,
       listener: (ev: MessageEvent) => void,
       useCapture?: boolean
@@ -60,12 +60,12 @@ describe("MicrosoftTeams", () => {
     location: {
       origin: tabOrigin,
       href: validOrigin,
-      assign: function(url: string): void {
+      assign: function (url: string): void {
         return;
       }
     },
     parent: {
-      postMessage: function(
+      postMessage: function (
         message: MessageRequest,
         targetOrigin: string
       ): void {
@@ -79,10 +79,10 @@ describe("MicrosoftTeams", () => {
       }
     } as Window,
     self: null as Window,
-    open: function(url: string, name: string, specs: string): Window {
+    open: function (url: string, name: string, specs: string): Window {
       return childWindow as Window;
     },
-    close: function(): void {
+    close: function (): void {
       return;
     },
     setInterval: (handler: Function, timeout: number): number =>
@@ -451,6 +451,19 @@ describe("MicrosoftTeams", () => {
     let navigateBackMessage = findMessageByFunc("navigateBack");
     expect(navigateBackMessage).not.toBeNull();
     expect(handlerInvoked).toBe(true);
+  });
+
+  it("should successfully register a change settings handler", () => {
+    initializeWithContext("content");
+    let handlerCalled = false;
+
+    microsoftTeams.registerChangeSettingsHandler(() => {
+      handlerCalled = true;
+    });
+
+    sendMessage("changeSettings", "");
+
+    expect(handlerCalled).toBeTruthy();
   });
 
   it("should successfully set validity state to true", () => {


### PR DESCRIPTION
Tab can register onSettingsHandler and when user click on settings to edit tab teams client will notify tab instead of opening tab config dialog