### PR TITLE
Adding 'Rigel' as a supported HostClientType

### DIFF
--- a/src/public/authentication.ts
+++ b/src/public/authentication.ts
@@ -31,7 +31,8 @@ export namespace authentication {
     ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove, frameContexts.task);
     if (GlobalVars.hostClientType === HostClientType.desktop ||
       GlobalVars.hostClientType === HostClientType.android ||
-      GlobalVars.hostClientType === HostClientType.ios) {
+      GlobalVars.hostClientType === HostClientType.ios ||
+      GlobalVars.hostClientType === HostClientType.rigel) {
       // Convert any relative URLs into absolute URLs before sending them over to the parent window.
       const link = document.createElement("a");
       link.href = authenticateParams.url;

--- a/src/public/constants.ts
+++ b/src/public/constants.ts
@@ -2,7 +2,8 @@ export const enum HostClientType {
   desktop = "desktop",
   web = "web",
   android = "android",
-  ios = "ios"
+  ios = "ios",
+  rigel = "rigel"
 }
 
 /**

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -265,7 +265,7 @@ export interface Context {
   isTeamArchived?: boolean;
 
   /**
-   * The type of the host client. Possible values are : android, ios, web, desktop
+   * The type of the host client. Possible values are : android, ios, web, desktop, rigel
    */
   hostClientType?: HostClientType;
 


### PR DESCRIPTION
Adding 'Rigel' as a supported HostClientType to allow consumers to detect if they are being projected by a Rigel device.  

This will allow users to detect if they are running on a Rigel device by checking the HostClientType returned in GetContext().  

Fix #183 