### PR TITLE
exporting private and public api explicit in index.ts file

### DIFF
--- a/src/private/index.ts
+++ b/src/private/index.ts
@@ -1,3 +1,22 @@
-export * from "./menus";
-export * from "./interfaces";
-export * from "./privateAPIs";
+export { menus } from "./menus";
+export {
+  ChatMembersInformation,
+  FilePreviewParameters,
+  NotificationTypes,
+  ShowNotificationParameters,
+  TeamInstanceParameters,
+  ThreadMember,
+  UserJoinedTeamsInformation,
+} from "./interfaces";
+export {
+  enterFullscreen,
+  executeDeepLink,
+  exitFullscreen,
+  getChatMembers,
+  getConfigSetting,
+  getUserJoinedTeams,
+  openFilePreview,
+  sendCustomMessage,
+  showNotification,
+  uploadCustomApp
+} from "./privateAPIs";

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -1,7 +1,40 @@
-export * from "./authentication";
-export * from "./constants";
-export * from "./interfaces";
-export * from "./publicAPIs";
-export * from "./settings";
-export * from "./tasks";
-export * from "./appWindow";
+export { authentication } from "./authentication";
+export {
+  HostClientType,
+  TaskModuleDimension,
+  TeamType,
+  UserTeamRole
+} from "./constants";
+export {
+  Context,
+  DeepLinkParameters,
+  TabInformation,
+  TabInstance,
+  TabInstanceParameters,
+  TaskInfo,
+  TeamInformation
+} from "./interfaces";
+export {
+  enablePrintCapability,
+  getContext,
+  getMruTabInstances,
+  getTabInstances,
+  initialize,
+  navigateBack,
+  navigateCrossDomain,
+  navigateToTab,
+  print,
+  registerBackButtonHandler,
+  registerBeforeUnloadHandler,
+  registerChangeSettingsHandler,
+  registerFullScreenHandler,
+  registerOnThemeChangeHandler,
+  shareDeepLink
+} from "./publicAPIs";
+export { settings } from "./settings";
+export { tasks } from "./tasks";
+export {
+  ChildAppWindow,
+  IAppWindow,
+  ParentAppWindow
+} from "./appWindow";


### PR DESCRIPTION
exporting private and public api explicit in index.ts file

This change will give control to export subset of functions/vars from a file. It will enable use keeping promise based api in same file with callback and bases on different index file we will export different function.