### PR TITLE
Saching/support error callback to sdk api

### DIFF
--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -20,10 +20,10 @@ export function generateRegExpFromUrls(urls: string[]): RegExp {
   return new RegExp(urlRegExp);
 }
 
-export function getGenericOnCompleteHandler(errorMessage?: string): (success: boolean, result: string) => void {
-  return (success: boolean, result: string) => {
+export function getGenericOnCompleteHandler(errorMessage?: string): (success: boolean, reason?: string) => void {
+  return (success: boolean, reason: string) => {
     if (!success) {
-      throw new Error(errorMessage ? errorMessage : result);
+      throw new Error(errorMessage ? errorMessage : reason);
     }
   };
 }

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -20,8 +20,8 @@ export function generateRegExpFromUrls(urls: string[]): RegExp {
   return new RegExp(urlRegExp);
 }
 
-export function registerGenericCallback(messageId, errorMessage?: string) {
-  GlobalVars.callbacks[messageId] = (success: boolean, result: string) => {
+export function getGenericOnCompleteHandler(errorMessage?: string): (success: boolean, result: string) => void {
+  return (success: boolean, result: string) => {
     if (!success) {
       throw new Error(errorMessage ? errorMessage : result);
     }

--- a/src/private/privateAPIs.ts
+++ b/src/private/privateAPIs.ts
@@ -2,7 +2,7 @@ import { ensureInitialized, sendMessageRequest } from "../internal/internalAPIs"
 import { GlobalVars } from "../internal/globalVars";
 import { frameContexts } from "../internal/constants";
 import { ChatMembersInformation, ShowNotificationParameters, FilePreviewParameters, TeamInstanceParameters, UserJoinedTeamsInformation } from "./interfaces";
-import { registerGenericCallback } from "../internal/utils";
+import { registerGenericCallback, getGenericOnCompleteHandler } from "../internal/utils";
 
 /**
  * @private
@@ -101,12 +101,12 @@ export function showNotification(
  * execute deep link API.
  * @param deepLink deep link.
  */
-export function executeDeepLink(deepLink: string): void {
+export function executeDeepLink(deepLink: string, onComplete?: (status: boolean, reason?: string) => void): void {
   ensureInitialized(frameContexts.content);
   const messageId = sendMessageRequest(GlobalVars.parentWindow, "executeDeepLink", [
     deepLink
   ]);
-  registerGenericCallback(messageId);
+  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
 }
 
 /**
@@ -116,13 +116,13 @@ export function executeDeepLink(deepLink: string): void {
  * Upload a custom App manifest directly to both team and personal scopes.
  * This method works just for the first party Apps.
  */
-export function uploadCustomApp(manifestBlob: Blob): void {
+export function uploadCustomApp(manifestBlob: Blob, onComplete?: (status: boolean, reason?: string) => void): void {
   ensureInitialized();
 
   const messageId = sendMessageRequest(GlobalVars.parentWindow, "uploadCustomApp", [
     manifestBlob
   ]);
-  registerGenericCallback(messageId);
+  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
 }
 
 /**

--- a/src/private/privateAPIs.ts
+++ b/src/private/privateAPIs.ts
@@ -2,7 +2,7 @@ import { ensureInitialized, sendMessageRequest } from "../internal/internalAPIs"
 import { GlobalVars } from "../internal/globalVars";
 import { frameContexts } from "../internal/constants";
 import { ChatMembersInformation, ShowNotificationParameters, FilePreviewParameters, TeamInstanceParameters, UserJoinedTeamsInformation } from "./interfaces";
-import { registerGenericCallback, getGenericOnCompleteHandler } from "../internal/utils";
+import { getGenericOnCompleteHandler } from "../internal/utils";
 
 /**
  * @private
@@ -106,7 +106,7 @@ export function executeDeepLink(deepLink: string, onComplete?: (status: boolean,
   const messageId = sendMessageRequest(GlobalVars.parentWindow, "executeDeepLink", [
     deepLink
   ]);
-  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
+  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler();
 }
 
 /**
@@ -122,7 +122,7 @@ export function uploadCustomApp(manifestBlob: Blob, onComplete?: (status: boolea
   const messageId = sendMessageRequest(GlobalVars.parentWindow, "uploadCustomApp", [
     manifestBlob
   ]);
-  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
+  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler();
 }
 
 /**

--- a/src/public/appWindow.ts
+++ b/src/public/appWindow.ts
@@ -1,7 +1,7 @@
 import { ensureInitialized, sendMessageRequest } from "../internal/internalAPIs";
 import { GlobalVars } from "../internal/globalVars";
 import { frameContexts } from "../internal/constants";
-import { registerGenericCallback, getGenericOnCompleteHandler } from "../internal/utils";
+import { getGenericOnCompleteHandler } from "../internal/utils";
 
 export interface IAppWindow {
   postMessage(message): void;
@@ -17,7 +17,7 @@ export class ChildAppWindow implements IAppWindow {
     const messageId = sendMessageRequest(GlobalVars.parentWindow, "messageForChild", [
       message
     ]);
-    GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
+    GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler();
   }
 
   public addEventListener(type: string, listener: (message: any) => void): void {
@@ -43,7 +43,7 @@ export class ParentAppWindow implements IAppWindow {
       message
     ]);
 
-    GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
+    GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler();
   }
 
   public addEventListener(type: string, listener: (message: any) => void): void {

--- a/src/public/appWindow.ts
+++ b/src/public/appWindow.ts
@@ -1,7 +1,7 @@
 import { ensureInitialized, sendMessageRequest } from "../internal/internalAPIs";
 import { GlobalVars } from "../internal/globalVars";
 import { frameContexts } from "../internal/constants";
-import { registerGenericCallback } from "../internal/utils";
+import { registerGenericCallback, getGenericOnCompleteHandler } from "../internal/utils";
 
 export interface IAppWindow {
   postMessage(message): void;
@@ -10,13 +10,14 @@ export interface IAppWindow {
 
 export class ChildAppWindow implements IAppWindow {
   public postMessage(
-    message: any
+    message: any,
+    onComplete?: (status: boolean, reason?: string) => void
   ): void {
     ensureInitialized();
     const messageId = sendMessageRequest(GlobalVars.parentWindow, "messageForChild", [
       message
     ]);
-    registerGenericCallback(messageId);
+    GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
   }
 
   public addEventListener(type: string, listener: (message: any) => void): void {
@@ -34,14 +35,15 @@ export class ParentAppWindow implements IAppWindow {
   }
 
   public postMessage(
-    message: any
+    message: any,
+    onComplete?: (status: boolean, reason?: string) => void
   ): void {
     ensureInitialized(frameContexts.task);
     const messageId = sendMessageRequest(GlobalVars.parentWindow, "messageForParent", [
       message
     ]);
 
-    registerGenericCallback(messageId);
+    GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
   }
 
   public addEventListener(type: string, listener: (message: any) => void): void {

--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -182,11 +182,12 @@ export function registerBackButtonHandler(handler: () => boolean): void {
  * Navigates back in the Teams client. See registerBackButtonHandler for more information on when
  * it's appropriate to use this method.
  */
-export function navigateBack(): void {
+export function navigateBack(onComplete?: (status: boolean, reason?: string) => void): void {
   ensureInitialized();
 
   const messageId = sendMessageRequest(GlobalVars.parentWindow, "navigateBack", []);
-  registerGenericCallback(messageId, "Back navigation is not supported in the current client or context.");
+  const errorMessage = "Back navigation is not supported in the current client or context.";
+  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
 }
 
 /**
@@ -225,7 +226,7 @@ export function registerChangeSettingsHandler(
  * continue working.
  * @param url The URL to navigate the frame to.
  */
-export function navigateCrossDomain(url: string): void {
+export function navigateCrossDomain(url: string, onComplete?: (status: boolean, reason?: string) => void): void {
   ensureInitialized(
     frameContexts.content,
     frameContexts.settings,
@@ -236,7 +237,8 @@ export function navigateCrossDomain(url: string): void {
   const messageId = sendMessageRequest(GlobalVars.parentWindow, "navigateCrossDomain", [
     url
   ]);
-  registerGenericCallback(messageId, "Cross-origin navigation is only supported for URLs matching the pattern registered in the manifest.");
+  const errorMessage = "Cross-origin navigation is only supported for URLs matching the pattern registered in the manifest.";
+  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
 }
 
 /**
@@ -292,11 +294,13 @@ export function shareDeepLink(deepLinkParameters: DeepLinkParameters): void {
  * Navigates the Microsoft Teams app to the specified tab instance.
  * @param tabInstance The tab instance to navigate to.
  */
-export function navigateToTab(tabInstance: TabInstance): void {
+export function navigateToTab(tabInstance: TabInstance, onComplete?: (status: boolean, reason?: string) => void): void {
   ensureInitialized();
 
   const messageId = sendMessageRequest(GlobalVars.parentWindow, "navigateToTab", [
     tabInstance
   ]);
-  registerGenericCallback(messageId, "Invalid internalTabInstanceId and/or channelId were/was provided");
+
+  const errorMessage = "Invalid internalTabInstanceId and/or channelId were/was provided";
+  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
 }

--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -4,7 +4,7 @@ import { version, frameContexts } from "../internal/constants";
 import { ExtendedWindow, MessageEvent } from "../internal/interfaces";
 import { settings } from "./settings";
 import { TabInformation, TabInstanceParameters, TabInstance, DeepLinkParameters, Context } from "./interfaces";
-import { registerGenericCallback } from "../internal/utils";
+import { getGenericOnCompleteHandler } from "../internal/utils";
 
 // ::::::::::::::::::::::: MicrosoftTeams SDK public API ::::::::::::::::::::
 /**
@@ -187,7 +187,7 @@ export function navigateBack(onComplete?: (status: boolean, reason?: string) => 
 
   const messageId = sendMessageRequest(GlobalVars.parentWindow, "navigateBack", []);
   const errorMessage = "Back navigation is not supported in the current client or context.";
-  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
+  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler(errorMessage);
 }
 
 /**
@@ -238,7 +238,7 @@ export function navigateCrossDomain(url: string, onComplete?: (status: boolean, 
     url
   ]);
   const errorMessage = "Cross-origin navigation is only supported for URLs matching the pattern registered in the manifest.";
-  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
+  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler(errorMessage);
 }
 
 /**
@@ -302,5 +302,5 @@ export function navigateToTab(tabInstance: TabInstance, onComplete?: (status: bo
   ]);
 
   const errorMessage = "Invalid internalTabInstanceId and/or channelId were/was provided";
-  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
+  GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler(errorMessage);
 }

--- a/src/public/settings.ts
+++ b/src/public/settings.ts
@@ -45,7 +45,7 @@ export namespace settings {
     const messageId = sendMessageRequest(GlobalVars.parentWindow, "settings.setSettings", [
       instanceSettings
     ]);
-    GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
+    GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler();
   }
 
   /**

--- a/src/public/settings.ts
+++ b/src/public/settings.ts
@@ -40,12 +40,17 @@ export namespace settings {
    * This is an asynchronous operation; calls to getSettings are not guaranteed to reflect the changed state.
    * @param settings The desired settings for this instance.
    */
-  export function setSettings(instanceSettings: Settings): void {
+  export function setSettings(instanceSettings: Settings, onComplete?: (status: boolean, reason?: string) => void): void {
     ensureInitialized(frameContexts.content, frameContexts.settings);
     const messageId = sendMessageRequest(GlobalVars.parentWindow, "settings.setSettings", [
       instanceSettings
     ]);
-    registerGenericCallback(messageId);
+    if (onComplete) {
+      GlobalVars.callbacks[messageId] = onComplete;
+    }
+    else {
+      registerGenericCallback(messageId);
+    }
   }
 
   /**

--- a/src/public/settings.ts
+++ b/src/public/settings.ts
@@ -1,7 +1,7 @@
 import { ensureInitialized, sendMessageRequest } from "../internal/internalAPIs";
 import { GlobalVars } from "../internal/globalVars";
 import { frameContexts } from "../internal/constants";
-import { registerGenericCallback } from "../internal/utils";
+import { getGenericOnCompleteHandler } from "../internal/utils";
 
 /**
  * Namespace to interact with the settings-specific part of the SDK.
@@ -45,12 +45,7 @@ export namespace settings {
     const messageId = sendMessageRequest(GlobalVars.parentWindow, "settings.setSettings", [
       instanceSettings
     ]);
-    if (onComplete) {
-      GlobalVars.callbacks[messageId] = onComplete;
-    }
-    else {
-      registerGenericCallback(messageId);
-    }
+    GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler()
   }
 
   /**


### PR DESCRIPTION
Problem: We have some sdk API for which if we get error then we throw Error on sdk. Developer don't have better way to listen for these error and related to api call.
Solution: with this change tab developer can pass an optional onComplete callBack: (success: boolean, reason?: string) => void

that will be called when api complete.