### PR TITLE
Add GCCH and DOD domains to valid origins list

### DIFF
--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -5,6 +5,8 @@ export const version = "1.4.1";
 export const validOrigins = [
   "https://teams.microsoft.com",
   "https://teams.microsoft.us",
+  "https://gov.teams.microsoft.us",
+  "https://dod.teams.microsoft.us",
   "https://int.teams.microsoft.com",
   "https://devspaces.skype.com",
   "https://ssauth.skype.com",

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -206,12 +206,17 @@ describe("MicrosoftTeams", () => {
   const supportedDomains = [
     "https://teams.microsoft.com",
     "https://teams.microsoft.us",
+    "https://gov.teams.microsoft.us",
+    "https://dod.teams.microsoft.us",
     "https://int.teams.microsoft.com",
     "https://devspaces.skype.com",
     "http://dev.local",
     "https://microsoft.sharepoint.com",
     "https://msft.spoppe.com",
-    "https://microsoft.sharepoint-df.com"
+    "https://microsoft.sharepoint-df.com",
+    "https://microsoft.sharepointonline.com",
+    "https://outlook.office.com",
+    "https://outlook-sdf.office.com"
   ];
 
   supportedDomains.forEach(supportedDomain => {


### PR DESCRIPTION
Some of our app partners are rolling out support for GCCH and DOD environments so we need to make sure our SDK works there.