### PR TITLE
#207 - Add missing fields to context

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "editor.formatOnSave": true,
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
   "search.exclude": {

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -206,9 +206,19 @@ export interface Context {
   teamType?: TeamType;
 
   /**
-   * The root SharePoint folder associated with the team.
+   * The root SharePoint site associated with the team.
    */
   teamSiteUrl?: string;
+
+  /**
+   * The domain of the root SharePoint site associated with the team.
+   */
+  teamSiteDomain?: string;
+
+  /**
+   * The relative path to the SharePoint site associated with the team.
+   */
+  teamSitePath?: string;
 
   /**
    * The relative path to the SharePoint folder associated with the channel.
@@ -268,7 +278,7 @@ export interface Context {
   hostClientType?: HostClientType;
 
   /**
-   * SharePoint context
+   * SharePoint context. This is only available when hosted in SharePoint.
    */
   sharepoint?: any;
 
@@ -283,8 +293,13 @@ export interface Context {
   userLicenseType?: string;
 
   /**
+   * The ID of the parent message from which this task module was launched.
+   * This is only available in task modules launched from bot cards.
+   */
+  parentMessageId?: string;
+
+  /**
    * Current ring ID
-   * ------
    */
   ringId?: string;
 }

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -394,17 +394,36 @@ describe("MicrosoftTeams", () => {
     expect(getContextMessage).not.toBeNull();
 
     let expectedContext: Context = {
-      locale: "someLocale",
       groupId: "someGroupId",
+      teamId: "someTeamId",
+      teamName: "someTeamName",
       channelId: "someChannelId",
+      channelName: "someChannelName",
       entityId: "someEntityId",
+      subEntityId: "someSubEntityId",
+      locale: "someLocale",
+      upn: "someUpn",
+      tid: "someTid",
+      theme: "someTheme",
       isFullScreen: true,
       teamType: TeamType.Staff,
       teamSiteUrl: "someSiteUrl",
+      teamSiteDomain: "someTeamSiteDomain",
+      teamSitePath: "someTeamSitePath",
+      channelRelativeUrl: "someChannelRelativeUrl",
       sessionId: "someSessionId",
       userTeamRole: UserTeamRole.Admin,
       chatId: "someChatId",
-      hostClientType: HostClientType.web
+      loginHint: "someLoginHint",
+      userPrincipalName: "someUserPrincipalName",
+      userObjectId: "someUserObjectId",
+      isTeamArchived: false,
+      hostClientType: HostClientType.web,
+      sharepoint: {},
+      tenantSKU: "someTenantSKU",
+      userLicenseType: "someUserLicenseType",
+      parentMessageId: "someParentMessageId",
+      ringId: "someRingId"
     };
 
     respondToMessage(getContextMessage, expectedContext);


### PR DESCRIPTION
This change adds a few missing fields to to the Context object:
- teamSiteDomain
- teamSitePath
- parentMessageId

These have already been implemented in the Teams client but are missing from our library.