### PR TITLE
adding explicit app load, initialization success/fail api

### DIFF
--- a/src/public/appInitialization.ts
+++ b/src/public/appInitialization.ts
@@ -1,0 +1,40 @@
+import { ensureInitialized, sendMessageRequest } from "../internal/internalAPIs";
+import { GlobalVars } from "../internal/globalVars";
+import { version } from "../internal/constants";
+
+export namespace appInitialization {
+  /**
+ * To notify app loaded to hide loading indicator
+ */
+  export function notifyAppLoaded(): void {
+    ensureInitialized();
+    sendMessageRequest(GlobalVars.parentWindow, "appInitialization.appLoaded", [version]);
+  }
+
+  /**
+   * To notify app Initialization successs and ready for user interaction
+   */
+  export function notifySuccess(): void {
+    ensureInitialized();
+    sendMessageRequest(GlobalVars.parentWindow, "appInitialization.success", [version]);
+  }
+
+  /**
+   * To notify app Initialization failed
+   */
+  export function notifyFailure(appInitializationFailedRequest: appInitialization.IFailedRequest): void {
+    ensureInitialized();
+    sendMessageRequest(GlobalVars.parentWindow, "appInitialization.failure", [appInitializationFailedRequest.reason, appInitializationFailedRequest.message]);
+  }
+
+  export const enum FailedReason {
+    AuthFailed = "AuthFailed",
+    Timeout = "Timeout",
+    Other = "Other"
+  }
+
+  export interface IFailedRequest {
+    reason: appInitialization.FailedReason;
+    message?: string;
+  }
+}

--- a/src/public/constants.ts
+++ b/src/public/constants.ts
@@ -32,9 +32,3 @@ export const enum TaskModuleDimension {
   Medium = "medium",
   Small = "small"
 }
-
-export const enum AppInitializationFailedReason {
-  AuthFailed = "AuthFailed",
-  Timeout = "Timeout",
-  Other = "Other"
-}

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -13,7 +13,7 @@ export {
   TabInstanceParameters,
   TaskInfo,
   TeamInformation,
-  IAppInitializationEvent
+  IAppInitializationFailedRequest
 } from "./interfaces";
 export {
   enablePrintCapability,
@@ -25,6 +25,9 @@ export {
   navigateBack,
   navigateCrossDomain,
   navigateToTab,
+  notifyAppLoad,
+  notifyAppInitializationSuccess,
+  notifyAppInitializationFailure,
   print,
   registerBackButtonHandler,
   registerBeforeUnloadHandler,

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -1,3 +1,4 @@
+export { appInitialization } from "./appInitialization";
 export { authentication } from "./authentication";
 export {
   HostClientType,
@@ -12,8 +13,7 @@ export {
   TabInstance,
   TabInstanceParameters,
   TaskInfo,
-  TeamInformation,
-  IAppInitializationFailedRequest
+  TeamInformation
 } from "./interfaces";
 export {
   enablePrintCapability,
@@ -25,9 +25,6 @@ export {
   navigateBack,
   navigateCrossDomain,
   navigateToTab,
-  notifyAppLoad,
-  notifyAppInitializationSuccess,
-  notifyAppInitializationFailure,
   print,
   registerBackButtonHandler,
   registerBeforeUnloadHandler,

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -399,15 +399,3 @@ export interface IAppInitializationFailedRequest {
   reason: AppInitializationFailedReason;
   message?: string;
 }
-
-export interface IAppInitializationEvent {
-  /**
-   * Indicates that the App initialization success and app is ready to interact.
-   */
-  notifySuccess(): void;
-  /**
-   * Indicates that app initialization failed.
-   * @param appInitializationFailedRequest Specifies a reason for the failure with optional message.
-   */
-  notifyFailure(appInitializationFailedRequest: IAppInitializationFailedRequest): void;
-}

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -1,4 +1,4 @@
-import { TaskModuleDimension, HostClientType, TeamType, UserTeamRole, AppInitializationFailedReason } from "./constants";
+import { TaskModuleDimension, HostClientType, TeamType, UserTeamRole } from "./constants";
 
 /**
 * Represents information about tabs for an app
@@ -393,9 +393,4 @@ export interface OpenConversationRequest {
   * A function that is called if the pane is closed
   */
   onCloseConversation?: (subEntityId: string, conversationId?: string) => void;
-}
-
-export interface IAppInitializationFailedRequest {
-  reason: AppInitializationFailedReason;
-  message?: string;
 }

--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -3,7 +3,7 @@ import { GlobalVars } from "../internal/globalVars";
 import { version, frameContexts } from "../internal/constants";
 import { ExtendedWindow, MessageEvent } from "../internal/interfaces";
 import { settings } from "./settings";
-import { TabInformation, TabInstanceParameters, TabInstance, DeepLinkParameters, Context, IAppInitializationFailedRequest } from "./interfaces";
+import { TabInformation, TabInstanceParameters, TabInstance, DeepLinkParameters, Context } from "./interfaces";
 import { getGenericOnCompleteHandler } from "../internal/utils";
 
 // ::::::::::::::::::::::: MicrosoftTeams SDK public API ::::::::::::::::::::
@@ -11,7 +11,7 @@ import { getGenericOnCompleteHandler } from "../internal/utils";
  * Initializes the library. This must be called before any other SDK calls
  * but after the frame is loaded successfully.
  */
-export function initialize(hostWindow: any = window) {
+export function initialize(hostWindow: any = window): void {
   // Independent components might not know whether the SDK is initialized so might call it to be safe.
   // Just no-op if that happens to make it easier to use.
   if (!GlobalVars.initializeCalled) {
@@ -86,30 +86,6 @@ export function initialize(hostWindow: any = window) {
       GlobalVars.isFramelessWindow = false;
     };
   }
-}
-
-/**
- * To notify app loaded to hide loading indicator
- */
-export function notifyAppLoad(): void {
-  ensureInitialized();
-  sendMessageRequest(GlobalVars.parentWindow, "appLoadCompleted", [version]);
-}
-
-/**
- * To notify app Initialization successs and ready for user interaction
- */
-export function notifyAppInitializationSuccess(): void {
-  ensureInitialized();
-  sendMessageRequest(GlobalVars.parentWindow, "appInitialization.success", [version]);
-}
-
-/**
- * To notify app Initialization failed
- */
-export function notifyAppInitializationFailure(appInitializationFailedRequest: IAppInitializationFailedRequest): void {
-  ensureInitialized();
-  sendMessageRequest(GlobalVars.parentWindow, "appInitialization.failure", [appInitializationFailedRequest.reason, appInitializationFailedRequest.message]);
 }
 
 /**


### PR DESCRIPTION
adding explicit app load, initialization success/fail api
This api can be use by tab to hide loading indicator before notifying appInitialization success/fail. 