### PR TITLE
Add the capability to use conversational subentity APIs in a personal app scope

### DIFF
--- a/src/internal/globalVars.ts
+++ b/src/internal/globalVars.ts
@@ -24,6 +24,6 @@ export class GlobalVars {
   public static backButtonPressHandler: () => boolean;
   public static beforeUnloadHandler: (readyToUnload: () => void) => boolean;
   public static changeSettingsHandler: () => void;
-  public static onStartConversationHandler: (sunEntityId: string, conversationId: string, threadId: string, entityId: string) => void;
-  public static onCloseConversationHandler: (sunEntityId: string, conversationId?: string, threadId?: string, entityId?: string) => void;
+  public static onStartConversationHandler: (subEntityId: string, conversationId: string, threadId: string, entityId: string) => void;
+  public static onCloseConversationHandler: (subEntityId: string, conversationId?: string, threadId?: string, entityId?: string) => void;
 }

--- a/src/internal/globalVars.ts
+++ b/src/internal/globalVars.ts
@@ -24,6 +24,6 @@ export class GlobalVars {
   public static backButtonPressHandler: () => boolean;
   public static beforeUnloadHandler: (readyToUnload: () => void) => boolean;
   public static changeSettingsHandler: () => void;
-  public static onStartConversationHandler: (sunEntityId: string, conversationId: string, threadId: string) => void;
-  public static onCloseConversationHandler: (sunEntityId: string, conversationId?: string, threadId?: string) => void;
+  public static onStartConversationHandler: (sunEntityId: string, conversationId: string, threadId: string, entityId: string) => void;
+  public static onCloseConversationHandler: (sunEntityId: string, conversationId?: string, threadId?: string, entityId?: string) => void;
 }

--- a/src/internal/globalVars.ts
+++ b/src/internal/globalVars.ts
@@ -24,6 +24,6 @@ export class GlobalVars {
   public static backButtonPressHandler: () => boolean;
   public static beforeUnloadHandler: (readyToUnload: () => void) => boolean;
   public static changeSettingsHandler: () => void;
-  public static onStartConversationHandler: (sunEntityId: string, conversationId: string) => void;
-  public static onCloseConversationHandler: (sunEntityId: string, conversationId?: string) => void;
+  public static onStartConversationHandler: (sunEntityId: string, conversationId: string, threadId: string) => void;
+  public static onCloseConversationHandler: (sunEntityId: string, conversationId?: string, threadId?: string) => void;
 }

--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -12,15 +12,15 @@ GlobalVars.handlers["changeSettings"] = handleChangeSettings;
 GlobalVars.handlers["startConversation"] = handleStartConversation;
 GlobalVars.handlers["closeConversation"] = handleCloseConversation;
 
-function handleStartConversation(subEntityId: string, conversationId: string): void {
+function handleStartConversation(subEntityId: string, conversationId: string, threadId: string): void {
   if (GlobalVars.onStartConversationHandler) {
-    GlobalVars.onStartConversationHandler(subEntityId, conversationId);
+    GlobalVars.onStartConversationHandler(subEntityId, conversationId, threadId);
   }
 }
 
-function handleCloseConversation(subEntityId: string, conversationId?: string): void {
+function handleCloseConversation(subEntityId: string, conversationId?: string, threadId?: string): void {
   if (GlobalVars.onCloseConversationHandler) {
-    GlobalVars.onCloseConversationHandler(subEntityId, conversationId);
+    GlobalVars.onCloseConversationHandler(subEntityId, conversationId, threadId);
   }
 }
 

--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -12,15 +12,15 @@ GlobalVars.handlers["changeSettings"] = handleChangeSettings;
 GlobalVars.handlers["startConversation"] = handleStartConversation;
 GlobalVars.handlers["closeConversation"] = handleCloseConversation;
 
-function handleStartConversation(subEntityId: string, conversationId: string, threadId: string): void {
+function handleStartConversation(subEntityId: string, conversationId: string, threadId: string, entityId: string): void {
   if (GlobalVars.onStartConversationHandler) {
-    GlobalVars.onStartConversationHandler(subEntityId, conversationId, threadId);
+    GlobalVars.onStartConversationHandler(subEntityId, conversationId, threadId, entityId);
   }
 }
 
-function handleCloseConversation(subEntityId: string, conversationId?: string, threadId?: string): void {
+function handleCloseConversation(subEntityId: string, conversationId?: string, threadId?: string, entityId?: string): void {
   if (GlobalVars.onCloseConversationHandler) {
-    GlobalVars.onCloseConversationHandler(subEntityId, conversationId, threadId);
+    GlobalVars.onCloseConversationHandler(subEntityId, conversationId, threadId, entityId);
   }
 }
 

--- a/src/private/conversations.ts
+++ b/src/private/conversations.ts
@@ -21,7 +21,9 @@ export namespace conversations {
     const messageId = sendMessageRequest(GlobalVars.parentWindow, "conversations.openConversation", [{
       title: openConversationRequest.title,
       subEntityId: openConversationRequest.subEntityId,
-      conversationId: openConversationRequest.conversationId
+      conversationId: openConversationRequest.conversationId,
+      threadId: openConversationRequest.threadId,
+      entityId: openConversationRequest.entityId
     }]);
     GlobalVars.onCloseConversationHandler = openConversationRequest.onCloseConversation;
     GlobalVars.onStartConversationHandler = openConversationRequest.onStartConversation;

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -392,7 +392,7 @@ export interface OpenConversationRequest {
   /**
    * The Id of the tab. This is optional and should be specified whenever a conversation is started in a personal scope
    */
-  entityId?: string;
+  entityId: string;
 
   /**
   * A function that is called once the conversation Id has been created

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -390,7 +390,7 @@ export interface OpenConversationRequest {
   threadId?: string;
 
   /**
-   * The Id of the tab. This is optional and should be specified whenever a conversation is started in a personal scope
+   * The entity Id of the tab
    */
   entityId: string;
 

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -385,6 +385,16 @@ export interface OpenConversationRequest {
   conversationId?: string;
 
   /**
+   * The Id of the channel. This is optional and should be specified whenever a conversation is started or opened in a personal app scope
+   */
+  threadId?: string;
+
+  /**
+   * The Id of the tab. This is optional and should be specified whenever a conversation is started in a personal scope
+   */
+  entityId?: string;
+
+  /**
   * A function that is called once the conversation Id has been created
   */
   onStartConversation?: (subEntityId: string, conversationId: string) => void;

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -1923,7 +1923,8 @@ describe("MicrosoftTeams", () => {
     it("should not allow calls before initialization", () => {
       const conversationRequest: OpenConversationRequest = {
         "subEntityId": "someEntityId",
-        "title": "someTitle"
+        "title": "someTitle",
+        "entityId": "someEntityId"
       };
       expect(() => conversations.openConversation(conversationRequest)).toThrowError(
         "The library has not yet been initialized"
@@ -1935,7 +1936,8 @@ describe("MicrosoftTeams", () => {
 
       const conversationRequest: OpenConversationRequest = {
         "subEntityId": "someEntityId",
-        "title": "someTitle"
+        "title": "someTitle",
+        "entityId": "someEntityId"
       };
       expect(() => conversations.openConversation(conversationRequest)).toThrowError(
         "This call is not allowed in the 'settings' context"
@@ -1946,7 +1948,8 @@ describe("MicrosoftTeams", () => {
       initializeWithContext("content");
       const conversationRequest: OpenConversationRequest = {
         "subEntityId": "someEntityId",
-        "title": "someTitle"
+        "title": "someTitle",
+        "entityId": "someEntityId"
       };
 
       conversations.openConversation(conversationRequest);

--- a/test/MicrosoftTeams.spec.ts
+++ b/test/MicrosoftTeams.spec.ts
@@ -1955,6 +1955,22 @@ describe("MicrosoftTeams", () => {
       expect(openConversationMessage).not.toBeNull();
       expect(openConversationMessage.args).toEqual([conversationRequest]);
     });
+
+    it("should successfully pass conversationRequest in a personal scope", () => {
+      initializeWithContext("content");
+      const conversationRequest: OpenConversationRequest = {
+        "subEntityId": "someEntityId",
+        "title": "someTitle",
+        "threadId": "someThreadId",
+        "entityId": "someEntityId"
+      };
+
+      conversations.openConversation(conversationRequest);
+
+      const openConversationMessage = findMessageByFunc("conversations.openConversation");
+      expect(openConversationMessage).not.toBeNull();
+      expect(openConversationMessage.args).toEqual([conversationRequest]);
+    });
   });
 
   describe("conversations.closeConversation", () => {


### PR DESCRIPTION
Changes to allow the API to be used in the personal app scope:

- The developer can now send in the thread Id and the entity Id while calling openConversation. This is so that in a personal scope we can start / open a conversation for the subentity in a tab in a particular team.

- We will send back the threadId and the entity Id along with the conversation Id and the subentity Id so that the developer can use it when opening the conversation in a personal app scope.