### PR TITLE
Changes to the SDK to make the entity Id optional and make the response send an object instead of individual parameters

### DIFF
--- a/src/internal/globalVars.ts
+++ b/src/internal/globalVars.ts
@@ -1,4 +1,5 @@
 import { MessageRequest } from "./interfaces";
+import { ConversationSubEntityCallback } from "../public/interfaces";
 export class GlobalVars {
   public static initializeCalled = false;
   public static currentWindow: Window | any;
@@ -24,6 +25,6 @@ export class GlobalVars {
   public static backButtonPressHandler: () => boolean;
   public static beforeUnloadHandler: (readyToUnload: () => void) => boolean;
   public static changeSettingsHandler: () => void;
-  public static onStartConversationHandler: (subEntityId: string, conversationId: string, channelId: string, entityId: string) => void;
-  public static onCloseConversationHandler: (subEntityId: string, conversationId?: string, channelId?: string, entityId?: string) => void;
+  public static onStartConversationHandler: (conversationSubEntityCallback: ConversationSubEntityCallback) => void;
+  public static onCloseConversationHandler: (conversationSubEntityCallback: ConversationSubEntityCallback) => void;
 }

--- a/src/internal/globalVars.ts
+++ b/src/internal/globalVars.ts
@@ -1,5 +1,5 @@
 import { MessageRequest } from "./interfaces";
-import { ConversationSubEntityCallback } from "../public/interfaces";
+import { ConversationSubEntityResponse } from "../public/interfaces";
 export class GlobalVars {
   public static initializeCalled = false;
   public static currentWindow: Window | any;
@@ -25,6 +25,6 @@ export class GlobalVars {
   public static backButtonPressHandler: () => boolean;
   public static beforeUnloadHandler: (readyToUnload: () => void) => boolean;
   public static changeSettingsHandler: () => void;
-  public static onStartConversationHandler: (conversationSubEntityCallback: ConversationSubEntityCallback) => void;
-  public static onCloseConversationHandler: (conversationSubEntityCallback: ConversationSubEntityCallback) => void;
+  public static onStartConversationHandler: (conversationSubEntityResponse: ConversationSubEntityResponse) => void;
+  public static onCloseConversationHandler: (conversationSubEntityResponse: ConversationSubEntityResponse) => void;
 }

--- a/src/internal/globalVars.ts
+++ b/src/internal/globalVars.ts
@@ -1,5 +1,5 @@
 import { MessageRequest } from "./interfaces";
-import { ConversationSubEntityResponse } from "../public/interfaces";
+import { ConversationResponse } from "../public/interfaces";
 export class GlobalVars {
   public static initializeCalled = false;
   public static currentWindow: Window | any;
@@ -25,6 +25,6 @@ export class GlobalVars {
   public static backButtonPressHandler: () => boolean;
   public static beforeUnloadHandler: (readyToUnload: () => void) => boolean;
   public static changeSettingsHandler: () => void;
-  public static onStartConversationHandler: (conversationSubEntityResponse: ConversationSubEntityResponse) => void;
-  public static onCloseConversationHandler: (conversationSubEntityResponse: ConversationSubEntityResponse) => void;
+  public static onStartConversationHandler: (conversationResponse: ConversationResponse) => void;
+  public static onCloseConversationHandler: (conversationResponse: ConversationResponse) => void;
 }

--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -14,13 +14,23 @@ GlobalVars.handlers["closeConversation"] = handleCloseConversation;
 
 function handleStartConversation(subEntityId: string, conversationId: string, channelId: string, entityId: string): void {
   if (GlobalVars.onStartConversationHandler) {
-    GlobalVars.onStartConversationHandler(subEntityId, conversationId, channelId, entityId);
+    GlobalVars.onStartConversationHandler({
+      subEntityId: subEntityId,
+      conversationId: conversationId,
+      channelId: channelId,
+      entityId: entityId
+    });
   }
 }
 
 function handleCloseConversation(subEntityId: string, conversationId?: string, channelId?: string, entityId?: string): void {
   if (GlobalVars.onCloseConversationHandler) {
-    GlobalVars.onCloseConversationHandler(subEntityId, conversationId, channelId, entityId);
+    GlobalVars.onCloseConversationHandler({
+      subEntityId: subEntityId,
+      conversationId: conversationId,
+      channelId: channelId,
+      entityId: entityId
+    });
   }
 }
 

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -397,10 +397,38 @@ export interface OpenConversationRequest {
   /**
   * A function that is called once the conversation Id has been created
   */
-  onStartConversation?: (subEntityId: string, conversationId: string) => void;
+  onStartConversation?: (conversationSubEntityCallback: ConversationSubEntityCallback) => void;
 
   /**
   * A function that is called if the pane is closed
   */
-  onCloseConversation?: (subEntityId: string, conversationId?: string) => void;
+  onCloseConversation?: (conversationSubEntityCallback: ConversationSubEntityCallback) => void;
+}
+
+/**
+ * @private
+ * Hide from docs.
+ * ------
+*/
+export interface ConversationSubEntityCallback {
+
+  /**
+  * The Id of the subEntity where the conversation is taking place
+  */
+  subEntityId: string;
+
+  /**
+  * The Id of the conversation. This is optional and should be specified whenever a previous conversation about a specific sub-entity has already been started before
+  */
+  conversationId?: string;
+
+  /**
+   * The Id of the channel. This is optional and should be specified whenever a conversation is started or opened in a personal app scope
+   */
+  channelId?: string;
+
+  /**
+   * The entity Id of the tab
+   */
+  entityId?: string;
 }

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -397,12 +397,12 @@ export interface OpenConversationRequest {
   /**
   * A function that is called once the conversation Id has been created
   */
-  onStartConversation?: (conversationSubEntityCallback: ConversationSubEntityCallback) => void;
+  onStartConversation?: (conversationSubEntityResponse: ConversationSubEntityResponse) => void;
 
   /**
   * A function that is called if the pane is closed
   */
-  onCloseConversation?: (conversationSubEntityCallback: ConversationSubEntityCallback) => void;
+  onCloseConversation?: (conversationSubEntityResponse: ConversationSubEntityResponse) => void;
 }
 
 /**
@@ -410,7 +410,7 @@ export interface OpenConversationRequest {
  * Hide from docs.
  * ------
 */
-export interface ConversationSubEntityCallback {
+export interface ConversationSubEntityResponse {
 
   /**
   * The Id of the subEntity where the conversation is taking place

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -397,12 +397,12 @@ export interface OpenConversationRequest {
   /**
   * A function that is called once the conversation Id has been created
   */
-  onStartConversation?: (conversationSubEntityResponse: ConversationSubEntityResponse) => void;
+  onStartConversation?: (conversationResponse: ConversationResponse) => void;
 
   /**
   * A function that is called if the pane is closed
   */
-  onCloseConversation?: (conversationSubEntityResponse: ConversationSubEntityResponse) => void;
+  onCloseConversation?: (conversationResponse: ConversationResponse) => void;
 }
 
 /**
@@ -410,7 +410,7 @@ export interface OpenConversationRequest {
  * Hide from docs.
  * ------
 */
-export interface ConversationSubEntityResponse {
+export interface ConversationResponse {
 
   /**
   * The Id of the subEntity where the conversation is taking place


### PR DESCRIPTION
Made the entity Id in the open conversation response as optional.
Also now sending back a ConversationRequest object instead of individual parameters. 

This will be a breaking change but we should be good since the conversational subentity APIs are still in beta and is not being currently used by a lot of devs.