### PR TITLE
Bundle all .dts file into one to provide better typing support

### DIFF
--- a/generate-dts.js
+++ b/generate-dts.js
@@ -2,7 +2,7 @@ const libraryName = 'microsoftTeams';
 const path = require('path');
 const fs = require('fs');
 const rimraf = require('rimraf');
-const timeout = 2000;
+const timeout = 20000;
 
 function DtsBundlePlugin() { }
 DtsBundlePlugin.prototype.apply = function (compiler) {
@@ -12,7 +12,7 @@ DtsBundlePlugin.prototype.apply = function (compiler) {
     const dtsBuilder = require('dts-builder');
 
     dtsBuilder.generateBundles([{
-      name: 'teams-js',
+      name: 'microsoftTeams',
       alias: 'microsoftTeams',
       sourceDir: './dts',
       destDir: './dist'
@@ -25,14 +25,13 @@ DtsBundlePlugin.prototype.apply = function (compiler) {
 
 function patchDTS(callback) {
   const self = this;
-  console.log('Replacing the references to officeJsHelpers and regularizing it.');
-  fs.readFile('./dist/teams-js.d.ts', 'utf8', (err, data) => {
+  console.log('Replacing the references to teamsJs and regularizing it.');
+  fs.readFile('./dist/microsoftTeams.d.ts', 'utf8', (err, data) => {
     if (err) {
       return console.log(err);
     }
 
     const result = replace(data)
-      (/teamsJs/gm, 'microsoftTeams')
       (/declare module 'microsoftTeams'/gm, 'declare module \'@microsoft/teams-js\'')
       (/^import microsoftTeams.*/g, '')
       (/^var _default: void;/, '')
@@ -40,16 +39,22 @@ function patchDTS(callback) {
       (/^\s*[\r\n]/gm, '')
       ();
 
-    fs.writeFile('./dist/teams-js.d.ts', result, 'utf8', (err) => {
+    fs.writeFile('./dist/microsoftTeams.d.ts', result, 'utf8', (err) => {
       if (err) {
         return console.log(err);
       }
 
-      fs.rename('./dist/teams-js.d.ts', './/dist/MicrosoftTeams.d.ts', (err) => {
+      fs.rename('./dist/microsoftTeams.d.ts', './/dist/MicrosoftTeams.d.ts', (err) => {
         if (err) {
           console.log('ERROR: ' + err);
           throw err;
         }
+
+        rimraf('./dts', () => {
+          if (callback) {
+            callback();
+          }
+        });
       });
     });
   });

--- a/generate-dts.js
+++ b/generate-dts.js
@@ -1,8 +1,7 @@
 const libraryName = 'microsoftTeams';
-const path = require('path');
 const fs = require('fs');
 const rimraf = require('rimraf');
-const timeout = 20000;
+const timeout = 2000;
 
 function DtsBundlePlugin() { }
 DtsBundlePlugin.prototype.apply = function (compiler) {
@@ -12,8 +11,8 @@ DtsBundlePlugin.prototype.apply = function (compiler) {
     const dtsBuilder = require('dts-builder');
 
     dtsBuilder.generateBundles([{
-      name: 'microsoftTeams',
-      alias: 'microsoftTeams',
+      name: libraryName,
+      alias: libraryName,
       sourceDir: './dts',
       destDir: './dist'
     }]);

--- a/generate-dts.js
+++ b/generate-dts.js
@@ -8,7 +8,7 @@ function DtsBundlePlugin() { }
 DtsBundlePlugin.prototype.apply = function (compiler) {
   const self = this;
 
-  compiler.plugin('emit', (_compilation, callback) => {
+  compiler.plugin('done', (_compilation, callback) => {
     const dtsBuilder = require('dts-builder');
 
     dtsBuilder.generateBundles([{

--- a/generate-dts.js
+++ b/generate-dts.js
@@ -1,0 +1,73 @@
+const libraryName = 'microsoftTeams';
+const path = require('path');
+const fs = require('fs');
+const rimraf = require('rimraf');
+const timeout = 2000;
+
+function DtsBundlePlugin() { }
+DtsBundlePlugin.prototype.apply = function (compiler) {
+  const self = this;
+
+  compiler.plugin('emit', (_compilation, callback) => {
+    const dtsBuilder = require('dts-builder');
+
+    dtsBuilder.generateBundles([{
+      name: 'teams-js',
+      alias: 'microsoftTeams',
+      sourceDir: './dts',
+      destDir: './dist'
+    }]);
+
+    console.log('Waiting for 2 seconds so that the dts can be merged before proceeding. If this fails the either increase the wait time or just re-run the task.');
+    setTimeout(() => patchDTS(callback), timeout);
+  });
+}
+
+function patchDTS(callback) {
+  const self = this;
+  console.log('Replacing the references to officeJsHelpers and regularizing it.');
+  fs.readFile('./dist/teams-js.d.ts', 'utf8', (err, data) => {
+    if (err) {
+      return console.log(err);
+    }
+
+    const result = replace(data)
+      (/teamsJs/gm, 'microsoftTeams')
+      (/declare module 'microsoftTeams'/gm, 'declare module \'@microsoft/teams-js\'')
+      (/^import microsoftTeams.*/g, '')
+      (/^var _default: void;/, '')
+      (/export default _default;/, '')
+      (/^\s*[\r\n]/gm, '')
+      ();
+
+    fs.writeFile('./dist/teams-js.d.ts', result, 'utf8', (err) => {
+      if (err) {
+        return console.log(err);
+      }
+
+      fs.rename('./dist/teams-js.d.ts', './/dist/MicrosoftTeams.d.ts', (err) => {
+        if (err) {
+          console.log('ERROR: ' + err);
+          throw err;
+        }
+      });
+    });
+  });
+}
+
+function replace(source) {
+  let current = source;
+
+  // tslint:disable-next-line:only-arrow-functions
+  return function stage(regex, value) {
+    if (arguments.length === 0) {
+      return current;
+    }
+    else {
+      current = current.replace(regex, value);
+      return stage;
+    }
+  };
+}
+
+module.exports = DtsBundlePlugin;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@types/jest": "^23.3.5",
     "del": "2.2.2",
+    "dts-bundle": "^0.7.3",
     "jest": "^23.6.0",
     "merge2": "1.0.2",
     "prettier": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@types/jest": "^23.3.5",
     "del": "2.2.2",
+    "dts-builder": "^1.1.6",
     "dts-bundle": "^0.7.3",
     "jest": "^23.6.0",
     "merge2": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.4.1",
   "description": "Microsoft Client SDK for building app for Microsoft teams",
   "main": "./dist/MicrosoftTeams.min.js",
-  "typings": "./dts/index.d.ts",
+  "typings": "./dist/MicrosoftTeams.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/OfficeDev/microsoft-teams-library-js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "declarationDir": "./dts",
+    "declarationDir": "./dtsTemp",
     "target": "es5",
     "module": "commonjs",
     "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "declarationDir": "./dtsTemp",
+    "declarationDir": "./dts",
     "target": "es5",
     "module": "commonjs",
     "moduleResolution": "node",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const libraryName = 'microsoftTeams';
 var plugins = [];
+const DtsBundlePlugin = require('./generate-dts');
 plugins.push(new DtsBundlePlugin());
 
 module.exports = {
@@ -40,19 +41,4 @@ module.exports = {
     })]
   },
   plugins: plugins
-};
-
-function DtsBundlePlugin() { }
-DtsBundlePlugin.prototype.apply = function (compiler) {
-  compiler.plugin('done', function () {
-    var dts = require('dts-bundle');
-
-    dts.bundle({
-      name: libraryName,
-      main: 'dts/index.d.ts',
-      out: '../dist/MicrosoftTeams.d.ts',
-      removeSource: false,
-      outputAsModuleFolder: false // to use npm in-package typings
-    });
-  });
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = {
     }]
   },
   optimization: {
-    minimize: false,
+    minimize: true,
     minimizer: [new UglifyJsPlugin({
       uglifyOptions: {
         compress: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,10 +49,10 @@ DtsBundlePlugin.prototype.apply = function (compiler) {
 
     dts.bundle({
       name: libraryName,
-      main: 'dtsTemp/index.d.ts',
-      out: '../dts/index.d.ts',
-      removeSource: true,
-      outputAsModuleFolder: true // to use npm in-package typings
+      main: 'dts/index.d.ts',
+      out: '../dist/MicrosoftTeams.d.ts',
+      removeSource: false,
+      outputAsModuleFolder: false // to use npm in-package typings
     });
   });
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const libraryName = 'microsoftTeams';
+var plugins = [];
+plugins.push(new DtsBundlePlugin());
 
 module.exports = {
   entry: {
@@ -26,7 +28,7 @@ module.exports = {
     }]
   },
   optimization: {
-    minimize: true,
+    minimize: false,
     minimizer: [new UglifyJsPlugin({
       uglifyOptions: {
         compress: {
@@ -36,5 +38,21 @@ module.exports = {
       },
       include: /\.min\.js$/
     })]
-  }
+  },
+  plugins: plugins
+};
+
+function DtsBundlePlugin() { }
+DtsBundlePlugin.prototype.apply = function (compiler) {
+  compiler.plugin('done', function () {
+    var dts = require('dts-bundle');
+
+    dts.bundle({
+      name: libraryName,
+      main: 'dtsTemp/index.d.ts',
+      out: '../dts/index.d.ts',
+      removeSource: true,
+      outputAsModuleFolder: true // to use npm in-package typings
+    });
+  });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,36 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@types/detect-indent@0.1.30":
+  version "0.1.30"
+  resolved "https://registry.yarnpkg.com/@types/detect-indent/-/detect-indent-0.1.30.tgz#dc682bb412b4e65ba098e70edad73b4833fb910d"
+
+"@types/glob@5.0.30":
+  version "5.0.30"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.30.tgz#1026409c5625a8689074602808d082b2867b8a51"
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/jest@^23.3.5":
   version "23.3.7"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.7.tgz#77f9a4332ccf8db680a31818ade3ee454c831a79"
+
+"@types/minimatch@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+
+"@types/mkdirp@0.3.29":
+  version "0.3.29"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
+
+"@types/node@*":
+  version "11.11.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.3.tgz#7c6b0f8eaf16ae530795de2ad1b85d34bf2f5c58"
+
+"@types/node@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.0.tgz#acaa89247afddc7967e9902fd11761dadea1a555"
 
 "@webassemblyjs/ast@1.7.10":
   version "1.7.10"
@@ -850,7 +877,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.1:
+commander@^2.12.1, commander@^2.9.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
 
@@ -1112,6 +1139,13 @@ des.js@^1.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
+detect-indent@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-0.2.0.tgz#042914498979ac2d9f3c73e4ff3e6877d3bc92b6"
+  dependencies:
+    get-stdin "^0.1.0"
+    minimist "^0.1.0"
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -1154,6 +1188,19 @@ domexception@^1.0.1:
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
   dependencies:
     webidl-conversions "^4.0.2"
+
+dts-bundle@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/dts-bundle/-/dts-bundle-0.7.3.tgz#372b7bb69c820782e6382f400739a69dced3d59a"
+  dependencies:
+    "@types/detect-indent" "0.1.30"
+    "@types/glob" "5.0.30"
+    "@types/mkdirp" "0.3.29"
+    "@types/node" "8.0.0"
+    commander "^2.9.0"
+    detect-indent "^0.2.0"
+    glob "^6.0.4"
+    mkdirp "^0.5.0"
 
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.6.1"
@@ -1571,6 +1618,10 @@ get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
 
+get-stdin@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-0.1.0.tgz#5998af24aafc802d15c82c685657eeb8b10d4a91"
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -1604,6 +1655,16 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
+
+glob@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.3"
@@ -2800,7 +2861,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@^3.0.3, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -2809,6 +2870,10 @@ minimatch@^3.0.3, minimatch@^3.0.4:
 minimist@0.0.8:
   version "0.0.8"
   resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+minimist@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
 
 minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1189,6 +1189,13 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
+dts-builder@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/dts-builder/-/dts-builder-1.1.6.tgz#eeaa3a07ee1cfbc3c64ec70e4f126cb467437918"
+  integrity sha512-HS5ZvUuGBpBkwTRNGZNQdcWbOvO0QOnFLYzO2GnhFuDbzMAan9onUpQmnk60v7Q0Uj575VrBxAnEGz4lahGO+Q==
+  dependencies:
+    mkdirp "^0.5.1"
+
 dts-bundle@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/dts-bundle/-/dts-bundle-0.7.3.tgz#372b7bb69c820782e6382f400739a69dced3d59a"


### PR DESCRIPTION
This will bundle all individual definition files into one that can be use to provide typing support whne library is not use as import module 
 - as triple slash reference (for example in Teams web Client code)

Note: Use same custom logic that is used by office js helpers project