### PR TITLE
Added the tab session Id in the sdk Context interface

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -309,9 +309,9 @@ export interface Context {
   ringId?: string;
 
   /**
-   * Unique ID for the current Tab session for use in correlating telemetry data.
+   * Unique ID for the current session for use in correlating telemetry data.
    */
-  tabSessionId?: string;
+  appSessionId?: string;
 }
 
 export interface DeepLinkParameters {

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -307,6 +307,11 @@ export interface Context {
    * Current ring ID
    */
   ringId?: string;
+
+  /**
+   * Unique ID for the current Tab session for use in correlating telemetry data.
+   */
+  tabSessionId?: string;
 }
 
 export interface DeepLinkParameters {

--- a/test/private/privateAPIs.spec.ts
+++ b/test/private/privateAPIs.spec.ts
@@ -267,7 +267,8 @@ describe("MicrosoftTeams-privateAPIs", () => {
       entityId: "someEntityId",
       teamType: TeamType.Edu,
       teamSiteUrl: "someSiteUrl",
-      sessionId: "someSessionId"
+      sessionId: "someSessionId",
+      tabSessionId: "tabSessionId"
     };
 
     // Get many responses to the same message

--- a/test/private/privateAPIs.spec.ts
+++ b/test/private/privateAPIs.spec.ts
@@ -268,7 +268,7 @@ describe("MicrosoftTeams-privateAPIs", () => {
       teamType: TeamType.Edu,
       teamSiteUrl: "someSiteUrl",
       sessionId: "someSessionId",
-      tabSessionId: "tabSessionId"
+      appSessionId: "appSessionId"
     };
 
     // Get many responses to the same message

--- a/test/public/publicAPIs.spec.ts
+++ b/test/public/publicAPIs.spec.ts
@@ -124,7 +124,8 @@ describe("MicrosoftTeams-publicAPIs", () => {
       tenantSKU: "someTenantSKU",
       userLicenseType: "someUserLicenseType",
       parentMessageId: "someParentMessageId",
-      ringId: "someRingId"
+      ringId: "someRingId",
+      tabSessionId: "tabSessionId"
     };
 
     utils.respondToMessage(getContextMessage, expectedContext);

--- a/test/public/publicAPIs.spec.ts
+++ b/test/public/publicAPIs.spec.ts
@@ -125,7 +125,7 @@ describe("MicrosoftTeams-publicAPIs", () => {
       userLicenseType: "someUserLicenseType",
       parentMessageId: "someParentMessageId",
       ringId: "someRingId",
-      tabSessionId: "tabSessionId"
+      appSessionId: "appSessionId"
     };
 
     utils.respondToMessage(getContextMessage, expectedContext);


### PR DESCRIPTION
We will stop using the app session Id for telemetry purpose. We will generate a new session Id everytime a tab is created. This will be used for telemetry investigation