### PR TITLE
#172 - Add callback to initialize

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,10 +11,12 @@ module.exports =  {
   },
   rules:  {
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
-    // e.g. "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/no-namespace": "warn",
+    "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/explicit-member-accessibility": "warn",
-    "@typescript-eslint/interface-name-prefix": "off"
+    "@typescript-eslint/interface-name-prefix": "off",
+    "@typescript-eslint/explicit-function-return-type": ["error", {
+      "allowExpressions": true
+    }],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,22 +1,25 @@
-module.exports =  {
-  parser:  '@typescript-eslint/parser',  // Specifies the ESLint parser
-  extends:  [
-    'plugin:@typescript-eslint/recommended',  // Uses the recommended rules from the @typescript-eslint/eslint-plugin
-    'prettier/@typescript-eslint',  // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
-    'plugin:prettier/recommended',  // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+module.exports = {
+  parser: '@typescript-eslint/parser', // Specifies the ESLint parser
+  extends: [
+    'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+    'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+    'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
-  parserOptions:  {
-    ecmaVersion:  2018,  // Allows for the parsing of modern ECMAScript features
-    sourceType:  'module',  // Allows for the use of imports
+  parserOptions: {
+    ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
+    sourceType: 'module', // Allows for the use of imports
   },
-  rules:  {
+  rules: {
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
-    "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/no-namespace": "off",
-    "@typescript-eslint/explicit-member-accessibility": "warn",
-    "@typescript-eslint/interface-name-prefix": "off",
-    "@typescript-eslint/explicit-function-return-type": ["error", {
-      "allowExpressions": true
-    }],
+    '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/no-namespace': 'off',
+    '@typescript-eslint/explicit-member-accessibility': 'warn',
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/explicit-function-return-type': [
+      'error',
+      {
+        allowExpressions: true,
+      },
+    ],
   },
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,8 +1,8 @@
-module.exports =  {
-  semi:  true,
-  trailingComma:  'all',
-  singleQuote:  true,
-  printWidth:  120,
-  tabWidth:  2,
+module.exports = {
+  semi: true,
+  trailingComma: 'all',
+  singleQuote: true,
+  printWidth: 120,
+  tabWidth: 2,
   useTabs: false,
 };

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,8 @@
   "search.exclude": {
     "**/dist": true
   },
-  "typescript.tsdk": "./node_modules/typescript/lib"
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "javascript.preferences.quoteStyle": "single",
+  "typescript.preferences.quoteStyle": "single",
+  "prettier.singleQuote": true
 }

--- a/generate-dts.js
+++ b/generate-dts.js
@@ -3,24 +3,28 @@ const fs = require('fs');
 const rimraf = require('rimraf');
 const timeout = 2000;
 
-function DtsBundlePlugin() { }
-DtsBundlePlugin.prototype.apply = function (compiler) {
+function DtsBundlePlugin() {}
+DtsBundlePlugin.prototype.apply = function(compiler) {
   const self = this;
 
   compiler.plugin('done', (_compilation, callback) => {
     const dtsBuilder = require('dts-builder');
 
-    dtsBuilder.generateBundles([{
-      name: libraryName,
-      alias: libraryName,
-      sourceDir: './dts',
-      destDir: './dist'
-    }]);
+    dtsBuilder.generateBundles([
+      {
+        name: libraryName,
+        alias: libraryName,
+        sourceDir: './dts',
+        destDir: './dist',
+      },
+    ]);
 
-    console.log('Waiting for 2 seconds so that the dts can be merged before proceeding. If this fails the either increase the wait time or just re-run the task.');
+    console.log(
+      'Waiting for 2 seconds so that the dts can be merged before proceeding. If this fails the either increase the wait time or just re-run the task.',
+    );
     setTimeout(() => patchDTS(callback), timeout);
   });
-}
+};
 
 function patchDTS(callback) {
   const self = this;
@@ -30,20 +34,17 @@ function patchDTS(callback) {
       return console.log(err);
     }
 
-    const result = replace(data)
-      (/declare module 'microsoftTeams'/gm, 'declare module \'@microsoft/teams-js\'')
-      (/^import microsoftTeams.*/g, '')
-      (/^var _default: void;/, '')
-      (/export default _default;/, '')
-      (/^\s*[\r\n]/gm, '')
-      ();
+    const result = replace(data)(/declare module 'microsoftTeams'/gm, "declare module '@microsoft/teams-js'")(
+      /^import microsoftTeams.*/g,
+      '',
+    )(/^var _default: void;/, '')(/export default _default;/, '')(/^\s*[\r\n]/gm, '')();
 
-    fs.writeFile('./dist/microsoftTeams.d.ts', result, 'utf8', (err) => {
+    fs.writeFile('./dist/microsoftTeams.d.ts', result, 'utf8', err => {
       if (err) {
         return console.log(err);
       }
 
-      fs.rename('./dist/microsoftTeams.d.ts', './/dist/MicrosoftTeams.d.ts', (err) => {
+      fs.rename('./dist/microsoftTeams.d.ts', './/dist/MicrosoftTeams.d.ts', err => {
         if (err) {
           console.log('ERROR: ' + err);
           throw err;
@@ -66,8 +67,7 @@ function replace(source) {
   return function stage(regex, value) {
     if (arguments.length === 0) {
       return current;
-    }
-    else {
+    } else {
       current = current.replace(regex, value);
       return stage;
     }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "yarn lint && webpack",
     "lint": "eslint ./src/**/*.ts",
     "doctor": "yarn lint --fix",
+    "prettier": "prettier --write '**/*.{ts,js,css,html}'",
     "test": "jest"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "yarn lint && webpack",
-    "lint": "eslint ./src/**/*.{js,ts}",
+    "lint": "eslint ./src/**/*.ts",
     "doctor": "yarn lint --fix",
     "test": "jest"
   },

--- a/src/internal/globalVars.ts
+++ b/src/internal/globalVars.ts
@@ -1,17 +1,19 @@
 import { MessageRequest } from './interfaces';
 import { ConversationResponse } from '../public/interfaces';
 export class GlobalVars {
-  public static initializeCalled = false;
+  public static initializeCalled: boolean = false;
+  public static initializeCompleted: boolean = false;
+  public static initializeCallbacks: { (): void }[] = [];
   public static currentWindow: Window | any;
   public static parentWindow: Window | any;
-  public static isFramelessWindow = false;
+  public static isFramelessWindow: boolean = false;
   public static parentOrigin: string;
   public static frameContext: string;
   public static childWindow: Window;
   public static childOrigin: string;
   public static parentMessageQueue: MessageRequest[] = [];
   public static childMessageQueue: MessageRequest[] = [];
-  public static nextMessageId = 0;
+  public static nextMessageId: number = 0;
   public static handlers: {
     [func: string]: Function;
   } = {};

--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -67,7 +67,7 @@ function handleBackButtonPress(): void {
 }
 
 function handleBeforeUnload(): void {
-  const readyToUnload = () => {
+  const readyToUnload = (): void => {
     sendMessageRequest(GlobalVars.parentWindow, 'readyToUnload', []);
   };
 
@@ -192,7 +192,7 @@ function handleChildMessage(evt: MessageEvent): void {
       const messageId = sendMessageRequest(GlobalVars.parentWindow, message.func, message.args);
 
       // tslint:disable-next-line:no-any
-      GlobalVars.callbacks[messageId] = (...args: any[]) => {
+      GlobalVars.callbacks[messageId] = (...args: any[]): void => {
         if (GlobalVars.childWindow) {
           sendMessageResponse(GlobalVars.childWindow, message.id, args);
         }

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -1,5 +1,3 @@
-import { GlobalVars } from './globalVars';
-
 // This will return a reg expression a given url
 function generateRegExpFromUrl(url: string): string {
   let urlRegExpPart = '^';
@@ -21,7 +19,7 @@ export function generateRegExpFromUrls(urls: string[]): RegExp {
 }
 
 export function getGenericOnCompleteHandler(errorMessage?: string): (success: boolean, reason?: string) => void {
-  return (success: boolean, reason: string) => {
+  return (success: boolean, reason: string): void => {
     if (!success) {
       throw new Error(errorMessage ? errorMessage : reason);
     }

--- a/src/private/privateAPIs.ts
+++ b/src/private/privateAPIs.ts
@@ -34,7 +34,7 @@ export function getUserJoinedTeams(
  * ------
  * Place the tab into full-screen mode.
  */
-export function enterFullscreen() {
+export function enterFullscreen(): void {
   ensureInitialized(frameContexts.content);
   sendMessageRequest(GlobalVars.parentWindow, 'enterFullscreen', []);
 }
@@ -45,7 +45,7 @@ export function enterFullscreen() {
  * ------
  * Reverts the tab into normal-screen mode.
  */
-export function exitFullscreen() {
+export function exitFullscreen(): void {
   ensureInitialized(frameContexts.content);
   sendMessageRequest(GlobalVars.parentWindow, 'exitFullscreen', []);
 }

--- a/src/public/authentication.ts
+++ b/src/public/authentication.ts
@@ -193,7 +193,7 @@ export namespace authentication {
     // in the authentication window. We could at some point choose to implement this method via a call to
     // authenticationWindow.location.href = url; however, we would first need to figure out how to
     // validate the URL against the tab's list of valid domains.
-    GlobalVars.handlers['navigateCrossDomain'] = (url: string) => {
+    GlobalVars.handlers['navigateCrossDomain'] = () => {
       return false;
     };
   }

--- a/src/public/settings.ts
+++ b/src/public/settings.ts
@@ -149,7 +149,7 @@ export namespace settings {
   class SaveEventImpl implements SaveEvent {
     public notified: boolean = false;
     public result: SaveParameters;
-    constructor(result?: SaveParameters) {
+    public constructor(result?: SaveParameters) {
       this.result = result ? result : {};
     }
     public notifySuccess(): void {

--- a/test/private/bot.spec.ts
+++ b/test/private/bot.spec.ts
@@ -1,8 +1,8 @@
-import { bot } from "../../src/private/bot";
+import { bot } from '../../src/private/bot';
 import { Utils } from '../utils';
-import { _uninitialize } from "../../src/public/publicAPIs";
+import { _uninitialize } from '../../src/public/publicAPIs';
 
-describe("bot", () => {
+describe('bot', () => {
   // Use to send a mock message from the app.
 
   const utils = new Utils();
@@ -21,18 +21,18 @@ describe("bot", () => {
     }
   });
 
-  describe("sendBotRequest", () => {
-    it("should not allow calls before initialization", () => {
+  describe('sendBotRequest', () => {
+    it('should not allow calls before initialization', () => {
       expect(() =>
-        bot.sendQuery({ query: "" }, () => {
+        bot.sendQuery({ query: '' }, () => {
           return;
-        })
-      ).toThrowError("The library has not yet been initialized");
+        }),
+      ).toThrowError('The library has not yet been initialized');
     });
-    it("should successfully send a request", () => {
-      utils.initializeWithContext("content");
+    it('should successfully send a request', () => {
+      utils.initializeWithContext('content');
       const request = {
-        query: "some query"
+        query: 'some query',
       };
 
       let botResponse: bot.QueryResponse;
@@ -45,7 +45,7 @@ describe("bot", () => {
       bot.sendQuery(request, handleBotResponse, handleError);
 
       // find message request in jest
-      const message = utils.findMessageByFunc("bot.executeQuery");
+      const message = utils.findMessageByFunc('bot.executeQuery');
 
       // check message is sending correct data
       expect(message).not.toBeUndefined();
@@ -54,19 +54,19 @@ describe("bot", () => {
       // simulate response
       const data = {
         success: true,
-        response: { data: ["some", "queried", "items"] }
+        response: { data: ['some', 'queried', 'items'] },
       };
 
       utils.respondToMessage(message, data.success, data.response);
 
       // check data is returned properly
-      expect(botResponse).toEqual({ data: ["some", "queried", "items"] });
+      expect(botResponse).toEqual({ data: ['some', 'queried', 'items'] });
       expect(error).toBeUndefined();
     });
-    it("should invoke error callback", () => {
-      utils.initializeWithContext("content");
+    it('should invoke error callback', () => {
+      utils.initializeWithContext('content');
       const request = {
-        query: "some broken query"
+        query: 'some broken query',
       };
 
       let botResponse: bot.QueryResponse;
@@ -76,52 +76,56 @@ describe("bot", () => {
       const handleError = (_error: string): any => (error = _error);
 
       bot.sendQuery(request, handleBotResponse, handleError);
-      const message = utils.findMessageByFunc("bot.executeQuery");
+      const message = utils.findMessageByFunc('bot.executeQuery');
       expect(message).not.toBeUndefined();
       expect(message.args).toContain(request);
 
       // simulate response
       const data = {
         success: false,
-        response: "Something went wrong..."
+        response: 'Something went wrong...',
       };
 
       utils.respondToMessage(message, data.success, data.response);
 
       // check data is returned properly
-      expect(error).toBe("Something went wrong...");
+      expect(error).toBe('Something went wrong...');
       expect(botResponse).toBeUndefined();
     });
   });
 
-  describe("getSupportedCommands", () => {
-    it("should not allow calls before initialization", () => {
+  describe('getSupportedCommands', () => {
+    it('should not allow calls before initialization', () => {
       expect(() =>
         bot.getSupportedCommands(() => {
           return;
-        })
-      ).toThrowError("The library has not yet been initialized");
+        }),
+      ).toThrowError('The library has not yet been initialized');
     });
 
-    it("should successfully send a request", () => {
-      utils.initializeWithContext("content");
+    it('should successfully send a request', () => {
+      utils.initializeWithContext('content');
 
       let botResponse: bot.Command[];
       let error: string;
 
-      const handleBotResponse = (response: bot.Command[]) => { botResponse = response };
-      const handleError = (_error: string) => { error = _error };
+      const handleBotResponse = (response: bot.Command[]) => {
+        botResponse = response;
+      };
+      const handleError = (_error: string) => {
+        error = _error;
+      };
 
       bot.getSupportedCommands(handleBotResponse, handleError);
 
-      const message = utils.findMessageByFunc("bot.getSupportedCommands");
+      const message = utils.findMessageByFunc('bot.getSupportedCommands');
       expect(message).not.toBeUndefined();
 
-      // Simulate response 
+      // Simulate response
       const data = {
         sucess: true,
-        response: [{ title: 'CMD1', id: 'CMD1' }]
-      }
+        response: [{ title: 'CMD1', id: 'CMD1' }],
+      };
 
       utils.respondToMessage(message, data.sucess, data.response);
 
@@ -130,54 +134,58 @@ describe("bot", () => {
       expect(error).toBeUndefined();
     });
 
-    it("should invoke error callback", () => {
-      utils.initializeWithContext("content");
+    it('should invoke error callback', () => {
+      utils.initializeWithContext('content');
 
       let botResponse: bot.Command[];
       let error: string;
 
-      const handleBotResponse = (response: bot.Command[]) => { botResponse = response };
-      const handleError = (_error: string) => { error = _error };
+      const handleBotResponse = (response: bot.Command[]) => {
+        botResponse = response;
+      };
+      const handleError = (_error: string) => {
+        error = _error;
+      };
 
       bot.getSupportedCommands(handleBotResponse, handleError);
 
-      const message = utils.findMessageByFunc("bot.getSupportedCommands");
+      const message = utils.findMessageByFunc('bot.getSupportedCommands');
       expect(message).not.toBeUndefined();
 
       // Simulate response
       const data = {
         success: false,
-        response: "Something went wrong..."
+        response: 'Something went wrong...',
       };
 
       utils.respondToMessage(message, data.success, data.response);
 
       // check data is returned properly
-      expect(error).toBe("Something went wrong...");
+      expect(error).toBe('Something went wrong...');
       expect(botResponse).toBeUndefined();
     });
   });
-  describe("authenticate", () => {
-    it("should not allow calls before initialization", () => {
+  describe('authenticate', () => {
+    it('should not allow calls before initialization', () => {
       const request = {
-        query: "",
-        commandId: "someCOmmand",
-        url: "someUrl"
+        query: '',
+        commandId: 'someCOmmand',
+        url: 'someUrl',
       };
       expect(() =>
         bot.authenticate(request, () => {
           return;
-        })
-      ).toThrowError("The library has not yet been initialized");
+        }),
+      ).toThrowError('The library has not yet been initialized');
     });
   });
 
-  it("should successfully send a request", () => {
-    utils.initializeWithContext("content");
+  it('should successfully send a request', () => {
+    utils.initializeWithContext('content');
     const request = {
-      query: "",
-      commandId: "someCommand",
-      url: "someUrl"
+      query: '',
+      commandId: 'someCommand',
+      url: 'someUrl',
     };
 
     let botResponse: bot.Results;
@@ -190,7 +198,7 @@ describe("bot", () => {
     bot.authenticate(request, handleAuth, handleError);
 
     // find message request in jest
-    const message = utils.findMessageByFunc("bot.authenticate");
+    const message = utils.findMessageByFunc('bot.authenticate');
 
     // check message is sending correct data
     expect(message).not.toBeUndefined();
@@ -199,22 +207,22 @@ describe("bot", () => {
     // simulate response
     const data = {
       success: true,
-      response: { data: ["some", "queried", "items"] }
+      response: { data: ['some', 'queried', 'items'] },
     };
 
     utils.respondToMessage(message, data.success, data.response);
 
     // authenticate should also return data because first query
-    expect(botResponse).toEqual({ data: ["some", "queried", "items"] });
+    expect(botResponse).toEqual({ data: ['some', 'queried', 'items'] });
     expect(error).toBeUndefined();
   });
 
-  it("should invoke error callback on unauthorized", () => {
-    utils.initializeWithContext("content");
+  it('should invoke error callback on unauthorized', () => {
+    utils.initializeWithContext('content');
     const request = {
-      query: "",
-      commandId: "someCommand",
-      url: "someUrl"
+      query: '',
+      commandId: 'someCommand',
+      url: 'someUrl',
     };
 
     let botResponse: bot.Results;
@@ -224,20 +232,20 @@ describe("bot", () => {
     const handleError = (_error: string): any => (error = _error);
 
     bot.authenticate(request, handleBotResponse, handleError);
-    const message = utils.findMessageByFunc("bot.authenticate");
+    const message = utils.findMessageByFunc('bot.authenticate');
     expect(message).not.toBeUndefined();
     expect(message.args).toContain(request);
 
     // simulate response
     const data = {
       success: false,
-      response: "Bot authorization was unsuccessful"
+      response: 'Bot authorization was unsuccessful',
     };
 
     utils.respondToMessage(message, data.success, data.response);
 
     // check data is returned properly
-    expect(error).toBe("Bot authorization was unsuccessful");
+    expect(error).toBe('Bot authorization was unsuccessful');
     expect(botResponse).toBeUndefined();
   });
 });

--- a/test/private/conversations.spec.ts
+++ b/test/private/conversations.spec.ts
@@ -1,9 +1,9 @@
-import { OpenConversationRequest } from "../../src/public/interfaces";
-import { conversations } from "../../src/private/conversations";
+import { OpenConversationRequest } from '../../src/public/interfaces';
+import { conversations } from '../../src/private/conversations';
 import { Utils } from '../utils';
-import { _uninitialize } from "../../src/public/publicAPIs";
+import { _uninitialize } from '../../src/public/publicAPIs';
 
-describe("conversations", () => {
+describe('conversations', () => {
   // Use to send a mock message from the app.
   const utils = new Utils();
 
@@ -21,74 +21,72 @@ describe("conversations", () => {
     }
   });
 
-  describe("openConversation", () => {
-    it("should not allow calls before initialization", () => {
+  describe('openConversation', () => {
+    it('should not allow calls before initialization', () => {
       const conversationRequest: OpenConversationRequest = {
-        "subEntityId": "someEntityId",
-        "title": "someTitle",
-        "entityId": "someEntityId"
+        subEntityId: 'someEntityId',
+        title: 'someTitle',
+        entityId: 'someEntityId',
       };
       expect(() => conversations.openConversation(conversationRequest)).toThrowError(
-        "The library has not yet been initialized"
+        'The library has not yet been initialized',
       );
     });
 
-    it("should not allow calls from settings context", () => {
-      utils.initializeWithContext("settings");
+    it('should not allow calls from settings context', () => {
+      utils.initializeWithContext('settings');
 
       const conversationRequest: OpenConversationRequest = {
-        "subEntityId": "someEntityId",
-        "title": "someTitle",
-        "entityId": "someEntityId"
+        subEntityId: 'someEntityId',
+        title: 'someTitle',
+        entityId: 'someEntityId',
       };
       expect(() => conversations.openConversation(conversationRequest)).toThrowError(
-        "This call is not allowed in the 'settings' context"
+        "This call is not allowed in the 'settings' context",
       );
     });
 
-    it("should successfully pass conversationRequest", () => {
-      utils.initializeWithContext("content");
+    it('should successfully pass conversationRequest', () => {
+      utils.initializeWithContext('content');
       const conversationRequest: OpenConversationRequest = {
-        "subEntityId": "someEntityId",
-        "title": "someTitle",
-        "entityId": "someEntityId"
+        subEntityId: 'someEntityId',
+        title: 'someTitle',
+        entityId: 'someEntityId',
       };
 
       conversations.openConversation(conversationRequest);
 
-      const openConversationMessage = utils.findMessageByFunc("conversations.openConversation");
+      const openConversationMessage = utils.findMessageByFunc('conversations.openConversation');
       expect(openConversationMessage).not.toBeNull();
       expect(openConversationMessage.args).toEqual([conversationRequest]);
     });
 
-    it("should successfully pass conversationRequest in a personal scope", () => {
-      utils.initializeWithContext("content");
+    it('should successfully pass conversationRequest in a personal scope', () => {
+      utils.initializeWithContext('content');
       const conversationRequest: OpenConversationRequest = {
-        "subEntityId": "someEntityId",
-        "title": "someTitle",
-        "channelId": "someChannelId",
-        "entityId": "someEntityId"
+        subEntityId: 'someEntityId',
+        title: 'someTitle',
+        channelId: 'someChannelId',
+        entityId: 'someEntityId',
       };
 
       conversations.openConversation(conversationRequest);
 
-      const openConversationMessage = utils.findMessageByFunc("conversations.openConversation");
+      const openConversationMessage = utils.findMessageByFunc('conversations.openConversation');
       expect(openConversationMessage).not.toBeNull();
       expect(openConversationMessage.args).toEqual([conversationRequest]);
     });
   });
 
-  describe("closeConversation", () => {
-    it("should not allow calls before initialization", () => {
-      expect(() => conversations.closeConversation()).toThrowError(
-        "The library has not yet been initialized"
-      );
+  describe('closeConversation', () => {
+    it('should not allow calls before initialization', () => {
+      expect(() => conversations.closeConversation()).toThrowError('The library has not yet been initialized');
     });
 
-    it("should not allow calls from settings context", () => {
-      utils.initializeWithContext("settings");
+    it('should not allow calls from settings context', () => {
+      utils.initializeWithContext('settings');
       expect(() => conversations.closeConversation()).toThrowError(
-        "This call is not allowed in the 'settings' context"
+        "This call is not allowed in the 'settings' context",
       );
     });
   });

--- a/test/private/conversations.spec.ts
+++ b/test/private/conversations.spec.ts
@@ -5,7 +5,6 @@ import { _uninitialize } from "../../src/public/publicAPIs";
 
 describe("conversations", () => {
   // Use to send a mock message from the app.
-
   const utils = new Utils();
 
   beforeEach(() => {

--- a/test/private/logs.spec.ts
+++ b/test/private/logs.spec.ts
@@ -4,7 +4,6 @@ import { _uninitialize } from "../../src/public/publicAPIs";
 
 describe("logs", () => {
   // Use to send a mock message from the app.
-
   const utils = new Utils();
 
   beforeEach(() => {

--- a/test/private/logs.spec.ts
+++ b/test/private/logs.spec.ts
@@ -1,8 +1,8 @@
-import { logs } from "../../src/private/logs";
-import { Utils } from "../utils";
-import { _uninitialize } from "../../src/public/publicAPIs";
+import { logs } from '../../src/private/logs';
+import { Utils } from '../utils';
+import { _uninitialize } from '../../src/public/publicAPIs';
 
-describe("logs", () => {
+describe('logs', () => {
   // Use to send a mock message from the app.
   const utils = new Utils();
 
@@ -20,53 +20,53 @@ describe("logs", () => {
     }
   });
 
-  describe("registerGetLogHandler", () => {
-    it("should not allow calls before initialization", () => {
+  describe('registerGetLogHandler', () => {
+    it('should not allow calls before initialization', () => {
       expect(() =>
-      logs.registerGetLogHandler(() => {
-          return "";
-        })
-      ).toThrowError("The library has not yet been initialized");
+        logs.registerGetLogHandler(() => {
+          return '';
+        }),
+      ).toThrowError('The library has not yet been initialized');
     });
 
-    it("should successfully register a get log handler", () => {
-      utils.initializeWithContext("content");
+    it('should successfully register a get log handler', () => {
+      utils.initializeWithContext('content');
 
       let handlerInvoked = false;
       logs.registerGetLogHandler(() => {
         handlerInvoked = true;
-        return "";
+        return '';
       });
 
-      utils.sendMessage("log.request");
+      utils.sendMessage('log.request');
 
       expect(handlerInvoked).toBe(true);
     });
 
-    it("getLog should call the get log handler and send the log", () => {
-      utils.initializeWithContext("content");
+    it('getLog should call the get log handler and send the log', () => {
+      utils.initializeWithContext('content');
 
       let handlerInvoked = false;
-      const log: string = "1/1/2019 Info - App initialized";
+      const log: string = '1/1/2019 Info - App initialized';
       logs.registerGetLogHandler(() => {
         handlerInvoked = true;
         return log;
       });
 
-      utils.sendMessage("log.request");
+      utils.sendMessage('log.request');
 
-      const sendLogMessage = utils.findMessageByFunc("log.receive");
+      const sendLogMessage = utils.findMessageByFunc('log.receive');
       expect(sendLogMessage).not.toBeNull();
       expect(sendLogMessage.args).toEqual([log]);
       expect(handlerInvoked).toBe(true);
     });
 
-    it("should not send log when no get log handler is registered", () => {
-      utils.initializeWithContext("content");
+    it('should not send log when no get log handler is registered', () => {
+      utils.initializeWithContext('content');
 
-      utils.sendMessage("log.request");
+      utils.sendMessage('log.request');
 
-      const sendLogMessage = utils.findMessageByFunc("log.receive");
+      const sendLogMessage = utils.findMessageByFunc('log.receive');
       expect(sendLogMessage).toBeNull();
     });
   });

--- a/test/private/privateAPIs.spec.ts
+++ b/test/private/privateAPIs.spec.ts
@@ -1,12 +1,20 @@
-import * as microsoftTeams from "../../src/public/publicAPIs";
-import { Context } from "../../src/public/interfaces";
-import { TeamInstanceParameters } from "../../src/private/interfaces";
-import { TeamType } from "../../src/public/constants";
+import * as microsoftTeams from '../../src/public/publicAPIs';
+import { Context } from '../../src/public/interfaces';
+import { TeamInstanceParameters } from '../../src/private/interfaces';
+import { TeamType } from '../../src/public/constants';
 import { Utils, MessageResponse } from '../utils';
-import { openFilePreview, getUserJoinedTeams, sendCustomMessage, getChatMembers, getConfigSetting, enterFullscreen, exitFullscreen } from "../../src/private/privateAPIs";
-import { initialize, _uninitialize, getContext } from "../../src/public/publicAPIs";
+import {
+  openFilePreview,
+  getUserJoinedTeams,
+  sendCustomMessage,
+  getChatMembers,
+  getConfigSetting,
+  enterFullscreen,
+  exitFullscreen,
+} from '../../src/private/privateAPIs';
+import { initialize, _initialize, _uninitialize, getContext } from '../../src/public/publicAPIs';
 
-describe("MicrosoftTeams-privateAPIs", () => {
+describe('MicrosoftTeams-privateAPIs', () => {
   // Use to send a mock message from the app.
 
   const utils = new Utils();
@@ -16,6 +24,9 @@ describe("MicrosoftTeams-privateAPIs", () => {
     utils.messages = [];
     utils.childMessages = [];
     utils.childWindow.closed = false;
+
+    // Set a mock window for testing
+    _initialize(utils.mockWindow);
   });
 
   afterEach(() => {
@@ -25,106 +36,79 @@ describe("MicrosoftTeams-privateAPIs", () => {
     }
   });
 
-  it("should exist in the global namespace", () => {
+  it('should exist in the global namespace', () => {
     expect(microsoftTeams).toBeDefined();
   });
 
-  it("should successfully initialize", () => {
-    initialize(utils.mockWindow);
-
-    expect(utils.processMessage).toBeDefined();
-    expect(utils.messages.length).toBe(1);
-
-    let initMessage = utils.findMessageByFunc("initialize");
-    expect(initMessage).not.toBeNull();
-    expect(initMessage.id).toBe(0);
-    expect(initMessage.func).toBe("initialize");
-    expect(initMessage.args.length).toEqual(1);
-    expect(initMessage.args[0]).toEqual("1.4.1");
-  });
-
-  it("should allow multiple initialize calls", () => {
-    for (let i = 0; i < 100; i++) {
-      initialize(utils.mockWindow);
-    }
-
-    // Still only one message actually sent, the extra calls just no-op'ed
-    expect(utils.processMessage).toBeDefined();
-    expect(utils.messages.length).toBe(1);
-  });
-
   const unSupportedDomains = [
-    "https://teams.com",
-    "https://teams.us",
-    "https://int.microsoft.com",
-    "https://dev.skype.com",
-    "http://localhost",
-    "https://microsoftsharepoint.com",
-    "https://msft.com",
-    "https://microsoft.sharepoint-xyz.com",
-    "http://teams.microsoft.com",
-    "http://microsoft.sharepoint-df.com",
-    "https://a.b.sharepoint.com",
-    "https://a.b.c.sharepoint.com"
+    'https://teams.com',
+    'https://teams.us',
+    'https://int.microsoft.com',
+    'https://dev.skype.com',
+    'http://localhost',
+    'https://microsoftsharepoint.com',
+    'https://msft.com',
+    'https://microsoft.sharepoint-xyz.com',
+    'http://teams.microsoft.com',
+    'http://microsoft.sharepoint-df.com',
+    'https://a.b.sharepoint.com',
+    'https://a.b.c.sharepoint.com',
   ];
 
   unSupportedDomains.forEach(unSupportedDomain => {
-    it(
-      "should reject utils.messages from unsupported domain: " + unSupportedDomain,
-      () => {
-        utils.initializeWithContext("content");
-        let callbackCalled = false;
-        getContext(() => {
-          callbackCalled = true;
-        });
-
-        let getContextMessage = utils.findMessageByFunc("getContext");
-        expect(getContextMessage).not.toBeNull();
-
-        callbackCalled = false;
-        utils.processMessage({
-          origin: unSupportedDomain,
-          source: utils.mockWindow.parent,
-          data: {
-            id: getContextMessage.id,
-            args: [
-              {
-                groupId: "someMaliciousValue"
-              }
-            ]
-          } as MessageResponse
-        } as MessageEvent);
-
-        expect(callbackCalled).toBe(false);
-      }
-    );
-  });
-
-  const supportedDomains = [
-    "https://teams.microsoft.com",
-    "https://teams.microsoft.us",
-    "https://gov.teams.microsoft.us",
-    "https://dod.teams.microsoft.us",
-    "https://int.teams.microsoft.com",
-    "https://devspaces.skype.com",
-    "http://dev.local",
-    "https://microsoft.sharepoint.com",
-    "https://msft.spoppe.com",
-    "https://microsoft.sharepoint-df.com",
-    "https://microsoft.sharepointonline.com",
-    "https://outlook.office.com",
-    "https://outlook-sdf.office.com"
-  ];
-
-  supportedDomains.forEach(supportedDomain => {
-    it("should allow utils.messages from supported domain " + supportedDomain, () => {
-      utils.initializeWithContext("content");
+    it('should reject utils.messages from unsupported domain: ' + unSupportedDomain, () => {
+      utils.initializeWithContext('content');
       let callbackCalled = false;
       getContext(() => {
         callbackCalled = true;
       });
 
-      let getContextMessage = utils.findMessageByFunc("getContext");
+      let getContextMessage = utils.findMessageByFunc('getContext');
+      expect(getContextMessage).not.toBeNull();
+
+      callbackCalled = false;
+      utils.processMessage({
+        origin: unSupportedDomain,
+        source: utils.mockWindow.parent,
+        data: {
+          id: getContextMessage.id,
+          args: [
+            {
+              groupId: 'someMaliciousValue',
+            },
+          ],
+        } as MessageResponse,
+      } as MessageEvent);
+
+      expect(callbackCalled).toBe(false);
+    });
+  });
+
+  const supportedDomains = [
+    'https://teams.microsoft.com',
+    'https://teams.microsoft.us',
+    'https://gov.teams.microsoft.us',
+    'https://dod.teams.microsoft.us',
+    'https://int.teams.microsoft.com',
+    'https://devspaces.skype.com',
+    'http://dev.local',
+    'https://microsoft.sharepoint.com',
+    'https://msft.spoppe.com',
+    'https://microsoft.sharepoint-df.com',
+    'https://microsoft.sharepointonline.com',
+    'https://outlook.office.com',
+    'https://outlook-sdf.office.com',
+  ];
+
+  supportedDomains.forEach(supportedDomain => {
+    it('should allow utils.messages from supported domain ' + supportedDomain, () => {
+      utils.initializeWithContext('content');
+      let callbackCalled = false;
+      getContext(() => {
+        callbackCalled = true;
+      });
+
+      let getContextMessage = utils.findMessageByFunc('getContext');
       expect(getContextMessage).not.toBeNull();
 
       utils.processMessage({
@@ -134,29 +118,29 @@ describe("MicrosoftTeams-privateAPIs", () => {
           id: getContextMessage.id,
           args: [
             {
-              groupId: "someMaliciousValue"
-            }
-          ]
-        } as MessageResponse
+              groupId: 'someMaliciousValue',
+            },
+          ],
+        } as MessageResponse,
       } as MessageEvent);
 
       expect(callbackCalled).toBe(true);
     });
   });
 
-  it("should not make calls to unsupported domains", () => {
-    initialize(utils.mockWindow);
+  it('should not make calls to unsupported domains', () => {
+    initialize();
 
-    let initMessage = utils.findMessageByFunc("initialize");
+    let initMessage = utils.findMessageByFunc('initialize');
     expect(initMessage).not.toBeNull();
 
     utils.processMessage({
-      origin: "https://some-malicious-site.com/",
+      origin: 'https://some-malicious-site.com/',
       source: utils.mockWindow.parent,
       data: {
         id: initMessage.id,
-        args: ["content"]
-      } as MessageResponse
+        args: ['content'],
+      } as MessageResponse,
     } as MessageEvent);
 
     // Try to make a call
@@ -168,8 +152,8 @@ describe("MicrosoftTeams-privateAPIs", () => {
     expect(utils.messages.length).toBe(1);
   });
 
-  it("should successfully handle calls queued before init completes", () => {
-    initialize(utils.mockWindow);
+  it('should successfully handle calls queued before init completes', () => {
+    initialize();
 
     // Another call made before the init response
     getContext(() => {
@@ -178,20 +162,20 @@ describe("MicrosoftTeams-privateAPIs", () => {
 
     // Only the init call went out
     expect(utils.messages.length).toBe(1);
-    let initMessage = utils.findMessageByFunc("initialize");
+    let initMessage = utils.findMessageByFunc('initialize');
     expect(initMessage).not.toBeNull();
-    expect(utils.findMessageByFunc("getContext")).toBeNull();
+    expect(utils.findMessageByFunc('getContext')).toBeNull();
 
     // init completes
-    utils.respondToMessage(initMessage, "content");
+    utils.respondToMessage(initMessage, 'content');
 
     // Now the getContext call should have been dequeued
     expect(utils.messages.length).toBe(2);
-    expect(utils.findMessageByFunc("getContext")).not.toBeNull();
+    expect(utils.findMessageByFunc('getContext')).not.toBeNull();
   });
 
-  it("should successfully handle out of order calls", () => {
-    utils.initializeWithContext("content");
+  it('should successfully handle out of order calls', () => {
+    utils.initializeWithContext('content');
 
     let actualContext1: Context;
     getContext(context => {
@@ -220,22 +204,22 @@ describe("MicrosoftTeams-privateAPIs", () => {
     expect(getContextMessage3).not.toBe(getContextMessage2);
 
     let expectedContext1: Context = {
-      locale: "someLocale1",
-      groupId: "someGroupId1",
-      channelId: "someChannelId1",
-      entityId: "someEntityId1"
+      locale: 'someLocale1',
+      groupId: 'someGroupId1',
+      channelId: 'someChannelId1',
+      entityId: 'someEntityId1',
     };
     let expectedContext2: Context = {
-      locale: "someLocale2",
-      groupId: "someGroupId2",
-      channelId: "someChannelId2",
-      entityId: "someEntityId2"
+      locale: 'someLocale2',
+      groupId: 'someGroupId2',
+      channelId: 'someChannelId2',
+      entityId: 'someEntityId2',
     };
     let expectedContext3: Context = {
-      locale: "someLocale3",
-      groupId: "someGroupId3",
-      channelId: "someChannelId3",
-      entityId: "someEntityId3"
+      locale: 'someLocale3',
+      groupId: 'someGroupId3',
+      channelId: 'someChannelId3',
+      entityId: 'someEntityId3',
     };
 
     // respond in the wrong order
@@ -249,25 +233,25 @@ describe("MicrosoftTeams-privateAPIs", () => {
     expect(actualContext3).toBe(expectedContext3);
   });
 
-  it("should only call callbacks once", () => {
-    utils.initializeWithContext("content");
+  it('should only call callbacks once', () => {
+    utils.initializeWithContext('content');
 
     let callbackCalled = 0;
     getContext(() => {
       callbackCalled++;
     });
 
-    let getContextMessage = utils.findMessageByFunc("getContext");
+    let getContextMessage = utils.findMessageByFunc('getContext');
     expect(getContextMessage).not.toBeNull();
 
     let expectedContext: Context = {
-      locale: "someLocale",
-      groupId: "someGroupId",
-      channelId: "someChannelId",
-      entityId: "someEntityId",
+      locale: 'someLocale',
+      groupId: 'someGroupId',
+      channelId: 'someChannelId',
+      entityId: 'someEntityId',
       teamType: TeamType.Edu,
-      teamSiteUrl: "someSiteUrl",
-      sessionId: "someSessionId"
+      teamSiteUrl: 'someSiteUrl',
+      sessionId: 'someSessionId',
     };
 
     // Get many responses to the same message
@@ -279,278 +263,250 @@ describe("MicrosoftTeams-privateAPIs", () => {
     expect(callbackCalled).toBe(1);
   });
 
-  it("should successfully open a file preview", () => {
-    utils.initializeWithContext("content");
+  it('should successfully open a file preview', () => {
+    utils.initializeWithContext('content');
 
     openFilePreview({
-      entityId: "someEntityId",
-      title: "someTitle",
-      description: "someDescription",
-      type: "someType",
-      objectUrl: "someObjectUrl",
-      downloadUrl: "someDownloadUrl",
-      webPreviewUrl: "someWebPreviewUrl",
-      webEditUrl: "someWebEditUrl",
-      baseUrl: "someBaseUrl",
+      entityId: 'someEntityId',
+      title: 'someTitle',
+      description: 'someDescription',
+      type: 'someType',
+      objectUrl: 'someObjectUrl',
+      downloadUrl: 'someDownloadUrl',
+      webPreviewUrl: 'someWebPreviewUrl',
+      webEditUrl: 'someWebEditUrl',
+      baseUrl: 'someBaseUrl',
       editFile: true,
-      subEntityId: "someSubEntityId"
+      subEntityId: 'someSubEntityId',
     });
 
-    let message = utils.findMessageByFunc("openFilePreview");
+    let message = utils.findMessageByFunc('openFilePreview');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(11);
-    expect(message.args[0]).toBe("someEntityId");
-    expect(message.args[1]).toBe("someTitle");
-    expect(message.args[2]).toBe("someDescription");
-    expect(message.args[3]).toBe("someType");
-    expect(message.args[4]).toBe("someObjectUrl");
-    expect(message.args[5]).toBe("someDownloadUrl");
-    expect(message.args[6]).toBe("someWebPreviewUrl");
-    expect(message.args[7]).toBe("someWebEditUrl");
-    expect(message.args[8]).toBe("someBaseUrl");
+    expect(message.args[0]).toBe('someEntityId');
+    expect(message.args[1]).toBe('someTitle');
+    expect(message.args[2]).toBe('someDescription');
+    expect(message.args[3]).toBe('someType');
+    expect(message.args[4]).toBe('someObjectUrl');
+    expect(message.args[5]).toBe('someDownloadUrl');
+    expect(message.args[6]).toBe('someWebPreviewUrl');
+    expect(message.args[7]).toBe('someWebEditUrl');
+    expect(message.args[8]).toBe('someBaseUrl');
     expect(message.args[9]).toBe(true);
-    expect(message.args[10]).toBe("someSubEntityId");
+    expect(message.args[10]).toBe('someSubEntityId');
   });
 
-  describe("getUserJoinedTeams", () => {
-    it("should not allow calls before initialization", () => {
+  describe('getUserJoinedTeams', () => {
+    it('should not allow calls before initialization', () => {
       expect(() =>
         getUserJoinedTeams(() => {
           return;
-        })
-      ).toThrowError("The library has not yet been initialized");
+        }),
+      ).toThrowError('The library has not yet been initialized');
     });
 
-    it("should allow a valid optional parameter set to true", () => {
-      utils.initializeWithContext("content");
+    it('should allow a valid optional parameter set to true', () => {
+      utils.initializeWithContext('content');
 
       let callbackCalled: boolean = false;
       getUserJoinedTeams(
         () => {
           callbackCalled = true;
         },
-        { favoriteTeamsOnly: true } as TeamInstanceParameters
+        { favoriteTeamsOnly: true } as TeamInstanceParameters,
       );
 
-      let getUserJoinedTeamsMessage = utils.findMessageByFunc("getUserJoinedTeams");
+      let getUserJoinedTeamsMessage = utils.findMessageByFunc('getUserJoinedTeams');
       expect(getUserJoinedTeamsMessage).not.toBeNull();
       utils.respondToMessage(getUserJoinedTeamsMessage, {});
       expect(callbackCalled).toBe(true);
     });
 
-    it("should allow a valid optional parameter set to false", () => {
-      utils.initializeWithContext("content");
+    it('should allow a valid optional parameter set to false', () => {
+      utils.initializeWithContext('content');
 
       let callbackCalled: boolean = false;
       getUserJoinedTeams(
         () => {
           callbackCalled = true;
         },
-        { favoriteTeamsOnly: false } as TeamInstanceParameters
+        { favoriteTeamsOnly: false } as TeamInstanceParameters,
       );
 
-      let getUserJoinedTeamsMessage = utils.findMessageByFunc("getUserJoinedTeams");
+      let getUserJoinedTeamsMessage = utils.findMessageByFunc('getUserJoinedTeams');
       expect(getUserJoinedTeamsMessage).not.toBeNull();
       utils.respondToMessage(getUserJoinedTeamsMessage, {});
       expect(callbackCalled).toBe(true);
     });
 
-    it("should allow a missing optional parameter", () => {
-      utils.initializeWithContext("content");
+    it('should allow a missing optional parameter', () => {
+      utils.initializeWithContext('content');
 
       let callbackCalled: boolean = false;
       getUserJoinedTeams(() => {
         callbackCalled = true;
       });
 
-      let getUserJoinedTeamsMessage = utils.findMessageByFunc("getUserJoinedTeams");
+      let getUserJoinedTeamsMessage = utils.findMessageByFunc('getUserJoinedTeams');
       expect(getUserJoinedTeamsMessage).not.toBeNull();
       utils.respondToMessage(getUserJoinedTeamsMessage, {});
       expect(callbackCalled).toBe(true);
     });
 
-    it("should allow a missing and valid optional parameter", () => {
-      utils.initializeWithContext("content");
+    it('should allow a missing and valid optional parameter', () => {
+      utils.initializeWithContext('content');
 
       let callbackCalled: boolean = false;
       getUserJoinedTeams(
         () => {
           callbackCalled = true;
         },
-        {} as TeamInstanceParameters
+        {} as TeamInstanceParameters,
       );
 
-      let getUserJoinedTeamsMessage = utils.findMessageByFunc("getUserJoinedTeams");
+      let getUserJoinedTeamsMessage = utils.findMessageByFunc('getUserJoinedTeams');
       expect(getUserJoinedTeamsMessage).not.toBeNull();
       utils.respondToMessage(getUserJoinedTeamsMessage, {});
       expect(callbackCalled).toBe(true);
     });
   });
 
-  describe("sendCustomMessage", () => {
-    it("should successfully pass message and provided arguments", () => {
-      utils.initializeWithContext("content");
+  describe('sendCustomMessage', () => {
+    it('should successfully pass message and provided arguments', () => {
+      utils.initializeWithContext('content');
 
-      const id = sendCustomMessage("customMessage", [
-        "arg1",
-        2,
-        3.0,
-        true
-      ]);
+      const id = sendCustomMessage('customMessage', ['arg1', 2, 3.0, true]);
 
-      let message = utils.findMessageByFunc("customMessage");
+      let message = utils.findMessageByFunc('customMessage');
       expect(message).not.toBeNull();
-      expect(message.args).toEqual(["arg1", 2, 3.0, true]);
+      expect(message.args).toEqual(['arg1', 2, 3.0, true]);
       expect(id).toBe(message.id);
     });
   });
 
-  describe("getChatMembers", () => {
-    it("should not allow calls before initialization", () => {
+  describe('getChatMembers', () => {
+    it('should not allow calls before initialization', () => {
       expect(() =>
         getChatMembers(() => {
           return;
-        })
-      ).toThrowError("The library has not yet been initialized");
+        }),
+      ).toThrowError('The library has not yet been initialized');
     });
 
-    it("should successfully get chat members", () => {
-      utils.initializeWithContext("content");
+    it('should successfully get chat members', () => {
+      utils.initializeWithContext('content');
 
       let callbackCalled: boolean = false;
       getChatMembers(() => {
         callbackCalled = true;
       });
 
-      let getChatMembersMessage = utils.findMessageByFunc("getChatMembers");
+      let getChatMembersMessage = utils.findMessageByFunc('getChatMembers');
       expect(getChatMembersMessage).not.toBeNull();
       utils.respondToMessage(getChatMembersMessage, {});
       expect(callbackCalled).toBe(true);
     });
   });
 
-  describe("getConfigSetting", () => {
-    it("should not allow calls before initialization", () => {
+  describe('getConfigSetting', () => {
+    it('should not allow calls before initialization', () => {
       expect(() =>
         getConfigSetting(() => {
           return;
-        }, "key")
-      ).toThrowError("The library has not yet been initialized");
+        }, 'key'),
+      ).toThrowError('The library has not yet been initialized');
     });
 
-    it("should allow a valid parameter", () => {
-      utils.initializeWithContext("content");
+    it('should allow a valid parameter', () => {
+      utils.initializeWithContext('content');
 
       let callbackCalled: boolean = false;
-      getConfigSetting(
-        () => {
-          callbackCalled = true;
-        }, "key"
-      );
+      getConfigSetting(() => {
+        callbackCalled = true;
+      }, 'key');
 
-      let getConfigSettingMessage = utils.findMessageByFunc("getConfigSetting");
+      let getConfigSettingMessage = utils.findMessageByFunc('getConfigSetting');
       expect(getConfigSettingMessage).not.toBeNull();
       utils.respondToMessage(getConfigSettingMessage, {});
       expect(callbackCalled).toBe(true);
     });
   });
 
-  describe("enterFullscreen", () => {
-    it("should not allow calls before initialization", () => {
-      expect(() => enterFullscreen()).toThrowError(
-        "The library has not yet been initialized"
-      );
+  describe('enterFullscreen', () => {
+    it('should not allow calls before initialization', () => {
+      expect(() => enterFullscreen()).toThrowError('The library has not yet been initialized');
     });
 
-    it("should not allow calls from settings context", () => {
-      utils.initializeWithContext("settings");
+    it('should not allow calls from settings context', () => {
+      utils.initializeWithContext('settings');
 
-      expect(() => enterFullscreen()).toThrowError(
-        "This call is not allowed in the 'settings' context"
-      );
+      expect(() => enterFullscreen()).toThrowError("This call is not allowed in the 'settings' context");
     });
 
-    it("should not allow calls from authentication context", () => {
-      utils.initializeWithContext("authentication");
+    it('should not allow calls from authentication context', () => {
+      utils.initializeWithContext('authentication');
 
-      expect(() => enterFullscreen()).toThrowError(
-        "This call is not allowed in the 'authentication' context"
-      );
+      expect(() => enterFullscreen()).toThrowError("This call is not allowed in the 'authentication' context");
     });
 
-    it("should not allow calls from remove context", () => {
-      utils.initializeWithContext("remove");
+    it('should not allow calls from remove context', () => {
+      utils.initializeWithContext('remove');
 
-      expect(() => enterFullscreen()).toThrowError(
-        "This call is not allowed in the 'remove' context"
-      );
+      expect(() => enterFullscreen()).toThrowError("This call is not allowed in the 'remove' context");
     });
 
-    it("should not allow calls from task context", () => {
-      utils.initializeWithContext("task");
+    it('should not allow calls from task context', () => {
+      utils.initializeWithContext('task');
 
-      expect(() => enterFullscreen()).toThrowError(
-        "This call is not allowed in the 'task' context"
-      );
+      expect(() => enterFullscreen()).toThrowError("This call is not allowed in the 'task' context");
     });
 
-    it("should successfully enter fullscreen", () => {
-      utils.initializeWithContext("content");
+    it('should successfully enter fullscreen', () => {
+      utils.initializeWithContext('content');
 
       enterFullscreen();
 
-      const enterFullscreenMessage = utils.findMessageByFunc("enterFullscreen");
+      const enterFullscreenMessage = utils.findMessageByFunc('enterFullscreen');
       expect(enterFullscreenMessage).not.toBeNull();
     });
   });
 
-  describe("exitFullscreen", () => {
-    it("should not allow calls before initialization", () => {
-      expect(() => exitFullscreen()).toThrowError(
-        "The library has not yet been initialized"
-      );
+  describe('exitFullscreen', () => {
+    it('should not allow calls before initialization', () => {
+      expect(() => exitFullscreen()).toThrowError('The library has not yet been initialized');
     });
 
-    it("should not allow calls from settings context", () => {
-      utils.initializeWithContext("settings");
+    it('should not allow calls from settings context', () => {
+      utils.initializeWithContext('settings');
 
-      expect(() => exitFullscreen()).toThrowError(
-        "This call is not allowed in the 'settings' context"
-      );
+      expect(() => exitFullscreen()).toThrowError("This call is not allowed in the 'settings' context");
     });
 
-    it("should not allow calls from authentication context", () => {
-      utils.initializeWithContext("authentication");
+    it('should not allow calls from authentication context', () => {
+      utils.initializeWithContext('authentication');
 
-      expect(() => exitFullscreen()).toThrowError(
-        "This call is not allowed in the 'authentication' context"
-      );
+      expect(() => exitFullscreen()).toThrowError("This call is not allowed in the 'authentication' context");
     });
 
-    it("should not allow calls from remove context", () => {
-      utils.initializeWithContext("remove");
+    it('should not allow calls from remove context', () => {
+      utils.initializeWithContext('remove');
 
-      expect(() => exitFullscreen()).toThrowError(
-        "This call is not allowed in the 'remove' context"
-      );
+      expect(() => exitFullscreen()).toThrowError("This call is not allowed in the 'remove' context");
     });
 
-    it("should not allow calls from task context", () => {
-      utils.initializeWithContext("task");
+    it('should not allow calls from task context', () => {
+      utils.initializeWithContext('task');
 
-      expect(() => exitFullscreen()).toThrowError(
-        "This call is not allowed in the 'task' context"
-      );
+      expect(() => exitFullscreen()).toThrowError("This call is not allowed in the 'task' context");
     });
 
-    it("should successfully exit fullscreen", () => {
-      utils.initializeWithContext("content");
+    it('should successfully exit fullscreen', () => {
+      utils.initializeWithContext('content');
 
       exitFullscreen();
 
-      const exitFullscreenMessage = utils.findMessageByFunc("exitFullscreen");
+      const exitFullscreenMessage = utils.findMessageByFunc('exitFullscreen');
       expect(exitFullscreenMessage).not.toBeNull();
     });
   });
-
 });

--- a/test/private/privateAPIs.spec.ts
+++ b/test/private/privateAPIs.spec.ts
@@ -250,9 +250,9 @@ describe('MicrosoftTeams-privateAPIs', () => {
       channelId: 'someChannelId',
       entityId: 'someEntityId',
       teamType: TeamType.Edu,
-      teamSiteUrl: "someSiteUrl",
-      sessionId: "someSessionId",
-      appSessionId: "appSessionId"
+      teamSiteUrl: 'someSiteUrl',
+      sessionId: 'someSessionId',
+      appSessionId: 'appSessionId',
     };
 
     // Get many responses to the same message

--- a/test/public/authentication.spec.ts
+++ b/test/public/authentication.spec.ts
@@ -1,6 +1,6 @@
 import { authentication } from "../../src/public/authentication";
 import { Utils } from '../utils';
-import { initialize, _uninitialize } from "../../src/public/publicAPIs";
+import { initialize, _uninitialize, _initialize } from "../../src/public/publicAPIs";
 
 describe("authentication", () => {
   // Use to send a mock message from the app.
@@ -12,6 +12,9 @@ describe("authentication", () => {
     utils.messages = [];
     utils.childMessages = [];
     utils.childWindow.closed = false;
+
+    // Set a mock window for testing
+    _initialize(utils.mockWindow);
   });
 
   afterEach(() => {
@@ -440,7 +443,7 @@ describe("authentication", () => {
   it("should not close auth window before notify success message has been sent", () => {
     let closeWindowSpy = spyOn(utils.mockWindow, "close").and.callThrough();
 
-    initialize(utils.mockWindow);
+    initialize();
     let initMessage = utils.findMessageByFunc("initialize");
     expect(initMessage).not.toBeNull();
 
@@ -462,7 +465,7 @@ describe("authentication", () => {
   it("should not close auth window before notify failure message has been sent", () => {
     let closeWindowSpy = spyOn(utils.mockWindow, "close").and.callThrough();
 
-    initialize(utils.mockWindow);
+    initialize();
     let initMessage = utils.findMessageByFunc("initialize");
     expect(initMessage).not.toBeNull();
 

--- a/test/public/authentication.spec.ts
+++ b/test/public/authentication.spec.ts
@@ -1,8 +1,8 @@
-import { authentication } from "../../src/public/authentication";
+import { authentication } from '../../src/public/authentication';
 import { Utils } from '../utils';
-import { initialize, _uninitialize, _initialize } from "../../src/public/publicAPIs";
+import { initialize, _uninitialize, _initialize } from '../../src/public/publicAPIs';
 
-describe("authentication", () => {
+describe('authentication', () => {
   // Use to send a mock message from the app.
 
   const utils = new Utils();
@@ -24,152 +24,148 @@ describe("authentication", () => {
     }
   });
 
-  it("should not allow authentication.authenticate calls before initialization", () => {
+  it('should not allow authentication.authenticate calls before initialization', () => {
     const authenticationParams: authentication.AuthenticateParameters = {
-      url: "https://someurl/",
+      url: 'https://someurl/',
       width: 100,
-      height: 200
+      height: 200,
     };
 
-    expect(() =>
-      authentication.authenticate(authenticationParams)
-    ).toThrowError("The library has not yet been initialized");
-  });
-
-  it("should not allow authentication.authenticate calls from authentication context", () => {
-    utils.initializeWithContext("authentication");
-
-    const authenticationParams = {
-      url: "https://someurl/",
-      width: 100,
-      height: 200
-    };
-
-    expect(() =>
-      authentication.authenticate(authenticationParams)
-    ).toThrowError(
-      "This call is not allowed in the 'authentication' context"
+    expect(() => authentication.authenticate(authenticationParams)).toThrowError(
+      'The library has not yet been initialized',
     );
   });
 
-  it("should allow authentication.authenticate calls from content context", () => {
-    utils.initializeWithContext("content");
+  it('should not allow authentication.authenticate calls from authentication context', () => {
+    utils.initializeWithContext('authentication');
 
     const authenticationParams = {
-      url: "https://someurl/",
+      url: 'https://someurl/',
       width: 100,
-      height: 200
+      height: 200,
+    };
+
+    expect(() => authentication.authenticate(authenticationParams)).toThrowError(
+      "This call is not allowed in the 'authentication' context",
+    );
+  });
+
+  it('should allow authentication.authenticate calls from content context', () => {
+    utils.initializeWithContext('content');
+
+    const authenticationParams = {
+      url: 'https://someurl/',
+      width: 100,
+      height: 200,
     };
     authentication.authenticate(authenticationParams);
   });
 
-  it("should allow authentication.authenticate calls from settings context", () => {
-    utils.initializeWithContext("settings");
+  it('should allow authentication.authenticate calls from settings context', () => {
+    utils.initializeWithContext('settings');
 
     const authenticationParams = {
-      url: "https://someurl/",
+      url: 'https://someurl/',
       width: 100,
-      height: 200
+      height: 200,
     };
     authentication.authenticate(authenticationParams);
   });
 
-  it("should allow authentication.authenticate calls from remove context", () => {
-    utils.initializeWithContext("remove");
+  it('should allow authentication.authenticate calls from remove context', () => {
+    utils.initializeWithContext('remove');
 
     const authenticationParams = {
-      url: "https://someurl/",
+      url: 'https://someurl/',
       width: 100,
-      height: 200
+      height: 200,
     };
     authentication.authenticate(authenticationParams);
   });
 
-  it("should allow authentication.authenticate calls from task context", () => {
-    utils.initializeWithContext("task");
+  it('should allow authentication.authenticate calls from task context', () => {
+    utils.initializeWithContext('task');
 
     const authenticationParams = {
-      url: "https://someurl/",
+      url: 'https://someurl/',
       width: 100,
-      height: 200
+      height: 200,
     };
     authentication.authenticate(authenticationParams);
   });
 
-  it("should successfully pop up the auth window", () => {
-    utils.initializeWithContext("content");
+  it('should successfully pop up the auth window', () => {
+    utils.initializeWithContext('content');
 
     let windowOpenCalled = false;
-    spyOn(utils.mockWindow, "open").and.callFake(
+    spyOn(utils.mockWindow, 'open').and.callFake(
       (url: string, name: string, specs: string): Window => {
-        expect(url).toEqual("https://someurl/");
-        expect(name).toEqual("_blank");
-        expect(specs.indexOf("width=100")).not.toBe(-1);
-        expect(specs.indexOf("height=200")).not.toBe(-1);
+        expect(url).toEqual('https://someurl/');
+        expect(name).toEqual('_blank');
+        expect(specs.indexOf('width=100')).not.toBe(-1);
+        expect(specs.indexOf('height=200')).not.toBe(-1);
         windowOpenCalled = true;
         return utils.childWindow as Window;
-      }
+      },
     );
 
     let authenticationParams = {
-      url: "https://someurl/",
+      url: 'https://someurl/',
       width: 100,
-      height: 200
+      height: 200,
     };
     authentication.authenticate(authenticationParams);
     expect(windowOpenCalled).toBe(true);
   });
 
-  it("should successfully pop up the auth window when authenticate called without authenticationParams for connectors", () => {
-    utils.initializeWithContext("content");
+  it('should successfully pop up the auth window when authenticate called without authenticationParams for connectors', () => {
+    utils.initializeWithContext('content');
 
     let windowOpenCalled = false;
-    spyOn(utils.mockWindow, "open").and.callFake(
+    spyOn(utils.mockWindow, 'open').and.callFake(
       (url: string, name: string, specs: string): Window => {
-        expect(url).toEqual("https://someurl/");
-        expect(name).toEqual("_blank");
-        expect(specs.indexOf("width=100")).not.toBe(-1);
-        expect(specs.indexOf("height=200")).not.toBe(-1);
+        expect(url).toEqual('https://someurl/');
+        expect(name).toEqual('_blank');
+        expect(specs.indexOf('width=100')).not.toBe(-1);
+        expect(specs.indexOf('height=200')).not.toBe(-1);
         windowOpenCalled = true;
         return utils.childWindow as Window;
-      }
+      },
     );
 
     let authenticationParams = {
-      url: "https://someurl/",
+      url: 'https://someurl/',
       width: 100,
-      height: 200
+      height: 200,
     };
-    authentication.registerAuthenticationHandlers(
-      authenticationParams
-    );
+    authentication.registerAuthenticationHandlers(authenticationParams);
     authentication.authenticate();
     expect(windowOpenCalled).toBe(true);
   });
 
-  it("should cancel the flow when the auth window gets closed before notifySuccess/notifyFailure are called", () => {
-    utils.initializeWithContext("content");
+  it('should cancel the flow when the auth window gets closed before notifySuccess/notifyFailure are called', () => {
+    utils.initializeWithContext('content');
 
     let windowOpenCalled = false;
-    spyOn(utils.mockWindow, "open").and.callFake(
+    spyOn(utils.mockWindow, 'open').and.callFake(
       (url: string, name: string, specs: string): Window => {
-        expect(url).toEqual("https://someurl/");
-        expect(name).toEqual("_blank");
-        expect(specs.indexOf("width=100")).not.toBe(-1);
-        expect(specs.indexOf("height=200")).not.toBe(-1);
+        expect(url).toEqual('https://someurl/');
+        expect(name).toEqual('_blank');
+        expect(specs.indexOf('width=100')).not.toBe(-1);
+        expect(specs.indexOf('height=200')).not.toBe(-1);
         windowOpenCalled = true;
         return utils.childWindow as Window;
-      }
+      },
     );
 
     let successResult: string;
     let failureReason: string;
     let authenticationParams = {
-      url: "https://someurl/",
+      url: 'https://someurl/',
       width: 100,
       height: 200,
       successCallback: (result: string) => (successResult = result),
-      failureCallback: (reason: string) => (failureReason = reason)
+      failureCallback: (reason: string) => (failureReason = reason),
     };
     authentication.authenticate(authenticationParams);
     expect(windowOpenCalled).toBe(true);
@@ -177,21 +173,21 @@ describe("authentication", () => {
     utils.childWindow.closed = true;
     setTimeout(() => {
       expect(successResult).toBeUndefined();
-      expect(failureReason).toEqual("CancelledByUser");
+      expect(failureReason).toEqual('CancelledByUser');
     }, 101);
   });
 
-  it("should successfully handle auth success", () => {
-    utils.initializeWithContext("content");
+  it('should successfully handle auth success', () => {
+    utils.initializeWithContext('content');
 
     let successResult: string;
     let failureReason: string;
     let authenticationParams = {
-      url: "https://someurl/",
+      url: 'https://someurl/',
       width: 100,
       height: 200,
       successCallback: (result: string) => (successResult = result),
-      failureCallback: (reason: string) => (failureReason = reason)
+      failureCallback: (reason: string) => (failureReason = reason),
     };
     authentication.authenticate(authenticationParams);
 
@@ -200,26 +196,26 @@ describe("authentication", () => {
       source: utils.childWindow,
       data: {
         id: 0,
-        func: "authentication.authenticate.success",
-        args: ["someResult"]
-      }
+        func: 'authentication.authenticate.success',
+        args: ['someResult'],
+      },
     } as MessageEvent);
 
-    expect(successResult).toEqual("someResult");
+    expect(successResult).toEqual('someResult');
     expect(failureReason).toBeUndefined();
   });
 
-  it("should successfully handle auth failure", () => {
-    utils.initializeWithContext("content");
+  it('should successfully handle auth failure', () => {
+    utils.initializeWithContext('content');
 
     let successResult: string;
     let failureReason: string;
     let authenticationParams = {
-      url: "https://someurl/",
+      url: 'https://someurl/',
       width: 100,
       height: 200,
       successCallback: (result: string) => (successResult = result),
-      failureCallback: (reason: string) => (failureReason = reason)
+      failureCallback: (reason: string) => (failureReason = reason),
     };
     authentication.authenticate(authenticationParams);
 
@@ -228,232 +224,218 @@ describe("authentication", () => {
       source: utils.childWindow,
       data: {
         id: 0,
-        func: "authentication.authenticate.failure",
-        args: ["someReason"]
-      }
+        func: 'authentication.authenticate.failure',
+        args: ['someReason'],
+      },
     } as MessageEvent);
 
     expect(successResult).toBeUndefined();
-    expect(failureReason).toEqual("someReason");
+    expect(failureReason).toEqual('someReason');
   });
 
-  ["android", "ios", "desktop"].forEach(hostClientType => {
+  ['android', 'ios', 'desktop'].forEach(hostClientType => {
     it(`should successfully pop up the auth window in the ${hostClientType} client`, () => {
-      utils.initializeWithContext("content", hostClientType);
+      utils.initializeWithContext('content', hostClientType);
 
       let authenticationParams = {
-        url: "https://someUrl",
+        url: 'https://someUrl',
         width: 100,
-        height: 200
+        height: 200,
       };
       authentication.authenticate(authenticationParams);
 
-      let message = utils.findMessageByFunc("authentication.authenticate");
+      let message = utils.findMessageByFunc('authentication.authenticate');
       expect(message).not.toBeNull();
       expect(message.args.length).toBe(3);
-      expect(message.args[0]).toBe(
-        authenticationParams.url.toLowerCase() + "/"
-      );
+      expect(message.args[0]).toBe(authenticationParams.url.toLowerCase() + '/');
       expect(message.args[1]).toBe(authenticationParams.width);
       expect(message.args[2]).toBe(authenticationParams.height);
     });
 
     it(`should successfully handle auth success in the ${hostClientType} client`, () => {
-      utils.initializeWithContext("content", hostClientType);
+      utils.initializeWithContext('content', hostClientType);
 
       let successResult: string;
       let failureReason: string;
       let authenticationParams = {
-        url: "https://someUrl",
+        url: 'https://someUrl',
         width: 100,
         height: 200,
         successCallback: (result: string) => (successResult = result),
-        failureCallback: (reason: string) => (failureReason = reason)
+        failureCallback: (reason: string) => (failureReason = reason),
       };
       authentication.authenticate(authenticationParams);
 
-      let message = utils.findMessageByFunc("authentication.authenticate");
+      let message = utils.findMessageByFunc('authentication.authenticate');
       expect(message).not.toBeNull();
 
-      utils.respondToMessage(message, true, "someResult");
+      utils.respondToMessage(message, true, 'someResult');
 
-      expect(successResult).toBe("someResult");
+      expect(successResult).toBe('someResult');
       expect(failureReason).toBeUndefined();
     });
 
     it(`should successfully handle auth failure in the ${hostClientType} client`, () => {
-      utils.initializeWithContext("content", hostClientType);
+      utils.initializeWithContext('content', hostClientType);
 
       let successResult: string;
       let failureReason: string;
       let authenticationParams = {
-        url: "https://someUrl",
+        url: 'https://someUrl',
         width: 100,
         height: 200,
         successCallback: (result: string) => (successResult = result),
-        failureCallback: (reason: string) => (failureReason = reason)
+        failureCallback: (reason: string) => (failureReason = reason),
       };
       authentication.authenticate(authenticationParams);
 
-      let message = utils.findMessageByFunc("authentication.authenticate");
+      let message = utils.findMessageByFunc('authentication.authenticate');
       expect(message).not.toBeNull();
 
-      utils.respondToMessage(message, false, "someReason");
+      utils.respondToMessage(message, false, 'someReason');
 
       expect(successResult).toBeUndefined();
-      expect(failureReason).toBe("someReason");
+      expect(failureReason).toBe('someReason');
     });
   });
 
-  it("should successfully notify auth success", () => {
-    utils.initializeWithContext("authentication");
+  it('should successfully notify auth success', () => {
+    utils.initializeWithContext('authentication');
 
-    authentication.notifySuccess("someResult");
-    let message = utils.findMessageByFunc("authentication.authenticate.success");
+    authentication.notifySuccess('someResult');
+    let message = utils.findMessageByFunc('authentication.authenticate.success');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(1);
-    expect(message.args[0]).toBe("someResult");
+    expect(message.args[0]).toBe('someResult');
   });
 
-  it("should do window redirect if callbackUrl is for win32 Outlook", () => {
+  it('should do window redirect if callbackUrl is for win32 Outlook', () => {
     let windowAssignSpyCalled = false;
-    spyOn(utils.mockWindow.location, "assign").and.callFake(
-      (url: string): void => {
-        windowAssignSpyCalled = true;
-        expect(url).toEqual(
-          "https://outlook.office.com/connectors?client_type=Win32_Outlook#/configurations&result=someResult&authSuccess"
-        );
-      }
-    );
+    spyOn(utils.mockWindow.location, 'assign').and.callFake((url: string): void => {
+      windowAssignSpyCalled = true;
+      expect(url).toEqual(
+        'https://outlook.office.com/connectors?client_type=Win32_Outlook#/configurations&result=someResult&authSuccess',
+      );
+    });
 
-    utils.initializeWithContext("authentication");
+    utils.initializeWithContext('authentication');
 
     authentication.notifySuccess(
-      "someResult",
-      "https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook%23%2Fconfigurations"
+      'someResult',
+      'https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook%23%2Fconfigurations',
     );
     expect(windowAssignSpyCalled).toBe(true);
   });
 
-  it("should do window redirect if callbackUrl is for win32 Outlook and no result param specified", () => {
+  it('should do window redirect if callbackUrl is for win32 Outlook and no result param specified', () => {
     let windowAssignSpyCalled = false;
-    spyOn(utils.mockWindow.location, "assign").and.callFake(
-      (url: string): void => {
-        windowAssignSpyCalled = true;
-        expect(url).toEqual(
-          "https://outlook.office.com/connectors?client_type=Win32_Outlook#/configurations&authSuccess"
-        );
-      }
-    );
+    spyOn(utils.mockWindow.location, 'assign').and.callFake((url: string): void => {
+      windowAssignSpyCalled = true;
+      expect(url).toEqual(
+        'https://outlook.office.com/connectors?client_type=Win32_Outlook#/configurations&authSuccess',
+      );
+    });
 
-    utils.initializeWithContext("authentication");
+    utils.initializeWithContext('authentication');
 
     authentication.notifySuccess(
       null,
-      "https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook%23%2Fconfigurations"
+      'https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook%23%2Fconfigurations',
     );
     expect(windowAssignSpyCalled).toBe(true);
   });
 
-  it("should do window redirect if callbackUrl is for win32 Outlook but does not have URL fragments", () => {
+  it('should do window redirect if callbackUrl is for win32 Outlook but does not have URL fragments', () => {
     let windowAssignSpyCalled = false;
-    spyOn(utils.mockWindow.location, "assign").and.callFake(
-      (url: string): void => {
-        windowAssignSpyCalled = true;
-        expect(url).toEqual(
-          "https://outlook.office.com/connectors?client_type=Win32_Outlook#&result=someResult&authSuccess"
-        );
-      }
-    );
+    spyOn(utils.mockWindow.location, 'assign').and.callFake((url: string): void => {
+      windowAssignSpyCalled = true;
+      expect(url).toEqual(
+        'https://outlook.office.com/connectors?client_type=Win32_Outlook#&result=someResult&authSuccess',
+      );
+    });
 
-    utils.initializeWithContext("authentication");
+    utils.initializeWithContext('authentication');
 
     authentication.notifySuccess(
-      "someResult",
-      "https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook"
+      'someResult',
+      'https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook',
     );
     expect(windowAssignSpyCalled).toBe(true);
   });
 
-  it("should successfully notify auth success if callbackUrl is not for win32 Outlook", () => {
-    utils.initializeWithContext("authentication");
+  it('should successfully notify auth success if callbackUrl is not for win32 Outlook', () => {
+    utils.initializeWithContext('authentication');
 
     authentication.notifySuccess(
-      "someResult",
-      "https%3A%2F%2Fsomeinvalidurl.com%3FcallbackUrl%3Dtest%23%2Fconfiguration"
+      'someResult',
+      'https%3A%2F%2Fsomeinvalidurl.com%3FcallbackUrl%3Dtest%23%2Fconfiguration',
     );
-    let message = utils.findMessageByFunc("authentication.authenticate.success");
+    let message = utils.findMessageByFunc('authentication.authenticate.success');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(1);
-    expect(message.args[0]).toBe("someResult");
+    expect(message.args[0]).toBe('someResult');
   });
 
-  it("should successfully notify auth failure", () => {
-    utils.initializeWithContext("authentication");
+  it('should successfully notify auth failure', () => {
+    utils.initializeWithContext('authentication');
 
-    authentication.notifyFailure("someReason");
+    authentication.notifyFailure('someReason');
 
-    let message = utils.findMessageByFunc("authentication.authenticate.failure");
+    let message = utils.findMessageByFunc('authentication.authenticate.failure');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(1);
-    expect(message.args[0]).toBe("someReason");
+    expect(message.args[0]).toBe('someReason');
   });
 
-  it("should do window redirect if callbackUrl is for win32 Outlook and auth failure happens", () => {
+  it('should do window redirect if callbackUrl is for win32 Outlook and auth failure happens', () => {
     let windowAssignSpyCalled = false;
-    spyOn(utils.mockWindow.location, "assign").and.callFake(
-      (url: string): void => {
-        windowAssignSpyCalled = true;
-        expect(url).toEqual(
-          "https://outlook.office.com/connectors?client_type=Win32_Outlook#/configurations&reason=someReason&authFailure"
-        );
-      }
-    );
+    spyOn(utils.mockWindow.location, 'assign').and.callFake((url: string): void => {
+      windowAssignSpyCalled = true;
+      expect(url).toEqual(
+        'https://outlook.office.com/connectors?client_type=Win32_Outlook#/configurations&reason=someReason&authFailure',
+      );
+    });
 
-    utils.initializeWithContext("authentication");
+    utils.initializeWithContext('authentication');
 
     authentication.notifyFailure(
-      "someReason",
-      "https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook%23%2Fconfigurations"
+      'someReason',
+      'https%3A%2F%2Foutlook.office.com%2Fconnectors%3Fclient_type%3DWin32_Outlook%23%2Fconfigurations',
     );
     expect(windowAssignSpyCalled).toBe(true);
   });
 
-  it("should successfully notify auth failure if callbackUrl is not for win32 Outlook", () => {
-    spyOn(utils.mockWindow.location, "assign").and.callFake(
-      (url: string): void => {
-        expect(url).toEqual(
-          "https://someinvalidurl.com?callbackUrl=test#/configuration&reason=someReason&authFailure"
-        );
-      }
-    );
+  it('should successfully notify auth failure if callbackUrl is not for win32 Outlook', () => {
+    spyOn(utils.mockWindow.location, 'assign').and.callFake((url: string): void => {
+      expect(url).toEqual('https://someinvalidurl.com?callbackUrl=test#/configuration&reason=someReason&authFailure');
+    });
 
-    utils.initializeWithContext("authentication");
+    utils.initializeWithContext('authentication');
 
     authentication.notifyFailure(
-      "someReason",
-      "https%3A%2F%2Fsomeinvalidurl.com%3FcallbackUrl%3Dtest%23%2Fconfiguration"
+      'someReason',
+      'https%3A%2F%2Fsomeinvalidurl.com%3FcallbackUrl%3Dtest%23%2Fconfiguration',
     );
-    let message = utils.findMessageByFunc("authentication.authenticate.failure");
+    let message = utils.findMessageByFunc('authentication.authenticate.failure');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(1);
-    expect(message.args[0]).toBe("someReason");
+    expect(message.args[0]).toBe('someReason');
   });
 
-  it("should not close auth window before notify success message has been sent", () => {
-    let closeWindowSpy = spyOn(utils.mockWindow, "close").and.callThrough();
+  it('should not close auth window before notify success message has been sent', () => {
+    let closeWindowSpy = spyOn(utils.mockWindow, 'close').and.callThrough();
 
     initialize();
-    let initMessage = utils.findMessageByFunc("initialize");
+    let initMessage = utils.findMessageByFunc('initialize');
     expect(initMessage).not.toBeNull();
 
-    authentication.notifySuccess("someResult");
-    let message = utils.findMessageByFunc("authentication.authenticate.success");
+    authentication.notifySuccess('someResult');
+    let message = utils.findMessageByFunc('authentication.authenticate.success');
     expect(message).toBeNull();
     expect(closeWindowSpy).not.toHaveBeenCalled();
 
-    utils.respondToMessage(initMessage, "authentication");
-    message = utils.findMessageByFunc("authentication.authenticate.success");
+    utils.respondToMessage(initMessage, 'authentication');
+    message = utils.findMessageByFunc('authentication.authenticate.success');
     expect(message).not.toBeNull();
 
     // Wait 100ms for the message queue and 200ms for the close delay
@@ -462,20 +444,20 @@ describe("authentication", () => {
     }, 301);
   });
 
-  it("should not close auth window before notify failure message has been sent", () => {
-    let closeWindowSpy = spyOn(utils.mockWindow, "close").and.callThrough();
+  it('should not close auth window before notify failure message has been sent', () => {
+    let closeWindowSpy = spyOn(utils.mockWindow, 'close').and.callThrough();
 
     initialize();
-    let initMessage = utils.findMessageByFunc("initialize");
+    let initMessage = utils.findMessageByFunc('initialize');
     expect(initMessage).not.toBeNull();
 
-    authentication.notifyFailure("someReason");
-    let message = utils.findMessageByFunc("authentication.authenticate.failure");
+    authentication.notifyFailure('someReason');
+    let message = utils.findMessageByFunc('authentication.authenticate.failure');
     expect(message).toBeNull();
     expect(closeWindowSpy).not.toHaveBeenCalled();
 
-    utils.respondToMessage(initMessage, "authentication");
-    message = utils.findMessageByFunc("authentication.authenticate.failure");
+    utils.respondToMessage(initMessage, 'authentication');
+    message = utils.findMessageByFunc('authentication.authenticate.failure');
     expect(message).not.toBeNull();
 
     // Wait 100ms for the message queue and 200ms for the close delay

--- a/test/public/publicAPIs.spec.ts
+++ b/test/public/publicAPIs.spec.ts
@@ -97,6 +97,23 @@ describe('MicrosoftTeams-publicAPIs', () => {
     expect(secondCallbackInvoked).toBe(true);
   });
 
+  it('should invoke callback immediatelly if initialization has already completed', () => {
+    initialize();
+    
+    expect(utils.processMessage).toBeDefined();
+    expect(utils.messages.length).toBe(1);
+
+    const initMessage = utils.findMessageByFunc('initialize');
+    utils.respondToMessage(initMessage, 'content');
+
+    let callbackInvoked: boolean = false;
+    initialize(() => {
+      callbackInvoked = true;
+    });
+
+    expect(callbackInvoked).toBe(true);
+  });
+
   it('should successfully register a change settings handler', () => {
     utils.initializeWithContext('content');
     let handlerCalled = false;

--- a/test/public/publicAPIs.spec.ts
+++ b/test/public/publicAPIs.spec.ts
@@ -186,11 +186,11 @@ describe('MicrosoftTeams-publicAPIs', () => {
       isTeamArchived: false,
       hostClientType: HostClientType.web,
       sharepoint: {},
-      tenantSKU: "someTenantSKU",
-      userLicenseType: "someUserLicenseType",
-      parentMessageId: "someParentMessageId",
-      ringId: "someRingId",
-      appSessionId: "appSessionId"
+      tenantSKU: 'someTenantSKU',
+      userLicenseType: 'someUserLicenseType',
+      parentMessageId: 'someParentMessageId',
+      ringId: 'someRingId',
+      appSessionId: 'appSessionId',
     };
 
     utils.respondToMessage(getContextMessage, expectedContext);
@@ -509,11 +509,9 @@ describe('MicrosoftTeams-publicAPIs', () => {
   it("Ctrl+P shouldn't call print handler if printCapabilty is disabled", () => {
     let handlerCalled = false;
     initialize();
-    spyOn(microsoftTeams, 'print').and.callFake(
-      (): void => {
-        handlerCalled = true;
-      },
-    );
+    spyOn(microsoftTeams, 'print').and.callFake((): void => {
+      handlerCalled = true;
+    });
     let printEvent = new Event('keydown');
     // tslint:disable:no-any
     (printEvent as any).keyCode = 80;
@@ -527,11 +525,9 @@ describe('MicrosoftTeams-publicAPIs', () => {
   it("Cmd+P shouldn't call print handler if printCapabilty is disabled", () => {
     let handlerCalled = false;
     initialize();
-    spyOn(microsoftTeams, 'print').and.callFake(
-      (): void => {
-        handlerCalled = true;
-      },
-    );
+    spyOn(microsoftTeams, 'print').and.callFake((): void => {
+      handlerCalled = true;
+    });
     let printEvent = new Event('keydown');
     // tslint:disable:no-any
     (printEvent as any).keyCode = 80;
@@ -546,11 +542,9 @@ describe('MicrosoftTeams-publicAPIs', () => {
     let handlerCalled = false;
     initialize();
     enablePrintCapability();
-    spyOn(window, 'print').and.callFake(
-      (): void => {
-        handlerCalled = true;
-      },
-    );
+    spyOn(window, 'print').and.callFake((): void => {
+      handlerCalled = true;
+    });
 
     print();
 
@@ -561,11 +555,9 @@ describe('MicrosoftTeams-publicAPIs', () => {
     let handlerCalled = false;
     initialize();
     enablePrintCapability();
-    spyOn(window, 'print').and.callFake(
-      (): void => {
-        handlerCalled = true;
-      },
-    );
+    spyOn(window, 'print').and.callFake((): void => {
+      handlerCalled = true;
+    });
     let printEvent = new Event('keydown');
     // tslint:disable:no-any
     (printEvent as any).keyCode = 80;
@@ -580,11 +572,9 @@ describe('MicrosoftTeams-publicAPIs', () => {
     let handlerCalled = false;
     initialize();
     enablePrintCapability();
-    spyOn(window, 'print').and.callFake(
-      (): void => {
-        handlerCalled = true;
-      },
-    );
+    spyOn(window, 'print').and.callFake((): void => {
+      handlerCalled = true;
+    });
     let printEvent = new Event('keydown');
     // tslint:disable:no-any
     (printEvent as any).keyCode = 80;

--- a/test/public/publicAPIs.spec.ts
+++ b/test/public/publicAPIs.spec.ts
@@ -1,13 +1,27 @@
-import * as microsoftTeams from "../../src/public/publicAPIs";
-import { TabInstanceParameters, Context } from "../../src/public/interfaces";
-import { TeamType, UserTeamRole, HostClientType } from "../../src/public/constants";
-import { executeDeepLink, navigateCrossDomain, getTabInstances, getMruTabInstances, shareDeepLink, registerBeforeUnloadHandler, enablePrintCapability, registerChangeSettingsHandler, getContext, _uninitialize, registerBackButtonHandler, registerOnThemeChangeHandler, initialize } from "../../src/public/publicAPIs";
-import { frameContexts } from "../../src/internal/constants";
+import * as microsoftTeams from '../../src/public/publicAPIs';
+import { TabInstanceParameters, Context } from '../../src/public/interfaces';
+import { TeamType, UserTeamRole, HostClientType } from '../../src/public/constants';
+import {
+  executeDeepLink,
+  navigateCrossDomain,
+  getTabInstances,
+  getMruTabInstances,
+  shareDeepLink,
+  registerBeforeUnloadHandler,
+  enablePrintCapability,
+  registerChangeSettingsHandler,
+  getContext,
+  _initialize,
+  _uninitialize,
+  registerBackButtonHandler,
+  registerOnThemeChangeHandler,
+  initialize,
+} from '../../src/public/publicAPIs';
+import { frameContexts } from '../../src/internal/constants';
 import { Utils } from '../utils';
 
-describe("MicrosoftTeams-publicAPIs", () => {
+describe('MicrosoftTeams-publicAPIs', () => {
   // Use to send a mock message from the app.
-
   const utils = new Utils();
 
   beforeEach(() => {
@@ -15,6 +29,9 @@ describe("MicrosoftTeams-publicAPIs", () => {
     utils.messages = [];
     utils.childMessages = [];
     utils.childWindow.closed = false;
+
+    // Set a mock window for testing
+    _initialize(utils.mockWindow);
   });
 
   afterEach(() => {
@@ -24,51 +41,99 @@ describe("MicrosoftTeams-publicAPIs", () => {
     }
   });
 
-  it("should not allow calls before initialization", () => {
+  it('should not allow calls before initialization', () => {
     expect(() =>
       getContext(() => {
         return;
-      })
-    ).toThrowError("The library has not yet been initialized");
+      }),
+    ).toThrowError('The library has not yet been initialized');
   });
 
-  it("should successfully register a change settings handler", () => {
-    utils.initializeWithContext("content");
+  it('should successfully initialize', () => {
+    initialize();
+
+    expect(utils.processMessage).toBeDefined();
+    expect(utils.messages.length).toBe(1);
+
+    let initMessage = utils.findMessageByFunc('initialize');
+    expect(initMessage).not.toBeNull();
+    expect(initMessage.id).toBe(0);
+    expect(initMessage.func).toBe('initialize');
+    expect(initMessage.args.length).toEqual(1);
+    expect(initMessage.args[0]).toEqual('1.4.1');
+  });
+
+  it('should allow multiple initialize calls', () => {
+    for (let i = 0; i < 100; i++) {
+      initialize();
+    }
+
+    // Still only one message actually sent, the extra calls just no-op'ed
+    expect(utils.processMessage).toBeDefined();
+    expect(utils.messages.length).toBe(1);
+  });
+
+  it('should invoke all callbacks once initialization completes', () => {
+    let firstCallbackInvoked: boolean = false;
+    initialize(() => {
+      firstCallbackInvoked = true;
+    });
+
+    let secondCallbackInvoked: boolean = false;
+    initialize(() => {
+      secondCallbackInvoked = true;
+    });
+
+    expect(utils.processMessage).toBeDefined();
+    expect(utils.messages.length).toBe(1);
+
+    expect(firstCallbackInvoked).toBe(false);
+    expect(secondCallbackInvoked).toBe(false);
+
+    const initMessage = utils.findMessageByFunc('initialize');
+    utils.respondToMessage(initMessage, 'content');
+
+    expect(firstCallbackInvoked).toBe(true);
+    expect(secondCallbackInvoked).toBe(true);
+  });
+
+  it('should successfully register a change settings handler', () => {
+    utils.initializeWithContext('content');
     let handlerCalled = false;
 
     registerChangeSettingsHandler(() => {
       handlerCalled = true;
     });
 
-    utils.sendMessage("changeSettings", "");
+    utils.sendMessage('changeSettings', '');
 
     expect(handlerCalled).toBeTruthy();
   });
 
-  it("should successfully register a theme change handler", () => {
-    utils.initializeWithContext("content");
+  it('should successfully register a theme change handler', () => {
+    utils.initializeWithContext('content');
 
     let newTheme: string;
     registerOnThemeChangeHandler(theme => {
       newTheme = theme;
     });
 
-    utils.sendMessage("themeChange", "someTheme");
+    utils.sendMessage('themeChange', 'someTheme');
 
-    expect(newTheme).toBe("someTheme");
+    expect(newTheme).toBe('someTheme');
   });
 
-  it("should call navigateBack automatically when no back button handler is registered", () => {
-    utils.initializeWithContext("content");
+  it('should call navigateBack automatically when no back button handler is registered', () => {
+    utils.initializeWithContext('content');
 
-    utils.sendMessage("backButtonPress");
+    utils.sendMessage('backButtonPress');
 
-    let navigateBackMessage = utils.findMessageByFunc("navigateBack");
+    let navigateBackMessage = utils.findMessageByFunc('navigateBack');
     expect(navigateBackMessage).not.toBeNull();
   });
 
-  it("should successfully register a back button handler and not call navigateBack if it returns true", () => {
-    utils.initializeWithContext("content");
+  it('should successfully register a back button handler and not call navigateBack if it returns true', () => {
+    utils.initializeWithContext('content');
 
     let handlerInvoked = false;
     registerBackButtonHandler(() => {
@@ -76,55 +141,55 @@ describe("MicrosoftTeams-publicAPIs", () => {
       return true;
     });
 
-    utils.sendMessage("backButtonPress");
+    utils.sendMessage('backButtonPress');
 
-    let navigateBackMessage = utils.findMessageByFunc("navigateBack");
+    let navigateBackMessage = utils.findMessageByFunc('navigateBack');
     expect(navigateBackMessage).toBeNull();
     expect(handlerInvoked).toBe(true);
   });
 
-  it("should successfully get context", () => {
-    utils.initializeWithContext("content");
+  it('should successfully get context', () => {
+    utils.initializeWithContext('content');
 
     let actualContext: Context;
     getContext(context => {
       actualContext = context;
     });
 
-    let getContextMessage = utils.findMessageByFunc("getContext");
+    let getContextMessage = utils.findMessageByFunc('getContext');
     expect(getContextMessage).not.toBeNull();
 
     let expectedContext: Context = {
-      groupId: "someGroupId",
-      teamId: "someTeamId",
-      teamName: "someTeamName",
-      channelId: "someChannelId",
-      channelName: "someChannelName",
-      entityId: "someEntityId",
-      subEntityId: "someSubEntityId",
-      locale: "someLocale",
-      upn: "someUpn",
-      tid: "someTid",
-      theme: "someTheme",
+      groupId: 'someGroupId',
+      teamId: 'someTeamId',
+      teamName: 'someTeamName',
+      channelId: 'someChannelId',
+      channelName: 'someChannelName',
+      entityId: 'someEntityId',
+      subEntityId: 'someSubEntityId',
+      locale: 'someLocale',
+      upn: 'someUpn',
+      tid: 'someTid',
+      theme: 'someTheme',
       isFullScreen: true,
       teamType: TeamType.Staff,
-      teamSiteUrl: "someSiteUrl",
-      teamSiteDomain: "someTeamSiteDomain",
-      teamSitePath: "someTeamSitePath",
-      channelRelativeUrl: "someChannelRelativeUrl",
-      sessionId: "someSessionId",
+      teamSiteUrl: 'someSiteUrl',
+      teamSiteDomain: 'someTeamSiteDomain',
+      teamSitePath: 'someTeamSitePath',
+      channelRelativeUrl: 'someChannelRelativeUrl',
+      sessionId: 'someSessionId',
       userTeamRole: UserTeamRole.Admin,
-      chatId: "someChatId",
-      loginHint: "someLoginHint",
-      userPrincipalName: "someUserPrincipalName",
-      userObjectId: "someUserObjectId",
+      chatId: 'someChatId',
+      loginHint: 'someLoginHint',
+      userPrincipalName: 'someUserPrincipalName',
+      userObjectId: 'someUserObjectId',
       isTeamArchived: false,
       hostClientType: HostClientType.web,
       sharepoint: {},
-      tenantSKU: "someTenantSKU",
-      userLicenseType: "someUserLicenseType",
-      parentMessageId: "someParentMessageId",
-      ringId: "someRingId"
+      tenantSKU: 'someTenantSKU',
+      userLicenseType: 'someUserLicenseType',
+      parentMessageId: 'someParentMessageId',
+      ringId: 'someRingId',
     };
 
     utils.respondToMessage(getContextMessage, expectedContext);
@@ -132,8 +197,8 @@ describe("MicrosoftTeams-publicAPIs", () => {
     expect(actualContext).toBe(expectedContext);
   });
 
-  it("should successfully register a back button handler and call navigateBack if it returns false", () => {
-    utils.initializeWithContext("content");
+  it('should successfully register a back button handler and call navigateBack if it returns false', () => {
+    utils.initializeWithContext('content');
 
     let handlerInvoked = false;
     registerBackButtonHandler(() => {
@@ -141,78 +206,72 @@ describe("MicrosoftTeams-publicAPIs", () => {
       return false;
     });
 
-    utils.sendMessage("backButtonPress");
+    utils.sendMessage('backButtonPress');
 
-    let navigateBackMessage = utils.findMessageByFunc("navigateBack");
+    let navigateBackMessage = utils.findMessageByFunc('navigateBack');
     expect(navigateBackMessage).not.toBeNull();
     expect(handlerInvoked).toBe(true);
   });
 
-  describe("navigateCrossDomain", () => {
-    it("should not allow calls before initialization", () => {
-      expect(() =>
-        navigateCrossDomain("https://valid.origin.com")
-      ).toThrowError("The library has not yet been initialized");
-    });
-
-    it("should not allow calls from authentication context", () => {
-      utils.initializeWithContext("authentication");
-
-      expect(() =>
-        navigateCrossDomain("https://valid.origin.com")
-      ).toThrowError(
-        "This call is not allowed in the 'authentication' context"
+  describe('navigateCrossDomain', () => {
+    it('should not allow calls before initialization', () => {
+      expect(() => navigateCrossDomain('https://valid.origin.com')).toThrowError(
+        'The library has not yet been initialized',
       );
     });
 
-    it("should allow calls from content context", () => {
-      utils.initializeWithContext("content");
+    it('should not allow calls from authentication context', () => {
+      utils.initializeWithContext('authentication');
 
-      navigateCrossDomain("https://valid.origin.com");
+      expect(() => navigateCrossDomain('https://valid.origin.com')).toThrowError(
+        "This call is not allowed in the 'authentication' context",
+      );
     });
 
-    it("should allow calls from settings context", () => {
-      utils.initializeWithContext("settings");
+    it('should allow calls from content context', () => {
+      utils.initializeWithContext('content');
 
-      navigateCrossDomain("https://valid.origin.com");
+      navigateCrossDomain('https://valid.origin.com');
     });
 
-    it("should allow calls from remove context", () => {
-      utils.initializeWithContext("remove");
+    it('should allow calls from settings context', () => {
+      utils.initializeWithContext('settings');
 
-      navigateCrossDomain("https://valid.origin.com");
+      navigateCrossDomain('https://valid.origin.com');
     });
 
-    it("should allow calls from task context", () => {
-      utils.initializeWithContext("task");
+    it('should allow calls from remove context', () => {
+      utils.initializeWithContext('remove');
 
-      navigateCrossDomain("https://valid.origin.com");
+      navigateCrossDomain('https://valid.origin.com');
     });
 
-    it("should successfully navigate cross-origin", () => {
-      utils.initializeWithContext("content");
+    it('should allow calls from task context', () => {
+      utils.initializeWithContext('task');
 
-      navigateCrossDomain("https://valid.origin.com");
+      navigateCrossDomain('https://valid.origin.com');
+    });
 
-      let navigateCrossDomainMessage = utils.findMessageByFunc("navigateCrossDomain");
+    it('should successfully navigate cross-origin', () => {
+      utils.initializeWithContext('content');
+
+      navigateCrossDomain('https://valid.origin.com');
+
+      let navigateCrossDomainMessage = utils.findMessageByFunc('navigateCrossDomain');
       expect(navigateCrossDomainMessage).not.toBeNull();
       expect(navigateCrossDomainMessage.args.length).toBe(1);
-      expect(navigateCrossDomainMessage.args[0]).toBe(
-        "https://valid.origin.com"
-      );
+      expect(navigateCrossDomainMessage.args[0]).toBe('https://valid.origin.com');
     });
 
-    it("should throw on invalid cross-origin navigation request", () => {
-      utils.initializeWithContext("settings");
+    it('should throw on invalid cross-origin navigation request', () => {
+      utils.initializeWithContext('settings');
 
-      navigateCrossDomain("https://invalid.origin.com");
+      navigateCrossDomain('https://invalid.origin.com');
 
-      let navigateCrossDomainMessage = utils.findMessageByFunc("navigateCrossDomain");
+      let navigateCrossDomainMessage = utils.findMessageByFunc('navigateCrossDomain');
       expect(navigateCrossDomainMessage).not.toBeNull();
       expect(navigateCrossDomainMessage.args.length).toBe(1);
-      expect(navigateCrossDomainMessage.args[0]).toBe(
-        "https://invalid.origin.com"
-      );
+      expect(navigateCrossDomainMessage.args[0]).toBe('https://invalid.origin.com');
 
       let respondWithFailure = () => {
         utils.respondToMessage(navigateCrossDomainMessage, false);
@@ -222,53 +281,47 @@ describe("MicrosoftTeams-publicAPIs", () => {
     });
   });
 
-  describe("getTabInstances", () => {
-    it("should allow a missing and valid optional parameter", () => {
-      utils.initializeWithContext("content");
+  describe('getTabInstances', () => {
+    it('should allow a missing and valid optional parameter', () => {
+      utils.initializeWithContext('content');
 
       getTabInstances(tabInfo => tabInfo);
-      getTabInstances(
-        tabInfo => tabInfo,
-        {} as TabInstanceParameters
-      );
+      getTabInstances(tabInfo => tabInfo, {} as TabInstanceParameters);
     });
   });
 
-  describe("getMruTabInstances", () => {
-    it("should allow a missing and valid optional parameter", () => {
-      utils.initializeWithContext("content");
+  describe('getMruTabInstances', () => {
+    it('should allow a missing and valid optional parameter', () => {
+      utils.initializeWithContext('content');
 
       getMruTabInstances(tabInfo => tabInfo);
-      getMruTabInstances(
-        tabInfo => tabInfo,
-        {} as TabInstanceParameters
-      );
+      getMruTabInstances(tabInfo => tabInfo, {} as TabInstanceParameters);
     });
   });
 
-  describe("executeDeepLink in content context ", () => {
-    it("should not allow calls before initialization", () => {
+  describe('executeDeepLink in content context ', () => {
+    it('should not allow calls before initialization', () => {
       expect(() =>
-        executeDeepLink("dummyLink", () => {
+        executeDeepLink('dummyLink', () => {
           return;
-        })
-      ).toThrowError("The library has not yet been initialized");
+        }),
+      ).toThrowError('The library has not yet been initialized');
     });
 
-    it("should successfully send a request", () => {
-      utils.initializeWithContext("content");
-      const request = "dummyDeepLink"
+    it('should successfully send a request', () => {
+      utils.initializeWithContext('content');
+      const request = 'dummyDeepLink';
 
       let requestResponse: boolean;
       let error: string;
 
-      const onComplete = (status: boolean, reason?: string) => (requestResponse = status, error = reason);
+      const onComplete = (status: boolean, reason?: string) => ((requestResponse = status), (error = reason));
 
       // send message request
       executeDeepLink(request, onComplete);
 
       // find message request in jest
-      const message = utils.findMessageByFunc("executeDeepLink");
+      const message = utils.findMessageByFunc('executeDeepLink');
 
       // check message is sending correct data
       expect(message).not.toBeUndefined();
@@ -276,7 +329,7 @@ describe("MicrosoftTeams-publicAPIs", () => {
 
       // simulate response
       const data = {
-        success: true
+        success: true,
       };
 
       utils.respondToMessage(message, data.success);
@@ -286,20 +339,20 @@ describe("MicrosoftTeams-publicAPIs", () => {
       expect(error).toBeUndefined();
     });
 
-    it("should invoke error callback", () => {
-      utils.initializeWithContext("content");
-      const request = "dummyDeepLink"
+    it('should invoke error callback', () => {
+      utils.initializeWithContext('content');
+      const request = 'dummyDeepLink';
 
       let requestResponse: boolean;
       let error: string;
 
-      const onComplete = (status: boolean, reason?: string) => (requestResponse = status, error = reason);
+      const onComplete = (status: boolean, reason?: string) => ((requestResponse = status), (error = reason));
 
       // send message request
       executeDeepLink(request, onComplete);
 
       // find message request in jest
-      const message = utils.findMessageByFunc("executeDeepLink");
+      const message = utils.findMessageByFunc('executeDeepLink');
 
       // check message is sending correct data
       expect(message).not.toBeUndefined();
@@ -308,29 +361,29 @@ describe("MicrosoftTeams-publicAPIs", () => {
       // simulate response
       const data = {
         success: false,
-        error: "Something went wrong..."
+        error: 'Something went wrong...',
       };
       utils.respondToMessage(message, data.success, data.error);
 
       // check data is returned properly
       expect(requestResponse).toBe(false);
-      expect(error).toBe("Something went wrong...");
+      expect(error).toBe('Something went wrong...');
     });
 
-    it("should successfully send a request", () => {
-      utils.initializeWithContext("content");
-      const request = "dummyDeepLink"
+    it('should successfully send a request', () => {
+      utils.initializeWithContext('content');
+      const request = 'dummyDeepLink';
 
       let requestResponse: boolean;
       let error: string;
 
-      const onComplete = (status: boolean, reason?: string) => (requestResponse = status, error = reason);
+      const onComplete = (status: boolean, reason?: string) => ((requestResponse = status), (error = reason));
 
       // send message request
       executeDeepLink(request, onComplete);
 
       // find message request in jest
-      const message = utils.findMessageByFunc("executeDeepLink");
+      const message = utils.findMessageByFunc('executeDeepLink');
 
       // check message is sending correct data
       expect(message).not.toBeUndefined();
@@ -338,7 +391,7 @@ describe("MicrosoftTeams-publicAPIs", () => {
 
       // simulate response
       const data = {
-        success: true
+        success: true,
       };
       utils.respondToMessage(message, data.success);
 
@@ -348,29 +401,29 @@ describe("MicrosoftTeams-publicAPIs", () => {
     });
   });
 
-  describe("executeDeepLink in task module context ", () => {
-    it("should not allow calls before initialization", () => {
+  describe('executeDeepLink in task module context ', () => {
+    it('should not allow calls before initialization', () => {
       expect(() =>
-        executeDeepLink("dummyLink", () => {
+        executeDeepLink('dummyLink', () => {
           return;
-        })
-      ).toThrowError("The library has not yet been initialized");
+        }),
+      ).toThrowError('The library has not yet been initialized');
     });
 
-    it("should successfully send a request", () => {
+    it('should successfully send a request', () => {
       utils.initializeWithContext(frameContexts.task);
-      const request = "dummyDeepLink"
+      const request = 'dummyDeepLink';
 
       let requestResponse: boolean;
       let error: string;
 
-      const onComplete = (status: boolean, reason?: string) => (requestResponse = status, error = reason);
+      const onComplete = (status: boolean, reason?: string) => ((requestResponse = status), (error = reason));
 
       // send message request
       executeDeepLink(request, onComplete);
 
       // find message request in jest
-      const message = utils.findMessageByFunc("executeDeepLink");
+      const message = utils.findMessageByFunc('executeDeepLink');
 
       // check message is sending correct data
       expect(message).not.toBeUndefined();
@@ -378,7 +431,7 @@ describe("MicrosoftTeams-publicAPIs", () => {
 
       // simulate response
       const data = {
-        success: true
+        success: true,
       };
 
       utils.respondToMessage(message, data.success);
@@ -388,20 +441,20 @@ describe("MicrosoftTeams-publicAPIs", () => {
       expect(error).toBeUndefined();
     });
 
-    it("should invoke error callback", () => {
+    it('should invoke error callback', () => {
       utils.initializeWithContext(frameContexts.task);
-      const request = "dummyDeepLink"
+      const request = 'dummyDeepLink';
 
       let requestResponse: boolean;
       let error: string;
 
-      const onComplete = (status: boolean, reason?: string) => (requestResponse = status, error = reason);
+      const onComplete = (status: boolean, reason?: string) => ((requestResponse = status), (error = reason));
 
       // send message request
       executeDeepLink(request, onComplete);
 
       // find message request in jest
-      const message = utils.findMessageByFunc("executeDeepLink");
+      const message = utils.findMessageByFunc('executeDeepLink');
 
       // check message is sending correct data
       expect(message).not.toBeUndefined();
@@ -410,30 +463,30 @@ describe("MicrosoftTeams-publicAPIs", () => {
       // simulate response
       const data = {
         success: false,
-        error: "Something went wrong..."
+        error: 'Something went wrong...',
       };
 
       utils.respondToMessage(message, data.success, data.error);
 
       // check data is returned properly
       expect(requestResponse).toBe(false);
-      expect(error).toBe("Something went wrong...");
+      expect(error).toBe('Something went wrong...');
     });
 
-    it("should successfully send a request", () => {
-      utils.initializeWithContext("content");
-      const request = "dummyDeepLink"
+    it('should successfully send a request', () => {
+      utils.initializeWithContext('content');
+      const request = 'dummyDeepLink';
 
       let requestResponse: boolean;
       let error: string;
 
-      const onComplete = (status: boolean, reason?: string) => (requestResponse = status, error = reason);
+      const onComplete = (status: boolean, reason?: string) => ((requestResponse = status), (error = reason));
 
       // send message request
       executeDeepLink(request, onComplete);
 
       // find message request in jest
-      const message = utils.findMessageByFunc("executeDeepLink");
+      const message = utils.findMessageByFunc('executeDeepLink');
 
       // check message is sending correct data
       expect(message).not.toBeUndefined();
@@ -441,7 +494,7 @@ describe("MicrosoftTeams-publicAPIs", () => {
 
       // simulate response
       const data = {
-        success: true
+        success: true,
       };
 
       utils.respondToMessage(message, data.success);
@@ -451,17 +504,16 @@ describe("MicrosoftTeams-publicAPIs", () => {
       expect(error).toBeUndefined();
     });
   });
-
 
   it("Ctrl+P shouldn't call print handler if printCapabilty is disabled", () => {
     let handlerCalled = false;
-    initialize(utils.mockWindow);
-    spyOn(microsoftTeams, "print").and.callFake(
+    initialize();
+    spyOn(microsoftTeams, 'print').and.callFake(
       (): void => {
         handlerCalled = true;
-      }
+      },
     );
-    let printEvent = new Event("keydown");
+    let printEvent = new Event('keydown');
     // tslint:disable:no-any
     (printEvent as any).keyCode = 80;
     (printEvent as any).ctrlKey = true;
@@ -473,13 +525,13 @@ describe("MicrosoftTeams-publicAPIs", () => {
 
   it("Cmd+P shouldn't call print handler if printCapabilty is disabled", () => {
     let handlerCalled = false;
-    initialize(utils.mockWindow);
-    spyOn(microsoftTeams, "print").and.callFake(
+    initialize();
+    spyOn(microsoftTeams, 'print').and.callFake(
       (): void => {
         handlerCalled = true;
-      }
+      },
     );
-    let printEvent = new Event("keydown");
+    let printEvent = new Event('keydown');
     // tslint:disable:no-any
     (printEvent as any).keyCode = 80;
     (printEvent as any).metaKey = true;
@@ -489,14 +541,14 @@ describe("MicrosoftTeams-publicAPIs", () => {
     expect(handlerCalled).toBeFalsy();
   });
 
-  it("print handler should successfully call default print handler", () => {
+  it('print handler should successfully call default print handler', () => {
     let handlerCalled = false;
-    initialize(utils.mockWindow);
+    initialize();
     enablePrintCapability();
-    spyOn(window, "print").and.callFake(
+    spyOn(window, 'print').and.callFake(
       (): void => {
         handlerCalled = true;
-      }
+      },
     );
 
     print();
@@ -504,16 +556,16 @@ describe("MicrosoftTeams-publicAPIs", () => {
     expect(handlerCalled).toBeTruthy();
   });
 
-  it("Ctrl+P should successfully call print handler", () => {
+  it('Ctrl+P should successfully call print handler', () => {
     let handlerCalled = false;
-    initialize(utils.mockWindow);
+    initialize();
     enablePrintCapability();
-    spyOn(window, "print").and.callFake(
+    spyOn(window, 'print').and.callFake(
       (): void => {
         handlerCalled = true;
-      }
+      },
     );
-    let printEvent = new Event("keydown");
+    let printEvent = new Event('keydown');
     // tslint:disable:no-any
     (printEvent as any).keyCode = 80;
     (printEvent as any).ctrlKey = true;
@@ -523,16 +575,16 @@ describe("MicrosoftTeams-publicAPIs", () => {
     expect(handlerCalled).toBeTruthy();
   });
 
-  it("Cmd+P should successfully call print handler", () => {
+  it('Cmd+P should successfully call print handler', () => {
     let handlerCalled = false;
-    initialize(utils.mockWindow);
+    initialize();
     enablePrintCapability();
-    spyOn(window, "print").and.callFake(
+    spyOn(window, 'print').and.callFake(
       (): void => {
         handlerCalled = true;
-      }
+      },
     );
-    let printEvent = new Event("keydown");
+    let printEvent = new Event('keydown');
     // tslint:disable:no-any
     (printEvent as any).keyCode = 80;
     (printEvent as any).metaKey = true;
@@ -542,17 +594,17 @@ describe("MicrosoftTeams-publicAPIs", () => {
     expect(handlerCalled).toBe(true);
   });
 
-  describe("registerBeforeUnloadHandler", () => {
-    it("should not allow calls before initialization", () => {
+  describe('registerBeforeUnloadHandler', () => {
+    it('should not allow calls before initialization', () => {
       expect(() =>
         registerBeforeUnloadHandler(() => {
           return false;
-        })
-      ).toThrowError("The library has not yet been initialized");
+        }),
+      ).toThrowError('The library has not yet been initialized');
     });
 
-    it("should successfully register a before unload handler", () => {
-      utils.initializeWithContext("content");
+    it('should successfully register a before unload handler', () => {
+      utils.initializeWithContext('content');
 
       let handlerInvoked = false;
       registerBeforeUnloadHandler(() => {
@@ -560,39 +612,39 @@ describe("MicrosoftTeams-publicAPIs", () => {
         return false;
       });
 
-      utils.sendMessage("beforeUnload");
+      utils.sendMessage('beforeUnload');
 
       expect(handlerInvoked).toBe(true);
     });
 
-    it("should call readyToUnload automatically when no before unload handler is registered", () => {
-      utils.initializeWithContext("content");
+    it('should call readyToUnload automatically when no before unload handler is registered', () => {
+      utils.initializeWithContext('content');
 
-      utils.sendMessage("beforeUnload");
+      utils.sendMessage('beforeUnload');
 
-      let readyToUnloadMessage = utils.findMessageByFunc("readyToUnload");
+      let readyToUnloadMessage = utils.findMessageByFunc('readyToUnload');
       expect(readyToUnloadMessage).not.toBeNull();
     });
 
-    it("should successfully share a deep link", () => {
-      utils.initializeWithContext("content");
+    it('should successfully share a deep link', () => {
+      utils.initializeWithContext('content');
 
       shareDeepLink({
-        subEntityId: "someSubEntityId",
-        subEntityLabel: "someSubEntityLabel",
-        subEntityWebUrl: "someSubEntityWebUrl"
+        subEntityId: 'someSubEntityId',
+        subEntityLabel: 'someSubEntityLabel',
+        subEntityWebUrl: 'someSubEntityWebUrl',
       });
 
-      let message = utils.findMessageByFunc("shareDeepLink");
+      let message = utils.findMessageByFunc('shareDeepLink');
       expect(message).not.toBeNull();
       expect(message.args.length).toBe(3);
-      expect(message.args[0]).toBe("someSubEntityId");
-      expect(message.args[1]).toBe("someSubEntityLabel");
-      expect(message.args[2]).toBe("someSubEntityWebUrl");
+      expect(message.args[0]).toBe('someSubEntityId');
+      expect(message.args[1]).toBe('someSubEntityLabel');
+      expect(message.args[2]).toBe('someSubEntityWebUrl');
     });
 
-    it("should successfully register a before unload handler and not call readyToUnload if it returns true", () => {
-      utils.initializeWithContext("content");
+    it('should successfully register a before unload handler and not call readyToUnload if it returns true', () => {
+      utils.initializeWithContext('content');
 
       let handlerInvoked = false;
       let readyToUnloadFunc: () => void;
@@ -602,16 +654,15 @@ describe("MicrosoftTeams-publicAPIs", () => {
         return true;
       });
 
-      utils.sendMessage("beforeUnload");
+      utils.sendMessage('beforeUnload');
 
-      let readyToUnloadMessage = utils.findMessageByFunc("readyToUnload");
+      let readyToUnloadMessage = utils.findMessageByFunc('readyToUnload');
       expect(readyToUnloadMessage).toBeNull();
       expect(handlerInvoked).toBe(true);
 
       readyToUnloadFunc();
-      readyToUnloadMessage = utils.findMessageByFunc("readyToUnload");
+      readyToUnloadMessage = utils.findMessageByFunc('readyToUnload');
       expect(readyToUnloadMessage).not.toBeNull();
     });
   });
-
 });

--- a/test/public/settings.spec.ts
+++ b/test/public/settings.spec.ts
@@ -1,8 +1,8 @@
-import { settings } from "../../src/public/settings";
+import { settings } from '../../src/public/settings';
 import { Utils } from '../utils';
-import { _uninitialize } from "../../src/public/publicAPIs";
+import { _uninitialize } from '../../src/public/publicAPIs';
 
-describe("settings", () => {
+describe('settings', () => {
   // Use to send a mock message from the app.
 
   const utils = new Utils();
@@ -21,75 +21,73 @@ describe("settings", () => {
     }
   });
 
-  it("should not allow calls from the wrong context", () => {
-    utils.initializeWithContext("content");
+  it('should not allow calls from the wrong context', () => {
+    utils.initializeWithContext('content');
 
-    expect(() => settings.setValidityState(true)).toThrowError(
-      "This call is not allowed in the 'content' context"
-    );
+    expect(() => settings.setValidityState(true)).toThrowError("This call is not allowed in the 'content' context");
   });
 
-  it("should successfully notify success on save when there is no registered handler", () => {
-    utils.initializeWithContext("settings");
+  it('should successfully notify success on save when there is no registered handler', () => {
+    utils.initializeWithContext('settings');
 
-    utils.sendMessage("settings.save");
+    utils.sendMessage('settings.save');
 
-    let message = utils.findMessageByFunc("settings.save.success");
+    let message = utils.findMessageByFunc('settings.save.success');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(0);
   });
 
-  it("should successfully register a remove handler", () => {
-    utils.initializeWithContext("remove");
+  it('should successfully register a remove handler', () => {
+    utils.initializeWithContext('remove');
 
     let handlerCalled = false;
     settings.registerOnRemoveHandler(() => {
       handlerCalled = true;
     });
 
-    utils.sendMessage("settings.remove");
+    utils.sendMessage('settings.remove');
 
     expect(handlerCalled).toBeTruthy();
   });
 
-  it("should successfully set validity state to true", () => {
-    utils.initializeWithContext("settings");
+  it('should successfully set validity state to true', () => {
+    utils.initializeWithContext('settings');
 
     settings.setValidityState(true);
 
-    let message = utils.findMessageByFunc("settings.setValidityState");
+    let message = utils.findMessageByFunc('settings.setValidityState');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(1);
     expect(message.args[0]).toBe(true);
   });
 
-  it("should successfully set validity state to false", () => {
-    utils.initializeWithContext("settings");
+  it('should successfully set validity state to false', () => {
+    utils.initializeWithContext('settings');
 
     settings.setValidityState(false);
 
-    let message = utils.findMessageByFunc("settings.setValidityState");
+    let message = utils.findMessageByFunc('settings.setValidityState');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(1);
     expect(message.args[0]).toBe(false);
   });
 
-  it("should successfully get settings", () => {
-    utils.initializeWithContext("settings");
+  it('should successfully get settings', () => {
+    utils.initializeWithContext('settings');
 
     let actualSettings: settings.Settings;
     settings.getSettings(settings => {
       actualSettings = settings;
     });
 
-    let message = utils.findMessageByFunc("settings.getSettings");
+    let message = utils.findMessageByFunc('settings.getSettings');
     expect(message).not.toBeNull();
 
     let expectedSettings: settings.Settings = {
-      suggestedDisplayName: "someSuggestedDisplayName",
-      contentUrl: "someContentUrl",
-      websiteUrl: "someWebsiteUrl",
-      entityId: "someEntityId"
+      suggestedDisplayName: 'someSuggestedDisplayName',
+      contentUrl: 'someContentUrl',
+      websiteUrl: 'someWebsiteUrl',
+      entityId: 'someEntityId',
     };
 
     utils.respondToMessage(message, expectedSettings);
@@ -97,56 +95,56 @@ describe("settings", () => {
     expect(actualSettings).toBe(expectedSettings);
   });
 
-  it("should successfully set settings", () => {
-    utils.initializeWithContext("settings");
+  it('should successfully set settings', () => {
+    utils.initializeWithContext('settings');
 
     let settingsObj: settings.Settings = {
-      suggestedDisplayName: "someSuggestedDisplayName",
-      contentUrl: "someContentUrl",
-      websiteUrl: "someWebsiteUrl",
-      entityId: "someEntityId"
+      suggestedDisplayName: 'someSuggestedDisplayName',
+      contentUrl: 'someContentUrl',
+      websiteUrl: 'someWebsiteUrl',
+      entityId: 'someEntityId',
     };
     settings.setSettings(settingsObj);
 
-    let message = utils.findMessageByFunc("settings.setSettings");
+    let message = utils.findMessageByFunc('settings.setSettings');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(1);
     expect(message.args[0]).toBe(settingsObj);
   });
 
-  it("should successfully register a save handler", () => {
-    utils.initializeWithContext("settings");
+  it('should successfully register a save handler', () => {
+    utils.initializeWithContext('settings');
 
     let handlerCalled = false;
     settings.registerOnSaveHandler(() => {
       handlerCalled = true;
     });
 
-    utils.sendMessage("settings.save");
+    utils.sendMessage('settings.save');
 
     expect(handlerCalled).toBe(true);
   });
 
-  it("should successfully register a remove handler", () => {
-    utils.initializeWithContext("settings");
+  it('should successfully register a remove handler', () => {
+    utils.initializeWithContext('settings');
 
     let handlerCalled = false;
     settings.registerOnSaveHandler(saveEvent => {
       handlerCalled = true;
-      expect(saveEvent.result["webhookUrl"]).not.toBeNull();
+      expect(saveEvent.result['webhookUrl']).not.toBeNull();
     });
 
-    utils.sendMessage("settings.save", [
+    utils.sendMessage('settings.save', [
       {
-        webhookUrl: "someWebhookUrl"
-      }
+        webhookUrl: 'someWebhookUrl',
+      },
     ]);
 
     expect(handlerCalled).toBe(true);
   });
 
-  it("should successfully override a save handler with another", () => {
-    utils.initializeWithContext("settings");
+  it('should successfully override a save handler with another', () => {
+    utils.initializeWithContext('settings');
 
     let handler1Called = false;
     let handler2Called = false;
@@ -157,14 +155,14 @@ describe("settings", () => {
       handler2Called = true;
     });
 
-    utils.sendMessage("settings.save");
+    utils.sendMessage('settings.save');
 
     expect(handler1Called).toBe(false);
     expect(handler2Called).toBe(true);
   });
 
-  it("should successfully notify success from the registered save handler", () => {
-    utils.initializeWithContext("settings");
+  it('should successfully notify success from the registered save handler', () => {
+    utils.initializeWithContext('settings');
 
     let handlerCalled = false;
     settings.registerOnSaveHandler(saveEvent => {
@@ -172,44 +170,44 @@ describe("settings", () => {
       handlerCalled = true;
     });
 
-    utils.sendMessage("settings.save");
+    utils.sendMessage('settings.save');
 
     expect(handlerCalled).toBe(true);
-    let message = utils.findMessageByFunc("settings.save.success");
+    let message = utils.findMessageByFunc('settings.save.success');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(0);
   });
 
-  it("should successfully notify failure from the registered save handler", () => {
-    utils.initializeWithContext("settings");
+  it('should successfully notify failure from the registered save handler', () => {
+    utils.initializeWithContext('settings');
 
     let handlerCalled = false;
     settings.registerOnSaveHandler(saveEvent => {
-      saveEvent.notifyFailure("someReason");
+      saveEvent.notifyFailure('someReason');
       handlerCalled = true;
     });
 
-    utils.sendMessage("settings.save");
+    utils.sendMessage('settings.save');
 
     expect(handlerCalled).toBe(true);
-    let message = utils.findMessageByFunc("settings.save.failure");
+    let message = utils.findMessageByFunc('settings.save.failure');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(1);
-    expect(message.args[0]).toBe("someReason");
+    expect(message.args[0]).toBe('someReason');
   });
 
-  it("should successfully notify success on remove when there is no registered handler", () => {
-    utils.initializeWithContext("remove");
+  it('should successfully notify success on remove when there is no registered handler', () => {
+    utils.initializeWithContext('remove');
 
-    utils.sendMessage("settings.remove");
+    utils.sendMessage('settings.remove');
 
-    let message = utils.findMessageByFunc("settings.remove.success");
+    let message = utils.findMessageByFunc('settings.remove.success');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(0);
   });
 
-  it("should successfully notify success from the registered remove handler", () => {
-    utils.initializeWithContext("remove");
+  it('should successfully notify success from the registered remove handler', () => {
+    utils.initializeWithContext('remove');
 
     let handlerCalled = false;
     settings.registerOnRemoveHandler(removeEvent => {
@@ -217,51 +215,47 @@ describe("settings", () => {
       handlerCalled = true;
     });
 
-    utils.sendMessage("settings.remove");
+    utils.sendMessage('settings.remove');
 
     expect(handlerCalled).toBe(true);
-    let message = utils.findMessageByFunc("settings.remove.success");
+    let message = utils.findMessageByFunc('settings.remove.success');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(0);
   });
 
-  it("should successfully notify failure from the registered remove handler", () => {
-    utils.initializeWithContext("remove");
+  it('should successfully notify failure from the registered remove handler', () => {
+    utils.initializeWithContext('remove');
 
     let handlerCalled = false;
     settings.registerOnRemoveHandler(removeEvent => {
-      removeEvent.notifyFailure("someReason");
+      removeEvent.notifyFailure('someReason');
       handlerCalled = true;
     });
 
-    utils.sendMessage("settings.remove");
+    utils.sendMessage('settings.remove');
 
     expect(handlerCalled).toBe(true);
-    let message = utils.findMessageByFunc("settings.remove.failure");
+    let message = utils.findMessageByFunc('settings.remove.failure');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(1);
-    expect(message.args[0]).toBe("someReason");
+    expect(message.args[0]).toBe('someReason');
   });
 
-  it("should not allow multiple notifies from the registered save handler", () => {
-    utils.initializeWithContext("settings");
+  it('should not allow multiple notifies from the registered save handler', () => {
+    utils.initializeWithContext('settings');
 
     let handlerCalled = false;
     settings.registerOnSaveHandler(saveEvent => {
       saveEvent.notifySuccess();
-      expect(() => saveEvent.notifySuccess()).toThrowError(
-        "The SaveEvent may only notify success or failure once."
-      );
-      expect(() => saveEvent.notifyFailure()).toThrowError(
-        "The SaveEvent may only notify success or failure once."
-      );
+      expect(() => saveEvent.notifySuccess()).toThrowError('The SaveEvent may only notify success or failure once.');
+      expect(() => saveEvent.notifyFailure()).toThrowError('The SaveEvent may only notify success or failure once.');
       handlerCalled = true;
     });
 
-    utils.sendMessage("settings.save");
+    utils.sendMessage('settings.save');
 
     expect(handlerCalled).toBe(true);
-    let message = utils.findMessageByFunc("settings.save.success");
+    let message = utils.findMessageByFunc('settings.save.success');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(0);
   });

--- a/test/public/tasks.spec.ts
+++ b/test/public/tasks.spec.ts
@@ -1,10 +1,10 @@
-import { TaskInfo } from "../../src/public/interfaces";
-import { TaskModuleDimension } from "../../src/public/constants";
-import { tasks } from "../../src/public/tasks";
+import { TaskInfo } from '../../src/public/interfaces';
+import { TaskModuleDimension } from '../../src/public/constants';
+import { tasks } from '../../src/public/tasks';
 import { Utils } from '../utils';
-import { _uninitialize } from "../../src/public/publicAPIs";
+import { _uninitialize } from '../../src/public/publicAPIs';
 
-describe("tasks", () => {
+describe('tasks', () => {
   // Use to send a mock message from the app.
 
   const utils = new Utils();
@@ -23,191 +23,165 @@ describe("tasks", () => {
     }
   });
 
-  describe("startTask", () => {
-    it("should not allow calls before initialization", () => {
+  describe('startTask', () => {
+    it('should not allow calls before initialization', () => {
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError(
-        "The library has not yet been initialized"
-      );
+      expect(() => tasks.startTask(taskInfo)).toThrowError('The library has not yet been initialized');
     });
 
-    it("should not allow calls from settings context", () => {
-      utils.initializeWithContext("settings");
+    it('should not allow calls from settings context', () => {
+      utils.initializeWithContext('settings');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError(
-        "This call is not allowed in the 'settings' context"
-      );
+      expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'settings' context");
     });
 
-    it("should not allow calls from authentication context", () => {
-      utils.initializeWithContext("authentication");
+    it('should not allow calls from authentication context', () => {
+      utils.initializeWithContext('authentication');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError(
-        "This call is not allowed in the 'authentication' context"
-      );
+      expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'authentication' context");
     });
 
-    it("should not allow calls from remove context", () => {
-      utils.initializeWithContext("remove");
+    it('should not allow calls from remove context', () => {
+      utils.initializeWithContext('remove');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError(
-        "This call is not allowed in the 'remove' context"
-      );
+      expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'remove' context");
     });
 
-    it("should not allow calls from task context", () => {
-      utils.initializeWithContext("task");
+    it('should not allow calls from task context', () => {
+      utils.initializeWithContext('task');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError(
-        "This call is not allowed in the 'task' context"
-      );
+      expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'task' context");
     });
 
-    it("should pass along entire TaskInfo parameter", () => {
-      utils.initializeWithContext("content");
+    it('should pass along entire TaskInfo parameter', () => {
+      utils.initializeWithContext('content');
 
       const taskInfo: TaskInfo = {
-        card: "someCard",
-        fallbackUrl: "someFallbackUrl",
+        card: 'someCard',
+        fallbackUrl: 'someFallbackUrl',
         height: TaskModuleDimension.Large,
         width: TaskModuleDimension.Large,
-        title: "someTitle",
-        url: "someUrl",
-        completionBotId: "someCompletionBotId"
+        title: 'someTitle',
+        url: 'someUrl',
+        completionBotId: 'someCompletionBotId',
       };
 
       tasks.startTask(taskInfo, () => {
         return;
       });
 
-      const startTaskMessage = utils.findMessageByFunc("tasks.startTask");
+      const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
       expect(startTaskMessage).not.toBeNull();
       expect(startTaskMessage.args).toEqual([taskInfo]);
     });
 
-    it("should invoke callback with result", () => {
-      utils.initializeWithContext("content");
+    it('should invoke callback with result', () => {
+      utils.initializeWithContext('content');
 
       let callbackCalled = false;
       const taskInfo: TaskInfo = {};
       tasks.startTask(taskInfo, (err, result) => {
         expect(err).toBeNull();
-        expect(result).toBe("someResult");
+        expect(result).toBe('someResult');
         callbackCalled = true;
       });
 
-      const startTaskMessage = utils.findMessageByFunc("tasks.startTask");
+      const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
       expect(startTaskMessage).not.toBeNull();
-      utils.respondToMessage(startTaskMessage, null, "someResult");
+      utils.respondToMessage(startTaskMessage, null, 'someResult');
       expect(callbackCalled).toBe(true);
     });
 
-    it("should invoke callback with error", () => {
-      utils.initializeWithContext("content");
+    it('should invoke callback with error', () => {
+      utils.initializeWithContext('content');
 
       let callbackCalled = false;
       const taskInfo: TaskInfo = {};
       tasks.startTask(taskInfo, (err, result) => {
-        expect(err).toBe("someError");
+        expect(err).toBe('someError');
         expect(result).toBeUndefined();
         callbackCalled = true;
       });
 
-      const startTaskMessage = utils.findMessageByFunc("tasks.startTask");
+      const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
       expect(startTaskMessage).not.toBeNull();
-      utils.respondToMessage(startTaskMessage, "someError");
+      utils.respondToMessage(startTaskMessage, 'someError');
       expect(callbackCalled).toBe(true);
     });
   });
 
-  describe("updateTask", () => {
-    it("should not allow calls before initialization", () => {
+  describe('updateTask', () => {
+    it('should not allow calls before initialization', () => {
       // tslint:disable-next-line:no-any
-      expect(() => tasks.updateTask({} as any)).toThrowError(
-        "The library has not yet been initialized"
-      );
+      expect(() => tasks.updateTask({} as any)).toThrowError('The library has not yet been initialized');
     });
 
-    it("should successfully pass taskInfo", () => {
-      utils.initializeWithContext("task");
+    it('should successfully pass taskInfo', () => {
+      utils.initializeWithContext('task');
       const taskInfo = { width: 10, height: 10 };
 
       tasks.updateTask(taskInfo);
 
-      const updateTaskMessage = utils.findMessageByFunc("tasks.updateTask");
+      const updateTaskMessage = utils.findMessageByFunc('tasks.updateTask');
       expect(updateTaskMessage).not.toBeNull();
       expect(updateTaskMessage.args).toEqual([taskInfo]);
     });
 
-    it("should throw an error if extra properties are provided", () => {
-      utils.initializeWithContext("task");
-      const taskInfo = { width: 10, height: 10, title: "anything" };
+    it('should throw an error if extra properties are provided', () => {
+      utils.initializeWithContext('task');
+      const taskInfo = { width: 10, height: 10, title: 'anything' };
 
       expect(() => tasks.updateTask(taskInfo)).toThrowError(
-        "updateTask requires a taskInfo argument containing only width and height"
+        'updateTask requires a taskInfo argument containing only width and height',
       );
     });
   });
 
-  describe("submitTask", () => {
-    it("should not allow calls before initialization", () => {
-      expect(() => tasks.submitTask()).toThrowError(
-        "The library has not yet been initialized"
-      );
+  describe('submitTask', () => {
+    it('should not allow calls before initialization', () => {
+      expect(() => tasks.submitTask()).toThrowError('The library has not yet been initialized');
     });
 
-    it("should not allow calls from settings context", () => {
-      utils.initializeWithContext("settings");
+    it('should not allow calls from settings context', () => {
+      utils.initializeWithContext('settings');
 
-      expect(() => tasks.submitTask()).toThrowError(
-        "This call is not allowed in the 'settings' context"
-      );
+      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'settings' context");
     });
 
-    it("should not allow calls from authentication context", () => {
-      utils.initializeWithContext("authentication");
+    it('should not allow calls from authentication context', () => {
+      utils.initializeWithContext('authentication');
 
-      expect(() => tasks.submitTask()).toThrowError(
-        "This call is not allowed in the 'authentication' context"
-      );
+      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'authentication' context");
     });
 
-    it("should not allow calls from remove context", () => {
-      utils.initializeWithContext("remove");
+    it('should not allow calls from remove context', () => {
+      utils.initializeWithContext('remove');
 
-      expect(() => tasks.submitTask()).toThrowError(
-        "This call is not allowed in the 'remove' context"
-      );
+      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'remove' context");
     });
 
-    it("should successfully pass result and appIds parameters when called from task context", () => {
-      utils.initializeWithContext("task");
+    it('should successfully pass result and appIds parameters when called from task context', () => {
+      utils.initializeWithContext('task');
 
-      tasks.submitTask("someResult", [
-        "someAppId",
-        "someOtherAppId"
-      ]);
+      tasks.submitTask('someResult', ['someAppId', 'someOtherAppId']);
 
-      const submitTaskMessage = utils.findMessageByFunc("tasks.completeTask");
+      const submitTaskMessage = utils.findMessageByFunc('tasks.completeTask');
       expect(submitTaskMessage).not.toBeNull();
-      expect(submitTaskMessage.args).toEqual([
-        "someResult",
-        ["someAppId", "someOtherAppId"]
-      ]);
+      expect(submitTaskMessage.args).toEqual(['someResult', ['someAppId', 'someOtherAppId']]);
     });
 
-    it("should handle a single string passed as appIds parameter", () => {
-      utils.initializeWithContext("task");
+    it('should handle a single string passed as appIds parameter', () => {
+      utils.initializeWithContext('task');
 
-      tasks.submitTask("someResult", "someAppId");
+      tasks.submitTask('someResult', 'someAppId');
 
-      const submitTaskMessage = utils.findMessageByFunc("tasks.completeTask");
+      const submitTaskMessage = utils.findMessageByFunc('tasks.completeTask');
       expect(submitTaskMessage).not.toBeNull();
-      expect(submitTaskMessage.args).toEqual(["someResult", ["someAppId"]]);
+      expect(submitTaskMessage.args).toEqual(['someResult', ['someAppId']]);
     });
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -102,7 +102,8 @@ export class Utils {
     frameContext: string,
     hostClientType?: string
   ): void => {
-    microsoftTeams1.initialize(this.mockWindow);
+    microsoftTeams1._initialize(this.mockWindow);
+    microsoftTeams1.initialize();
 
     const initMessage = this.findMessageByFunc("initialize");
     expect(initMessage).not.toBeNull();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,4 @@
-import * as microsoftTeams1 from "../src/public/publicAPIs";
+import * as microsoftTeams1 from '../src/public/publicAPIs';
 export interface MessageRequest {
   id: number;
   func: string;
@@ -11,9 +11,9 @@ export interface MessageResponse {
 }
 
 export class Utils {
-  public tabOrigin = "https://example.com";
+  public tabOrigin = 'https://example.com';
 
-  public validOrigin = "https://teams.microsoft.com";
+  public validOrigin = 'https://teams.microsoft.com';
 
   public mockWindow;
 
@@ -34,82 +34,66 @@ export class Utils {
       outerHeight: 768,
       screenLeft: 0,
       screenTop: 0,
-      addEventListener: function (
-        type: string,
-        listener: (ev: MessageEvent) => void,
-        useCapture?: boolean
-      ): void {
-        if (type === "message") {
+      addEventListener: function(type: string, listener: (ev: MessageEvent) => void, useCapture?: boolean): void {
+        if (type === 'message') {
           that.processMessage = listener;
         }
       },
-      removeEventListener: function (
-        type: string,
-        listener: (ev: MessageEvent) => void,
-        useCapture?: boolean
-      ): void {
-        if (type === "message") {
+      removeEventListener: function(type: string, listener: (ev: MessageEvent) => void, useCapture?: boolean): void {
+        if (type === 'message') {
           that.processMessage = null;
         }
       },
       location: {
         origin: that.tabOrigin,
         href: that.validOrigin,
-        assign: function (url: string): void {
+        assign: function(url: string): void {
           return;
-        }
+        },
       },
       parent: {
-        postMessage: function (
-          message: MessageRequest,
-          targetOrigin: string
-        ): void {
-          if (message.func === "initialize") {
-            expect(targetOrigin).toEqual("*");
+        postMessage: function(message: MessageRequest, targetOrigin: string): void {
+          if (message.func === 'initialize') {
+            expect(targetOrigin).toEqual('*');
           } else {
             expect(targetOrigin).toEqual(that.validOrigin);
           }
           that.messages.push(message);
-        }
+        },
       } as Window,
       self: null as Window,
-      open: function (url: string, name: string, specs: string): Window {
+      open: function(url: string, name: string, specs: string): Window {
         return that.childWindow as Window;
       },
-      close: function (): void {
+      close: function(): void {
         return;
       },
-      setInterval: (handler: Function, timeout: number): number =>
-        setInterval(handler, timeout)
+      setInterval: (handler: Function, timeout: number): number => setInterval(handler, timeout),
     };
     this.mockWindow.self = this.mockWindow as Window;
 
     this.childWindow = {
-      postMessage: function (message: MessageRequest, targetOrigin: string): void {
+      postMessage: function(message: MessageRequest, targetOrigin: string): void {
         that.childMessages.push(message);
       },
-      close: function (): void {
+      close: function(): void {
         return;
       },
-      closed: false
+      closed: false,
     };
   }
 
-
   public processMessage: (ev: MessageEvent) => void;
 
-  public initializeWithContext = (
-    frameContext: string,
-    hostClientType?: string
-  ): void => {
+  public initializeWithContext = (frameContext: string, hostClientType?: string): void => {
     microsoftTeams1._initialize(this.mockWindow);
     microsoftTeams1.initialize();
 
-    const initMessage = this.findMessageByFunc("initialize");
+    const initMessage = this.findMessageByFunc('initialize');
     expect(initMessage).not.toBeNull();
 
     this.respondToMessage(initMessage, frameContext, hostClientType);
-  }
+  };
 
   public findMessageByFunc = (func: string): MessageRequest => {
     for (let i = 0; i < this.messages.length; i++) {
@@ -119,7 +103,7 @@ export class Utils {
     }
 
     return null;
-  }
+  };
 
   // tslint:disable-next-line:no-any
   public respondToMessage = (message: MessageRequest, ...args: any[]): void => {
@@ -128,10 +112,10 @@ export class Utils {
       source: this.mockWindow.parent,
       data: {
         id: message.id,
-        args: args
-      } as MessageResponse
+        args: args,
+      } as MessageResponse,
     } as MessageEvent);
-  }
+  };
 
   // tslint:disable-next-line:no-any
   public sendMessage = (func: string, ...args: any[]): void => {
@@ -140,8 +124,8 @@ export class Utils {
       source: this.mockWindow.parent,
       data: {
         func: func,
-        args: args
-      }
+        args: args,
+      },
     } as MessageEvent);
-  }
+  };
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,38 +7,42 @@ plugins.push(new DtsBundlePlugin());
 
 module.exports = {
   entry: {
-    'MicrosoftTeams': './src/index.ts',
-    'MicrosoftTeams.min': './src/index.ts'
+    MicrosoftTeams: './src/index.ts',
+    'MicrosoftTeams.min': './src/index.ts',
   },
   output: {
     filename: '[name].js',
     path: path.resolve(__dirname, 'dist'),
     library: libraryName,
     libraryTarget: 'umd',
-    umdNamedDefine: true
+    umdNamedDefine: true,
   },
-  devtool: "source-map",
+  devtool: 'source-map',
   resolve: {
-    extensions: ['.tsx', '.ts', '.js']
+    extensions: ['.tsx', '.ts', '.js'],
   },
   module: {
-    rules: [{
-      test: /\.tsx?$/,
-      use: 'ts-loader',
-      exclude: /node_modules/
-    }]
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
   },
   optimization: {
     minimize: true,
-    minimizer: [new UglifyJsPlugin({
-      uglifyOptions: {
-        compress: {
-          reduce_funcs: false,
-          inline: false
+    minimizer: [
+      new UglifyJsPlugin({
+        uglifyOptions: {
+          compress: {
+            reduce_funcs: false,
+            inline: false,
+          },
         },
-      },
-      include: /\.min\.js$/
-    })]
+        include: /\.min\.js$/,
+      }),
+    ],
   },
-  plugins: plugins
+  plugins: plugins,
 };


### PR DESCRIPTION
This change adds a callback to the initialize API that will be called once initialization completes. This can be used as follows:
```
microsoftTeams.initialize(() => {
  // Initialization complete
});
```

Or turned into a promise-based API like so:
```
return new Promise(resolve => {
  microsoftTeams.initialize(() => {
    resolve();
  });
});
```