### PR TITLE
Add support for app load handling

### DIFF
--- a/src/internal/globalVars.ts
+++ b/src/internal/globalVars.ts
@@ -1,5 +1,5 @@
 import { MessageRequest } from './interfaces';
-import { ConversationResponse, PreloadedAppContext } from '../public/interfaces';
+import { ConversationResponse, LoadContext } from '../public/interfaces';
 export class GlobalVars {
   public static initializeCalled = false;
   public static currentWindow: Window | any;
@@ -23,10 +23,10 @@ export class GlobalVars {
   public static themeChangeHandler: (theme: string) => void;
   public static fullScreenChangeHandler: (isFullScreen: boolean) => void;
   public static backButtonPressHandler: () => boolean;
+  public static loadHandler: (context: LoadContext) => void;
   public static beforeUnloadHandler: (readyToUnload: () => void) => boolean;
   public static changeSettingsHandler: () => void;
   public static onStartConversationHandler: (conversationResponse: ConversationResponse) => void;
   public static onCloseConversationHandler: (conversationResponse: ConversationResponse) => void;
   public static getLogHandler: () => string;
-  public static willLoadPreloadedAppHandler: (context: PreloadedAppContext) => void;
 }

--- a/src/internal/globalVars.ts
+++ b/src/internal/globalVars.ts
@@ -1,5 +1,5 @@
 import { MessageRequest } from './interfaces';
-import { ConversationResponse } from '../public/interfaces';
+import { ConversationResponse, PreloadedAppContext } from '../public/interfaces';
 export class GlobalVars {
   public static initializeCalled = false;
   public static currentWindow: Window | any;
@@ -28,4 +28,5 @@ export class GlobalVars {
   public static onStartConversationHandler: (conversationResponse: ConversationResponse) => void;
   public static onCloseConversationHandler: (conversationResponse: ConversationResponse) => void;
   public static getLogHandler: () => string;
+  public static willLoadPreloadedAppHandler: (context: PreloadedAppContext) => void;
 }

--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -1,18 +1,18 @@
 import { navigateBack } from '../public/publicAPIs';
+import { LoadContext } from '../public/interfaces';
 import { validOriginRegExp } from './constants';
 import { GlobalVars } from './globalVars';
 import { MessageResponse, MessageRequest, ExtendedWindow, MessageEvent } from './interfaces';
-import { PreloadedAppContext } from '../public/interfaces';
 
 // ::::::::::::::::::::MicrosoftTeams SDK Internal :::::::::::::::::
 GlobalVars.handlers['themeChange'] = handleThemeChange;
 GlobalVars.handlers['fullScreenChange'] = handleFullScreenChange;
 GlobalVars.handlers['backButtonPress'] = handleBackButtonPress;
+GlobalVars.handlers['load'] = handleLoad;
 GlobalVars.handlers['beforeUnload'] = handleBeforeUnload;
 GlobalVars.handlers['changeSettings'] = handleChangeSettings;
 GlobalVars.handlers['startConversation'] = handleStartConversation;
 GlobalVars.handlers['closeConversation'] = handleCloseConversation;
-GlobalVars.handlers['willLoadPreloadedApp'] = handleWillLoadPreloadedApp;
 
 function handleStartConversation(
   subEntityId: string,
@@ -56,16 +56,6 @@ function handleThemeChange(theme: string): void {
   }
 }
 
-function handleWillLoadPreloadedApp(context: PreloadedAppContext): void {
-  if (GlobalVars.willLoadPreloadedAppHandler) {
-    GlobalVars.willLoadPreloadedAppHandler(context);
-  }
-
-  if (GlobalVars.childWindow) {
-    sendMessageRequest(GlobalVars.childWindow, 'willLoadPreloadedApp', [context]);
-  }
-}
-
 function handleFullScreenChange(isFullScreen: boolean): void {
   if (GlobalVars.fullScreenChangeHandler) {
     GlobalVars.fullScreenChangeHandler(isFullScreen);
@@ -75,6 +65,16 @@ function handleFullScreenChange(isFullScreen: boolean): void {
 function handleBackButtonPress(): void {
   if (!GlobalVars.backButtonPressHandler || !GlobalVars.backButtonPressHandler()) {
     navigateBack();
+  }
+}
+
+function handleLoad(context: LoadContext): void {
+  if (GlobalVars.willLoadPreloadedAppHandler) {
+    GlobalVars.willLoadPreloadedAppHandler(context);
+  }
+
+  if (GlobalVars.childWindow) {
+    sendMessageRequest(GlobalVars.childWindow, 'load', [context]);
   }
 }
 

--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -2,6 +2,7 @@ import { navigateBack } from '../public/publicAPIs';
 import { validOriginRegExp } from './constants';
 import { GlobalVars } from './globalVars';
 import { MessageResponse, MessageRequest, ExtendedWindow, MessageEvent } from './interfaces';
+import { PreloadedAppContext } from '../public/interfaces';
 
 // ::::::::::::::::::::MicrosoftTeams SDK Internal :::::::::::::::::
 GlobalVars.handlers['themeChange'] = handleThemeChange;
@@ -11,6 +12,7 @@ GlobalVars.handlers['beforeUnload'] = handleBeforeUnload;
 GlobalVars.handlers['changeSettings'] = handleChangeSettings;
 GlobalVars.handlers['startConversation'] = handleStartConversation;
 GlobalVars.handlers['closeConversation'] = handleCloseConversation;
+GlobalVars.handlers['willLoadPreloadedApp'] = handleWillLoadPreloadedApp;
 
 function handleStartConversation(
   subEntityId: string,
@@ -51,6 +53,16 @@ function handleThemeChange(theme: string): void {
 
   if (GlobalVars.childWindow) {
     sendMessageRequest(GlobalVars.childWindow, 'themeChange', [theme]);
+  }
+}
+
+function handleWillLoadPreloadedApp(context: PreloadedAppContext): void {
+  if (GlobalVars.willLoadPreloadedAppHandler) {
+    GlobalVars.willLoadPreloadedAppHandler(context);
+  }
+
+  if (GlobalVars.childWindow) {
+    sendMessageRequest(GlobalVars.childWindow, 'willLoadPreloadedApp', [context]);
   }
 }
 

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -4,6 +4,7 @@ export { HostClientType, TaskModuleDimension, TeamType, UserTeamRole } from './c
 export {
   Context,
   DeepLinkParameters,
+  LoadContext,
   TabInformation,
   TabInstance,
   TabInstanceParameters,
@@ -25,6 +26,7 @@ export {
   registerBeforeUnloadHandler,
   registerChangeSettingsHandler,
   registerFullScreenHandler,
+  registerLoadHandler,
   registerOnThemeChangeHandler,
   shareDeepLink,
 } from './publicAPIs';

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -440,9 +440,14 @@ export interface ConversationResponse {
  * @private
  * Hide from docs.
  */
-export interface PreloadedAppContext {
+export interface LoadContext {
   /**
    * The enitity that is requested to be loaded
    */
-  entityId?: string;
+  entityId: string;
+
+  /**
+   * The content URL that is requested to be loaded
+   */
+  contentUrl: string;
 }

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -435,3 +435,14 @@ export interface ConversationResponse {
    */
   entityId?: string;
 }
+
+/**
+ * @private
+ * Hide from docs.
+ */
+export interface PreloadedAppContext {
+  /**
+   * The enitity that is requested to be loaded
+   */
+  entityId?: string;
+}

--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -3,7 +3,7 @@ import { GlobalVars } from '../internal/globalVars';
 import { version, frameContexts } from '../internal/constants';
 import { ExtendedWindow, MessageEvent } from '../internal/interfaces';
 import { settings } from './settings';
-import { TabInformation, TabInstanceParameters, TabInstance, DeepLinkParameters, Context } from './interfaces';
+import { TabInformation, TabInstanceParameters, TabInstance, DeepLinkParameters, Context, PreloadedAppContext } from './interfaces';
 import { getGenericOnCompleteHandler } from '../internal/utils';
 import { logs } from '../private/logs';
 
@@ -289,4 +289,15 @@ export function navigateToTab(tabInstance: TabInstance, onComplete?: (status: bo
 
   const errorMessage = 'Invalid internalTabInstanceId and/or channelId were/was provided';
   GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler(errorMessage);
+}
+
+/**
+ * @private
+ * @param handler The handler to invoke when a preloaded app is about to load.
+ */
+export function registerWillLoadPreloadedAppHandler(handler: (context: PreloadedAppContext) => void): void {
+  ensureInitialized();
+
+  GlobalVars.willLoadPreloadedAppHandler = handler;
+  handler && sendMessageRequest(GlobalVars.parentWindow, 'registerHandler', ['willLoadPreloadedApp']);
 }

--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -3,7 +3,7 @@ import { GlobalVars } from '../internal/globalVars';
 import { version, frameContexts } from '../internal/constants';
 import { ExtendedWindow, MessageEvent } from '../internal/interfaces';
 import { settings } from './settings';
-import { TabInformation, TabInstanceParameters, TabInstance, DeepLinkParameters, Context, PreloadedAppContext } from './interfaces';
+import { TabInformation, TabInstanceParameters, TabInstance, DeepLinkParameters, Context, LoadContext } from './interfaces';
 import { getGenericOnCompleteHandler } from '../internal/utils';
 import { logs } from '../private/logs';
 
@@ -59,6 +59,7 @@ export function initialize(hostWindow: any = window): void {
         registerFullScreenHandler(null);
         registerBackButtonHandler(null);
         registerBeforeUnloadHandler(null);
+        registerLoadHandler(null);
         logs.registerGetLogHandler(null);
       }
 
@@ -184,6 +185,18 @@ export function navigateBack(onComplete?: (status: boolean, reason?: string) => 
 
 /**
  * @private
+ * Registers a handler to be called when the page has been requested to load.
+ * @param handler The handler to invoke when the page isloaded.
+ */
+export function registerLoadHandler(handler: (context: LoadContext) => void): void {
+  ensureInitialized();
+
+  GlobalVars.loadHandler = handler;
+  handler && sendMessageRequest(GlobalVars.parentWindow, 'registerHandler', ['load']);
+}
+
+/**
+ * @private
  * Registers a handler to be called before the page is unloaded.
  * @param handler The handler to invoke before the page is unloaded. If this handler returns true the page should
  * invoke the readyToUnload function provided to it once it's ready to be unloaded.
@@ -291,13 +304,3 @@ export function navigateToTab(tabInstance: TabInstance, onComplete?: (status: bo
   GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler(errorMessage);
 }
 
-/**
- * @private
- * @param handler The handler to invoke when a preloaded app is about to load.
- */
-export function registerWillLoadPreloadedAppHandler(handler: (context: PreloadedAppContext) => void): void {
-  ensureInitialized();
-
-  GlobalVars.willLoadPreloadedAppHandler = handler;
-  handler && sendMessageRequest(GlobalVars.parentWindow, 'registerHandler', ['willLoadPreloadedApp']);
-}

--- a/test/public/publicAPIs.spec.ts
+++ b/test/public/publicAPIs.spec.ts
@@ -1,7 +1,7 @@
 import * as microsoftTeams from "../../src/public/publicAPIs";
-import { TabInstanceParameters, Context } from "../../src/public/interfaces";
+import { TabInstanceParameters, Context, LoadContext } from "../../src/public/interfaces";
 import { TeamType, UserTeamRole, HostClientType } from "../../src/public/constants";
-import { executeDeepLink, navigateCrossDomain, getTabInstances, getMruTabInstances, shareDeepLink, registerBeforeUnloadHandler, enablePrintCapability, registerChangeSettingsHandler, getContext, _uninitialize, registerBackButtonHandler, registerOnThemeChangeHandler, initialize } from "../../src/public/publicAPIs";
+import { executeDeepLink, navigateCrossDomain, getTabInstances, getMruTabInstances, shareDeepLink, registerLoadHandler, registerBeforeUnloadHandler, enablePrintCapability, registerChangeSettingsHandler, getContext, _uninitialize, registerBackButtonHandler, registerOnThemeChangeHandler, initialize } from "../../src/public/publicAPIs";
 import { frameContexts } from "../../src/internal/constants";
 import { Utils } from '../utils';
 
@@ -540,6 +540,29 @@ describe("MicrosoftTeams-publicAPIs", () => {
 
     document.dispatchEvent(printEvent);
     expect(handlerCalled).toBe(true);
+  });
+
+  describe("registerLoadHandler", () => {
+    it("should not allow calls before initialization", () => {
+      expect(() =>
+        registerLoadHandler(() => {
+          return false;
+        })
+      ).toThrowError("The library has not yet been initialized");
+    });
+    it("should successfully register handler", () => {
+      utils.initializeWithContext("content");
+
+      let handlerInvoked = false;
+      registerLoadHandler(() => {
+        handlerInvoked = true;
+        return false;
+      });
+
+      utils.sendMessage("load");
+
+      expect(handlerInvoked).toBe(true);
+    });
   });
 
   describe("registerBeforeUnloadHandler", () => {


### PR DESCRIPTION
Adding load handler to be used in application caching in Teams and also give notification to apps that their app is about to be loaded and shown to the user.