### PR TITLE
Adding local.teams.microsoft.com as valid host domain for teams sdk

### DIFF
--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -10,8 +10,8 @@ export const validOrigins = [
   'https://int.teams.microsoft.com',
   'https://devspaces.skype.com',
   'https://ssauth.skype.com',
-  'http://dev.local', // local development
-  'http://dev.local:8080', // local development
+  'https://local.teams.office.com', // local development
+  'https://local.teams.office.com:8080', // local development
   'https://msft.spoppe.com',
   'https://*.sharepoint.com',
   'https://*.sharepoint-df.com',

--- a/test/private/privateAPIs.spec.ts
+++ b/test/private/privateAPIs.spec.ts
@@ -91,7 +91,7 @@ describe('MicrosoftTeams-privateAPIs', () => {
     'https://dod.teams.microsoft.us',
     'https://int.teams.microsoft.com',
     'https://devspaces.skype.com',
-    'http://dev.local',
+    'https://local.teams.office.com',
     'https://microsoft.sharepoint.com',
     'https://msft.spoppe.com',
     'https://microsoft.sharepoint-df.com',


### PR DESCRIPTION
Adding local.teams.microsoft.com as valid host domain for teams sdk