### PR TITLE
Enable cross-frame custom messaging in tabs and personalApp

### DIFF
--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -18,6 +18,9 @@ export const validOrigins = [
   'https://*.sharepointonline.com',
   'https://outlook.office.com',
   'https://outlook-sdf.office.com',
+  'https://*.teams.microsoft.com',
+  'https://tasks.office.com'
+
 ];
 
 // Ensure these declarations stay in sync with the framework.

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -19,8 +19,7 @@ export const validOrigins = [
   'https://outlook.office.com',
   'https://outlook-sdf.office.com',
   'https://*.teams.microsoft.com',
-  'https://tasks.office.com'
-
+  'https://tasks.office.com',
 ];
 
 // Ensure these declarations stay in sync with the framework.

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -18,9 +18,7 @@ export const validOrigins = [
   'https://*.sharepointonline.com',
   'https://outlook.office.com',
   'https://outlook-sdf.office.com',
-  'https://retailservices-dev.teams.microsoft.com', // Teams: Tasks(Dev) app
-  'https://retailservices.teams.microsoft.com', // Teams: Tasks app
-  'https://tasks.office.com', // Planner
+  'https://*.teams.microsoft.com',
 ];
 
 // Ensure these declarations stay in sync with the framework.
@@ -33,3 +31,8 @@ export const frameContexts = {
 };
 
 export const validOriginRegExp = generateRegExpFromUrls(validOrigins);
+
+/**
+ * USer specified message origins should satisfy this test
+ */
+export const userOriginUrlValidationRegExp = /^https\:\/\//;

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -18,8 +18,9 @@ export const validOrigins = [
   'https://*.sharepointonline.com',
   'https://outlook.office.com',
   'https://outlook-sdf.office.com',
-  'https://*.teams.microsoft.com',
-  'https://tasks.office.com',
+  'https://retailservices-dev.teams.microsoft.com', // Teams: Tasks(Dev) app
+  'https://retailservices.teams.microsoft.com', // Teams: Tasks app
+  'https://tasks.office.com', // Planner
 ];
 
 // Ensure these declarations stay in sync with the framework.

--- a/src/internal/globalVars.ts
+++ b/src/internal/globalVars.ts
@@ -3,6 +3,8 @@ import { ConversationResponse, LoadContext } from '../public/interfaces';
 export class GlobalVars {
   public static initializeCalled: boolean = false;
   public static initializeCompleted: boolean = false;
+  public static additionalValidOrigins: string[] = [];
+  public static additionalValidOriginsRegexp: RegExp = null;
   public static initializeCallbacks: { (): void }[] = [];
   public static currentWindow: Window | any;
   public static parentWindow: Window | any;

--- a/src/internal/interfaces.ts
+++ b/src/internal/interfaces.ts
@@ -3,12 +3,12 @@
  * Hide from docs
  * Shim in definitions used for browser-compat
  */
-export interface MessageEvent {
+export interface DOMMessageEvent {
   origin?: any;
   source?: any;
   data?: any;
   // Needed for Chrome1964
-  originalEvent: MessageEvent;
+  originalEvent: DOMMessageEvent;
 }
 
 /**
@@ -25,11 +25,11 @@ export interface TeamsNativeClient {
  */
 export interface ExtendedWindow extends Window {
   nativeInterface: TeamsNativeClient;
-  onNativeMessage(evt: MessageEvent): void;
+  onNativeMessage(evt: DOMMessageEvent): void;
 }
 
 export interface MessageRequest {
-  id: number;
+  id?: number;
   func: string;
   args?: any[]; // tslint:disable-line:no-any The args here are a passthrough to postMessage where we do allow any[]
 }
@@ -37,4 +37,12 @@ export interface MessageRequest {
 export interface MessageResponse {
   id: number;
   args?: any[]; // tslint:disable-line:no-any The args here are a passthrough from OnMessage where we do receive any[]
+}
+
+/**
+ * Meant for Message objects that are sent to children without id
+ */
+export interface DOMMessageEvent {
+  func: string;
+  args?: any[]; // tslint:disable-line:no-any The args here are a passthrough to postMessage where we do allow any[]
 }

--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -264,7 +264,7 @@ export function waitForMessageQueue(targetWindow: Window, callback: () => void):
 }
 
 /**
- * TODO: hardcode to only parent
+ * Send a message to parent. Uses nativeInterface on mobile to communicate with parent context
  */
 export function sendMessageRequestToParent(
   actionName: string,
@@ -292,7 +292,7 @@ export function sendMessageRequestToParent(
 }
 
 /**
- * TODO: hardcode to only child
+ * Send a response to child for a message request that was from child
  */
 function sendMessageResponseToChild(
   id: number,

--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -123,8 +123,8 @@ export function processMessage(evt: DOMMessageEvent): void {
 
   // Process only if the message is coming from a different window and a valid origin
   // valid origins are either a pre-known
-  const messageSource = evt.source || evt.originalEvent.source;
-  const messageOrigin = evt.origin || evt.originalEvent.origin;
+  const messageSource = evt.source || (evt.originalEvent && evt.originalEvent.source);
+  const messageOrigin = evt.origin || (evt.originalEvent && evt.originalEvent.origin);
   if (!shouldProcessMessage(messageSource, messageOrigin)) {
     return;
   }
@@ -144,11 +144,16 @@ export function processMessage(evt: DOMMessageEvent): void {
  * Validates the message source and origin, if it should be processed
  */
 function shouldProcessMessage(messageSource: Window, messageOrigin: string): boolean {
-  // Process if message source is a different window and if origin is either
-  // whitelisted or marked as valid by user during initialization
-  if (messageSource === GlobalVars.currentWindow) {
+  // Process if message source is a different window and if origin is either in
+  // Teams' pre-known whitelist or supplied as valid origin by user during initialization
+  if (GlobalVars.currentWindow && messageSource === GlobalVars.currentWindow) {
     return false;
-  } else if (messageOrigin === GlobalVars.currentWindow.location.origin) {
+  } else if (
+    GlobalVars.currentWindow &&
+    GlobalVars.currentWindow.location &&
+    messageOrigin &&
+    messageOrigin === GlobalVars.currentWindow.location.origin
+  ) {
     return true;
   } else if (
     validOriginRegExp.test(messageOrigin.toLowerCase()) ||

--- a/src/private/bot.ts
+++ b/src/private/bot.ts
@@ -1,5 +1,5 @@
 import { GlobalVars } from '../internal/globalVars';
-import { ensureInitialized, sendMessageRequest } from '../internal/internalAPIs';
+import { ensureInitialized, sendMessageRequestToParent } from '../internal/internalAPIs';
 
 /**
  * @private
@@ -22,7 +22,7 @@ export namespace bot {
   ): void {
     ensureInitialized();
 
-    const messageId = sendMessageRequest(GlobalVars.parentWindow, 'bot.executeQuery', [botRequest]);
+    const messageId = sendMessageRequestToParent('bot.executeQuery', [botRequest]);
 
     GlobalVars.callbacks[messageId] = (success: boolean, response: string | QueryResponse) => {
       if (success) {
@@ -46,7 +46,7 @@ export namespace bot {
   ): void {
     ensureInitialized();
 
-    const messageId = sendMessageRequest(GlobalVars.parentWindow, 'bot.getSupportedCommands');
+    const messageId = sendMessageRequestToParent('bot.getSupportedCommands');
 
     GlobalVars.callbacks[messageId] = (success: boolean, response: string | Command[]) => {
       if (success) {
@@ -72,7 +72,7 @@ export namespace bot {
   ): void {
     ensureInitialized();
 
-    const messageId = sendMessageRequest(GlobalVars.parentWindow, 'bot.authenticate', [authRequest]);
+    const messageId = sendMessageRequestToParent('bot.authenticate', [authRequest]);
 
     GlobalVars.callbacks[messageId] = (success: boolean, response: string | Results) => {
       if (success) {

--- a/src/private/conversations.ts
+++ b/src/private/conversations.ts
@@ -1,4 +1,4 @@
-import { ensureInitialized, sendMessageRequest } from '../internal/internalAPIs';
+import { ensureInitialized, sendMessageRequestToParent } from '../internal/internalAPIs';
 import { GlobalVars } from '../internal/globalVars';
 import { frameContexts } from '../internal/constants';
 import { OpenConversationRequest } from '../public/interfaces';
@@ -15,7 +15,7 @@ export namespace conversations {
    */
   export function openConversation(openConversationRequest: OpenConversationRequest): void {
     ensureInitialized(frameContexts.content);
-    const messageId = sendMessageRequest(GlobalVars.parentWindow, 'conversations.openConversation', [
+    const messageId = sendMessageRequestToParent('conversations.openConversation', [
       {
         title: openConversationRequest.title,
         subEntityId: openConversationRequest.subEntityId,
@@ -41,7 +41,7 @@ export namespace conversations {
    */
   export function closeConversation(): void {
     ensureInitialized(frameContexts.content);
-    sendMessageRequest(GlobalVars.parentWindow, 'conversations.closeConversation');
+    sendMessageRequestToParent('conversations.closeConversation');
     GlobalVars.onCloseConversationHandler = null;
     GlobalVars.onStartConversationHandler = null;
   }

--- a/src/private/index.ts
+++ b/src/private/index.ts
@@ -19,6 +19,7 @@ export {
   openFilePreview,
   sendCustomMessage,
   showNotification,
+  sendCustomMessageToChild,
   addCustomHandler,
   uploadCustomApp,
 } from './privateAPIs';

--- a/src/private/index.ts
+++ b/src/private/index.ts
@@ -19,6 +19,7 @@ export {
   openFilePreview,
   sendCustomMessage,
   showNotification,
+  addCustomHandler,
   uploadCustomApp,
 } from './privateAPIs';
 export { conversations } from './conversations';

--- a/src/private/index.ts
+++ b/src/private/index.ts
@@ -19,8 +19,8 @@ export {
   openFilePreview,
   sendCustomMessage,
   showNotification,
-  sendCustomMessageToChild,
-  addCustomHandler,
+  sendCustomEvent,
+  registerCustomHandler,
   uploadCustomApp,
 } from './privateAPIs';
 export { conversations } from './conversations';

--- a/src/private/logs.ts
+++ b/src/private/logs.ts
@@ -1,4 +1,4 @@
-import { ensureInitialized, sendMessageRequest } from '../internal/internalAPIs';
+import { ensureInitialized, sendMessageRequestToParent } from '../internal/internalAPIs';
 import { GlobalVars } from '../internal/globalVars';
 
 /**
@@ -14,7 +14,7 @@ export namespace logs {
   function handleGetLogRequest(): void {
     if (GlobalVars.getLogHandler) {
       const log: string = GlobalVars.getLogHandler();
-      sendMessageRequest(GlobalVars.parentWindow, 'log.receive', [log]);
+      sendMessageRequestToParent('log.receive', [log]);
     }
   }
 
@@ -29,6 +29,6 @@ export namespace logs {
     ensureInitialized();
 
     GlobalVars.getLogHandler = handler;
-    handler && sendMessageRequest(GlobalVars.parentWindow, 'registerHandler', ['log.request']);
+    handler && sendMessageRequestToParent('registerHandler', ['log.request']);
   }
 }

--- a/src/private/menus.ts
+++ b/src/private/menus.ts
@@ -1,4 +1,4 @@
-import { ensureInitialized, sendMessageRequest } from '../internal/internalAPIs';
+import { ensureInitialized, sendMessageRequestToParent } from '../internal/internalAPIs';
 import { GlobalVars } from '../internal/globalVars';
 /**
  * Namespace to interact with the menu-specific part of the SDK.
@@ -97,12 +97,12 @@ export namespace menus {
   export function setUpViews(viewConfig: ViewConfiguration[], handler: (id: string) => boolean): void {
     ensureInitialized();
     viewConfigItemPressHandler = handler;
-    sendMessageRequest(GlobalVars.parentWindow, 'setUpViews', [viewConfig]);
+    sendMessageRequestToParent('setUpViews', [viewConfig]);
   }
   function handleViewConfigItemPress(id: string): void {
     if (!viewConfigItemPressHandler || !viewConfigItemPressHandler(id)) {
       ensureInitialized();
-      sendMessageRequest(GlobalVars.parentWindow, 'viewConfigItemPress', [id]);
+      sendMessageRequestToParent('viewConfigItemPress', [id]);
     }
   }
   /**
@@ -113,12 +113,12 @@ export namespace menus {
   export function setNavBarMenu(items: MenuItem[], handler: (id: string) => boolean): void {
     ensureInitialized();
     navBarMenuItemPressHandler = handler;
-    sendMessageRequest(GlobalVars.parentWindow, 'setNavBarMenu', [items]);
+    sendMessageRequestToParent('setNavBarMenu', [items]);
   }
   function handleNavBarMenuItemPress(id: string): void {
     if (!navBarMenuItemPressHandler || !navBarMenuItemPressHandler(id)) {
       ensureInitialized();
-      sendMessageRequest(GlobalVars.parentWindow, 'handleNavBarMenuItemPress', [id]);
+      sendMessageRequestToParent('handleNavBarMenuItemPress', [id]);
     }
   }
   export interface ActionMenuParameters {
@@ -139,12 +139,12 @@ export namespace menus {
   export function showActionMenu(params: ActionMenuParameters, handler: (id: string) => boolean): void {
     ensureInitialized();
     actionMenuItemPressHandler = handler;
-    sendMessageRequest(GlobalVars.parentWindow, 'showActionMenu', [params]);
+    sendMessageRequestToParent('showActionMenu', [params]);
   }
   function handleActionMenuItemPress(id: string): void {
     if (!actionMenuItemPressHandler || !actionMenuItemPressHandler(id)) {
       ensureInitialized();
-      sendMessageRequest(GlobalVars.parentWindow, 'handleActionMenuItemPress', [id]);
+      sendMessageRequestToParent('handleActionMenuItemPress', [id]);
     }
   }
 }

--- a/src/private/privateAPIs.ts
+++ b/src/private/privateAPIs.ts
@@ -122,7 +122,6 @@ export function sendCustomMessage(
   return sendMessageRequest(GlobalVars.parentWindow, actionName, args);
 }
 
-
 /**
  * @private
  * Internal use only
@@ -134,8 +133,8 @@ export function addCustomHandler(
   actionName: string,
   customHandler: (
     // tslint:disable-next-line:no-any
-    args?: any[]
-  ) => void
+    args?: any[],
+  ) => void,
 ): void {
   ensureInitialized();
   GlobalVars.handlers[actionName] = customHandler;

--- a/src/private/privateAPIs.ts
+++ b/src/private/privateAPIs.ts
@@ -108,7 +108,7 @@ export function uploadCustomApp(manifestBlob: Blob, onComplete?: (status: boolea
 /**
  * @private
  * Internal use only
- * Sends a custom action message to Teams.
+ * Sends a custom action MessageRequest to Teams or parent window
  * @param actionName Specifies name of the custom action to be sent
  * @param args Specifies additional arguments passed to the action
  * @param callback Optionally specify a callback to receive response parameters from the parent
@@ -135,7 +135,7 @@ export function sendCustomMessage(
 /**
  * @private
  * Internal use only
- * Sends a custom action message to a child iframe, only if you are not using auth popup.
+ * Sends a custom action MessageEvent to a child iframe/window, only if you are not using auth popup.
  * Otherwise it will go to the auth popup (which becomes the child)
  * @param actionName Specifies name of the custom action to be sent
  * @param args Specifies additional arguments passed to the action

--- a/src/private/privateAPIs.ts
+++ b/src/private/privateAPIs.ts
@@ -122,6 +122,25 @@ export function sendCustomMessage(
   return sendMessageRequest(GlobalVars.parentWindow, actionName, args);
 }
 
+
+/**
+ * @private
+ * Internal use only
+ * Adds a custom handler for an action
+ * @param actionName Specifies name of the action message to handle
+ * @param customHandler The callback to invoke when the action message is received
+ */
+export function addCustomHandler(
+  actionName: string,
+  customHandler: (
+    // tslint:disable-next-line:no-any
+    args?: any[]
+  ) => void
+): void {
+  ensureInitialized();
+  GlobalVars.handlers[actionName] = customHandler;
+}
+
 /**
  * @private
  * Hide from docs

--- a/src/private/privateAPIs.ts
+++ b/src/private/privateAPIs.ts
@@ -1,4 +1,4 @@
-import { ensureInitialized, sendMessageRequest, sendCustomMessageRequest } from '../internal/internalAPIs';
+import { ensureInitialized, sendMessageRequestToParent, sendMessageEventToChild } from '../internal/internalAPIs';
 import { GlobalVars } from '../internal/globalVars';
 import { frameContexts } from '../internal/constants';
 import {
@@ -24,7 +24,7 @@ export function getUserJoinedTeams(
 ): void {
   ensureInitialized();
 
-  const messageId = sendMessageRequest(GlobalVars.parentWindow, 'getUserJoinedTeams', [teamInstanceParameters]);
+  const messageId = sendMessageRequestToParent('getUserJoinedTeams', [teamInstanceParameters]);
   GlobalVars.callbacks[messageId] = callback;
 }
 
@@ -36,7 +36,7 @@ export function getUserJoinedTeams(
  */
 export function enterFullscreen(): void {
   ensureInitialized(frameContexts.content);
-  sendMessageRequest(GlobalVars.parentWindow, 'enterFullscreen', []);
+  sendMessageRequestToParent('enterFullscreen', []);
 }
 
 /**
@@ -47,7 +47,7 @@ export function enterFullscreen(): void {
  */
 export function exitFullscreen(): void {
   ensureInitialized(frameContexts.content);
-  sendMessageRequest(GlobalVars.parentWindow, 'exitFullscreen', []);
+  sendMessageRequestToParent('exitFullscreen', []);
 }
 
 /**
@@ -74,7 +74,7 @@ export function openFilePreview(filePreviewParameters: FilePreviewParameters): v
     filePreviewParameters.subEntityId,
   ];
 
-  sendMessageRequest(GlobalVars.parentWindow, 'openFilePreview', params);
+  sendMessageRequestToParent('openFilePreview', params);
 }
 
 /**
@@ -88,7 +88,7 @@ export function openFilePreview(filePreviewParameters: FilePreviewParameters): v
 export function showNotification(showNotificationParameters: ShowNotificationParameters): void {
   ensureInitialized(frameContexts.content);
   const params = [showNotificationParameters.message, showNotificationParameters.notificationType];
-  sendMessageRequest(GlobalVars.parentWindow, 'showNotification', params);
+  sendMessageRequestToParent('showNotification', params);
 }
 
 /**
@@ -101,7 +101,7 @@ export function showNotification(showNotificationParameters: ShowNotificationPar
 export function uploadCustomApp(manifestBlob: Blob, onComplete?: (status: boolean, reason?: string) => void): void {
   ensureInitialized();
 
-  const messageId = sendMessageRequest(GlobalVars.parentWindow, 'uploadCustomApp', [manifestBlob]);
+  const messageId = sendMessageRequestToParent('uploadCustomApp', [manifestBlob]);
   GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler();
 }
 
@@ -123,7 +123,7 @@ export function sendCustomMessage(
 ): number {
   ensureInitialized();
 
-  const messageId = sendMessageRequest(GlobalVars.parentWindow, actionName, args);
+  const messageId = sendMessageRequestToParent(actionName, args);
   if (typeof callback === 'function') {
     GlobalVars.callbacks[messageId] = (...args: any[]): void => {
       callback.apply(null, args);
@@ -135,12 +135,13 @@ export function sendCustomMessage(
 /**
  * @private
  * Internal use only
- * Sends a custom action message to a child window or iframe.
+ * Sends a custom action message to a child iframe, only if you are not using auth popup.
+ * Otherwise it will go to the auth popup (which becomes the child)
  * @param actionName Specifies name of the custom action to be sent
  * @param args Specifies additional arguments passed to the action
  * @returns id of sent message
  */
-export function sendCustomMessageToChild(
+export function sendCustomEvent(
   actionName: string,
   // tslint:disable-next-line:no-any
   args?: any[],
@@ -151,17 +152,17 @@ export function sendCustomMessageToChild(
   if (!GlobalVars.childWindow) {
     throw new Error('The child window has not yet been initialized or is not present');
   }
-  sendCustomMessageRequest(GlobalVars.childWindow, actionName, args);
+  sendMessageEventToChild(actionName, args);
 }
 
 /**
  * @private
  * Internal use only
- * Adds a custom handler for an action sent by a childWindow
+ * Adds a handler for an action sent by a child window or parent window
  * @param actionName Specifies name of the action message to handle
  * @param customHandler The callback to invoke when the action message is received. The return value is sent to the child
  */
-export function addCustomHandler(
+export function registerCustomHandler(
   actionName: string,
   customHandler: (
     // tslint:disable-next-line:no-any
@@ -186,7 +187,7 @@ export function addCustomHandler(
 export function getChatMembers(callback: (chatMembersInformation: ChatMembersInformation) => void): void {
   ensureInitialized();
 
-  const messageId = sendMessageRequest(GlobalVars.parentWindow, 'getChatMembers');
+  const messageId = sendMessageRequestToParent('getChatMembers');
   GlobalVars.callbacks[messageId] = callback;
 }
 
@@ -201,6 +202,6 @@ export function getChatMembers(callback: (chatMembersInformation: ChatMembersInf
 export function getConfigSetting(callback: (value: string) => void, key: string): void {
   ensureInitialized();
 
-  const messageId = sendMessageRequest(GlobalVars.parentWindow, 'getConfigSetting', [key]);
+  const messageId = sendMessageRequestToParent('getConfigSetting', [key]);
   GlobalVars.callbacks[messageId] = callback;
 }

--- a/src/public/appInitialization.ts
+++ b/src/public/appInitialization.ts
@@ -1,5 +1,4 @@
-import { ensureInitialized, sendMessageRequest } from '../internal/internalAPIs';
-import { GlobalVars } from '../internal/globalVars';
+import { ensureInitialized, sendMessageRequestToParent } from '../internal/internalAPIs';
 import { version } from '../internal/constants';
 
 export namespace appInitialization {
@@ -8,7 +7,7 @@ export namespace appInitialization {
    */
   export function notifyAppLoaded(): void {
     ensureInitialized();
-    sendMessageRequest(GlobalVars.parentWindow, 'appInitialization.appLoaded', [version]);
+    sendMessageRequestToParent('appInitialization.appLoaded', [version]);
   }
 
   /**
@@ -16,7 +15,7 @@ export namespace appInitialization {
    */
   export function notifySuccess(): void {
     ensureInitialized();
-    sendMessageRequest(GlobalVars.parentWindow, 'appInitialization.success', [version]);
+    sendMessageRequestToParent('appInitialization.success', [version]);
   }
 
   /**
@@ -24,7 +23,7 @@ export namespace appInitialization {
    */
   export function notifyFailure(appInitializationFailedRequest: appInitialization.IFailedRequest): void {
     ensureInitialized();
-    sendMessageRequest(GlobalVars.parentWindow, 'appInitialization.failure', [
+    sendMessageRequestToParent('appInitialization.failure', [
       appInitializationFailedRequest.reason,
       appInitializationFailedRequest.message,
     ]);

--- a/src/public/appWindow.ts
+++ b/src/public/appWindow.ts
@@ -1,4 +1,4 @@
-import { ensureInitialized, sendMessageRequest } from '../internal/internalAPIs';
+import { ensureInitialized, sendMessageRequestToParent } from '../internal/internalAPIs';
 import { GlobalVars } from '../internal/globalVars';
 import { frameContexts } from '../internal/constants';
 import { getGenericOnCompleteHandler } from '../internal/utils';
@@ -11,7 +11,7 @@ export interface IAppWindow {
 export class ChildAppWindow implements IAppWindow {
   public postMessage(message: any, onComplete?: (status: boolean, reason?: string) => void): void {
     ensureInitialized();
-    const messageId = sendMessageRequest(GlobalVars.parentWindow, 'messageForChild', [message]);
+    const messageId = sendMessageRequestToParent('messageForChild', [message]);
     GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler();
   }
 
@@ -31,7 +31,7 @@ export class ParentAppWindow implements IAppWindow {
 
   public postMessage(message: any, onComplete?: (status: boolean, reason?: string) => void): void {
     ensureInitialized(frameContexts.task);
-    const messageId = sendMessageRequest(GlobalVars.parentWindow, 'messageForParent', [message]);
+    const messageId = sendMessageRequestToParent('messageForParent', [message]);
 
     GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler();
   }

--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -3,9 +3,10 @@ import {
   ensureInitialized,
   sendMessageRequestToParent,
   handleParentMessage,
+  processAdditionalValidOrigins,
 } from '../internal/internalAPIs';
 import { GlobalVars } from '../internal/globalVars';
-import { version, frameContexts, userOriginUrlValidationRegExp } from '../internal/constants';
+import { version, frameContexts } from '../internal/constants';
 import { ExtendedWindow, DOMMessageEvent } from '../internal/interfaces';
 import { settings } from './settings';
 import {
@@ -16,7 +17,7 @@ import {
   Context,
   LoadContext,
 } from './interfaces';
-import { getGenericOnCompleteHandler, generateRegExpFromUrls } from '../internal/utils';
+import { getGenericOnCompleteHandler } from '../internal/utils';
 import { logs } from '../private/logs';
 
 // ::::::::::::::::::::::: MicrosoftTeams SDK public API ::::::::::::::::::::
@@ -111,24 +112,17 @@ export function initialize(callback?: () => void, validMessageOrigins?: string[]
     };
   }
 
+  // Handle additional valid message origins if specified
+  if (Array.isArray(validMessageOrigins)) {
+    processAdditionalValidOrigins(validMessageOrigins);
+  }
+
   // Handle the callback if specified:
   // 1. If initialization has already completed then just call it right away
   // 2. If initialization hasn't completed then add it to the array of callbacks
   //    that should be invoked once initialization does complete
   if (callback) {
     GlobalVars.initializeCompleted ? callback() : GlobalVars.initializeCallbacks.push(callback);
-  }
-
-  // Handle additional valid message origins if specified
-  if (Array.isArray(validMessageOrigins)) {
-    GlobalVars.additionalValidOrigins = GlobalVars.additionalValidOrigins.concat(
-      validMessageOrigins.filter((_origin: string) => {
-        return typeof _origin === 'string' && userOriginUrlValidationRegExp.test(_origin);
-      }),
-    );
-    if (GlobalVars.additionalValidOrigins.length > 0) {
-      GlobalVars.additionalValidOriginsRegexp = generateRegExpFromUrls(GlobalVars.additionalValidOrigins);
-    }
   }
 }
 

--- a/src/public/settings.ts
+++ b/src/public/settings.ts
@@ -1,4 +1,4 @@
-import { ensureInitialized, sendMessageRequest } from '../internal/internalAPIs';
+import { ensureInitialized, sendMessageRequestToParent } from '../internal/internalAPIs';
 import { GlobalVars } from '../internal/globalVars';
 import { frameContexts } from '../internal/constants';
 import { getGenericOnCompleteHandler } from '../internal/utils';
@@ -20,7 +20,7 @@ export namespace settings {
    */
   export function setValidityState(validityState: boolean): void {
     ensureInitialized(frameContexts.settings, frameContexts.remove);
-    sendMessageRequest(GlobalVars.parentWindow, 'settings.setValidityState', [validityState]);
+    sendMessageRequestToParent('settings.setValidityState', [validityState]);
   }
 
   /**
@@ -29,7 +29,7 @@ export namespace settings {
    */
   export function getSettings(callback: (instanceSettings: Settings) => void): void {
     ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove);
-    const messageId = sendMessageRequest(GlobalVars.parentWindow, 'settings.getSettings');
+    const messageId = sendMessageRequestToParent('settings.getSettings');
     GlobalVars.callbacks[messageId] = callback;
   }
 
@@ -43,7 +43,7 @@ export namespace settings {
     onComplete?: (status: boolean, reason?: string) => void,
   ): void {
     ensureInitialized(frameContexts.content, frameContexts.settings);
-    const messageId = sendMessageRequest(GlobalVars.parentWindow, 'settings.setSettings', [instanceSettings]);
+    const messageId = sendMessageRequestToParent('settings.setSettings', [instanceSettings]);
     GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler();
   }
 
@@ -57,7 +57,7 @@ export namespace settings {
   export function registerOnSaveHandler(handler: (evt: SaveEvent) => void): void {
     ensureInitialized(frameContexts.settings);
     saveHandler = handler;
-    handler && sendMessageRequest(GlobalVars.parentWindow, 'registerHandler', ['save']);
+    handler && sendMessageRequestToParent('registerHandler', ['save']);
   }
 
   /**
@@ -70,7 +70,7 @@ export namespace settings {
   export function registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void {
     ensureInitialized(frameContexts.remove);
     removeHandler = handler;
-    handler && sendMessageRequest(GlobalVars.parentWindow, 'registerHandler', ['remove']);
+    handler && sendMessageRequestToParent('registerHandler', ['remove']);
   }
 
   function handleSave(result?: SaveParameters): void {
@@ -154,12 +154,12 @@ export namespace settings {
     }
     public notifySuccess(): void {
       this.ensureNotNotified();
-      sendMessageRequest(GlobalVars.parentWindow, 'settings.save.success');
+      sendMessageRequestToParent('settings.save.success');
       this.notified = true;
     }
     public notifyFailure(reason?: string): void {
       this.ensureNotNotified();
-      sendMessageRequest(GlobalVars.parentWindow, 'settings.save.failure', [reason]);
+      sendMessageRequestToParent('settings.save.failure', [reason]);
       this.notified = true;
     }
     private ensureNotNotified(): void {
@@ -188,13 +188,13 @@ export namespace settings {
 
     public notifySuccess(): void {
       this.ensureNotNotified();
-      sendMessageRequest(GlobalVars.parentWindow, 'settings.remove.success');
+      sendMessageRequestToParent('settings.remove.success');
       this.notified = true;
     }
 
     public notifyFailure(reason?: string): void {
       this.ensureNotNotified();
-      sendMessageRequest(GlobalVars.parentWindow, 'settings.remove.failure', [reason]);
+      sendMessageRequestToParent('settings.remove.failure', [reason]);
       this.notified = true;
     }
 

--- a/src/public/tasks.ts
+++ b/src/public/tasks.ts
@@ -1,5 +1,5 @@
 import { TaskInfo } from './interfaces';
-import { ensureInitialized, sendMessageRequest } from '../internal/internalAPIs';
+import { ensureInitialized, sendMessageRequestToParent } from '../internal/internalAPIs';
 import { GlobalVars } from '../internal/globalVars';
 import { frameContexts } from '../internal/constants';
 import { IAppWindow, ChildAppWindow } from './appWindow';
@@ -17,7 +17,7 @@ export namespace tasks {
   export function startTask(taskInfo: TaskInfo, submitHandler?: (err: string, result: string) => void): IAppWindow {
     ensureInitialized(frameContexts.content);
 
-    const messageId = sendMessageRequest(GlobalVars.parentWindow, 'tasks.startTask', [taskInfo]);
+    const messageId = sendMessageRequestToParent('tasks.startTask', [taskInfo]);
     GlobalVars.callbacks[messageId] = submitHandler;
     return new ChildAppWindow();
   }
@@ -31,7 +31,7 @@ export namespace tasks {
     const { width, height, ...extra } = taskInfo;
 
     if (!Object.keys(extra).length) {
-      sendMessageRequest(GlobalVars.parentWindow, 'tasks.updateTask', [taskInfo]);
+      sendMessageRequestToParent('tasks.updateTask', [taskInfo]);
     } else {
       throw new Error('updateTask requires a taskInfo argument containing only width and height');
     }
@@ -46,9 +46,6 @@ export namespace tasks {
     ensureInitialized(frameContexts.content, frameContexts.task);
 
     // Send tasks.completeTask instead of tasks.submitTask message for backward compatibility with Mobile clients
-    sendMessageRequest(GlobalVars.parentWindow, 'tasks.completeTask', [
-      result,
-      Array.isArray(appIds) ? appIds : [appIds],
-    ]);
+    sendMessageRequestToParent('tasks.completeTask', [result, Array.isArray(appIds) ? appIds : [appIds]]);
   }
 }

--- a/test/private/privateAPIs.spec.ts
+++ b/test/private/privateAPIs.spec.ts
@@ -7,6 +7,7 @@ import {
   openFilePreview,
   getUserJoinedTeams,
   sendCustomMessage,
+  addCustomHandler,
   getChatMembers,
   getConfigSetting,
   enterFullscreen,
@@ -98,6 +99,8 @@ describe('MicrosoftTeams-privateAPIs', () => {
     'https://microsoft.sharepointonline.com',
     'https://outlook.office.com',
     'https://outlook-sdf.office.com',
+    'https://retailservices.teams.microsoft.com',
+    'https://tasks.office.com'
   ];
 
   supportedDomains.forEach(supportedDomain => {
@@ -382,6 +385,22 @@ describe('MicrosoftTeams-privateAPIs', () => {
       expect(message).not.toBeNull();
       expect(message.args).toEqual(['arg1', 2, 3.0, true]);
       expect(id).toBe(message.id);
+    });
+  });
+
+  describe('addCustomHandler', () => {
+    it('should successfully pass message and provided arguments', () => {
+      utils.initializeWithContext('content');
+
+      let callbackCalled: boolean = false,
+        callbackArgs: any[] = null;
+      addCustomHandler('customMessage', (args) => {
+        callbackCalled = true;
+        callbackArgs = args;
+      });
+
+      //TODO: send a custom message 'customMessage' to this window 
+      //and validate the callback called with correct args
     });
   });
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -34,12 +34,12 @@ export class Utils {
       outerHeight: 768,
       screenLeft: 0,
       screenTop: 0,
-      addEventListener: function(type: string, listener: (ev: MessageEvent) => void, useCapture?: boolean): void {
+      addEventListener: function (type: string, listener: (ev: MessageEvent) => void, useCapture?: boolean): void {
         if (type === 'message') {
           that.processMessage = listener;
         }
       },
-      removeEventListener: function(type: string, listener: (ev: MessageEvent) => void, useCapture?: boolean): void {
+      removeEventListener: function (type: string, listener: (ev: MessageEvent) => void, useCapture?: boolean): void {
         if (type === 'message') {
           that.processMessage = null;
         }
@@ -47,12 +47,12 @@ export class Utils {
       location: {
         origin: that.tabOrigin,
         href: that.validOrigin,
-        assign: function(url: string): void {
+        assign: function (url: string): void {
           return;
         },
       },
       parent: {
-        postMessage: function(message: MessageRequest, targetOrigin: string): void {
+        postMessage: function (message: MessageRequest, targetOrigin: string): void {
           if (message.func === 'initialize') {
             expect(targetOrigin).toEqual('*');
           } else {
@@ -62,10 +62,10 @@ export class Utils {
         },
       } as Window,
       self: null as Window,
-      open: function(url: string, name: string, specs: string): Window {
+      open: function (url: string, name: string, specs: string): Window {
         return that.childWindow as Window;
       },
-      close: function(): void {
+      close: function (): void {
         return;
       },
       setInterval: (handler: Function, timeout: number): number => setInterval(handler, timeout),
@@ -73,10 +73,10 @@ export class Utils {
     this.mockWindow.self = this.mockWindow as Window;
 
     this.childWindow = {
-      postMessage: function(message: MessageRequest, targetOrigin: string): void {
+      postMessage: function (message: MessageRequest, targetOrigin: string): void {
         that.childMessages.push(message);
       },
-      close: function(): void {
+      close: function (): void {
         return;
       },
       closed: false,
@@ -85,9 +85,9 @@ export class Utils {
 
   public processMessage: (ev: MessageEvent) => void;
 
-  public initializeWithContext = (frameContext: string, hostClientType?: string): void => {
+  public initializeWithContext = (frameContext: string, hostClientType?: string, callback?: () => void, validMessageOrigins?: string[]): void => {
     microsoftTeams1._initialize(this.mockWindow);
-    microsoftTeams1.initialize();
+    microsoftTeams1.initialize(callback, validMessageOrigins);
 
     const initMessage = this.findMessageByFunc('initialize');
     expect(initMessage).not.toBeNull();
@@ -105,7 +105,7 @@ export class Utils {
   };
 
   public findMessageInChildByFunc = (func: string): MessageRequest => {
-    if(this.childMessages && this.childMessages.length){
+    if (this.childMessages && this.childMessages.length) {
       for (let i = 0; i < this.childMessages.length; i++) {
         if (this.childMessages[i].func === func) {
           return this.childMessages[i];

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -81,6 +81,7 @@ export class Utils {
       },
       closed: false,
     };
+    this.mockWindow.child = this.childWindow as Window;
   }
 
   public processMessage: (ev: MessageEvent) => void;
@@ -101,7 +102,17 @@ export class Utils {
         return this.messages[i];
       }
     }
+    return null;
+  };
 
+  public findMessageInChildByFunc = (func: string): MessageRequest => {
+    if(this.childMessages && this.childMessages.length){
+      for (let i = 0; i < this.childMessages.length; i++) {
+        if (this.childMessages[i].func === func) {
+          return this.childMessages[i];
+        }
+      }
+    }
     return null;
   };
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -81,7 +81,6 @@ export class Utils {
       },
       closed: false,
     };
-    this.mockWindow.child = this.childWindow as Window;
   }
 
   public processMessage: (ev: MessageEvent) => void;


### PR DESCRIPTION
This implements API that allows app channel tabs and personal app to communicate with any child iframes/windows using custom action messages
- (new) (public) initialize() now accepts a list of valid domains from which this window can accept messages
- (new) sendCustomEvent() enables message sending to child
- (new) registerCustomHandler() enables listening to messaging from child
- child window can send message to parent using already existing sendCustomMessage()
- add optional callback to sendCustomMessage()
- add some type safety to message handling logic, handler result tested against undefined instead of truthy
- add Teams domains as valid message origins to allow postMessage processing
- Rename internal API to be parent/child specific
- MessageRequest is only meant for parent
- MesageEvent is meant for child and has no id
- rename window 'message' MessageEvent interface to DOMMessageEvent
- fix internalAPIs handleThemeChange and handleLoad to use sendMessageEventToChild when sending an unsolicited message event to any children
- added unit tests for new APIs

Testing done: Verified all frame communication scenarios (navigation, focus/blur, sync data event) used by the Tasks app which has Planner webpage as iframe inside it. Both, Tasks app and Planner webpage used this modified sdk in the testing
