### PR TITLE
adding isCallingAllowed & isPSTNCallingAllowed in the Context Interface

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -321,7 +321,7 @@ export interface Context {
   /**
    * Represents whether PSTN calling is allowed for the current logged in User
    */
-  isPSTNCallingAllowed?: boolean
+  isPSTNCallingAllowed?: boolean;
 }
 
 export interface DeepLinkParameters {

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -312,6 +312,16 @@ export interface Context {
    * Unique ID for the current session for use in correlating telemetry data.
    */
   appSessionId?: string;
+
+  /**
+   * Represents whether calling is allowed for the current logged in User
+   */
+  isCallingAllowed?: boolean;
+
+  /**
+   * Represents whether PSTN calling is allowed for the current logged in User
+   */
+  isPSTNCallingAllowed?: boolean
 }
 
 export interface DeepLinkParameters {


### PR DESCRIPTION
For apps which can execute the `placeCall` deeplink adding the following properties in the `Context` 

1. `isCallingAllowed`
2. `isPSTNCallingAllowed`

to check beforehand whether calling & pstn calling is allowed for the current logged in user