### PR TITLE
Add defaultOneNoteSectionId attribute to the Context interface

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -322,6 +322,12 @@ export interface Context {
    * Represents whether PSTN calling is allowed for the current logged in User
    */
   isPSTNCallingAllowed?: boolean;
+
+  /**
+   * The OneNote section ID that is linked to the channel.
+   * Used in Class/Staff/PLC teams.
+   */
+  defaultOneNoteSectionId?: string;
 }
 
 export interface DeepLinkParameters {

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -325,7 +325,6 @@ export interface Context {
 
   /**
    * The OneNote section ID that is linked to the channel.
-   * Used in Class/Staff/PLC teams.
    */
   defaultOneNoteSectionId?: string;
 }


### PR DESCRIPTION
Add the defaultOneNoteSectionId attribute to the Context interface. This is a new attribute that will be published by the MiddleTier