### PR TITLE
Add the subtext to the list of parameters in the conversational subentities request

### DIFF
--- a/src/private/conversations.ts
+++ b/src/private/conversations.ts
@@ -22,7 +22,7 @@ export namespace conversations {
         conversationId: openConversationRequest.conversationId,
         channelId: openConversationRequest.channelId,
         entityId: openConversationRequest.entityId,
-        subtext: openConversationRequest.subtext
+        subtext: openConversationRequest.subtext,
       },
     ]);
     GlobalVars.onCloseConversationHandler = openConversationRequest.onCloseConversation;

--- a/src/private/conversations.ts
+++ b/src/private/conversations.ts
@@ -22,6 +22,7 @@ export namespace conversations {
         conversationId: openConversationRequest.conversationId,
         channelId: openConversationRequest.channelId,
         entityId: openConversationRequest.entityId,
+        subtext: openConversationRequest.subtext
       },
     ]);
     GlobalVars.onCloseConversationHandler = openConversationRequest.onCloseConversation;

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -419,6 +419,11 @@ export interface OpenConversationRequest {
   entityId: string;
 
   /**
+   * The subtext of the tab
+   */
+  subtext?: string;
+
+  /**
    * A function that is called once the conversation Id has been created
    */
   onStartConversation?: (conversationResponse: ConversationResponse) => void;


### PR DESCRIPTION
We received feedback that certain apps want to use a subtext that will be displayed in the deeplink chiclet for the conversation. Adding that parameter in here.