### PR TITLE
Add localeInfo to the Context interface

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -142,7 +142,6 @@ export interface LocaleInfo {
   longTime: string;
 }
 
-
 export interface Context {
   /**
    * The Office 365 group ID for the team with which the content is associated.

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -134,16 +134,14 @@ export interface TeamInformation {
  * Represents OS locale info used for formatting date and time data
  */
 export interface LocaleInfo {
+  platform: string;
   regionalFormat: string;
-  date: {
-    shortDate: string;
-    longDate: string;
-    shortTime: string;
-    longTime: string;
-    calendar: string;
-    firstDayOfWeek: string;
-  };
+  shortDate: string;
+  longDate: string;
+  shortTime: string;
+  longTime: string;
 }
+
 
 export interface Context {
   /**
@@ -200,7 +198,7 @@ export interface Context {
    * the @microsoft/globe NPM package to ensure your app respects the user's OS date and
    * time format configuration
    */
-  localeInfo?: LocaleInfo;
+  osLocaleInfo?: LocaleInfo;
 
   /**
    * @deprecated Use loginHint or userPrincipalName.

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -129,6 +129,22 @@ export interface TeamInformation {
    */
   userTeamRole?: UserTeamRole;
 }
+
+/**
+ * Represents OS locale info used for formatting date and time data
+ */
+export interface LocaleInfo {
+  regionalFormat: string;
+  date: {
+    shortDate: string;
+    longDate: string;
+    shortTime: string;
+    longTime: string;
+    calendar: string;
+    firstDayOfWeek: string;
+  }
+}
+
 export interface Context {
   /**
    * The Office 365 group ID for the team with which the content is associated.
@@ -168,7 +184,8 @@ export interface Context {
 
   /**
    * The developer-defined unique ID for the sub-entity this content points to.
-   * This field should be used to restore to a specific state within an entity, such as scrolling to or activating a specific piece of content.
+   * This field should be used to restore to a specific state within an entity,
+   * such as scrolling to or activating a specific piece of content.
    */
   subEntityId?: string;
 
@@ -177,6 +194,13 @@ export interface Context {
    * languageId-countryId (for example, en-us).
    */
   locale: string;
+
+  /**
+   * More detailed locale info from the user's OS if available. Can be used together with
+   * the @microsoft/globe NPM package to ensure your app respects the user's OS date and
+   * time format configuration
+   */
+  localeInfo?: LocaleInfo;
 
   /**
    * @deprecated Use loginHint or userPrincipalName.

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -134,7 +134,7 @@ export interface TeamInformation {
  * Represents OS locale info used for formatting date and time data
  */
 export interface LocaleInfo {
-  platform: string;
+  platform: 'windows' | 'macos';
   regionalFormat: string;
   shortDate: string;
   longDate: string;

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -142,7 +142,7 @@ export interface LocaleInfo {
     longTime: string;
     calendar: string;
     firstDayOfWeek: string;
-  }
+  };
 }
 
 export interface Context {


### PR DESCRIPTION
This change adds the localeInfo property to the Context interface in preparation for enabling the Teams Client to provide this information to our hosted apps so that they can respect the OS date & time format settings when displaying this kind of data. Formatting can be handled via the @microsoft/globe library found here:
https://www.npmjs.com/package/@microsoft/globe