### PR TITLE
Update ref to childWindow if current ref is closed when updating relationships

### DIFF
--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -168,10 +168,10 @@ function shouldProcessMessage(messageSource: Window, messageOrigin: string): boo
 function updateRelationships(messageSource: Window, messageOrigin: string): void {
   // Determine whether the source of the message is our parent or child and update our
   // window and origin pointer accordingly
-  if (!GlobalVars.parentWindow || messageSource === GlobalVars.parentWindow) {
+  if (!GlobalVars.parentWindow || GlobalVars.parentWindow.closed || messageSource === GlobalVars.parentWindow) {
     GlobalVars.parentWindow = messageSource;
     GlobalVars.parentOrigin = messageOrigin;
-  } else if (!GlobalVars.childWindow || messageSource === GlobalVars.childWindow) {
+  } else if (!GlobalVars.childWindow || GlobalVars.childWindow.closed || messageSource === GlobalVars.childWindow) {
     GlobalVars.childWindow = messageSource;
     GlobalVars.childOrigin = messageOrigin;
   }


### PR DESCRIPTION
If the current childWindow (iframe or otherwise) is closed/unmounted from DOM and a new child is mounted/created then the first event received from the new child ("initialize") is ignored since it does not match current ref to childWindow. However, in this same function (line 184) we nullify any closed childWindow refs anyway. This PR fixes that logic to also account for updating relationships if windows that are current refs are closed (closed or iframe removed from DOM)

This bug lead to the side-effect that we ignored the initialize event from odd-numbered new children and it keep them waiting. When we remove this new child and create a second new child, that works fine as the closed window ref got cleaned up as part of first child's initialize call. So even-numbered new children get responses to their initialize events.