### PR TITLE
Add isArchived, isLocked, and TeamType info to getUserJoinedTeam

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -128,6 +128,21 @@ export interface TeamInformation {
    * Role of current user in the team
    */
   userTeamRole?: UserTeamRole;
+
+  /**
+   * The type of the team.
+   */
+  teamType?: TeamType;
+
+  /**
+   * The locked status of the team
+   */
+  isTeamLocked?: boolean;
+
+  /**
+   * The archived status of the team
+   */
+  isTeamArchived?: boolean;
 }
 
 /**


### PR DESCRIPTION
This change adds isArchived, isLocked and TeamType to the private getUserJoinedTeams SDK callback. 
The teams WebClient change is already merged.