### PR TITLE
Add claims parameter to getAuthToken API in Client SDK

### DIFF
--- a/src/public/authentication.ts
+++ b/src/public/authentication.ts
@@ -61,16 +61,17 @@ export namespace authentication {
   }
 
   /**
-   * @private
-   * Hide from docs.
-   * ------
    * Requests an Azure AD token to be issued on behalf of the app. The token is acquired from the cache
    * if it is not expired. Otherwise a request is sent to Azure AD to obtain a new token.
    * @param authTokenRequest A set of values that configure the token request.
    */
   export function getAuthToken(authTokenRequest: AuthTokenRequest): void {
     ensureInitialized();
-    const messageId = sendMessageRequestToParent('authentication.getAuthToken', [authTokenRequest.resources]);
+    const messageId = sendMessageRequestToParent('authentication.getAuthToken', [
+      authTokenRequest.resources,
+      authTokenRequest.claims,
+      authTokenRequest.silent,
+    ]);
     GlobalVars.callbacks[messageId] = (success: boolean, result: string) => {
       if (success) {
         authTokenRequest.successCallback(result);
@@ -321,16 +322,20 @@ export namespace authentication {
      */
     failureCallback?: (reason?: string) => void;
   }
-  /**
-   * @private
-   * Hide from docs.
-   * ------
-   */
+
   export interface AuthTokenRequest {
     /**
-     * An array of resource URIs identifying the target resources for which the token should be requested.
+     * An optional list of resource for which to acquire the access token; only used for full trust apps.
      */
-    resources: string[];
+    resources?: string[];
+    /**
+     * An optional list of claims which to pass to AAD when requesting the access token.
+     */
+    claims?: string[];
+    /**
+     * An optional flag indicating whether to attempt the token acquisition silently or allow a prompt to be shown.
+     */
+    silent?: boolean;
     /**
      * A function that is called if the token request succeeds, with the resulting token.
      */
@@ -340,6 +345,7 @@ export namespace authentication {
      */
     failureCallback?: (reason: string) => void;
   }
+
   /**
    * @private
    * Hide from docs.
@@ -355,6 +361,7 @@ export namespace authentication {
      */
     failureCallback?: (reason: string) => void;
   }
+
   /**
    * @private
    * Hide from docs.

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -129,6 +129,19 @@ export interface TeamInformation {
    */
   userTeamRole?: UserTeamRole;
 }
+
+/**
+ * Represents OS locale info used for formatting date and time data
+ */
+export interface LocaleInfo {
+  platform: 'windows' | 'macos';
+  regionalFormat: string;
+  shortDate: string;
+  longDate: string;
+  shortTime: string;
+  longTime: string;
+}
+
 export interface Context {
   /**
    * The Office 365 group ID for the team with which the content is associated.
@@ -168,7 +181,8 @@ export interface Context {
 
   /**
    * The developer-defined unique ID for the sub-entity this content points to.
-   * This field should be used to restore to a specific state within an entity, such as scrolling to or activating a specific piece of content.
+   * This field should be used to restore to a specific state within an entity,
+   * such as scrolling to or activating a specific piece of content.
    */
   subEntityId?: string;
 
@@ -177,6 +191,13 @@ export interface Context {
    * languageId-countryId (for example, en-us).
    */
   locale: string;
+
+  /**
+   * More detailed locale info from the user's OS if available. Can be used together with
+   * the @microsoft/globe NPM package to ensure your app respects the user's OS date and
+   * time format configuration
+   */
+  osLocaleInfo?: LocaleInfo;
 
   /**
    * @deprecated Use loginHint or userPrincipalName.


### PR DESCRIPTION
This change adds a couple of new parameters to the getAuthToken call:
1. `claims` - an optional list of claims which to pass to AAD when requesting the access token; used for SSM/LLT support
2. `silent` - an optional flag indicating whether to attempt the token acquisition silently or allow a prompt to be shown

It also makes the getAuthToken API public since it's now supported for 3P apps as well.