### PR TITLE
Support new frame context for tab rendered in side panel

### DIFF
--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -42,7 +42,7 @@ export const frameContexts = {
   authentication: 'authentication',
   remove: 'remove',
   task: 'task',
-  sidePanel: "sidePanel"
+  sidePanel: 'sidePanel',
 };
 
 export const validOriginRegExp = generateRegExpFromUrls(validOrigins);

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -42,6 +42,7 @@ export const frameContexts = {
   authentication: 'authentication',
   remove: 'remove',
   task: 'task',
+  sidePanel: "sidePanel"
 };
 
 export const validOriginRegExp = generateRegExpFromUrls(validOrigins);

--- a/src/public/authentication.ts
+++ b/src/public/authentication.ts
@@ -31,7 +31,7 @@ export namespace authentication {
    */
   export function authenticate(authenticateParameters?: AuthenticateParameters): void {
     const authenticateParams = authenticateParameters !== undefined ? authenticateParameters : authParams;
-    ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove, frameContexts.task);
+    ensureInitialized(frameContexts.content, frameContexts.sidePanel, frameContexts.settings, frameContexts.remove, frameContexts.task);
     if (
       GlobalVars.hostClientType === HostClientType.desktop ||
       GlobalVars.hostClientType === HostClientType.android ||

--- a/src/public/authentication.ts
+++ b/src/public/authentication.ts
@@ -31,7 +31,13 @@ export namespace authentication {
    */
   export function authenticate(authenticateParameters?: AuthenticateParameters): void {
     const authenticateParams = authenticateParameters !== undefined ? authenticateParameters : authParams;
-    ensureInitialized(frameContexts.content, frameContexts.sidePanel, frameContexts.settings, frameContexts.remove, frameContexts.task);
+    ensureInitialized(
+      frameContexts.content,
+      frameContexts.sidePanel,
+      frameContexts.settings,
+      frameContexts.remove,
+      frameContexts.task,
+    );
     if (
       GlobalVars.hostClientType === HostClientType.desktop ||
       GlobalVars.hostClientType === HostClientType.android ||

--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -281,7 +281,13 @@ export function registerChangeSettingsHandler(handler: () => void): void {
  * @param url The URL to navigate the frame to.
  */
 export function navigateCrossDomain(url: string, onComplete?: (status: boolean, reason?: string) => void): void {
-  ensureInitialized(frameContexts.content, frameContexts.sidePanel, frameContexts.settings, frameContexts.remove, frameContexts.task);
+  ensureInitialized(
+    frameContexts.content,
+    frameContexts.sidePanel,
+    frameContexts.settings,
+    frameContexts.remove,
+    frameContexts.task,
+  );
 
   const messageId = sendMessageRequestToParent('navigateCrossDomain', [url]);
   const errorMessage =

--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -281,7 +281,7 @@ export function registerChangeSettingsHandler(handler: () => void): void {
  * @param url The URL to navigate the frame to.
  */
 export function navigateCrossDomain(url: string, onComplete?: (status: boolean, reason?: string) => void): void {
-  ensureInitialized(frameContexts.content, frameContexts.settings, frameContexts.remove, frameContexts.task);
+  ensureInitialized(frameContexts.content, frameContexts.sidePanel, frameContexts.settings, frameContexts.remove, frameContexts.task);
 
   const messageId = sendMessageRequestToParent('navigateCrossDomain', [url]);
   const errorMessage =
@@ -325,7 +325,7 @@ export function getMruTabInstances(
  * @param deepLinkParameters ID and label for the link and fallback URL.
  */
 export function shareDeepLink(deepLinkParameters: DeepLinkParameters): void {
-  ensureInitialized(frameContexts.content);
+  ensureInitialized(frameContexts.content, frameContexts.sidePanel);
 
   sendMessageRequestToParent('shareDeepLink', [
     deepLinkParameters.subEntityId,
@@ -339,7 +339,7 @@ export function shareDeepLink(deepLinkParameters: DeepLinkParameters): void {
  * @param deepLink deep link.
  */
 export function executeDeepLink(deepLink: string, onComplete?: (status: boolean, reason?: string) => void): void {
-  ensureInitialized(frameContexts.content, frameContexts.task);
+  ensureInitialized(frameContexts.content, frameContexts.sidePanel, frameContexts.task);
   const messageId = sendMessageRequestToParent('executeDeepLink', [deepLink]);
   GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler();
 }

--- a/src/public/tasks.ts
+++ b/src/public/tasks.ts
@@ -15,7 +15,7 @@ export namespace tasks {
    * @param submitHandler Handler to call when the task module is completed
    */
   export function startTask(taskInfo: TaskInfo, submitHandler?: (err: string, result: string) => void): IAppWindow {
-    ensureInitialized(frameContexts.content);
+    ensureInitialized(frameContexts.content, frameContexts.sidePanel);
 
     const messageId = sendMessageRequestToParent('tasks.startTask', [taskInfo]);
     GlobalVars.callbacks[messageId] = submitHandler;
@@ -27,7 +27,7 @@ export namespace tasks {
    * @param taskInfo An object containing width and height properties
    */
   export function updateTask(taskInfo: TaskInfo): void {
-    ensureInitialized(frameContexts.content, frameContexts.task);
+    ensureInitialized(frameContexts.content, frameContexts.sidePanel, frameContexts.task);
     const { width, height, ...extra } = taskInfo;
 
     if (!Object.keys(extra).length) {
@@ -43,7 +43,7 @@ export namespace tasks {
    * @param appIds Helps to validate that the call originates from the same appId as the one that invoked the task module
    */
   export function submitTask(result?: string | object, appIds?: string | string[]): void {
-    ensureInitialized(frameContexts.content, frameContexts.task);
+    ensureInitialized(frameContexts.content, frameContexts.sidePanel, frameContexts.task);
 
     // Send tasks.completeTask instead of tasks.submitTask message for backward compatibility with Mobile clients
     sendMessageRequestToParent('tasks.completeTask', [result, Array.isArray(appIds) ? appIds : [appIds]]);

--- a/test/public/authentication.spec.ts
+++ b/test/public/authentication.spec.ts
@@ -72,6 +72,17 @@ describe('authentication', () => {
     authentication.authenticate(authenticationParams);
   });
 
+  it('should allow authentication.authenticate calls from sidePanel context', () => {
+    utils.initializeWithContext('sidePanel');
+
+    const authenticationParams = {
+      url: 'https://someurl/',
+      width: 100,
+      height: 200,
+    };
+    authentication.authenticate(authenticationParams);
+  });
+
   it('should allow authentication.authenticate calls from remove context', () => {
     utils.initializeWithContext('remove');
 

--- a/test/public/publicAPIs.spec.ts
+++ b/test/public/publicAPIs.spec.ts
@@ -255,6 +255,12 @@ describe('MicrosoftTeams-publicAPIs', () => {
       navigateCrossDomain('https://valid.origin.com');
     });
 
+    it('should allow calls from sidePanel context', () => {
+      utils.initializeWithContext('sidePanel');
+
+      navigateCrossDomain('https://valid.origin.com');
+    });
+
     it('should allow calls from settings context', () => {
       utils.initializeWithContext('settings');
 
@@ -393,6 +399,108 @@ describe('MicrosoftTeams-publicAPIs', () => {
 
     it('should successfully send a request', () => {
       utils.initializeWithContext('content');
+      const request = 'dummyDeepLink';
+
+      let requestResponse: boolean;
+      let error: string;
+
+      const onComplete = (status: boolean, reason?: string) => ((requestResponse = status), (error = reason));
+
+      // send message request
+      executeDeepLink(request, onComplete);
+
+      // find message request in jest
+      const message = utils.findMessageByFunc('executeDeepLink');
+
+      // check message is sending correct data
+      expect(message).not.toBeUndefined();
+      expect(message.args).toContain(request);
+
+      // simulate response
+      const data = {
+        success: true,
+      };
+      utils.respondToMessage(message, data.success);
+
+      // check data is returned properly
+      expect(requestResponse).toBe(true);
+      expect(error).toBeUndefined();
+    });
+  });
+
+  describe('executeDeepLink in sidePanel context ', () => {
+    it('should not allow calls before initialization', () => {
+      expect(() =>
+        executeDeepLink('dummyLink', () => {
+          return;
+        }),
+      ).toThrowError('The library has not yet been initialized');
+    });
+
+    it('should successfully send a request', () => {
+      utils.initializeWithContext('sidePanel');
+      const request = 'dummyDeepLink';
+
+      let requestResponse: boolean;
+      let error: string;
+
+      const onComplete = (status: boolean, reason?: string) => ((requestResponse = status), (error = reason));
+
+      // send message request
+      executeDeepLink(request, onComplete);
+
+      // find message request in jest
+      const message = utils.findMessageByFunc('executeDeepLink');
+
+      // check message is sending correct data
+      expect(message).not.toBeUndefined();
+      expect(message.args).toContain(request);
+
+      // simulate response
+      const data = {
+        success: true,
+      };
+
+      utils.respondToMessage(message, data.success);
+
+      // check data is returned properly
+      expect(requestResponse).toBe(true);
+      expect(error).toBeUndefined();
+    });
+
+    it('should invoke error callback', () => {
+      utils.initializeWithContext('sidePanel');
+      const request = 'dummyDeepLink';
+
+      let requestResponse: boolean;
+      let error: string;
+
+      const onComplete = (status: boolean, reason?: string) => ((requestResponse = status), (error = reason));
+
+      // send message request
+      executeDeepLink(request, onComplete);
+
+      // find message request in jest
+      const message = utils.findMessageByFunc('executeDeepLink');
+
+      // check message is sending correct data
+      expect(message).not.toBeUndefined();
+      expect(message.args).toContain(request);
+
+      // simulate response
+      const data = {
+        success: false,
+        error: 'Something went wrong...',
+      };
+      utils.respondToMessage(message, data.success, data.error);
+
+      // check data is returned properly
+      expect(requestResponse).toBe(false);
+      expect(error).toBe('Something went wrong...');
+    });
+
+    it('should successfully send a request', () => {
+      utils.initializeWithContext('sidePanel');
       const request = 'dummyDeepLink';
 
       let requestResponse: boolean;
@@ -660,8 +768,25 @@ describe('MicrosoftTeams-publicAPIs', () => {
       expect(readyToUnloadMessage).not.toBeNull();
     });
 
-    it('should successfully share a deep link', () => {
+    it('should successfully share a deep link in content context', () => {
       utils.initializeWithContext('content');
+
+      shareDeepLink({
+        subEntityId: 'someSubEntityId',
+        subEntityLabel: 'someSubEntityLabel',
+        subEntityWebUrl: 'someSubEntityWebUrl',
+      });
+
+      let message = utils.findMessageByFunc('shareDeepLink');
+      expect(message).not.toBeNull();
+      expect(message.args.length).toBe(3);
+      expect(message.args[0]).toBe('someSubEntityId');
+      expect(message.args[1]).toBe('someSubEntityLabel');
+      expect(message.args[2]).toBe('someSubEntityWebUrl');
+    });
+
+    it('should successfully share a deep link in sidePanel context', () => {
+      utils.initializeWithContext('sidePanel');
 
       shareDeepLink({
         subEntityId: 'someSubEntityId',

--- a/test/public/tasks.spec.ts
+++ b/test/public/tasks.spec.ts
@@ -57,7 +57,29 @@ describe('tasks', () => {
       expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'task' context");
     });
 
-    it('should pass along entire TaskInfo parameter', () => {
+    it('should pass along entire TaskInfo parameter in sidePanel context', () => {
+      utils.initializeWithContext('sidePanel');
+
+      const taskInfo: TaskInfo = {
+        card: 'someCard',
+        fallbackUrl: 'someFallbackUrl',
+        height: TaskModuleDimension.Large,
+        width: TaskModuleDimension.Large,
+        title: 'someTitle',
+        url: 'someUrl',
+        completionBotId: 'someCompletionBotId',
+      };
+
+      tasks.startTask(taskInfo, () => {
+        return;
+      });
+
+      const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
+      expect(startTaskMessage).not.toBeNull();
+      expect(startTaskMessage.args).toEqual([taskInfo]);
+    });
+
+    it('should pass along entire TaskInfo parameter in content', () => {
       utils.initializeWithContext('content');
 
       const taskInfo: TaskInfo = {
@@ -120,7 +142,18 @@ describe('tasks', () => {
       expect(() => tasks.updateTask({} as any)).toThrowError('The library has not yet been initialized');
     });
 
-    it('should successfully pass taskInfo', () => {
+    it('should successfully pass taskInfo in sidePanel context', () => {
+      utils.initializeWithContext('sidePanel');
+      const taskInfo = { width: 10, height: 10 };
+
+      tasks.updateTask(taskInfo);
+
+      const updateTaskMessage = utils.findMessageByFunc('tasks.updateTask');
+      expect(updateTaskMessage).not.toBeNull();
+      expect(updateTaskMessage.args).toEqual([taskInfo]);
+    });
+
+    it('should successfully pass taskInfo in task context', () => {
       utils.initializeWithContext('task');
       const taskInfo = { width: 10, height: 10 };
 
@@ -162,6 +195,16 @@ describe('tasks', () => {
       utils.initializeWithContext('remove');
 
       expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'remove' context");
+    });
+
+    it('should successfully pass result and appIds parameters when called from sidePanel context', () => {
+      utils.initializeWithContext('sidePanel');
+
+      tasks.submitTask('someResult', ['someAppId', 'someOtherAppId']);
+
+      const submitTaskMessage = utils.findMessageByFunc('tasks.completeTask');
+      expect(submitTaskMessage).not.toBeNull();
+      expect(submitTaskMessage.args).toEqual(['someResult', ['someAppId', 'someOtherAppId']]);
     });
 
     it('should successfully pass result and appIds parameters when called from task context', () => {


### PR DESCRIPTION
Support new frame context for tab rendered in side panel

### List of SDK API available in side panel
1. initialize
2.  authenticate APIs, getAuthToken, getUser, 
3. navigateCrossDomain, registerThemeChangeHandlers
4. shareDeepLink
5. executeDeepLink
6. Tasks APIs

### List of SDK API that works in content but not in side panel context
1. Conversation APIs
2. enterFullscreen, exitFullscreen
3. openFilePreview
4. showNotification
5. registerChangeSettingsHandler, setFrameContext,
6. Settings APIs