### PR TITLE
exposing meetingId as part of tab sdk

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -366,6 +366,11 @@ export interface Context {
   isPSTNCallingAllowed?: boolean;
 
   /**
+   * Meeting Id used by tab when running in meeting context
+   */
+  meetingId?: string;
+
+  /**
    * The OneNote section ID that is linked to the channel.
    */
   defaultOneNoteSectionId?: string;

--- a/test/public/publicAPIs.spec.ts
+++ b/test/public/publicAPIs.spec.ts
@@ -211,12 +211,14 @@ describe('MicrosoftTeams-publicAPIs', () => {
       parentMessageId: 'someParentMessageId',
       ringId: 'someRingId',
       appSessionId: 'appSessionId',
+      meetingId: 'dummyMeetingId'
     };
 
     utils.respondToMessage(getContextMessage, expectedContext);
 
     expect(actualContext).toBe(expectedContext);
     expect(actualContext.frameContext).toBe(FrameContexts.content);
+    expect(actualContext.meetingId).toBe('dummyMeetingId');
   });
 
   it('should successfully get frame context in side panel', () => {


### PR DESCRIPTION
exposing meetingId as part of tab sdk which will be use by tabs running in meeting context.