### PR TITLE
Allow the executeDeepLink API to be called from the tab configuration dialog

### DIFF
--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -352,7 +352,7 @@ export function shareDeepLink(deepLinkParameters: DeepLinkParameters): void {
  * @param deepLink deep link.
  */
 export function executeDeepLink(deepLink: string, onComplete?: (status: boolean, reason?: string) => void): void {
-  ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.task);
+  ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.settings, FrameContexts.task);
   const messageId = sendMessageRequestToParent('executeDeepLink', [deepLink]);
   GlobalVars.callbacks[messageId] = onComplete ? onComplete : getGenericOnCompleteHandler();
 }


### PR DESCRIPTION
This change allows the `microsoftTeams.executeDeepLink` API to be called from the tab configuration dialog (i.e. `settings` frame context)