### PR TITLE
Fix the type in Media[] returned in selectMedia callback

### DIFF
--- a/src/public/media.ts
+++ b/src/public/media.ts
@@ -97,6 +97,18 @@ export function captureImage(callback: (error: SdkError, files: File[]) => void)
  * Media object returned by the select Media API
  */
 export class Media extends File {
+  constructor(that: Media = null) {
+    super();
+    if (that) {
+      this.content = that.content;
+      this.format = that.format;
+      this.mimeType = that.mimeType;
+      this.name = that.name;
+      this.preview = that.preview;
+      this.size = that.size;
+    }
+  }
+
   /**
    * A preview of the file which is a lightweight representation.
    * In case of images this will be a thumbnail/compressed image in base64 encoding.
@@ -352,20 +364,14 @@ export function selectMedia(mediaInputs: MediaInputs, callback: (error: SdkError
   const messageId = sendMessageRequestToParent('selectMedia', params);
 
   // What comes back from native at attachments would just be objects and will be missing getMedia method on them.
-  GlobalVars.callbacks[messageId] = (err: SdkError, attachs: Media[]) => {
-    let mediaArray: Media[] = null;
-    if (attachs) {
-      mediaArray = [];
-      for (let attachment of attachs) {
-        const media = new Media();
-        media.content = attachment.content;
-        media.format = attachment.format;
-        media.mimeType = attachment.mimeType;
-        media.name = attachment.name;
-        media.preview = attachment.preview;
-        media.size = attachment.size;
-        mediaArray.push(media);
-      }
+  GlobalVars.callbacks[messageId] = (err: SdkError, localAttachments: Media[]) => {
+    if (!localAttachments) {
+      callback(err, null);
+      return;
+    }
+    let mediaArray: Media[] = [];
+    for (let attachment of localAttachments) {
+      mediaArray.push(new Media(attachment));
     }
     callback(err, mediaArray);
   };

--- a/src/public/media.ts
+++ b/src/public/media.ts
@@ -350,7 +350,25 @@ export function selectMedia(mediaInputs: MediaInputs, callback: (error: SdkError
 
   const params = [mediaInputs];
   const messageId = sendMessageRequestToParent('selectMedia', params);
-  GlobalVars.callbacks[messageId] = callback;
+
+  // What comes back from native at attachments would just be objects and will be missing getMedia method on them.
+  GlobalVars.callbacks[messageId] = (err: SdkError, attachs: Media[]) => {
+    let mediaArray: Media[] = null;
+    if (attachs) {
+      mediaArray = [];
+      for (let attachment of attachs) {
+        const media = new Media();
+        media.content = attachment.content;
+        media.format = attachment.format;
+        media.mimeType = attachment.mimeType;
+        media.name = attachment.name;
+        media.preview = attachment.preview;
+        media.size = attachment.size;
+        mediaArray.push(media);
+      }
+    }
+    callback(err, mediaArray);
+  };
 }
 
 /**

--- a/test/public/media.spec.ts
+++ b/test/public/media.spec.ts
@@ -285,6 +285,7 @@ describe('media', () => {
     expect(media.content).not.toBeNull();
     expect(media.size).not.toBeNull();
     expect(typeof media.size === 'number').toBeTruthy();
+    expect(media.getMedia).toBeDefined();
   });
 
   it('selectMedia calls with error', () => {


### PR DESCRIPTION
This is a minor fix on top of the selectMedia API. When objects are sent over from native layer (Android or iOS) they are just objects and do not have a type. In selectMedia callback, we promise to deliver Media objects. Sending the objects as received from native layer does not really send Media objects, they do ducktype Media, but will be missing getMedia method.

The fix is to have one level of indirection, receive the array from native in our callback and create new Media objects which confirms with the promise and return those.