### PR TITLE
Align interface with Teams mobile client

### DIFF
--- a/src/private/menus.ts
+++ b/src/private/menus.ts
@@ -40,7 +40,7 @@ export namespace menus {
     /**
      * Display icon of the menu item. The icon value must be a string having SVG icon content.
      */
-    public icon?: string;
+    public icon: string;
     /**
      * Selected state display icon of the menu item. The icon value must be a string having SVG icon content.
      */


### PR DESCRIPTION
Upcoming versions of the teams mobile client require icon to be set for the Action Menu to work properly. 