### PR TITLE
comment updated for viewImages callback and size check added for getMedia API

### DIFF
--- a/src/internal/mediaUtil.ts
+++ b/src/internal/mediaUtil.ts
@@ -1,5 +1,7 @@
 import { AssembleAttachment, MediaChunk, MediaInputs, FileFormat, ImageUri } from '../public/media';
 
+export const fiftyMbInKb = 50 * 1024;
+
 /**
  * Helper function to create a blob from media chunks based on their sequence
  */
@@ -58,8 +60,8 @@ export function validateSelectMediaInputs(mediaInputs: MediaInputs): boolean {
 /**
  * Returns true if the get Media params are valid and false otherwise
  */
-export function validateGetMediaInputs(mimeType: string, format: FileFormat, content: string): boolean {
-  if (mimeType == null || format == null || format != FileFormat.ID || content == null) {
+export function validateGetMediaInputs(mimeType: string, format: FileFormat, content: string, size: number): boolean {
+  if (mimeType == null || format == null || format != FileFormat.ID || content == null || size > fiftyMbInKb) {
     return false;
   }
   return true;

--- a/src/public/media.ts
+++ b/src/public/media.ts
@@ -9,6 +9,7 @@ import {
   validateSelectMediaInputs,
   validateGetMediaInputs,
   validateViewImagesInput,
+  fiftyMbInKb,
 } from '../internal/mediaUtil';
 
 /**
@@ -129,9 +130,12 @@ export class Media extends File {
       callback(oldPlatformError, null);
       return;
     }
-    if (!validateGetMediaInputs(this.mimeType, this.format, this.content)) {
-      const invalidInput: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
-      callback(invalidInput, null);
+    if (!validateGetMediaInputs(this.mimeType, this.format, this.content, this.size)) {
+      let errorName: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
+      if (this.size > fiftyMbInKb) {
+        errorName = { errorCode: ErrorCode.SIZE_EXCEEDED };
+      }
+      callback(errorName, null);
       return;
     }
     const actionName = generateGUID();
@@ -380,7 +384,7 @@ export function selectMedia(mediaInputs: MediaInputs, callback: (error: SdkError
 /**
  * View images using native image viewer
  * @param uriList urilist of images to be viewed - can be content uri or server url. supports upto 10 Images in one go
- * @param result returns back error if encountered, there will be no callback in case of success
+ * @param callback returns back error if encountered, returns null in case of success
  */
 export function viewImages(uriList: ImageUri[], callback: (error?: SdkError) => void): void {
   if (!callback) {

--- a/test/internal/mediaUtil.spec.ts
+++ b/test/internal/mediaUtil.spec.ts
@@ -92,27 +92,27 @@ describe('mediaUtil', () => {
    * Validate Get Media Input
    */
   it('test validateGetMediaInputs with all null params', () => {
-    const result = validateGetMediaInputs(null, null, null);
+    const result = validateGetMediaInputs(null, null, null, 0);
     expect(result).toBeFalsy();
   });
 
   it('test validateGetMediaInputs with null format and content', () => {
-    const result = validateGetMediaInputs("image/jpeg", null, null);
+    const result = validateGetMediaInputs("image/jpeg", null, null, 0);
     expect(result).toBeFalsy();
   });
 
   it('test validateGetMediaInputs with null content', () => {
-    const result = validateGetMediaInputs("image/jpeg", FileFormat.ID, null);
+    const result = validateGetMediaInputs("image/jpeg", FileFormat.ID, null, 0);
     expect(result).toBeFalsy();
   });
 
   it('test validateGetMediaInputs with invalid params', () => {
-    const result = validateGetMediaInputs("image/jpeg", FileFormat.Base64, "Something not null");
+    const result = validateGetMediaInputs("image/jpeg", FileFormat.Base64, "Something not null", 0);
     expect(result).toBeFalsy();
   });
 
   it('test success case for validate get media input function', () => {
-    const result = validateGetMediaInputs("image/jpeg", FileFormat.ID, "Something not null");
+    const result = validateGetMediaInputs("image/jpeg", FileFormat.ID, "Something not null", 10);
     expect(result).toBeTruthy();
   });
 

--- a/test/public/media.spec.ts
+++ b/test/public/media.spec.ts
@@ -325,6 +325,7 @@ describe('media', () => {
     media.content = "1234567";
     media.mimeType = "image/jpeg";
     media.format = FileFormat.ID;
+    media.size = 10;
     expect(() => media.getMedia(null)).toThrowError(
       '[get Media] Callback cannot be null',
     );
@@ -338,6 +339,7 @@ describe('media', () => {
     media.content = "1234567";
     media.mimeType = null;
     media.format = FileFormat.ID;
+    media.size = 10;
     media.getMedia((error: SdkError, blob: Blob) => {
       mediaError = error;
     });
@@ -353,6 +355,7 @@ describe('media', () => {
     media.content = null;
     media.mimeType = "image/jpeg";
     media.format = FileFormat.ID;
+    media.size = 10;
     media.getMedia((error: SdkError, blob: Blob) => {
       mediaError = error;
     });
@@ -368,6 +371,7 @@ describe('media', () => {
     media.content = "1234567";
     media.mimeType = "image/jpeg";
     media.format = FileFormat.Base64;
+    media.size = 10;
     media.getMedia((error: SdkError, blob: Blob) => {
       mediaError = error;
     });
@@ -382,6 +386,7 @@ describe('media', () => {
     media.content = "1234567";
     media.mimeType = "image/jpeg";
     media.format = FileFormat.ID;
+    media.size = 10;
     media.getMedia((error: SdkError, blob: Blob) => {
       mediaError = error;
     });
@@ -396,6 +401,7 @@ describe('media', () => {
     media.content = "1234567";
     media.mimeType = "image/jpeg";
     media.format = FileFormat.ID;
+    media.size = 10;
     media.getMedia(emptyCallback);
     let message = mobilePlatformMock.findMessageByFunc('getMedia');
     expect(message).not.toBeNull();
@@ -410,6 +416,7 @@ describe('media', () => {
     media.content = "1234567";
     media.mimeType = "image/jpeg";
     media.format = FileFormat.ID;
+    media.size = 10;
     media.getMedia((error: SdkError, blob: Blob) => {
       mediaError = error;
       file = blob;
@@ -439,6 +446,7 @@ describe('media', () => {
     media.content = "1234567";
     media.mimeType = "image/jpeg";
     media.format = FileFormat.ID;
+    media.size = 10;
     media.getMedia((error: SdkError, blob: Blob) => {
       mediaError = error;
       file = blob;


### PR DESCRIPTION
1. viewImages API returns null error callback in case of success - updated comment
2. getMedia API is capped at 50 MB 