### PR TITLE
Removed const enum as it creates issue with some projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 
 # Visual Studio cache/options directory
 .vs/
+.DS_Store

--- a/src/private/interfaces.ts
+++ b/src/private/interfaces.ts
@@ -22,7 +22,7 @@ export interface ThreadMember {
   upn: string;
 }
 
-export const enum NotificationTypes {
+export enum NotificationTypes {
   fileDownloadStart = 'fileDownloadStart',
   fileDownloadComplete = 'fileDownloadComplete',
 }

--- a/src/public/appInitialization.ts
+++ b/src/public/appInitialization.ts
@@ -29,7 +29,7 @@ export namespace appInitialization {
     ]);
   }
 
-  export const enum FailedReason {
+  export enum FailedReason {
     AuthFailed = 'AuthFailed',
     Timeout = 'Timeout',
     Other = 'Other',

--- a/src/public/constants.ts
+++ b/src/public/constants.ts
@@ -38,6 +38,9 @@ export enum UserTeamRole {
   Guest = 2,
 }
 
+/**
+ * Task module dimension enum
+ */
 export enum TaskModuleDimension {
   Large = 'large',
   Medium = 'medium',

--- a/src/public/constants.ts
+++ b/src/public/constants.ts
@@ -1,4 +1,4 @@
-export const enum HostClientType {
+export enum HostClientType {
   desktop = 'desktop',
   web = 'web',
   android = 'android',
@@ -7,7 +7,7 @@ export const enum HostClientType {
 }
 
 // Ensure these declarations stay in sync with the framework.
-export const enum FrameContexts {
+export enum FrameContexts {
   settings = 'settings',
   content = 'content',
   authentication = 'authentication',
@@ -21,7 +21,7 @@ export const enum FrameContexts {
  * Indicates the team type, currently used to distinguish between different team
  * types in Office 365 for Education (team types 1, 2, 3, and 4).
  */
-export const enum TeamType {
+export enum TeamType {
   Standard = 0,
   Edu = 1,
   Class = 2,
@@ -32,13 +32,13 @@ export const enum TeamType {
 /**
  * Indicates the various types of roles of a user in a team.
  */
-export const enum UserTeamRole {
+export enum UserTeamRole {
   Admin = 0,
   User = 1,
   Guest = 2,
 }
 
-export const enum TaskModuleDimension {
+export enum TaskModuleDimension {
   Large = 'large',
   Medium = 'medium',
   Small = 'small',
@@ -47,7 +47,7 @@ export const enum TaskModuleDimension {
 /**
  * The type of the channel with which the content is associated.
  */
-export const enum ChannelType {
+export enum ChannelType {
   Regular = 'Regular',
   Private = 'Private',
 }

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -544,7 +544,7 @@ export interface SdkError {
   message?: string;
 }
 
-export const enum ErrorCode {
+export enum ErrorCode {
   /**
    * API not supported in the current platform.
    */

--- a/src/public/media.ts
+++ b/src/public/media.ts
@@ -252,7 +252,7 @@ export interface AudioProps {
 /**
  * The modes in which camera can be launched in select Media API
  */
-export const enum CameraStartMode {
+export enum CameraStartMode {
   Photo = 1,
   Document = 2,
   Whiteboard = 3,
@@ -262,7 +262,7 @@ export const enum CameraStartMode {
 /**
  * Specifies the image source
  */
-export const enum Source {
+export enum Source {
   Camera = 1,
   Gallery = 2,
 }
@@ -270,7 +270,7 @@ export const enum Source {
 /**
  * Specifies the type of Media
  */
-export const enum MediaType {
+export enum MediaType {
   Image = 1,
   // Video = 2, // Not implemented yet
   // ImageOrVideo = 3, // Not implemented yet
@@ -288,7 +288,7 @@ export interface ImageUri {
 /**
  * ID contains a mapping for content uri on platform's side, URL is generic
  */
-export const enum ImageUriType {
+export enum ImageUriType {
   ID = 1,
   URL = 2,
 }


### PR DESCRIPTION
The change is only to have imported const enum to be just enum.

https://github.com/OfficeDev/microsoft-teams-library-js/issues/267

I do not see an issue if we just import enum rather than const enum

Few useful references on why const enum does not work in some scenarios:

https://ncjamieson.com/dont-export-const-enums/
microsoft/TypeScript#5243