### PR TITLE
Expose media API enums properly

### DIFF
--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -37,4 +37,19 @@ export {
 export { settings } from './settings';
 export { tasks } from './tasks';
 export { ChildAppWindow, IAppWindow, ParentAppWindow } from './appWindow';
-export { captureImage, File, FileFormat, selectMedia, viewImages, Media } from './media';
+export {
+  AudioProps,
+  CameraStartMode,
+  File,
+  FileFormat,
+  ImageProps,
+  ImageUri,
+  ImageUriType,
+  Media,
+  MediaInputs,
+  MediaType,
+  Source,
+  captureImage,
+  selectMedia,
+  viewImages,
+} from './media';

--- a/test/public/publicAPIs.spec.ts
+++ b/test/public/publicAPIs.spec.ts
@@ -24,6 +24,7 @@ import {
 } from '../../src/public/publicAPIs';
 import { FrameContexts } from '../../src/public/constants';
 import { Utils } from '../utils';
+import { version } from '../../src/internal/constants';
 
 describe('MicrosoftTeams-publicAPIs', () => {
   // Use to send a mock message from the app.
@@ -65,7 +66,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
     expect(initMessage.id).toBe(0);
     expect(initMessage.func).toBe('initialize');
     expect(initMessage.args.length).toEqual(1);
-    expect(initMessage.args[0]).toEqual('1.7.0');
+    expect(initMessage.args[0]).toEqual(version);
   });
 
   it('should allow multiple initialize calls', () => {
@@ -934,7 +935,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
     expect(initMessage.id).toBe(0);
     expect(initMessage.func).toBe('initialize');
     expect(initMessage.args.length).toEqual(1);
-    expect(initMessage.args[0]).toEqual('1.7.0');
+    expect(initMessage.args[0]).toEqual(version);
     let message = utils.findMessageByFunc('setFrameContext');
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(1);


### PR DESCRIPTION
Media API enums were not exposed properly for API consumer. Corrected that.

Also one of the test had hard coded version number, which is now moved into a reference to version from constants.ts