### PR TITLE
App button hover enter and leave APIs

### DIFF
--- a/src/internal/globalVars.ts
+++ b/src/internal/globalVars.ts
@@ -36,5 +36,6 @@ export class GlobalVars {
   public static onCloseConversationHandler: (conversationResponse: ConversationResponse) => void;
   public static getLogHandler: () => string;
   public static appButtonClickHandler: () => void;
-  public static appButtonHoverHandler: () => void;
+  public static appButtonHoverEnterHandler: () => void;
+  public static appButtonHoverLeaveHandler: () => void;
 }

--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -15,7 +15,8 @@ GlobalVars.handlers['changeSettings'] = handleChangeSettings;
 GlobalVars.handlers['startConversation'] = handleStartConversation;
 GlobalVars.handlers['closeConversation'] = handleCloseConversation;
 GlobalVars.handlers['appButtonClick'] = handleAppButtonClick;
-GlobalVars.handlers['appButtonHover'] = handleAppButtonHover;
+GlobalVars.handlers['appButtonHoverEnter'] = handleAppButtonHoverEnter;
+GlobalVars.handlers['appButtonHoverLeave'] = handleAppButtonHoverLeave;
 
 function handleStartConversation(
   subEntityId: string,
@@ -103,9 +104,15 @@ function handleAppButtonClick(): void {
   }
 }
 
-function handleAppButtonHover(): void {
-  if (GlobalVars.appButtonHoverHandler) {
-    GlobalVars.appButtonHoverHandler();
+function handleAppButtonHoverEnter(): void {
+  if (GlobalVars.appButtonHoverEnterHandler) {
+    GlobalVars.appButtonHoverEnterHandler();
+  }
+}
+
+function handleAppButtonHoverLeave(): void {
+  if (GlobalVars.appButtonHoverLeaveHandler) {
+    GlobalVars.appButtonHoverLeaveHandler();
   }
 }
 

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -32,7 +32,8 @@ export {
   registerOnLoadHandler,
   registerOnThemeChangeHandler,
   registerAppButtonClickHandler,
-  registerAppButtonHoverHandler,
+  registerAppButtonHoverEnterHandler,
+  registerAppButtonHoverLeaveHandler,
   setFrameContext,
   shareDeepLink,
 } from './publicAPIs';

--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -230,15 +230,27 @@ export function registerAppButtonClickHandler(handler: () => void): void {
 }
 
 /**
- * Registers a handler for hovering the app button.
+ * Registers a handler for entering hover of the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
- * @param handler The handler to invoke when the personal app button is hovered in the app bar.
+ * @param handler The handler to invoke when entering hover of the personal app button in the app bar.
  */
-export function registerAppButtonHoverHandler(handler: () => void): void {
+export function registerAppButtonHoverEnterHandler(handler: () => void): void {
   ensureInitialized();
 
-  GlobalVars.appButtonHoverHandler = handler;
-  handler && sendMessageRequestToParent('registerHandler', ['appButtonHover']);
+  GlobalVars.appButtonHoverEnterHandler = handler;
+  handler && sendMessageRequestToParent('registerHandler', ['appButtonHoverEnter']);
+}
+
+/**
+ * Registers a handler for exiting hover of the app button.
+ * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
+ * @param handler The handler to invoke when exiting hover of the personal app button in the app bar.
+ */
+export function registerAppButtonHoverLeaveHandler(handler: () => void): void {
+  ensureInitialized();
+
+  GlobalVars.appButtonHoverLeaveHandler = handler;
+  handler && sendMessageRequestToParent('registerHandler', ['appButtonHoverLeave']);
 }
 
 /**

--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -223,7 +223,7 @@ export function registerFullScreenHandler(handler: (isFullScreen: boolean) => vo
  * @param handler The handler to invoke when the personal app button is clicked in the app bar.
  */
 export function registerAppButtonClickHandler(handler: () => void): void {
-  ensureInitialized();
+  ensureInitialized(FrameContexts.content);
 
   GlobalVars.appButtonClickHandler = handler;
   handler && sendMessageRequestToParent('registerHandler', ['appButtonClick']);
@@ -235,7 +235,7 @@ export function registerAppButtonClickHandler(handler: () => void): void {
  * @param handler The handler to invoke when entering hover of the personal app button in the app bar.
  */
 export function registerAppButtonHoverEnterHandler(handler: () => void): void {
-  ensureInitialized();
+  ensureInitialized(FrameContexts.content);
 
   GlobalVars.appButtonHoverEnterHandler = handler;
   handler && sendMessageRequestToParent('registerHandler', ['appButtonHoverEnter']);
@@ -247,7 +247,7 @@ export function registerAppButtonHoverEnterHandler(handler: () => void): void {
  * @param handler The handler to invoke when exiting hover of the personal app button in the app bar.
  */
 export function registerAppButtonHoverLeaveHandler(handler: () => void): void {
-  ensureInitialized();
+  ensureInitialized(FrameContexts.content);
 
   GlobalVars.appButtonHoverLeaveHandler = handler;
   handler && sendMessageRequestToParent('registerHandler', ['appButtonHoverLeave']);

--- a/test/public/publicAPIs.spec.ts
+++ b/test/public/publicAPIs.spec.ts
@@ -20,7 +20,8 @@ import {
   setFrameContext,
   initializeWithFrameContext,
   registerAppButtonClickHandler,
-  registerAppButtonHoverHandler
+  registerAppButtonHoverEnterHandler,
+  registerAppButtonHoverLeaveHandler
 } from '../../src/public/publicAPIs';
 import { FrameContexts } from '../../src/public/constants';
 import { Utils } from '../utils';
@@ -146,15 +147,28 @@ describe('MicrosoftTeams-publicAPIs', () => {
     expect(handlerCalled).toBeTruthy();
   });
 
-  it('should successfully register a app button hover handler', () => {
+  it('should successfully register a app button hover enter handler', () => {
     utils.initializeWithContext('content');
     let handlerCalled = false;
 
-    registerAppButtonHoverHandler(() => {
+    registerAppButtonHoverEnterHandler(() => {
       handlerCalled = true;
     });
 
-    utils.sendMessage('appButtonHover', '');
+    utils.sendMessage('appButtonHoverEnter', '');
+
+    expect(handlerCalled).toBeTruthy();
+  });
+
+  it('should successfully register a app button hover leave handler', () => {
+    utils.initializeWithContext('content');
+    let handlerCalled = false;
+
+    registerAppButtonHoverLeaveHandler(() => {
+      handlerCalled = true;
+    });
+
+    utils.sendMessage('appButtonHoverLeave', '');
 
     expect(handlerCalled).toBeTruthy();
   });


### PR DESCRIPTION
Previous single app button hover api was not sufficient. Both a hover enter and hover leave API are now added to allow the sdk consumer to engage functionality both when entering hover and leaving hover. 