### PR TITLE
Limit returnFocus API to FrameContexts.content 

### DIFF
--- a/src/public/navigation.ts
+++ b/src/public/navigation.ts
@@ -13,7 +13,7 @@ import { FrameContexts } from './constants';
  * @param navigateForward Determines the direction to focus in teams app.
  */
 export function returnFocus(navigateForward?: boolean): void {
-  ensureInitialized();
+  ensureInitialized(FrameContexts.content);
 
   sendMessageRequestToParent('returnFocus', [navigateForward]);
 }


### PR DESCRIPTION
Limit returnFocus API to content FrameContext