### PR TITLE
Update filePreviewParameters for openFilePreview

### DIFF
--- a/src/private/index.ts
+++ b/src/private/index.ts
@@ -9,6 +9,7 @@ export {
   TeamInstanceParameters,
   ThreadMember,
   UserJoinedTeamsInformation,
+  ViewerActionTypes,
 } from './interfaces';
 export {
   enterFullscreen,

--- a/src/private/interfaces.ts
+++ b/src/private/interfaces.ts
@@ -84,6 +84,7 @@ export interface FilePreviewParameters {
   baseUrl?: string;
 
   /**
+   * Deprecated; prefer using viewerAction instead
    * Optional; indicates whether the file should be opened in edit mode
    */
   editFile?: boolean;
@@ -93,6 +94,11 @@ export interface FilePreviewParameters {
    * This field should be used to restore to a specific state within an entity, such as scrolling to or activating a specific piece of content.
    */
   subEntityId?: string;
+
+  /**
+   * Optional; indicates the mode in which file should be opened. Takes precedence over edit mode.
+   */
+  viewerAction?: 'view' | 'edit' | 'editNew';
 }
 
 /**

--- a/src/private/interfaces.ts
+++ b/src/private/interfaces.ts
@@ -37,6 +37,17 @@ export interface ShowNotificationParameters {
  * Hide from docs.
  * ------
  */
+export enum ViewerActionTypes {
+  view = 'view',
+  edit = 'edit',
+  editNew = 'editNew',
+}
+
+/**
+ * @private
+ * Hide from docs.
+ * ------
+ */
 export interface FilePreviewParameters {
   /**
    * The developer-defined unique ID for the file.
@@ -98,7 +109,7 @@ export interface FilePreviewParameters {
   /**
    * Optional; indicates the mode in which file should be opened. Takes precedence over edit mode.
    */
-  viewerAction?: 'view' | 'edit' | 'editNew';
+  viewerAction?: ViewerActionTypes;
 }
 
 /**

--- a/src/private/privateAPIs.ts
+++ b/src/private/privateAPIs.ts
@@ -72,6 +72,7 @@ export function openFilePreview(filePreviewParameters: FilePreviewParameters): v
     filePreviewParameters.baseUrl,
     filePreviewParameters.editFile,
     filePreviewParameters.subEntityId,
+    filePreviewParameters.viewerAction,
   ];
 
   sendMessageRequestToParent('openFilePreview', params);

--- a/test/private/privateAPIs.spec.ts
+++ b/test/private/privateAPIs.spec.ts
@@ -1,6 +1,6 @@
 import * as microsoftTeams from '../../src/public/publicAPIs';
 import { Context } from '../../src/public/interfaces';
-import { TeamInstanceParameters } from '../../src/private/interfaces';
+import { TeamInstanceParameters, ViewerActionTypes } from '../../src/private/interfaces';
 import { TeamType } from '../../src/public/constants';
 import { Utils, MessageResponse, MessageRequest } from '../utils';
 import {
@@ -174,7 +174,6 @@ describe('MicrosoftTeams-privateAPIs', () => {
     // Only the init call went out
     expect(utils.messages.length).toBe(1);
     expect(callbackCalled).toBe(false);
-
   });
 
   it('should successfully handle calls queued before init completes', () => {
@@ -304,7 +303,7 @@ describe('MicrosoftTeams-privateAPIs', () => {
       baseUrl: 'someBaseUrl',
       editFile: true,
       subEntityId: 'someSubEntityId',
-      viewerAction: 'view',
+      viewerAction: ViewerActionTypes.view,
     });
 
     let message = utils.findMessageByFunc('openFilePreview');

--- a/test/private/privateAPIs.spec.ts
+++ b/test/private/privateAPIs.spec.ts
@@ -304,11 +304,12 @@ describe('MicrosoftTeams-privateAPIs', () => {
       baseUrl: 'someBaseUrl',
       editFile: true,
       subEntityId: 'someSubEntityId',
+      viewerAction: 'view',
     });
 
     let message = utils.findMessageByFunc('openFilePreview');
     expect(message).not.toBeNull();
-    expect(message.args.length).toBe(11);
+    expect(message.args.length).toBe(12);
     expect(message.args[0]).toBe('someEntityId');
     expect(message.args[1]).toBe('someTitle');
     expect(message.args[2]).toBe('someDescription');
@@ -320,6 +321,7 @@ describe('MicrosoftTeams-privateAPIs', () => {
     expect(message.args[8]).toBe('someBaseUrl');
     expect(message.args[9]).toBe(true);
     expect(message.args[10]).toBe('someSubEntityId');
+    expect(message.args[11]).toBe('view');
   });
 
   describe('getUserJoinedTeams', () => {


### PR DESCRIPTION
Previously teams used to support opening a file only in view/edit mode. Hence we were using a boolean `editFile`.

Teams, can now support multiple modes.(`"view" | "edit" | "editNew"`). Adding a new filePreviewParameter to enable this.
