### PR TITLE
Export ChannelType from index.ts

### DIFF
--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -1,6 +1,6 @@
 export { appInitialization } from './appInitialization';
 export { authentication } from './authentication';
-export { FrameContexts, HostClientType, TaskModuleDimension, TeamType, UserTeamRole } from './constants';
+export { FrameContexts, HostClientType, TaskModuleDimension, TeamType, UserTeamRole, ChannelType } from './constants';
 export {
   Context,
   DeepLinkParameters,


### PR DESCRIPTION
When we moved from const enums to enums in #267, the exported list did not have ChannelType. Earlier when it was a const enum, it worked without this export. Now this export is needed.
