### PR TITLE
Adding partial response infra to postIDResponse callback and Change getMedia API's postResponse from handler to callback with backward compatibility

### DIFF
--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -232,6 +232,8 @@ export function handleParentMessage(evt: DOMMessageEvent): void {
     const callback = GlobalVars.callbacks[message.id];
     if (callback) {
       callback.apply(null, message.args);
+
+      // Remove the callback to ensure that the callback is called only once and to free up memory if response is a complete response
       if (!isPartialResponse(evt)) {
         delete GlobalVars.callbacks[message.id];
       }

--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -232,9 +232,13 @@ export function handleParentMessage(evt: DOMMessageEvent): void {
     const callback = GlobalVars.callbacks[message.id];
     if (callback) {
       callback.apply(null, message.args);
-
-      // Remove the callback to ensure that the callback is called only once and to free up memory.
-      delete GlobalVars.callbacks[message.id];
+      if (
+        !('isPartialResponse' in evt.data) ||
+        !(typeof evt.data.isPartialResponse === 'boolean') ||
+        !(evt.data.isPartialResponse === true)
+      ) {
+        delete GlobalVars.callbacks[message.id];
+      }
     }
   } else if ('func' in evt.data && typeof evt.data.func === 'string') {
     // Delegate the request to the proper handler

--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -232,11 +232,7 @@ export function handleParentMessage(evt: DOMMessageEvent): void {
     const callback = GlobalVars.callbacks[message.id];
     if (callback) {
       callback.apply(null, message.args);
-      if (
-        !('isPartialResponse' in evt.data) ||
-        !(typeof evt.data.isPartialResponse === 'boolean') ||
-        !(evt.data.isPartialResponse === true)
-      ) {
+      if (!isPartialResponse(evt)) {
         delete GlobalVars.callbacks[message.id];
       }
     }
@@ -249,6 +245,14 @@ export function handleParentMessage(evt: DOMMessageEvent): void {
       handler.apply(this, message.args);
     }
   }
+}
+
+function isPartialResponse(evt: DOMMessageEvent): boolean {
+  return (
+    'isPartialResponse' in evt.data &&
+    typeof evt.data.isPartialResponse === 'boolean' &&
+    evt.data.isPartialResponse === true
+  );
 }
 
 function handleChildMessage(evt: DOMMessageEvent): void {

--- a/src/internal/internalAPIs.ts
+++ b/src/internal/internalAPIs.ts
@@ -250,11 +250,7 @@ export function handleParentMessage(evt: DOMMessageEvent): void {
 }
 
 function isPartialResponse(evt: DOMMessageEvent): boolean {
-  return (
-    'isPartialResponse' in evt.data &&
-    typeof evt.data.isPartialResponse === 'boolean' &&
-    evt.data.isPartialResponse === true
-  );
+  return evt.data.isPartialResponse === true;
 }
 
 function handleChildMessage(evt: DOMMessageEvent): void {

--- a/src/internal/mediaUtil.ts
+++ b/src/internal/mediaUtil.ts
@@ -93,7 +93,7 @@ export function validateScanBarCodeInput(barCodeConfig: media.BarCodeConfig): bo
   return true;
 }
 
-export function callGetMediaViaCallbacks(requiredVersion: string): boolean {
+export function callGetMediaViaHandlers(requiredVersion: string): boolean {
   const value = compareSDKVersions(requiredVersion, GlobalVars.clientSupportedSDKVersion);
   if (isNaN(value)) {
     return false;

--- a/src/internal/mediaUtil.ts
+++ b/src/internal/mediaUtil.ts
@@ -1,6 +1,4 @@
 import { media } from '../public/media';
-import { GlobalVars } from './globalVars';
-import { compareSDKVersions } from './utils';
 
 /**
  * Helper function to create a blob from media chunks based on their sequence
@@ -91,12 +89,4 @@ export function validateScanBarCodeInput(barCodeConfig: media.BarCodeConfig): bo
     }
   }
   return true;
-}
-
-export function callGetMediaViaCallback(requiredVersion: string): boolean {
-  const value = compareSDKVersions(GlobalVars.clientSupportedSDKVersion, requiredVersion);
-  if (isNaN(value)) {
-    return false;
-  }
-  return value >= 0;
 }

--- a/src/internal/mediaUtil.ts
+++ b/src/internal/mediaUtil.ts
@@ -1,4 +1,6 @@
 import { media } from '../public/media';
+import { GlobalVars } from './globalVars';
+import { compareSDKVersions } from './utils';
 
 /**
  * Helper function to create a blob from media chunks based on their sequence
@@ -89,4 +91,12 @@ export function validateScanBarCodeInput(barCodeConfig: media.BarCodeConfig): bo
     }
   }
   return true;
+}
+
+export function callGetMediaViaCallbacks(requiredVersion: string): boolean {
+  const value = compareSDKVersions(requiredVersion, GlobalVars.clientSupportedSDKVersion);
+  if (isNaN(value)) {
+    return false;
+  }
+  return value >= 0;
 }

--- a/src/internal/mediaUtil.ts
+++ b/src/internal/mediaUtil.ts
@@ -93,8 +93,8 @@ export function validateScanBarCodeInput(barCodeConfig: media.BarCodeConfig): bo
   return true;
 }
 
-export function callGetMediaViaHandlers(requiredVersion: string): boolean {
-  const value = compareSDKVersions(requiredVersion, GlobalVars.clientSupportedSDKVersion);
+export function callGetMediaViaCallback(requiredVersion: string): boolean {
+  const value = compareSDKVersions(GlobalVars.clientSupportedSDKVersion, requiredVersion);
   if (isNaN(value)) {
     return false;
   }

--- a/src/public/media.ts
+++ b/src/public/media.ts
@@ -10,7 +10,7 @@ import {
   validateGetMediaInputs,
   validateViewImagesInput,
   validateScanBarCodeInput,
-  callGetMediaViaHandlers,
+  callGetMediaViaCallback,
 } from '../internal/mediaUtil';
 
 export namespace media {
@@ -142,10 +142,10 @@ export namespace media {
         callback(invalidInput, null);
         return;
       }
-      if (callGetMediaViaHandlers('2.0.0')) {
-        this.getMediaViaHandler(callback);
-      } else {
+      if (callGetMediaViaCallback('2.0.0')) {
         this.getMediaViaCallback(callback);
+      } else {
+        this.getMediaViaHandler(callback);
       }
     }
 

--- a/src/public/media.ts
+++ b/src/public/media.ts
@@ -142,6 +142,7 @@ export namespace media {
         callback(invalidInput, null);
         return;
       }
+      // Call the new get media implementation via callbacks if the client version is greater than or equal to '2.0.0'
       if (callGetMediaViaCallback('2.0.0')) {
         this.getMediaViaCallback(callback);
       } else {

--- a/src/public/media.ts
+++ b/src/public/media.ts
@@ -10,7 +10,7 @@ import {
   validateGetMediaInputs,
   validateViewImagesInput,
   validateScanBarCodeInput,
-  callGetMediaViaCallbacks,
+  callGetMediaViaHandlers,
 } from '../internal/mediaUtil';
 
 export namespace media {
@@ -142,10 +142,10 @@ export namespace media {
         callback(invalidInput, null);
         return;
       }
-      if (callGetMediaViaCallbacks('2.0.0')) {
-        this.getMediaViaCallback(callback);
-      } else {
+      if (callGetMediaViaHandlers('2.0.0')) {
         this.getMediaViaHandler(callback);
+      } else {
+        this.getMediaViaCallback(callback);
       }
     }
 


### PR DESCRIPTION
 **Scenario**
Currently callbacks were supported for request/response but only one response could be sent for a callback. We have modified the pattern by introducing a new field isPartialResponse. If isPartialResponse is set to true callback will not be deleted on teams js sdk library and multiple callbacks can be sent back using the same id. When the platform doesn't need to send anymore callback, in the final one it can remove the isPartialResponse field and use the existing postIDResponse() or use postCompleteResponse() function to send the final callback. (which will get deleted on the platform)

getMedia needs to send more than one response. It was using handlers before but now we have onboarded getMedia() to callbacks with isPartialResponse.

[comment]: # "What is the user scenario this change is trying to fix? Try to bring in some context. Screenshots may be helpful but not always necessary."

**Validation**
- Verified that getMedia() works via the new callback method
- Verified backward compatibility of getMedia() that it continues to work on the older client versions
- Verified that isPartialResponse field is successfully received on teams js sdk library when postPartialResponse function is used

