### PR TITLE
Update version to release-1.9.0-beta.2 (#457)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "1.7.0",
+  "version": "1.9.0-beta.2",
   "description": "Microsoft Client SDK for building app for Microsoft teams",
   "main": "./dist/MicrosoftTeams.min.js",
   "typings": "./dist/MicrosoftTeams.d.ts",

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -1,6 +1,6 @@
 import { generateRegExpFromUrls } from './utils';
 
-export const version = '1.7.0';
+export const version = '1.9.0-beta.2';
 /**
  * This is the SDK version when all SDK APIs started to check platform compatibility for the APIs.
  */

--- a/src/internal/mediaUtil.ts
+++ b/src/internal/mediaUtil.ts
@@ -74,3 +74,19 @@ export function validateViewImagesInput(uriList: media.ImageUri[]): boolean {
   }
   return true;
 }
+
+/**
+ * Returns true if the scan barcode param is valid and false otherwise
+ */
+export function validateScanBarCodeInput(barCodeConfig: media.BarCodeConfig): boolean {
+  if (barCodeConfig) {
+    if (
+      barCodeConfig.timeOutIntervalInSec === null ||
+      barCodeConfig.timeOutIntervalInSec <= 0 ||
+      barCodeConfig.timeOutIntervalInSec > 60
+    ) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -596,6 +596,10 @@ export enum ErrorCode {
    */
   USER_ABORT = 8000,
   /**
+   * Could not complete the operation in the given time interval
+   */
+  OPERATION_TIMED_OUT = 8001,
+  /**
    * Platform code is old and doesn't implement this API
    */
   OLD_PLATFORM = 9000,

--- a/test/public/media.spec.ts
+++ b/test/public/media.spec.ts
@@ -7,13 +7,14 @@ import { Utils } from '../utils';
 import { media } from '../../src/public/media';
 
 /**
- * Test cases for device APIs
+ * Test cases for media APIs
  */
 describe('media', () => {
   const mobilePlatformMock = new FramelessPostMocks();
   const desktopPlatformMock = new Utils()
   const minVersionForCaptureImage = '1.7.0';
   const mediaAPISupportVersion = '1.8.0';
+  const scanBarCodeAPISupportVersion = '1.9.0';
 
   beforeEach(() => {
     mobilePlatformMock.messages = [];
@@ -569,5 +570,171 @@ describe('media', () => {
       }
     } as DOMMessageEvent)
     expect(mediaError.errorCode).toBe(ErrorCode.FILE_NOT_FOUND);
+  });
+
+  /**
+   * ScanBarCode API tests
+   */
+  it('should not allow scanBarCode calls with null callback', () => {
+    expect(() => media.scanBarCode(null, null)).toThrowError(
+      '[media.scanBarCode] Callback cannot be null',
+    );
+  });
+
+  it('should not allow scanBarCode calls with null callback after init context', () => {
+    mobilePlatformMock.initializeWithContext(FrameContexts.content);
+    mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+    expect(() => media.scanBarCode(null, null)).toThrowError(
+      '[media.scanBarCode] Callback cannot be null',
+    );
+  });
+
+  it('should not allow scanBarCode calls before initialization', () => {
+    expect(() => media.scanBarCode(emptyCallback, null)).toThrowError(
+      'The library has not yet been initialized',
+    );
+  });
+
+  it('scanBarCode call in default version of platform support fails', () => {
+    mobilePlatformMock.initializeWithContext(FrameContexts.task);
+    let error;
+    media.scanBarCode((e: SdkError, d: string) => {
+      error = e;
+    });
+    expect(error).not.toBeNull();
+    expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
+  });
+
+  it('should not allow scanBarCode calls for authentication frame context', () => {
+    mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
+    mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+    expect(() => media.scanBarCode(emptyCallback, null)).toThrowError(
+      "This call is not allowed in the 'authentication' context",
+    );
+  });
+
+  it('scanBarCode call in task frameContext works', () => {
+    mobilePlatformMock.initializeWithContext(FrameContexts.task);
+    mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+    media.scanBarCode(emptyCallback, null);
+    let message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+    expect(message).not.toBeNull();
+    expect(message.args.length).toBe(1);
+  });
+
+  it('scanBarCode call in content frameContext works', () => {
+    mobilePlatformMock.initializeWithContext(FrameContexts.content);
+    mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+    media.scanBarCode(emptyCallback, null);
+    let message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+    expect(message).not.toBeNull();
+    expect(message.args.length).toBe(1);
+  });
+
+  it('scanBarCode calls with successful result', () => {
+    mobilePlatformMock.initializeWithContext(FrameContexts.content);
+    mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+    let decodedText: string, mediaError: SdkError;
+    media.scanBarCode((e: SdkError, d: string) => {
+      mediaError = e;
+      decodedText = d;
+    });
+
+    let message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+    expect(message).not.toBeNull();
+    expect(message.args.length).toBe(1);
+
+    let callbackId = message.id;
+    let response : string = 'decodedText';
+    mobilePlatformMock.respondToMessage({
+      data: {
+        id: callbackId,
+        args: [undefined, response]
+      }
+    } as DOMMessageEvent)
+
+    expect(mediaError).toBeFalsy();
+    expect(decodedText).toBe('decodedText');
+  });
+
+  it('scanBarCode with optional barcode config calls with successful result', () => {
+    mobilePlatformMock.initializeWithContext(FrameContexts.content);
+    mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+    let decodedText: string, mediaError: SdkError;
+    let barCodeConfig: media.BarCodeConfig = {
+      timeOutIntervalInSec: 40
+    };
+    media.scanBarCode((e: SdkError, d: string) => {
+      mediaError = e;
+      decodedText = d;
+    }, barCodeConfig);
+
+    let message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+    expect(message).not.toBeNull();
+    expect(message.args.length).toBe(1);
+
+    let callbackId = message.id;
+    let response : string = 'decodedText';
+    mobilePlatformMock.respondToMessage({
+      data: {
+        id: callbackId,
+        args: [undefined, response]
+      }
+    } as DOMMessageEvent)
+
+    expect(mediaError).toBeFalsy();
+    expect(decodedText).not.toBeNull;
+    expect(decodedText).toBe('decodedText');
+  });
+
+  it('scanBarCode calls with error', () => {
+    mobilePlatformMock.initializeWithContext(FrameContexts.content);
+    mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+    let decodedText: string, mediaError: SdkError;
+    media.scanBarCode((e: SdkError, d: string) => {
+      mediaError = e;
+      decodedText = d;
+    });
+
+    let message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+    expect(message).not.toBeNull();
+    expect(message.args.length).toBe(1);
+
+    let callbackId = message.id;
+    mobilePlatformMock.respondToMessage({
+      data: {
+        id: callbackId,
+        args: [{ errorCode: ErrorCode.OPERATION_TIMED_OUT }]
+      }
+    } as DOMMessageEvent)
+
+    expect(decodedText).toBeFalsy();
+    expect(mediaError.errorCode).toBe(ErrorCode.OPERATION_TIMED_OUT);
+  });
+
+  it('should not allow scanBarCode calls with invalid timeOutIntervalInSec', () => {
+    mobilePlatformMock.initializeWithContext(FrameContexts.task);
+    mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+    let barCodeConfig: any = {
+      timeOutIntervalInSec: 0
+    };
+    let mediaError: SdkError;
+    media.scanBarCode((e: SdkError, d: string) => {
+      mediaError = e;
+    }, barCodeConfig);
+    expect(mediaError).not.toBeNull();
+    expect(mediaError.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+  });
+
+  it('should allow scanBarCode calls when timeOutIntervalInSec is not passed in config params', () => {
+    mobilePlatformMock.initializeWithContext(FrameContexts.task);
+    mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+    let barCodeConfig: media.BarCodeConfig = {
+    };
+    let mediaError: SdkError;
+    media.scanBarCode((e: SdkError, d: string) => {
+      mediaError = e;
+    }, barCodeConfig);
+    expect(mediaError).toBeFalsy();
   });
 });


### PR DESCRIPTION
* Update version

* Scan Barcode API for webapps (#447)

* Added new API to scan barcode and QR code

* Moving scanBarCode API to media namespace

* Changing the Barcode API required version to 1.9.0

* Renaming Scan_time_out error code to Operation_timed_out

* Added tests for scanBarCode API

* Fixing comments for scanBarCode API

* Addressing code review comments

* Added few more barcode tests

* Removing optional barcodeType from BarCodeConfig

Co-authored-by: Vivek Kaarthek <vivra@microsoft.com>
Co-authored-by: samyuktha-tamvada <65152623+samyuktha-tamvada@users.noreply.github.com>