### PR TITLE
Scan BarCode API to return NotSupported Error on desktop and web platform

### DIFF
--- a/src/public/media.ts
+++ b/src/public/media.ts
@@ -440,7 +440,7 @@ export namespace media {
 
     if (!GlobalVars.isFramelessWindow) {
       const notSupportedError: SdkError = { errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM };
-      callback(notSupportedError, undefined);
+      callback(notSupportedError, null);
       return;
     }
 

--- a/src/public/media.ts
+++ b/src/public/media.ts
@@ -428,7 +428,7 @@ export namespace media {
 
   /**
    * Scan Barcode/QRcode using camera
-   * Note: For desktop, this API is not supported. Callback will be resolved with ErrorCode.NotSupported.
+   * Note: For desktop and web, this API is not supported. Callback will be resolved with ErrorCode.NotSupported.
    * @param callback callback to invoke after scanning the barcode
    * @param config optional input configuration to customize the barcode scanning experience
    */

--- a/src/public/media.ts
+++ b/src/public/media.ts
@@ -428,6 +428,7 @@ export namespace media {
 
   /**
    * Scan Barcode/QRcode using camera
+   * Note: For desktop, this API is not supported. Callback will be resolved with ErrorCode.NotSupported.
    * @param callback callback to invoke after scanning the barcode
    * @param config optional input configuration to customize the barcode scanning experience
    */
@@ -436,6 +437,12 @@ export namespace media {
       throw new Error('[media.scanBarCode] Callback cannot be null');
     }
     ensureInitialized(FrameContexts.content, FrameContexts.task);
+
+    if (!GlobalVars.isFramelessWindow) {
+      const notSupportedError: SdkError = { errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM };
+      callback(notSupportedError, undefined);
+      return;
+    }
 
     if (!isAPISupportedByPlatform(scanBarCodeAPIMobileSupportVersion)) {
       const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };

--- a/src/public/media.ts
+++ b/src/public/media.ts
@@ -1,7 +1,7 @@
 import { GlobalVars } from '../internal/globalVars';
 import { SdkError, ErrorCode } from './interfaces';
 import { ensureInitialized, sendMessageRequestToParent, isAPISupportedByPlatform } from '../internal/internalAPIs';
-import { FrameContexts } from './constants';
+import { FrameContexts, HostClientType } from './constants';
 import { generateGUID } from '../internal/utils';
 import {
   createFile,
@@ -484,7 +484,11 @@ export namespace media {
     }
     ensureInitialized(FrameContexts.content, FrameContexts.task);
 
-    if (!GlobalVars.isFramelessWindow) {
+    if (
+      GlobalVars.hostClientType === HostClientType.desktop ||
+      GlobalVars.hostClientType === HostClientType.web ||
+      GlobalVars.hostClientType === HostClientType.rigel
+    ) {
       const notSupportedError: SdkError = { errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM };
       callback(notSupportedError, null);
       return;

--- a/test/public/media.spec.ts
+++ b/test/public/media.spec.ts
@@ -1,6 +1,6 @@
 import { FramelessPostMocks } from '../framelessPostMocks';
 import { _initialize, _uninitialize } from '../../src/public/publicAPIs';
-import { FrameContexts } from '../../src/public/constants';
+import { FrameContexts, HostClientType } from '../../src/public/constants';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { SdkError, ErrorCode } from '../../src/public/interfaces';
 import { Utils } from '../utils';
@@ -739,7 +739,7 @@ describe('media', () => {
   });
 
   it('should not allow scanBarCode calls in desktop', () => {
-    desktopPlatformMock.initializeWithContext(FrameContexts.content);
+    desktopPlatformMock.initializeWithContext(FrameContexts.content, HostClientType.desktop);
     let error;
     media.scanBarCode((e: SdkError, d: string) => {
       error = e;

--- a/test/public/media.spec.ts
+++ b/test/public/media.spec.ts
@@ -737,4 +737,14 @@ describe('media', () => {
     }, barCodeConfig);
     expect(mediaError).toBeFalsy();
   });
+
+  it('should not allow scanBarCode calls in desktop', () => {
+    desktopPlatformMock.initializeWithContext(FrameContexts.content);
+    let error;
+    media.scanBarCode((e: SdkError, d: string) => {
+      error = e;
+    });
+    expect(error).not.toBeNull();
+    expect(error.errorCode).toBe(ErrorCode.NOT_SUPPORTED_ON_PLATFORM);
+  });
 });


### PR DESCRIPTION
ScanBarCode API is only available for mobile platform and not supported on Desktop and web platform
ErrorCode.NOT_SUPPORTED_ON_PLATFORM (i.e 100 errorcode) will be returned in the callback on desktop and web platform.

Tests:
Did manual testing using a custom app, tested the following:

- ScanBarCode API works on mobile platform

- ScanBarCode API returns ErrorCode.NOT_SUPPORTED_ON_PLATFORM (i.e 100 errorcode) on desktop and web platform