### PR TITLE
Cmd/ronak/getskypetoken

### DIFF
--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -19,19 +19,19 @@ export namespace meeting {
     /**
      * meeting title name of the meeting
      */
-    meetingTitle?: string;
+    meetingTitle: string;
     /**
      * organizer id of the meeting
      */
-    organizerId?: string;
+    organizerId: string;
     /**
      * tenant id of the meeting
      */
-    tenantId?: string;
+    tenantId: string;
     /**
      * url to join the current meeting
      */
-    joinUrl?: string;
+    joinUrl: string;
   }
 
   /**
@@ -70,11 +70,13 @@ export namespace meeting {
 
   /**
    * Allows an app to get the meeting details for the meeting
-   * @param callback Callback contains 2 parameters, error and result.
+   * @param callback Callback contains 2 parameters, error and meetingDetails.
    * error can either contain an error of type SdkError, incase of an error, or null when get is successful
-   * result can either contain a string value, incase of a successful get or null when the get fails
+   * result can either contain a IMeetingDetails value, incase of a successful get or null when the get fails
    */
-  export function getMeetingDetails(callback: (error: SdkError | null, result: string | null) => void): void {
+  export function getMeetingDetails(
+    callback: (error: SdkError | null, meetingDetails: IMeetingDetails | null) => void,
+  ): void {
     if (!callback) {
       throw new Error('[get meeting details] Callback cannot be null');
     }

--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -19,19 +19,19 @@ export namespace meeting {
     /**
      * meeting title name of the meeting
      */
-    meetingTitle: string;
+    meetingTitle?: string;
     /**
      * organizer id of the meeting
      */
-    organizerId: string;
+    organizerId?: string;
     /**
      * tenant id of the meeting
      */
-    tenantId: string;
+    tenantId?: string;
     /**
      * url to join the current meeting
      */
-    joinUrl: string;
+    joinUrl?: string;
   }
 
   /**

--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -70,13 +70,11 @@ export namespace meeting {
 
   /**
    * Allows an app to get the meeting details for the meeting
-   * @param callback Callback contains 2 parameters, error and meetingDetails.
+   * @param callback Callback contains 2 parameters, error and result.
    * error can either contain an error of type SdkError, incase of an error, or null when get is successful
-   * result can either contain a IMeetingDetails value, incase of a successful get or null when the get fails
+   * result can either contain a string value, incase of a successful get or null when the get fails
    */
-  export function getMeetingDetails(
-    callback: (error: SdkError | null, meetingDetails: IMeetingDetails | null) => void,
-  ): void {
+  export function getMeetingDetails(callback: (error: SdkError | null, result: string | null) => void): void {
     if (!callback) {
       throw new Error('[get meeting details] Callback cannot be null');
     }

--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -84,4 +84,21 @@ export namespace meeting {
     const messageId = sendMessageRequestToParent('meeting.getMeetingDetails');
     GlobalVars.callbacks[messageId] = callback;
   }
+
+  /**
+   * Allows an app to get the authentication token for the anonymous or guest user in the meeting
+   * @param callback Callback contains 2 parameters, error and authenticationTokenOfAnonymousUser.
+   * error can either contain an error of type SdkError, incase of an error, or null when get is successful
+   * authenticationTokenOfAnonymousUser can either contain a string value, incase of a successful get or null when the get fails
+   */
+  export function getAuthenticationTokenForAnonymousUser(
+    callback: (error: SdkError | null, authenticationTokenOfAnonymousUser: string | null) => void,
+  ): void {
+    if (!callback) {
+      throw new Error('[get Authentication Token For AnonymousUser] Callback cannot be null');
+    }
+    ensureInitialized();
+    const messageId = sendMessageRequestToParent('meeting.getAuthenticationTokenForAnonymousUser');
+    GlobalVars.callbacks[messageId] = callback;
+  }
 }

--- a/test/public/meeting.spec.ts
+++ b/test/public/meeting.spec.ts
@@ -153,78 +153,70 @@ describe('meeting', () => {
       expect(returnedResult).toBe(null);
     });
   });
-  describe('getMeetingDetails', () => {
+  describe("getMeetingDetails", () => {
     it('should not allow get meeting details calls with null callback', () => {
       expect(() => meeting.getMeetingDetails(null)).toThrowError('[get meeting details] Callback cannot be null');
     });
-    it('should not allow calls before initialization', () => {
+    it("should not allow calls before initialization", () => {
       expect(() =>
         meeting.getMeetingDetails(() => {
           return;
         }),
-      ).toThrowError('The library has not yet been initialized');
+      ).toThrowError("The library has not yet been initialized");
     });
 
-    it('should successfully get the meeting details', () => {
-      desktopPlatformMock.initializeWithContext('content');
+    it("should successfully get the meeting details", () => {
+      desktopPlatformMock.initializeWithContext("content");
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
-      let returnedMeetingResult: meeting.IMeetingDetails | null;
-      meeting.getMeetingDetails((error: SdkError, meetingDetails: meeting.IMeetingDetails) => {
+      let returnedResult: string | null;
+      meeting.getMeetingDetails((error: SdkError, result: string) => {
         callbackCalled = true;
-        returnedMeetingResult = meetingDetails;
+        returnedResult = result;
         returnedSdkError = error;
       });
 
-      let getMeetingDetailsMessage = desktopPlatformMock.findMessageByFunc('meeting.getMeetingDetails');
+      let getMeetingDetailsMessage = desktopPlatformMock.findMessageByFunc("meeting.getMeetingDetails");
       expect(getMeetingDetailsMessage).not.toBeNull();
       let callbackId = getMeetingDetailsMessage.id;
-      let meetingDetails: meeting.IMeetingDetails = {
-        scheduledStartTime: '2020-12-21T21:30:00+00:00',
-        scheduledEndTime: '2020-12-21T22:00:00+00:00',
-        meetingTitle: 'Get meeting details test meeting',
-        organizerId: '8:orgid:6b33ac33-85ae-4995-be29-1d38a77aa8e3',
-        tenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47',
-        joinUrl:
-          'https://teams.microsoft.com/l/meetup-join/19%3ameeting_qwertyuiop[phgfdsasdfghjkjbvcxcvbnmyt1234567890!@#$%^&*(%40thread.v2/0?context=%7b%22Tid%22%3a%2272f988bf-86f1-41af-91ab-2d7cd011db47%22%2c%22Oid%22%3a%226b33ac33-85ae-4995-be29-1d38a77aa8e3%22%7d',
-      }​​​​;
+      let mockData = `{​​​​"scheduledStartTime":"2020-12-21T21:30:00+00:00","scheduledEndTime":"2020-12-21T22:00:00+00:00","meetingTitle":"Get meeting details test meeting","organizerId":"8:orgid:6b33ac33-85ae-4995-be29-1d38a77aa8e3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","joinUrl":"https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZTVhMWViNDAtM2JjOC00MWQyLWI5MzctZjM2ODM3YjQzM2Vi%40thread.v2/0?context=%7b%22Tid%22%3a%2272f988bf-86f1-41af-91ab-2d7cd011db47%22%2c%22Oid%22%3a%226b33ac33-85ae-4995-be29-1d38a77aa8e3%22%7d"}​​​​`;
       desktopPlatformMock.respondToMessage({
         data: {
           id: callbackId,
-          args: [null, meetingDetails],
-        },
+          args: [null, mockData],
+        }
       } as DOMMessageEvent);
       expect(callbackCalled).toBe(true);
       expect(returnedSdkError).toBeNull();
-      expect(returnedMeetingResult).toStrictEqual(meetingDetails);
+      expect(returnedResult).toStrictEqual(mockData);
     });
 
-    it('should return error code 500', () => {
-      desktopPlatformMock.initializeWithContext('content');
+    it("should return error code 500", () => {
+      desktopPlatformMock.initializeWithContext("content");
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
-      let returnedMeetingDetails: meeting.IMeetingDetails | null;
-      meeting.getMeetingDetails((error: SdkError, meetingDetails: meeting.IMeetingDetails) => {
+      let returnedResult: string | null;
+      meeting.getMeetingDetails((error: SdkError, result: string) => {
         callbackCalled = true;
-        returnedMeetingDetails = meetingDetails;
+        returnedResult = result;
         returnedSdkError = error;
       });
 
-      let getMeetingDetailsMessage = desktopPlatformMock.findMessageByFunc('meeting.getMeetingDetails');
+      let getMeetingDetailsMessage = desktopPlatformMock.findMessageByFunc("meeting.getMeetingDetails");
       expect(getMeetingDetailsMessage).not.toBeNull();
       let callbackId = getMeetingDetailsMessage.id;
       desktopPlatformMock.respondToMessage({
         data: {
           id: callbackId,
-          args: [{ errorCode: ErrorCode.INTERNAL_ERROR }, null],
+          args: [{ errorCode: ErrorCode.INTERNAL_ERROR }, null]
         },
       } as DOMMessageEvent);
       expect(callbackCalled).toBe(true);
       expect(returnedSdkError).not.toBeNull();
       expect(returnedSdkError).toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
-      expect(returnedMeetingDetails).toBe(null);
+      expect(returnedResult).toBe(null);
     });
   });
 });

--- a/test/public/meeting.spec.ts
+++ b/test/public/meeting.spec.ts
@@ -153,70 +153,78 @@ describe('meeting', () => {
       expect(returnedResult).toBe(null);
     });
   });
-  describe("getMeetingDetails", () => {
+  describe('getMeetingDetails', () => {
     it('should not allow get meeting details calls with null callback', () => {
       expect(() => meeting.getMeetingDetails(null)).toThrowError('[get meeting details] Callback cannot be null');
     });
-    it("should not allow calls before initialization", () => {
+    it('should not allow calls before initialization', () => {
       expect(() =>
         meeting.getMeetingDetails(() => {
           return;
         }),
-      ).toThrowError("The library has not yet been initialized");
+      ).toThrowError('The library has not yet been initialized');
     });
 
-    it("should successfully get the meeting details", () => {
-      desktopPlatformMock.initializeWithContext("content");
+    it('should successfully get the meeting details', () => {
+      desktopPlatformMock.initializeWithContext('content');
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
-      let returnedResult: string | null;
-      meeting.getMeetingDetails((error: SdkError, result: string) => {
+      let returnedMeetingResult: meeting.IMeetingDetails | null;
+      meeting.getMeetingDetails((error: SdkError, meetingDetails: meeting.IMeetingDetails) => {
         callbackCalled = true;
-        returnedResult = result;
+        returnedMeetingResult = meetingDetails;
         returnedSdkError = error;
       });
 
-      let getMeetingDetailsMessage = desktopPlatformMock.findMessageByFunc("meeting.getMeetingDetails");
+      let getMeetingDetailsMessage = desktopPlatformMock.findMessageByFunc('meeting.getMeetingDetails');
       expect(getMeetingDetailsMessage).not.toBeNull();
       let callbackId = getMeetingDetailsMessage.id;
-      let mockData = `{​​​​"scheduledStartTime":"2020-12-21T21:30:00+00:00","scheduledEndTime":"2020-12-21T22:00:00+00:00","meetingTitle":"Get meeting details test meeting","organizerId":"8:orgid:6b33ac33-85ae-4995-be29-1d38a77aa8e3","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","joinUrl":"https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZTVhMWViNDAtM2JjOC00MWQyLWI5MzctZjM2ODM3YjQzM2Vi%40thread.v2/0?context=%7b%22Tid%22%3a%2272f988bf-86f1-41af-91ab-2d7cd011db47%22%2c%22Oid%22%3a%226b33ac33-85ae-4995-be29-1d38a77aa8e3%22%7d"}​​​​`;
+      let meetingDetails: meeting.IMeetingDetails = {
+        scheduledStartTime: '2020-12-21T21:30:00+00:00',
+        scheduledEndTime: '2020-12-21T22:00:00+00:00',
+        meetingTitle: 'Get meeting details test meeting',
+        organizerId: '8:orgid:6b33ac33-85ae-4995-be29-1d38a77aa8e3',
+        tenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47',
+        joinUrl:
+          'https://teams.microsoft.com/l/meetup-join/19%3ameeting_qwertyuiop[phgfdsasdfghjkjbvcxcvbnmyt1234567890!@#$%^&*(%40thread.v2/0?context=%7b%22Tid%22%3a%2272f988bf-86f1-41af-91ab-2d7cd011db47%22%2c%22Oid%22%3a%226b33ac33-85ae-4995-be29-1d38a77aa8e3%22%7d',
+      }​​​​;
       desktopPlatformMock.respondToMessage({
         data: {
           id: callbackId,
-          args: [null, mockData],
-        }
+          args: [null, meetingDetails],
+        },
       } as DOMMessageEvent);
       expect(callbackCalled).toBe(true);
       expect(returnedSdkError).toBeNull();
-      expect(returnedResult).toStrictEqual(mockData);
+      expect(returnedMeetingResult).toStrictEqual(meetingDetails);
     });
 
-    it("should return error code 500", () => {
-      desktopPlatformMock.initializeWithContext("content");
+    it('should return error code 500', () => {
+      desktopPlatformMock.initializeWithContext('content');
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
-      let returnedResult: string | null;
-      meeting.getMeetingDetails((error: SdkError, result: string) => {
+      let returnedMeetingDetails: meeting.IMeetingDetails | null;
+      meeting.getMeetingDetails((error: SdkError, meetingDetails: meeting.IMeetingDetails) => {
         callbackCalled = true;
-        returnedResult = result;
+        returnedMeetingDetails = meetingDetails;
         returnedSdkError = error;
       });
 
-      let getMeetingDetailsMessage = desktopPlatformMock.findMessageByFunc("meeting.getMeetingDetails");
+      let getMeetingDetailsMessage = desktopPlatformMock.findMessageByFunc('meeting.getMeetingDetails');
       expect(getMeetingDetailsMessage).not.toBeNull();
       let callbackId = getMeetingDetailsMessage.id;
       desktopPlatformMock.respondToMessage({
         data: {
           id: callbackId,
-          args: [{ errorCode: ErrorCode.INTERNAL_ERROR }, null]
+          args: [{ errorCode: ErrorCode.INTERNAL_ERROR }, null],
         },
       } as DOMMessageEvent);
       expect(callbackCalled).toBe(true);
       expect(returnedSdkError).not.toBeNull();
       expect(returnedSdkError).toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
-      expect(returnedResult).toBe(null);
+      expect(returnedMeetingDetails).toBe(null);
     });
   });
 });


### PR DESCRIPTION
Anonymous users are not supported to interact with Extensibility apps in side-panels during an ongoing meeting. Extensibility App needs to authorize users before allowing access to the app. Right now, extensibility apps can authorize and provide access to users based on AAD tokens. Whereas in the case of anonymous users, the AAD token is null.  

To enable anonymous users to access specified apps decided by app developers, we can provide a Skype Token and authorize limited access to CMD functionality. For apps to authorize anonymous users, they need to have access to Skype Token and validate it. 