### PR TITLE
Add the sourceOrigin and userClickTime in the getContext call

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -384,6 +384,16 @@ export interface Context {
    * Personal app icon y coordinate position
    */
   appIconPosition?: number;
+
+  /**
+   * Source origin from where the tab is opened
+   */
+  sourceOrigin?: string;
+
+  /**
+   * Time when the user clicked on the tab
+   */
+  userClickTime?: string;
 }
 
 export interface DeepLinkParameters {

--- a/test/private/privateAPIs.spec.ts
+++ b/test/private/privateAPIs.spec.ts
@@ -278,6 +278,8 @@ describe('MicrosoftTeams-privateAPIs', () => {
       teamSiteUrl: 'someSiteUrl',
       sessionId: 'someSessionId',
       appSessionId: 'appSessionId',
+      sourceOrigin: 'someOrigin',
+      userClickTime: 'someTime'
     };
 
     // Get many responses to the same message


### PR DESCRIPTION
This will be used by the WPX apps mostly to understand where the tab was opened from and the timestamp when the tab was opened