### PR TITLE
Add TFL domain to valid origins list

### DIFF
--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -15,6 +15,7 @@ export const validOrigins = [
   'https://gov.teams.microsoft.us',
   'https://dod.teams.microsoft.us',
   'https://int.teams.microsoft.com',
+  'https://teams.live.com',
   'https://devspaces.skype.com',
   'https://ssauth.skype.com',
   'https://local.teams.office.com', // local development


### PR DESCRIPTION
This change allows Teams Apps to be hosted in the Teams For Life Client.