### PR TITLE
#435 - registerOnRemoveHandler is not allowed in the settings context

### DIFF
--- a/src/public/settings.ts
+++ b/src/public/settings.ts
@@ -68,7 +68,7 @@ export namespace settings {
    * @param handler The handler to invoke when the user selects the remove button.
    */
   export function registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void {
-    ensureInitialized(FrameContexts.remove);
+    ensureInitialized(FrameContexts.remove, FrameContexts.settings);
     removeHandler = handler;
     handler && sendMessageRequestToParent('registerHandler', ['remove']);
   }


### PR DESCRIPTION
Both configuration and removal of connectors happens in the settings context and therefore the `registerOnRemoveHandler` API should be supported there.