### PR TITLE
adding teamTemplateId to getContext

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -394,6 +394,11 @@ export interface Context {
    * Time when the user clicked on the tab
    */
   userClickTime?: number;
+
+  /**
+   * Team Template ID if there was a Team Template associated with the creation of the team.
+   */
+  teamTemplateId?: string;
 }
 
 export interface DeepLinkParameters {

--- a/test/private/privateAPIs.spec.ts
+++ b/test/private/privateAPIs.spec.ts
@@ -280,6 +280,7 @@ describe('MicrosoftTeams-privateAPIs', () => {
       appSessionId: 'appSessionId',
       sourceOrigin: 'someOrigin',
       userClickTime: 1000,
+      teamTemplateId: 'com.microsoft.teams.ManageAProject',
     };
 
     // Get many responses to the same message


### PR DESCRIPTION
This PR adds the field teamTemplateId to the context object, which is an optional field to be populated if the team object was created with a Team Template.