### PR TITLE
Add surfaceHub platform to HostClientType

### DIFF
--- a/src/public/constants.ts
+++ b/src/public/constants.ts
@@ -4,6 +4,7 @@ export enum HostClientType {
   android = 'android',
   ios = 'ios',
   rigel = 'rigel',
+  surfaceHub2 = 'surfaceHub2',
 }
 
 // Ensure these declarations stay in sync with the framework.

--- a/src/public/constants.ts
+++ b/src/public/constants.ts
@@ -4,7 +4,7 @@ export enum HostClientType {
   android = 'android',
   ios = 'ios',
   rigel = 'rigel',
-  surfaceHub2 = 'surfaceHub2',
+  surfaceHub = 'surfaceHub',
 }
 
 // Ensure these declarations stay in sync with the framework.


### PR DESCRIPTION
Add surfaceHub2 platform to HostClientType with value='surfaceHub'.
Use this value for SurfaceHub 2s specific scenarios/workflows.