### PR TITLE
Added check for clientSupportedSdkVersion and hostclient for `getUserJoinedTeams` execution on android

### DIFF
--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -7,6 +7,41 @@ export const version = '1.9.0';
 export const defaultSDKVersionForCompatCheck = '1.6.0';
 
 /**
+ * Minimum required client supported version for {@link getUserJoinedTeams} to be supported on {@link HostClientType.android}
+ */
+export const getUserJoinedTeamsSupportedAndroidClientVersion = '2.0.1';
+
+/**
+ * This is the SDK version when location APIs (getLocation and showLocation) are supported.
+ */
+export const locationAPIsRequiredVersion = '1.9.0';
+
+/**
+ * This is the SDK version when people picker API is supported on mobile.
+ */
+export const peoplePickerRequiredVersion = '2.0.0';
+
+/**
+ * This is the SDK version when captureImage API is supported on mobile.
+ */
+export const captureImageMobileSupportVersion = '1.7.0';
+
+/**
+ * This is the SDK version when media APIs is supported on all three platforms ios, android and web.
+ */
+export const mediaAPISupportVersion = '1.8.0';
+
+/**
+ * This is the SDK version when getMedia API is supported via Callbacks on all three platforms ios, android and web.
+ */
+export const getMediaCallbackSupportVersion = '2.0.0';
+
+/**
+ * This is the SDK version when scanBarCode API is supported on mobile.
+ */
+export const scanBarCodeAPIMobileSupportVersion = '1.9.0';
+
+/**
  * List of supported Host origins
  */
 export const validOrigins = [

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -27,7 +27,7 @@ export const peoplePickerRequiredVersion = '2.0.0';
 export const captureImageMobileSupportVersion = '1.7.0';
 
 /**
- * This is the SDK version when media APIs is supported on all three platforms ios, android and web.
+ * This is the SDK version when media APIs are supported on all three platforms ios, android and web.
  */
 export const mediaAPISupportVersion = '1.8.0';
 

--- a/src/private/privateAPIs.ts
+++ b/src/private/privateAPIs.ts
@@ -14,8 +14,7 @@ import { menus } from './menus';
 import { registerHandler } from '../internal/handlers';
 import { GlobalVars } from '../internal/globalVars';
 import { ErrorCode, SdkError } from '../public/interfaces';
-
-const getUserJoinedTeamsSupportedAndroidClientVersion = '2.0.1';
+import { getUserJoinedTeamsSupportedAndroidClientVersion } from '../internal/constants';
 
 export function initializePrivateApis(): void {
   menus.initialize();

--- a/src/private/privateAPIs.ts
+++ b/src/private/privateAPIs.ts
@@ -1,5 +1,5 @@
-import { ensureInitialized } from '../internal/internalAPIs';
-import { FrameContexts } from '../public/constants';
+import { ensureInitialized, isAPISupportedByPlatform } from '../internal/internalAPIs';
+import { FrameContexts, HostClientType } from '../public/constants';
 import {
   ChatMembersInformation,
   ShowNotificationParameters,
@@ -12,6 +12,10 @@ import { getGenericOnCompleteHandler } from '../internal/utils';
 import { Communication, sendMessageToParent, sendMessageEventToChild } from '../internal/communication';
 import { menus } from './menus';
 import { registerHandler } from '../internal/handlers';
+import { GlobalVars } from '../internal/globalVars';
+import { ErrorCode, SdkError } from '../public/interfaces';
+
+const getUserJoinedTeamsSupportedAndroidClientVersion = '2.0.1';
 
 export function initializePrivateApis(): void {
   menus.initialize();
@@ -30,6 +34,14 @@ export function getUserJoinedTeams(
   teamInstanceParameters?: TeamInstanceParameters,
 ): void {
   ensureInitialized();
+
+  if (
+    GlobalVars.hostClientType === HostClientType.android &&
+    !isAPISupportedByPlatform(getUserJoinedTeamsSupportedAndroidClientVersion)
+  ) {
+    const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
+    throw new Error(JSON.stringify(oldPlatformError));
+  }
 
   sendMessageToParent('getUserJoinedTeams', [teamInstanceParameters], callback);
 }

--- a/src/public/location.ts
+++ b/src/public/location.ts
@@ -2,13 +2,9 @@ import { SdkError, ErrorCode } from './interfaces';
 import { ensureInitialized, isAPISupportedByPlatform } from '../internal/internalAPIs';
 import { FrameContexts } from './constants';
 import { sendMessageToParent } from '../internal/communication';
+import { locationAPIsRequiredVersion } from '../internal/constants';
 
 export namespace location {
-  /**
-   * This is the SDK version when location APIs (getLocation and showLocation) are supported.
-   */
-  export const locationAPIsRequiredVersion = '1.9.0';
-
   export interface LocationProps {
     /**
     whether user can alter location or not

--- a/src/public/media.ts
+++ b/src/public/media.ts
@@ -13,28 +13,14 @@ import {
 } from '../internal/mediaUtil';
 import { sendMessageToParent } from '../internal/communication';
 import { registerHandler, removeHandler } from '../internal/handlers';
+import {
+  captureImageMobileSupportVersion,
+  mediaAPISupportVersion,
+  getMediaCallbackSupportVersion,
+  scanBarCodeAPIMobileSupportVersion,
+} from '../internal/constants';
 
 export namespace media {
-  /**
-   * This is the SDK version when captureImage API is supported on mobile.
-   */
-  const captureImageMobileSupportVersion = '1.7.0';
-
-  /**
-   * This is the SDK version when media APIs is supported on all three platforms ios, android and web.
-   */
-  const mediaAPISupportVersion = '1.8.0';
-
-  /**
-   * This is the SDK version when getMedia API is supported via Callbacks on all three platforms ios, android and web.
-   */
-  const getMediaCallbackSupportVersion = '2.0.0';
-
-  /**
-   * This is the SDK version when scanBarCode API is supported on mobile.
-   */
-  const scanBarCodeAPIMobileSupportVersion = '1.9.0';
-
   /**
    * Enum for file formats supported
    */

--- a/src/public/people.ts
+++ b/src/public/people.ts
@@ -3,13 +3,9 @@ import { FrameContexts } from './constants';
 import { ErrorCode, SdkError } from './interfaces';
 import { validatePeoplePickerInput } from '../internal/mediaUtil';
 import { sendMessageToParent } from '../internal/communication';
+import { peoplePickerRequiredVersion } from '../internal/constants';
 
 export namespace people {
-  /**
-   * This is the SDK version when people picker API is supported on mobile.
-   */
-  export const peoplePickerRequiredVersion = '2.0.0';
-
   /**
    * Launches a people picker and allows the user to select one or more people from the list
    * If the app is added to personal app scope the people picker launched is org wide and if the app is added to a chat/channel, people picker launched is also limited to the members of chat/channel

--- a/test/public/location.spec.ts
+++ b/test/public/location.spec.ts
@@ -4,6 +4,7 @@ import { _initialize, _uninitialize } from '../../src/public/publicAPIs';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { Utils } from '../utils';
 import { FrameContexts } from '../../src/public/constants';
+import { locationAPIsRequiredVersion } from '../../src/internal/constants';
 
 /**
  * Test cases for location APIs
@@ -11,7 +12,7 @@ import { FrameContexts } from '../../src/public/constants';
 describe('location', () => {
   const mobilePlatformMock = new FramelessPostMocks();
   const desktopPlatformMock = new Utils()
-  const minVersionForLocationAPIs = location.locationAPIsRequiredVersion;
+  const minVersionForLocationAPIs = locationAPIsRequiredVersion;
   const defaultLocationProps: location.LocationProps = {allowChooseLocation: false, showMap: false};
   const defaultLocation: location.Location = {latitude: 17, longitude: 17, accuracy: -1, timestamp: 100};
   


### PR DESCRIPTION
Explain Defect

- The android client released support for a private JS SDK API userJoinedTeams(), support for the same was released at around August 2020.
- However, the released native implementation had a bug that did not return the correct user role. It returned Admin as the role for all TeamInformation.userTeamRole returned. This impaired critical workflows in the Assignments app, wherein they show different UI based on whether a user is a teacher or a student, leading to a student seeing UI meant for a Teacher.
- The bug was fixed for the android client release in January 2021, for the build version number 1416/1.0.0.2021022202.
- However even with the fix, there are customers who are on an older version of the android client, due to the critical nature of the impact, assignments is not able to roll out the feature.
- Along with the fix, Assignments app also requires a way to identify if they are running on an older android client that does not have the required fix, so that they can turn off the functionality only on that client and roll it out for rest.

Explain fix
- Please refer to the following [one-pager](https://microsoft-my.sharepoint.com/:w:/p/shbhadra/EXgJP9sLeKpIq_TmPAqtjOEBV4PGei_9KSeNodqO80jYag?e=qi3tOr) for details of the proposed solution and the associated pros and cons.
- The associated changes on the android client can be seen in this [PR](https://domoreexp.visualstudio.com/Teamspace/_git/SkypeSpaces-Android/pullrequest/331425)

Validation
Validated by adding the JS SDK changes to a local version of microsoft-teams-test-tab, validated the following flows:

With newer JS SDK :
- Throws an error on older android clients (i.e. clients that set the CLIENT_SUPPORTED_JS_SDK_VERSION to 2.0.0 and lower).
- Returns the correct result on the newer android clients (setting the above value to 2.0.1)
- For non-full trust apps on the newer android client, sends a null response.

Did sanity test for selectMedia, getMedia and location APIs.