### PR TITLE
Adding error to LiveStreamState and updating start, stop APIs

### DIFF
--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -85,6 +85,16 @@ export namespace meeting {
      * indicates whether meeting is streaming
      */
     isStreaming: boolean;
+
+    /**
+     * error object in case there is a failure
+     */
+    error?: {
+      /** error code from the streaming service, e.g. IngestionFailure */
+      code: string;
+      /** detailed error message string */
+      message?: string;
+    };
   }
 
   export enum MeetingType {
@@ -183,12 +193,11 @@ export namespace meeting {
    * Allows an app to request the live streaming be started at the given streaming url
    * @param streamUrl the url to the stream resource
    * @param streamKey the key to the stream resource
-   * @param callback Callback contains 2 parameters: error and liveStreamState.
-   * error can either contain an error of type SdkError, in case of an error, or null when operation is successful
-   * liveStreamState can either contain a LiveStreamState value, or null when operation fails
+   * @param callback Callback contains error parameter which can be of type SdkError in case of an error, or null when operation is successful
+   * Use getLiveStreamState or registerLiveStreamChangedHandler to get updates on the live stream state
    */
   export function requestStartLiveStreaming(
-    callback: (error: SdkError | null, liveStreamState: LiveStreamState | null) => void,
+    callback: (error: SdkError | null) => void,
     streamUrl: string,
     streamKey?: string,
   ): void {
@@ -201,13 +210,10 @@ export namespace meeting {
 
   /**
    * Allows an app to request the live streaming be stopped at the given streaming url
-   * @param callback Callback contains 2 parameters: error and liveStreamState.
-   * error can either contain an error of type SdkError, in case of an error, or null when operation is successful
-   * liveStreamState can either contain a LiveStreamState value, or null when operation fails
+   * @param callback Callback contains error parameter which can be of type SdkError in case of an error, or null when operation is successful
+   * Use getLiveStreamState or registerLiveStreamChangedHandler to get updates on the live stream state
    */
-  export function requestStopLiveStreaming(
-    callback: (error: SdkError | null, liveStreamState: LiveStreamState | null) => void,
-  ): void {
+  export function requestStopLiveStreaming(callback: (error: SdkError | null) => void): void {
     if (!callback) {
       throw new Error('[request stop live streaming] Callback cannot be null');
     }

--- a/test/public/meeting.spec.ts
+++ b/test/public/meeting.spec.ts
@@ -400,13 +400,11 @@ describe('meeting', () => {
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
-      let returnedLiveStreamState: meeting.LiveStreamState | null;
 
       meeting.requestStartLiveStreaming(
-        (error: SdkError, liveStreamState: meeting.LiveStreamState) => {
+        (error: SdkError) => {
           callbackCalled = true;
           returnedSdkError = error;
-          returnedLiveStreamState = liveStreamState;
         },
         'streamurl',
         'streamkey',
@@ -426,21 +424,18 @@ describe('meeting', () => {
       expect(callbackCalled).toBe(true);
       expect(returnedSdkError).not.toBeNull();
       expect(returnedSdkError).toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
-      expect(returnedLiveStreamState).toBe(null);
     });
 
-    it('should successfully get live stream state', () => {
+    it('should successfully request start live streaming', () => {
       desktopPlatformMock.initializeWithContext(FrameContexts.sidePanel);
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
-      let returnedLiveStreamState: meeting.LiveStreamState | null;
 
       meeting.requestStartLiveStreaming(
-        (error: SdkError, liveStreamState: meeting.LiveStreamState) => {
+        (error: SdkError) => {
           callbackCalled = true;
           returnedSdkError = error;
-          returnedLiveStreamState = liveStreamState;
         },
         'streamurl',
         'streamkey',
@@ -459,8 +454,7 @@ describe('meeting', () => {
 
       expect(callbackCalled).toBe(true);
       expect(returnedSdkError).toBe(null);
-      expect(returnedLiveStreamState).not.toBeNull();
-      expect(returnedLiveStreamState).toEqual({ isStreaming: true });
+      expect(requestStartLiveStreamMessage.args).toEqual(['streamurl', 'streamkey']);
     });
   });
 
@@ -480,12 +474,10 @@ describe('meeting', () => {
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
-      let returnedLiveStreamState: meeting.LiveStreamState | null;
 
-      meeting.requestStopLiveStreaming((error: SdkError, liveStreamState: meeting.LiveStreamState) => {
+      meeting.requestStopLiveStreaming((error: SdkError) => {
         callbackCalled = true;
         returnedSdkError = error;
-        returnedLiveStreamState = liveStreamState;
       });
 
       let requestStopLiveStreamingMessage = desktopPlatformMock.findMessageByFunc('meeting.requestStopLiveStreaming');
@@ -502,20 +494,17 @@ describe('meeting', () => {
       expect(callbackCalled).toBe(true);
       expect(returnedSdkError).not.toBeNull();
       expect(returnedSdkError).toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
-      expect(returnedLiveStreamState).toBe(null);
     });
 
-    it('should successfully get live stream state', () => {
+    it('should successfully request start live streaming', () => {
       desktopPlatformMock.initializeWithContext(FrameContexts.sidePanel);
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
-      let returnedLiveStreamState: meeting.LiveStreamState | null;
 
-      meeting.requestStopLiveStreaming((error: SdkError, liveStreamState: meeting.LiveStreamState) => {
+      meeting.requestStopLiveStreaming((error: SdkError) => {
         callbackCalled = true;
         returnedSdkError = error;
-        returnedLiveStreamState = liveStreamState;
       });
 
       let requestStopLiveStreamingMessage = desktopPlatformMock.findMessageByFunc('meeting.requestStopLiveStreaming');
@@ -531,8 +520,6 @@ describe('meeting', () => {
 
       expect(callbackCalled).toBe(true);
       expect(returnedSdkError).toBe(null);
-      expect(returnedLiveStreamState).not.toBeNull();
-      expect(returnedLiveStreamState).toEqual({ isStreaming: false });
     });
   });
 


### PR DESCRIPTION
- Adding error property to liveStreamState, so that we can expose streaming errors to the apps.
- Removing liveStreamState property from the start, stop callback as the developer will anyway need to use registerLiveStreamChangedHandler to subscribe to changes from service side.