### PR TITLE
Adding new session terminated enum

### DIFF
--- a/src/private/remoteCamera.ts
+++ b/src/private/remoteCamera.ts
@@ -138,6 +138,7 @@ export namespace remoteCamera {
     DataChannelError,
     ControllerCancelled,
     ControlDisabled,
+    ControlTerminatedToAllowOtherController,
   }
 
   /**


### PR DESCRIPTION
Adding another enum to handle an additional potential remote camera session termination reason