### PR TITLE
Get a team's channels by providing teamId API

### DIFF
--- a/src/private/teams.ts
+++ b/src/private/teams.ts
@@ -30,10 +30,7 @@ export namespace teams {
    * Get a list of channels belong to a Team
    * @param groupId a team's objectId
    */
-  export function getTeamChannels(
-    groupId: string,
-    callback: (error: SdkError, channels: ChannelInfo[]) => void,
-  ): void {
+  export function getTeamChannels(groupId: string, callback: (error: SdkError, channels: ChannelInfo[]) => void): void {
     ensureInitialized(FrameContexts.content);
 
     if (!groupId) {

--- a/src/private/teams.ts
+++ b/src/private/teams.ts
@@ -1,0 +1,50 @@
+import { sendMessageToParent } from '../internal/communication';
+import { ensureInitialized } from '../internal/internalAPIs';
+import { FrameContexts, SdkError } from '../public';
+
+/**
+ * Namespace to interact with the files specific part of the SDK.
+ *
+ * @private
+ * Hide from docs
+ */
+export namespace teams {
+
+  export enum ChannelType {
+    Regular = 0,
+    Private = 1,
+    Shared = 2
+  }
+
+  export interface TeamsChannelInfo {
+    siteUrl: string;
+    objectId: string;
+    folderRelativeUrl: string;
+    displayName: string;
+    channelType: ChannelType;
+  }
+
+  /**
+   * @private
+   * Hide from docs
+   *
+   * Get a list of channels belong to a Team
+   * @param teamId a team's objectId
+   */
+  export function getTeamsChannels(
+    teamId: string,
+    callback: (error: SdkError, channels: TeamsChannelInfo[]) => void,
+  ): void {
+    ensureInitialized(FrameContexts.content);
+
+    if (!teamId) {
+      throw new Error('[teams.getTeamsChannels] teamId cannot be null or empty');
+    }
+
+    if (!callback) {
+      throw new Error('[teams.getTeamsChannels] Callback cannot be null');
+    }
+
+    sendMessageToParent('teams.getTeamsChannels', [teamId], callback);
+  }
+}

--- a/src/private/teams.ts
+++ b/src/private/teams.ts
@@ -28,22 +28,22 @@ export namespace teams {
    * Hide from docs
    *
    * Get a list of channels belong to a Team
-   * @param teamId a team's objectId
+   * @param groupId a team's objectId
    */
-  export function getTeamsChannels(
-    teamId: string,
+  export function getTeamChannels(
+    groupId: string,
     callback: (error: SdkError, channels: TeamsChannelInfo[]) => void,
   ): void {
     ensureInitialized(FrameContexts.content);
 
-    if (!teamId) {
-      throw new Error('[teams.getTeamsChannels] teamId cannot be null or empty');
+    if (!groupId) {
+      throw new Error('[teams.getTeamChannels] groupId cannot be null or empty');
     }
 
     if (!callback) {
-      throw new Error('[teams.getTeamsChannels] Callback cannot be null');
+      throw new Error('[teams.getTeamChannels] Callback cannot be null');
     }
 
-    sendMessageToParent('teams.getTeamsChannels', [teamId], callback);
+    sendMessageToParent('teams.getTeamChannels', [groupId], callback);
   }
 }

--- a/src/private/teams.ts
+++ b/src/private/teams.ts
@@ -9,11 +9,10 @@ import { FrameContexts, SdkError } from '../public';
  * Hide from docs
  */
 export namespace teams {
-
   export enum ChannelType {
     Regular = 0,
     Private = 1,
-    Shared = 2
+    Shared = 2,
   }
 
   export interface TeamsChannelInfo {

--- a/src/private/teams.ts
+++ b/src/private/teams.ts
@@ -15,7 +15,7 @@ export namespace teams {
     Shared = 2,
   }
 
-  export interface TeamsChannelInfo {
+  export interface ChannelInfo {
     siteUrl: string;
     objectId: string;
     folderRelativeUrl: string;
@@ -32,7 +32,7 @@ export namespace teams {
    */
   export function getTeamChannels(
     groupId: string,
-    callback: (error: SdkError, channels: TeamsChannelInfo[]) => void,
+    callback: (error: SdkError, channels: ChannelInfo[]) => void,
   ): void {
     ensureInitialized(FrameContexts.content);
 

--- a/test/private/teams.spec.ts
+++ b/test/private/teams.spec.ts
@@ -50,7 +50,7 @@ describe('teams', () => {
 
     it('should trigger callback correctly', () => {
       utils.initializeWithContext('content');
-      const mockTeamsChannels: teams.TeamsChannelInfo[] = [
+      const mockTeamsChannels: teams.ChannelInfo[] = [
         {
           siteUrl: 'https://microsoft.sharepoint.com/teams/teamsName',
           objectId: 'someId',

--- a/test/private/teams.spec.ts
+++ b/test/private/teams.spec.ts
@@ -1,0 +1,76 @@
+import { teams } from '../../src/private/teams';
+import { Utils } from '../utils';
+import { _initialize, _uninitialize } from '../../src/public/publicAPIs';
+
+describe('teams', () => {
+  const utils = new Utils();
+  const emptyCallback = () => {};
+
+  beforeEach(() => {
+    utils.processMessage = null;
+    utils.messages = [];
+    utils.childMessages = [];
+    utils.childWindow.closed = false;
+    utils.mockWindow.parent = utils.parentWindow;
+
+    // Set a mock window for testing
+    _initialize(utils.mockWindow);
+  });
+
+  afterEach(() => {
+    // Reset the object since it's a singleton
+    if (_uninitialize) {
+      _uninitialize();
+    }
+  });
+
+  describe('getTeamsChannels', () => {
+    it('should not allow calls before initialization', () => {
+      expect(() => teams.getTeamsChannels('teamId', emptyCallback)).toThrowError(
+        'The library has not yet been initialized',
+      );
+    });
+
+    it('should not allow calls without frame context initialization', () => {
+      utils.initializeWithContext('settings');
+      expect(() => teams.getTeamsChannels('teamId', emptyCallback)).toThrowError(
+        "This call is not allowed in the 'settings' context",
+      );
+    });
+
+    it('should not allow calls with null teamId', () => {
+      utils.initializeWithContext('content');
+      expect(() => teams.getTeamsChannels(null, emptyCallback)).toThrowError();
+    });
+
+    it('should not allow calls with empty callback', () => {
+      utils.initializeWithContext('content');
+      expect(() => teams.getTeamsChannels('teamId', null)).toThrowError();
+    });
+
+    it('should trigger callback correctly', () => {
+      utils.initializeWithContext('content');
+      const mockTeamsChannels: teams.TeamsChannelInfo[] = [
+        {
+          siteUrl: 'https://microsoft.sharepoint.com/teams/teamsName',
+          objectId: 'someId',
+          folderRelativeUrl: '/teams/teamsName/Shared Documents/General',
+          displayName: 'General',
+          channelType: teams.ChannelType.Regular,
+        },
+      ];
+
+      const callback = jest.fn((err, folders) => {
+        expect(err).toBeFalsy();
+        expect(folders).toEqual(mockTeamsChannels);
+      });
+
+      teams.getTeamsChannels('teamId', callback);
+
+      const getCloudStorageFoldersMessage = utils.findMessageByFunc('teams.getTeamsChannels');
+      expect(getCloudStorageFoldersMessage).not.toBeNull();
+      utils.respondToMessage(getCloudStorageFoldersMessage, false, mockTeamsChannels);
+      expect(callback).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/private/teams.spec.ts
+++ b/test/private/teams.spec.ts
@@ -24,28 +24,28 @@ describe('teams', () => {
     }
   });
 
-  describe('getTeamsChannels', () => {
+  describe('getTeamChannels', () => {
     it('should not allow calls before initialization', () => {
-      expect(() => teams.getTeamsChannels('teamId', emptyCallback)).toThrowError(
+      expect(() => teams.getTeamChannels('groupId', emptyCallback)).toThrowError(
         'The library has not yet been initialized',
       );
     });
 
     it('should not allow calls without frame context initialization', () => {
       utils.initializeWithContext('settings');
-      expect(() => teams.getTeamsChannels('teamId', emptyCallback)).toThrowError(
+      expect(() => teams.getTeamChannels('groupId', emptyCallback)).toThrowError(
         "This call is not allowed in the 'settings' context",
       );
     });
 
-    it('should not allow calls with null teamId', () => {
+    it('should not allow calls with null groupId', () => {
       utils.initializeWithContext('content');
-      expect(() => teams.getTeamsChannels(null, emptyCallback)).toThrowError();
+      expect(() => teams.getTeamChannels(null, emptyCallback)).toThrowError();
     });
 
     it('should not allow calls with empty callback', () => {
       utils.initializeWithContext('content');
-      expect(() => teams.getTeamsChannels('teamId', null)).toThrowError();
+      expect(() => teams.getTeamChannels('groupId', null)).toThrowError();
     });
 
     it('should trigger callback correctly', () => {
@@ -65,9 +65,9 @@ describe('teams', () => {
         expect(folders).toEqual(mockTeamsChannels);
       });
 
-      teams.getTeamsChannels('teamId', callback);
+      teams.getTeamChannels('groupId', callback);
 
-      const getCloudStorageFoldersMessage = utils.findMessageByFunc('teams.getTeamsChannels');
+      const getCloudStorageFoldersMessage = utils.findMessageByFunc('teams.getTeamChannels');
       expect(getCloudStorageFoldersMessage).not.toBeNull();
       utils.respondToMessage(getCloudStorageFoldersMessage, false, mockTeamsChannels);
       expect(callback).toHaveBeenCalled();


### PR DESCRIPTION
The following PR introduces the following new private API

`teams.getTeamsChannels`

This will be privateAPI that will be nested under `teams` namespace. It will be allowed only for 1P apps.