### PR TITLE
Add frame context check for meeting APIs

### DIFF
--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -119,7 +119,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[get incoming client audio state] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel);
+    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
     sendMessageToParent('getIncomingClientAudioState', callback);
   }
 
@@ -134,7 +134,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[toggle incoming client audio] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel);
+    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
     sendMessageToParent('toggleIncomingClientAudio', callback);
   }
 
@@ -174,7 +174,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[get Authentication Token For AnonymousUser] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel);
+    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
     sendMessageToParent('meeting.getAuthenticationTokenForAnonymousUser', callback);
   }
 

--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -119,7 +119,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[get incoming client audio state] Callback cannot be null');
     }
-    ensureInitialized();
+    ensureInitialized(FrameContexts.sidePanel);
     sendMessageToParent('getIncomingClientAudioState', callback);
   }
 
@@ -134,7 +134,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[toggle incoming client audio] Callback cannot be null');
     }
-    ensureInitialized();
+    ensureInitialized(FrameContexts.sidePanel);
     sendMessageToParent('toggleIncomingClientAudio', callback);
   }
 
@@ -152,7 +152,12 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[get meeting details] Callback cannot be null');
     }
-    ensureInitialized();
+    ensureInitialized(
+      FrameContexts.sidePanel,
+      FrameContexts.meetingStage,
+      FrameContexts.settings,
+      FrameContexts.content,
+    );
     sendMessageToParent('meeting.getMeetingDetails', callback);
   }
 
@@ -169,7 +174,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[get Authentication Token For AnonymousUser] Callback cannot be null');
     }
-    ensureInitialized();
+    ensureInitialized(FrameContexts.sidePanel);
     sendMessageToParent('meeting.getAuthenticationTokenForAnonymousUser', callback);
   }
 

--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -119,7 +119,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[get incoming client audio state] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
+    ensureInitialized(FrameContexts.sidePanel);
     sendMessageToParent('getIncomingClientAudioState', callback);
   }
 
@@ -134,7 +134,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[toggle incoming client audio] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
+    ensureInitialized(FrameContexts.sidePanel);
     sendMessageToParent('toggleIncomingClientAudio', callback);
   }
 
@@ -174,7 +174,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[get Authentication Token For AnonymousUser] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
+    ensureInitialized(FrameContexts.sidePanel);
     sendMessageToParent('meeting.getAuthenticationTokenForAnonymousUser', callback);
   }
 

--- a/test/public/meeting.spec.ts
+++ b/test/public/meeting.spec.ts
@@ -37,7 +37,7 @@ describe('meeting', () => {
     });
 
     it('should successfully toggle the incoming client audio', () => {
-      desktopPlatformMock.initializeWithContext('content');
+      desktopPlatformMock.initializeWithContext('sidePanel');
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
@@ -63,7 +63,7 @@ describe('meeting', () => {
     });
 
     it('should return error code 500', () => {
-      desktopPlatformMock.initializeWithContext('content');
+      desktopPlatformMock.initializeWithContext('sidePanel');
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
@@ -104,7 +104,7 @@ describe('meeting', () => {
     });
 
     it('should successfully get the incoming client audio state', () => {
-      desktopPlatformMock.initializeWithContext('content');
+      desktopPlatformMock.initializeWithContext('meetingStage');
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
@@ -130,7 +130,7 @@ describe('meeting', () => {
     });
 
     it('should return error code 500', () => {
-      desktopPlatformMock.initializeWithContext('content');
+      desktopPlatformMock.initializeWithContext('sidePanel');
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
@@ -215,7 +215,7 @@ describe('meeting', () => {
     });
 
     it('should return error code 500', () => {
-      desktopPlatformMock.initializeWithContext('content');
+      desktopPlatformMock.initializeWithContext('meetingStage');
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
@@ -256,7 +256,7 @@ describe('meeting', () => {
     });
 
     it('should successfully get the anonymous user token of the user in meeting', () => {
-      desktopPlatformMock.initializeWithContext('content');
+      desktopPlatformMock.initializeWithContext('meetingStage');
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
@@ -284,7 +284,7 @@ describe('meeting', () => {
       expect(returnedSkypeToken).toBe(mockAuthenticationToken);
     });
     it('should return error code 500', () => {
-      desktopPlatformMock.initializeWithContext('content');
+      desktopPlatformMock.initializeWithContext('sidePanel');
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
       let returnedSkypeToken: string | null;

--- a/test/public/meeting.spec.ts
+++ b/test/public/meeting.spec.ts
@@ -104,7 +104,7 @@ describe('meeting', () => {
     });
 
     it('should successfully get the incoming client audio state', () => {
-      desktopPlatformMock.initializeWithContext('meetingStage');
+      desktopPlatformMock.initializeWithContext('sidePanel');
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
@@ -256,7 +256,7 @@ describe('meeting', () => {
     });
 
     it('should successfully get the anonymous user token of the user in meeting', () => {
-      desktopPlatformMock.initializeWithContext('meetingStage');
+      desktopPlatformMock.initializeWithContext('sidePanel');
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;


### PR DESCRIPTION
Incoming Audio APIs will only be supported in side panel
getAuthenticationTokenForAnonymousUser API will only be supported in side panel
getMeetingDetails API will be supported in sidePanel, meetingStage, setting*, content contexts

*setting context is available in in-meeting and also in pre/post meeting. meeting details is only supported in pre/post meeting and not in-meeting settings context. API will still be a no-op when called from in-meeting context.