### PR TITLE
Release 1.11.0 beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "1.10.0",
+  "version": "1.11.0-beta.4",
   "description": "Microsoft Client SDK for building app for Microsoft teams",
   "main": "./dist/MicrosoftTeams.min.js",
   "typings": "./dist/MicrosoftTeams.d.ts",

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -1,6 +1,6 @@
 import { generateRegExpFromUrls } from './utils';
 
-export const version = '1.10.0';
+export const version = '1.11.0-beta.4';
 /**
  * This is the SDK version when all SDK APIs started to check platform compatibility for the APIs.
  */

--- a/src/public/monetization.ts
+++ b/src/public/monetization.ts
@@ -1,0 +1,37 @@
+import { sendMessageToParent } from '../internal/communication';
+import { ensureInitialized } from '../internal/internalAPIs';
+import { SdkError } from './interfaces';
+
+export namespace monetization {
+  /**
+   * @private
+   * Hide from docs
+   * Data structure to represent a subscription plan.
+   */
+  export interface PlanInfo {
+    /**
+     * plan id
+     */
+    planId: string;
+    /**
+     * term of the plan
+     */
+    term: string;
+  }
+
+  /**
+   * @private
+   * Hide from docs
+   * Open dialog to start user's purchase experience
+   * @param callback Callback contains 1 parameters, error.
+   * @param planInfo optional parameter. It contains info of the subscription plan pushed to users.
+   * error can either contain an error of type SdkError, incase of an error, or null when get is successful
+   */
+  export function openPurchaseExperience(callback: (error: SdkError | null) => void, planInfo?: PlanInfo): void {
+    if (!callback) {
+      throw new Error('[open purchase experience] Callback cannot be null');
+    }
+    ensureInitialized();
+    sendMessageToParent('monetization.openPurchaseExperience', [planInfo], callback);
+  }
+}


### PR DESCRIPTION
Request beta release for this branch for testing purpose.

Building my folder in Yuri's test app in following PR. 
https://github.com/ydogandjiev/microsoft-teams-test-tab/pull/47/files

Expecting this release can generate a static script like this that I can import to my test tab index.html.
    <script src="https://statics.teams.microsoft.com/sdk/v1.4.1/js/MicrosoftTeams.min.js"></script>
Expect the v1.4.1 would be replaced for 1.11.0-beta.4, or please advise me what the version string would be like.

Without this script, the microsoftTeams function is simply not working.


