### PR TITLE
Add the app launch id to the getContext call.

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -376,6 +376,11 @@ export interface Context {
   appSessionId?: string;
 
   /**
+   * ID for the current visible app which is different for across cached sessions. Used for correlating telemetry data``
+   */
+  appLaunchId?: string;
+
+  /**
    * Represents whether calling is allowed for the current logged in User
    */
   isCallingAllowed?: boolean;

--- a/test/private/privateAPIs.spec.ts
+++ b/test/private/privateAPIs.spec.ts
@@ -279,6 +279,7 @@ describe('MicrosoftTeams-privateAPIs', () => {
       teamSiteUrl: 'someSiteUrl',
       sessionId: 'someSessionId',
       appSessionId: 'appSessionId',
+      appLaunchId: 'appLaunchId',
       sourceOrigin: 'someOrigin',
       userClickTime: 1000,
       teamTemplateId: 'com.microsoft.teams.ManageAProject',

--- a/test/public/publicAPIs.spec.ts
+++ b/test/public/publicAPIs.spec.ts
@@ -283,6 +283,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
       parentMessageId: 'someParentMessageId',
       ringId: 'someRingId',
       appSessionId: 'appSessionId',
+      appLaunchId: 'appLaunchId',
       meetingId: 'dummyMeetingId'
     };
     //insert expected time comparison here?


### PR DESCRIPTION
Problem: Currently we have the appSessionId that is used to understand availability issues and debug them. Its a unique id that is shared with the developer (via getContext). When an issue happens then we can correlate the two telemetry pipelines (Teams and Developer's Telemetry) and understand what the actual issue was.

But with app caching, the appSessionId will persist across sessions. So its difficult for some teams (like WPX) to understand which session actually failed.

Solution: We are introducing a new id called appLaunchId which will be different across different cached sessions.