### PR TITLE
Add stopSharingAppContentToStage API

### DIFF
--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -256,4 +256,20 @@ export namespace meeting {
     ensureInitialized(FrameContexts.sidePanel);
     sendMessageToParent('meeting.shareAppContentToStage', [appContentUrl], callback);
   }
+
+  /**
+   * Terminates current stage sharing session in meeting
+   * @param callback Callback contains 2 parameters, error and result.
+   * error can either contain an error of type SdkError (error indication), or null (non-error indication)
+   * result can either contain a true boolean value (successful termination), or null (unsuccessful fetch)
+   */
+  export function stopSharingAppContentToStage(
+    callback: (error: SdkError | null, result: boolean | null) => void,
+  ): void {
+    if (!callback) {
+      throw new Error('[stop sharing app content to stage] Callback cannot be null');
+    }
+    ensureInitialized(FrameContexts.sidePanel);
+    sendMessageToParent('meeting.stopSharingAppContentToStage', callback);
+  }
 }

--- a/test/public/meeting.spec.ts
+++ b/test/public/meeting.spec.ts
@@ -625,5 +625,78 @@ describe('meeting', () => {
         expect;
       });
     });
+
+    describe('stopSharingAppContentToStage', () => {
+      it('should not allow to terminate stage sharing session with null callback', () => {
+        expect(() => meeting.stopSharingAppContentToStage(null)).toThrowError(
+          '[stop sharing app content to stage] Callback cannot be null',
+        );
+      });
+
+      it('should not allow calls before initialization', () => {
+        expect(() =>
+          meeting.stopSharingAppContentToStage(() => {
+            return;
+          }),
+        ).toThrowError('The library has not yet been initialized');
+      });
+
+      it('should successfully terminate app content stage sharing session', () => {
+        desktopPlatformMock.initializeWithContext(FrameContexts.sidePanel);
+
+        let callbackCalled = false;
+        let returnedSdkError: SdkError | null;
+        let returnedResult: boolean | null;
+        meeting.stopSharingAppContentToStage((error: SdkError, result: boolean) => {
+          callbackCalled = true;
+          returnedResult = result;
+          returnedSdkError = error;
+        });
+
+        let stopSharingAppContentToStageMessage = desktopPlatformMock.findMessageByFunc(
+          'meeting.stopSharingAppContentToStage',
+        );
+        expect(stopSharingAppContentToStageMessage).not.toBeNull();
+        let callbackId = stopSharingAppContentToStageMessage.id;
+        desktopPlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [null, true],
+          },
+        } as DOMMessageEvent);
+        expect(callbackCalled).toBe(true);
+        expect(returnedSdkError).toBeNull();
+        expect(returnedResult).toBe(true);
+      });
+
+      it('should return correct error information', () => {
+        desktopPlatformMock.initializeWithContext(FrameContexts.sidePanel);
+
+        let callbackCalled = false;
+        let returnedSdkError: SdkError | null;
+        let returnedResult: boolean | null;
+        meeting.stopSharingAppContentToStage((error: SdkError, result: boolean) => {
+          callbackCalled = true;
+          returnedResult = result;
+          returnedSdkError = error;
+        });
+
+        let stopSharingAppContentToStageMessage = desktopPlatformMock.findMessageByFunc(
+          'meeting.stopSharingAppContentToStage',
+        );
+        expect(stopSharingAppContentToStageMessage).not.toBeNull();
+        let callbackId = stopSharingAppContentToStageMessage.id;
+        desktopPlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [{ errorCode: ErrorCode.INTERNAL_ERROR }, null],
+          },
+        } as DOMMessageEvent);
+        expect(callbackCalled).toBe(true);
+        expect(returnedSdkError).not.toBeNull();
+        expect(returnedSdkError).toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
+        expect(returnedResult).toBe(null);
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR adds the `stopSharingAppContentToStage` API to the Teams Client Library.

The `stopSharingAppContentToStage` API is used for terminating a current stage sharing session during a meeting. 

In the event of an error, an `SDKError` error will be returned. In the event of a successful stage sharing termination, `true` will be returned