### PR TITLE
Prepare to release version 1.11.0-beta.6 [v2]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "1.10.0",
+  "version": "1.11.0-beta.6",
   "description": "Microsoft Client SDK for building app for Microsoft teams",
   "main": "./dist/MicrosoftTeams.min.js",
   "typings": "./dist/MicrosoftTeams.d.ts",

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -1,6 +1,6 @@
 import { generateRegExpFromUrls } from './utils';
 
-export const version = '1.10.0';
+export const version = '1.11.0-beta.6';
 /**
  * The SDK version when all SDK APIs started to check platform compatibility for the APIs was 1.6.0.
  * Modified to 2.0.1 which is hightest till now so that if any client doesn't pass version in initialize function, it will be set to highest.


### PR DESCRIPTION
This PR prepares for beta release for the following version: 1.11.0-beta.6.

Previous PR (https://github.com/OfficeDev/microsoft-teams-library-js/pull/644) for updating to this version incorrectly named the branch and should be disregarded