### PR TITLE
Add people.openCard API

### DIFF
--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -29,12 +29,6 @@ export const locationAPIsRequiredVersion = '1.9.0';
 export const peoplePickerRequiredVersion = '2.0.0';
 
 /**
- * This is the SDK version when open card API is supported on mobile.
- * TODO: Work out what this version should be
- */
-export const openCardRequiredVersion = '2.0.0';
-
-/**
  * This is the SDK version when captureImage API is supported on mobile.
  */
 export const captureImageMobileSupportVersion = '1.7.0';

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -29,6 +29,12 @@ export const locationAPIsRequiredVersion = '1.9.0';
 export const peoplePickerRequiredVersion = '2.0.0';
 
 /**
+ * This is the SDK version when open card API is supported on mobile.
+ * TODO: Work out what this version should be
+ */
+export const openCardRequiredVersion = '2.0.0';
+
+/**
  * This is the SDK version when captureImage API is supported on mobile.
  */
 export const captureImageMobileSupportVersion = '1.7.0';

--- a/src/internal/mediaUtil.ts
+++ b/src/internal/mediaUtil.ts
@@ -1,4 +1,3 @@
-import { people } from '../public/people';
 import { media } from '../public/media';
 
 /**
@@ -99,37 +98,6 @@ export function validateScanBarCodeInput(barCodeConfig: media.BarCodeConfig): bo
       barCodeConfig.timeOutIntervalInSec > 60
     ) {
       return false;
-    }
-  }
-  return true;
-}
-
-/**
- * Returns true if the people picker params are valid and false otherwise
- */
-export function validatePeoplePickerInput(peoplePickerInputs: people.PeoplePickerInputs): boolean {
-  if (peoplePickerInputs) {
-    if (peoplePickerInputs.title) {
-      if (typeof peoplePickerInputs.title !== 'string') {
-        return false;
-      }
-    }
-
-    if (peoplePickerInputs.setSelected) {
-      if (typeof peoplePickerInputs.setSelected !== 'object') {
-        return false;
-      }
-    }
-
-    if (peoplePickerInputs.openOrgWideSearchInChatOrChannel) {
-      if (typeof peoplePickerInputs.openOrgWideSearchInChatOrChannel !== 'boolean') {
-        return false;
-      }
-    }
-    if (peoplePickerInputs.singleSelect) {
-      if (typeof peoplePickerInputs.singleSelect !== 'boolean') {
-        return false;
-      }
     }
   }
   return true;

--- a/src/internal/peopleUtil.ts
+++ b/src/internal/peopleUtil.ts
@@ -37,17 +37,17 @@ export function validatePeoplePickerInput(peoplePickerInputs: people.PeoplePicke
  * @returns true if the parameters are valid, false otherwise
  */
 export function validateOpenCardRequest(openCardRequest: people.OpenCardRequest): boolean {
-  if (!openCardRequest || !openCardRequest.parameters || !openCardRequest.parameters.personaInfo) {
+  if (!openCardRequest || !openCardRequest.cardParameters || !openCardRequest.cardParameters.personaInfo) {
     return false;
   }
 
-  if (!validateHostAppProvidedPersonaIdentifiers(openCardRequest.parameters.personaInfo.identifiers)) {
+  if (!validateHostAppProvidedPersonaIdentifiers(openCardRequest.cardParameters.personaInfo.identifiers)) {
     return false;
   }
 
   if (
-    !openCardRequest.parameters.openCardTriggerType ||
-    typeof openCardRequest.parameters.openCardTriggerType !== 'string'
+    !openCardRequest.cardParameters.openCardTriggerType ||
+    typeof openCardRequest.cardParameters.openCardTriggerType !== 'string'
   ) {
     return false;
   }
@@ -56,7 +56,7 @@ export function validateOpenCardRequest(openCardRequest: people.OpenCardRequest)
     return false;
   }
 
-  if (openCardRequest.parameters.behavior && openCardRequest.parameters.behavior !== 'object') {
+  if (openCardRequest.cardParameters.behavior && openCardRequest.cardParameters.behavior !== 'object') {
     return false;
   }
 

--- a/src/internal/peopleUtil.ts
+++ b/src/internal/peopleUtil.ts
@@ -3,7 +3,7 @@ import { people } from '../public/people';
 /**
  * Returns true if the people picker params are valid and false otherwise
  */
- export function validatePeoplePickerInput(peoplePickerInputs: people.PeoplePickerInputs): boolean {
+export function validatePeoplePickerInput(peoplePickerInputs: people.PeoplePickerInputs): boolean {
   if (peoplePickerInputs) {
     if (peoplePickerInputs.title) {
       if (typeof peoplePickerInputs.title !== 'string') {
@@ -31,6 +31,57 @@ import { people } from '../public/people';
   return true;
 }
 
+/**
+ * Validates the request parameters
+ * @param openCardRequest The request parameters
+ * @returns true if the parameters are valid, false otherwise
+ */
 export function validateOpenCardRequest(openCardRequest: people.OpenCardRequest): boolean {
-  return !!openCardRequest;
+  if (!openCardRequest || !openCardRequest.parameters || !openCardRequest.parameters.personaInfo) {
+    return false;
+  }
+
+  if (!validateHostAppProvidedPersonaIdentifiers(openCardRequest.parameters.personaInfo.identifiers)) {
+    return false;
+  }
+
+  if (
+    !openCardRequest.parameters.openCardTriggerType ||
+    typeof openCardRequest.parameters.openCardTriggerType !== 'string'
+  ) {
+    return false;
+  }
+
+  if (!openCardRequest.targetBoundingRect || typeof openCardRequest.targetBoundingRect !== 'object') {
+    return false;
+  }
+
+  if (openCardRequest.parameters.behavior && openCardRequest.parameters.behavior !== 'object') {
+    return false;
+  }
+
+  return true;
+}
+
+function validateHostAppProvidedPersonaIdentifiers(identifiers: people.IHostAppProvidedPersonaIdentifiers): boolean {
+  if (!identifiers || typeof identifiers !== 'object') {
+    return false;
+  }
+
+  if (!identifiers.PersonaType || typeof identifiers.PersonaType !== 'string') {
+    return false;
+  }
+
+  // Validate at least one identifier was passed.
+  if (
+    !identifiers.AadObjectId &&
+    !identifiers.OlsPersonaId &&
+    !identifiers.Smtp &&
+    !identifiers.TeamsMri &&
+    !identifiers.Upn
+  ) {
+    return false;
+  }
+
+  return true;
 }

--- a/src/internal/peopleUtil.ts
+++ b/src/internal/peopleUtil.ts
@@ -41,7 +41,7 @@ export function validateOpenCardRequest(openCardRequest: people.OpenCardRequest)
     return false;
   }
 
-  if (!validateHostAppProvidedPersonaIdentifiers(openCardRequest.cardParameters.personaInfo.identifiers)) {
+  if (!validatePersonaIdentifiers(openCardRequest.cardParameters.personaInfo.identifiers)) {
     return false;
   }
 
@@ -63,7 +63,7 @@ export function validateOpenCardRequest(openCardRequest: people.OpenCardRequest)
   return true;
 }
 
-function validateHostAppProvidedPersonaIdentifiers(identifiers: people.IHostAppProvidedPersonaIdentifiers): boolean {
+function validatePersonaIdentifiers(identifiers: people.PersonaIdentifiers): boolean {
   if (!identifiers || typeof identifiers !== 'object') {
     return false;
   }
@@ -73,13 +73,7 @@ function validateHostAppProvidedPersonaIdentifiers(identifiers: people.IHostAppP
   }
 
   // Validate at least one identifier was passed.
-  if (
-    !identifiers.AadObjectId &&
-    !identifiers.OlsPersonaId &&
-    !identifiers.Smtp &&
-    !identifiers.TeamsMri &&
-    !identifiers.Upn
-  ) {
+  if (!identifiers.AadObjectId && !identifiers.Smtp && !identifiers.TeamsMri && !identifiers.Upn) {
     return false;
   }
 

--- a/src/internal/peopleUtil.ts
+++ b/src/internal/peopleUtil.ts
@@ -1,0 +1,36 @@
+import { people } from '../public/people';
+
+/**
+ * Returns true if the people picker params are valid and false otherwise
+ */
+ export function validatePeoplePickerInput(peoplePickerInputs: people.PeoplePickerInputs): boolean {
+  if (peoplePickerInputs) {
+    if (peoplePickerInputs.title) {
+      if (typeof peoplePickerInputs.title !== 'string') {
+        return false;
+      }
+    }
+
+    if (peoplePickerInputs.setSelected) {
+      if (typeof peoplePickerInputs.setSelected !== 'object') {
+        return false;
+      }
+    }
+
+    if (peoplePickerInputs.openOrgWideSearchInChatOrChannel) {
+      if (typeof peoplePickerInputs.openOrgWideSearchInChatOrChannel !== 'boolean') {
+        return false;
+      }
+    }
+    if (peoplePickerInputs.singleSelect) {
+      if (typeof peoplePickerInputs.singleSelect !== 'boolean') {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+export function validateOpenCardRequest(openCardRequest: people.OpenCardRequest): boolean {
+  return !!openCardRequest;
+}

--- a/src/public/people.ts
+++ b/src/public/people.ts
@@ -3,7 +3,7 @@ import { FrameContexts } from './constants';
 import { ErrorCode, SdkError } from './interfaces';
 import { validatePeoplePickerInput } from '../internal/mediaUtil';
 import { sendMessageToParent } from '../internal/communication';
-import { peoplePickerRequiredVersion } from '../internal/constants';
+import { openCardRequiredVersion, peoplePickerRequiredVersion } from '../internal/constants';
 
 export namespace people {
   /**
@@ -84,5 +84,86 @@ export namespace people {
      * Optional; email of the selected user
      */
     email?: string;
+  }
+
+  /**
+   * TODO
+   * @param callback TODO
+   * @param openCardInputs TODO
+   */
+  export function openCard(callback: (error: SdkError) => void, openCardInputs?: OpenCardInputs): void {
+    if (!callback) {
+      throw new Error('[open card] Callback cannot be null');
+    }
+
+    ensureInitialized(FrameContexts.content, FrameContexts.task, FrameContexts.settings);
+
+    // if (!isAPISupportedByPlatform(openCardRequiredVersion)) {
+    //   const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
+    //   callback(oldPlatformError);
+    //   return;
+    // }
+
+    // if (!validatePeoplePickerInput(peoplePickerInputs)) {
+    //   const invalidInput: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
+    //   callback(invalidInput);
+    //   return;
+    // }
+
+    sendMessageToParent('people.openCard', [openCardInputs], callback);
+  }
+
+  /**
+   * The type of the persona to resolve.
+   *  - User: An organization or consumer user.
+   *  - External: A user external to the current organization.
+   *  - NotResolved: ???
+   */
+  export type PersonaType = 'User' | 'External' | 'NotResolved';
+
+  /**
+   * The type of the card trigger.
+   *  - MouseHover: The user hovered a target.
+   *  - MouseClick: The user clicked a target.
+   *  - KeyboardPress: The user initiated the card with their keyboard (typically pressing enter or space while focusing a target).
+   *  - HostAppRequest: The card is being opened programmatically.
+   */
+  export type OpenCardTriggerType = 'MouseHover' | 'MouseClick' | 'KeyboardPress' | 'HostAppRequest';
+
+  /**
+   * The identifiers that are supported for resolving the user while opening the card.
+   */
+  export interface PersonaIdentifiers {
+    readonly HostAppPersonaId?: string;
+    readonly OlsPersonaId?: string;
+    readonly LocationId?: string;
+    readonly TeamsMri?: string;
+    readonly AadObjectId?: string;
+    readonly SatoriId?: string;
+    readonly Smtp?: string;
+    readonly Upn?: string;
+    readonly PersonaType: PersonaType;
+    readonly PermanentEntryId?: string;
+    readonly DisplayName?: string;
+  }
+
+  /**
+   * Input parameters provided to the openCard API.
+   */
+  export interface OpenCardInputs {
+    /**
+     * The bounding rectangle of the target.
+     */
+    targetBoundingRect: ClientRect;
+
+    /**
+     * The identifiers to resolve the user when opening the card.
+     */
+    identifiers: PersonaIdentifiers;
+
+    /**
+     * The trigger type of the card open.
+     */
+    openCardTriggerType: OpenCardTriggerType;
   }
 }

--- a/src/public/people.ts
+++ b/src/public/people.ts
@@ -228,6 +228,6 @@ export namespace people {
     /**
      * The parameters to provide to the live persona card component when opening the card.
      */
-    parameters: ILivePersonaCardParameters;
+    cardParameters: ILivePersonaCardParameters;
   }
 }

--- a/src/public/people.ts
+++ b/src/public/people.ts
@@ -1,9 +1,9 @@
 import { ensureInitialized, isAPISupportedByPlatform } from '../internal/internalAPIs';
 import { FrameContexts } from './constants';
 import { ErrorCode, SdkError } from './interfaces';
-import { validatePeoplePickerInput } from '../internal/mediaUtil';
 import { sendMessageToParent } from '../internal/communication';
-import { openCardRequiredVersion, peoplePickerRequiredVersion } from '../internal/constants';
+import { peoplePickerRequiredVersion } from '../internal/constants';
+import { validateOpenCardRequest, validatePeoplePickerInput } from '../internal/peopleUtil';
 
 export namespace people {
   /**
@@ -98,17 +98,11 @@ export namespace people {
 
     ensureInitialized(FrameContexts.content, FrameContexts.task, FrameContexts.settings);
 
-    // if (!isAPISupportedByPlatform(openCardRequiredVersion)) {
-    //   const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
-    //   callback(oldPlatformError);
-    //   return;
-    // }
-
-    // if (!validatePeoplePickerInput(peoplePickerInputs)) {
-    //   const invalidInput: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
-    //   callback(invalidInput);
-    //   return;
-    // }
+    if (!validateOpenCardRequest(openCardRequest)) {
+      const invalidInput: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
+      callback(invalidInput);
+      return;
+    }
 
     sendMessageToParent('people.openCard', [openCardRequest], callback);
   }
@@ -133,18 +127,19 @@ export namespace people {
   /**
    * TODO: Document this.
    */
+  export type LivePersonaCardPlacementMode = "Default" | "AnchorSide";
+
+  /**
+   * TODO: Document this.
+   */
   export interface IHostAppProvidedPersonaIdentifiers {
     readonly HostAppPersonaId?: string;
     readonly OlsPersonaId?: string;
-    readonly LocationId?: string;
     readonly TeamsMri?: string;
     readonly AadObjectId?: string;
-    readonly SatoriId?: string;
     readonly Smtp?: string;
     readonly Upn?: string;
     readonly PersonaType: PersonaType;
-    readonly PermanentEntryId?: string;
-    readonly DisplayName?: string;
   }
 
   /**
@@ -153,11 +148,14 @@ export namespace people {
   export interface IHostAppProvidedPersona {
     identifiers: IHostAppProvidedPersonaIdentifiers;
     displayName?: string;
-    firstName?: string;
-    lastName?: string;
-    // isUnauthenticatedSender?: boolean;
-    // isTier3Brand?: boolean;
-    // skypeId?: string;
+  }
+
+  /**
+   * TODO: Document this.
+   */
+  export interface ILivePersonaCardBehavior {
+    enableStickiness?: boolean;
+    cardPlacementMode?: LivePersonaCardPlacementMode;
   }
 
   /**
@@ -165,17 +163,7 @@ export namespace people {
    */
   export interface ILivePersonaCardParameters {
     personaInfo: IHostAppProvidedPersona;
-    // behavior: ILivePersonaCardBehavior;
-    // externalAppSessionCorrelationId?: string;
-    // clientScenario?: string;
-    // ariaLabel?: string;
-    /**
-     * If this is set to true, the hover-target does not set nor interfere with accessibility-properties on
-     * the child element.
-     * @default false
-     */
-    // disableAccessibilityDefaults?: boolean;
-    // tabIndex?: number;
+    behavior: ILivePersonaCardBehavior;
     openCardTriggerType?: OpenCardTriggerType;
   }
 

--- a/src/public/people.ts
+++ b/src/public/people.ts
@@ -87,9 +87,9 @@ export namespace people {
   }
 
   /**
-   * TODO
-   * @param callback TODO
-   * @param openCardInputs TODO
+   * Opens a profile card at a specified position to show profile information about a person.
+   * @param callback Returns an error if one occurred, or null if the card open succeeded.
+   * @param openCardRequest The parameters to position the card and identify the target user.
    */
   export function openCard(callback: (error: SdkError) => void, openCardRequest?: OpenCardRequest): void {
     if (!callback) {
@@ -111,7 +111,7 @@ export namespace people {
    * The type of the persona to resolve.
    *  - User: An organization or consumer user.
    *  - External: A user external to the current organization.
-   *  - NotResolved: TODO
+   *  - NotResolved: A user with unknown type.
    */
   export type PersonaType = 'User' | 'External' | 'NotResolved';
 
@@ -125,46 +125,95 @@ export namespace people {
   export type OpenCardTriggerType = 'MouseHover' | 'MouseClick' | 'KeyboardPress' | 'HostAppRequest';
 
   /**
-   * TODO: Document this.
+   * The relative position to place the card.
+   *  - Default: Positions the card over the target.
+   *  - AnchorSide: Positions the card to the side of the target.
    */
-  export type LivePersonaCardPlacementMode = "Default" | "AnchorSide";
+  export type LivePersonaCardPlacementMode = 'Default' | 'AnchorSide';
 
   /**
-   * TODO: Document this.
+   * The set of identifiers that are supported for resolving the persona.
    */
   export interface IHostAppProvidedPersonaIdentifiers {
-    readonly HostAppPersonaId?: string;
+    /**
+     * The Exchange contact ID.
+     */
     readonly OlsPersonaId?: string;
+
+    /**
+     * The Teams messaging resource identifier.
+     */
     readonly TeamsMri?: string;
+
+    /**
+     * The AAD object id.
+     */
     readonly AadObjectId?: string;
+
+    /**
+     * The primary SMTP address.
+     */
     readonly Smtp?: string;
+
+    /**
+     * The user principle name.
+     */
     readonly Upn?: string;
+
+    /**
+     * The type of the persona.
+     */
     readonly PersonaType: PersonaType;
   }
 
   /**
-   * TODO: Document this.
+   * The persona to open the card for.
    */
   export interface IHostAppProvidedPersona {
+    /**
+     * The set of identifiers that are supported for resolving the persona.
+     */
     identifiers: IHostAppProvidedPersonaIdentifiers;
+
+    /**
+     * Optional display name override. If not specified the user's display name will be resolved normally.
+     */
     displayName?: string;
   }
 
   /**
-   * TODO: Document this.
+   * Optional behavior configuration for the card.
    */
   export interface ILivePersonaCardBehavior {
+    /**
+     * Configures if the card should remain open until the user clicks outside the card.
+     */
     enableStickiness?: boolean;
+
+    /**
+     * Configures how the card should be placed relative to the target.
+     */
     cardPlacementMode?: LivePersonaCardPlacementMode;
   }
 
   /**
-   * TODO: Document this.
+   * The parameters used by the live persona card package to configure the card.
    */
   export interface ILivePersonaCardParameters {
+    /**
+     * The information about the persona to open the card for.
+     */
     personaInfo: IHostAppProvidedPersona;
-    behavior: ILivePersonaCardBehavior;
-    openCardTriggerType?: OpenCardTriggerType;
+
+    /**
+     * Specifies which user interaction was used to trigger the API call.
+     */
+    openCardTriggerType: OpenCardTriggerType;
+
+    /**
+     * Optional configuration of the card behavior.
+     */
+    behavior?: ILivePersonaCardBehavior;
   }
 
   /**
@@ -177,7 +226,7 @@ export namespace people {
     targetBoundingRect: ClientRect;
 
     /**
-     * The parameters to provide to the live persona card when opening the card.
+     * The parameters to provide to the live persona card component when opening the card.
      */
     parameters: ILivePersonaCardParameters;
   }

--- a/src/public/people.ts
+++ b/src/public/people.ts
@@ -91,7 +91,7 @@ export namespace people {
    * @param callback TODO
    * @param openCardInputs TODO
    */
-  export function openCard(callback: (error: SdkError) => void, openCardInputs?: OpenCardInputs): void {
+  export function openCard(callback: (error: SdkError) => void, openCardRequest?: OpenCardRequest): void {
     if (!callback) {
       throw new Error('[open card] Callback cannot be null');
     }
@@ -110,14 +110,14 @@ export namespace people {
     //   return;
     // }
 
-    sendMessageToParent('people.openCard', [openCardInputs], callback);
+    sendMessageToParent('people.openCard', [openCardRequest], callback);
   }
 
   /**
    * The type of the persona to resolve.
    *  - User: An organization or consumer user.
    *  - External: A user external to the current organization.
-   *  - NotResolved: ???
+   *  - NotResolved: TODO
    */
   export type PersonaType = 'User' | 'External' | 'NotResolved';
 
@@ -131,9 +131,9 @@ export namespace people {
   export type OpenCardTriggerType = 'MouseHover' | 'MouseClick' | 'KeyboardPress' | 'HostAppRequest';
 
   /**
-   * The identifiers that are supported for resolving the user while opening the card.
+   * TODO: Document this.
    */
-  export interface PersonaIdentifiers {
+  export interface IHostAppProvidedPersonaIdentifiers {
     readonly HostAppPersonaId?: string;
     readonly OlsPersonaId?: string;
     readonly LocationId?: string;
@@ -148,22 +148,49 @@ export namespace people {
   }
 
   /**
+   * TODO: Document this.
+   */
+  export interface IHostAppProvidedPersona {
+    identifiers: IHostAppProvidedPersonaIdentifiers;
+    displayName?: string;
+    firstName?: string;
+    lastName?: string;
+    // isUnauthenticatedSender?: boolean;
+    // isTier3Brand?: boolean;
+    // skypeId?: string;
+  }
+
+  /**
+   * TODO: Document this.
+   */
+  export interface ILivePersonaCardParameters {
+    personaInfo: IHostAppProvidedPersona;
+    // behavior: ILivePersonaCardBehavior;
+    // externalAppSessionCorrelationId?: string;
+    // clientScenario?: string;
+    // ariaLabel?: string;
+    /**
+     * If this is set to true, the hover-target does not set nor interfere with accessibility-properties on
+     * the child element.
+     * @default false
+     */
+    // disableAccessibilityDefaults?: boolean;
+    // tabIndex?: number;
+    openCardTriggerType?: OpenCardTriggerType;
+  }
+
+  /**
    * Input parameters provided to the openCard API.
    */
-  export interface OpenCardInputs {
+  export interface OpenCardRequest {
     /**
      * The bounding rectangle of the target.
      */
     targetBoundingRect: ClientRect;
 
     /**
-     * The identifiers to resolve the user when opening the card.
+     * The parameters to provide to the live persona card when opening the card.
      */
-    identifiers: PersonaIdentifiers;
-
-    /**
-     * The trigger type of the card open.
-     */
-    openCardTriggerType: OpenCardTriggerType;
+    parameters: ILivePersonaCardParameters;
   }
 }

--- a/src/public/people.ts
+++ b/src/public/people.ts
@@ -129,17 +129,12 @@ export namespace people {
    *  - Default: Positions the card over the target.
    *  - AnchorSide: Positions the card to the side of the target.
    */
-  export type LivePersonaCardPlacementMode = 'Default' | 'AnchorSide';
+  export type CardPlacementMode = 'Default' | 'AnchorSide';
 
   /**
    * The set of identifiers that are supported for resolving the persona.
    */
-  export interface IHostAppProvidedPersonaIdentifiers {
-    /**
-     * The Exchange contact ID.
-     */
-    readonly OlsPersonaId?: string;
-
+  export interface PersonaIdentifiers {
     /**
      * The Teams messaging resource identifier.
      */
@@ -169,11 +164,11 @@ export namespace people {
   /**
    * The persona to open the card for.
    */
-  export interface IHostAppProvidedPersona {
+  export interface Persona {
     /**
      * The set of identifiers that are supported for resolving the persona.
      */
-    identifiers: IHostAppProvidedPersonaIdentifiers;
+    identifiers: PersonaIdentifiers;
 
     /**
      * Optional display name override. If not specified the user's display name will be resolved normally.
@@ -184,7 +179,7 @@ export namespace people {
   /**
    * Optional behavior configuration for the card.
    */
-  export interface ILivePersonaCardBehavior {
+  export interface CardBehavior {
     /**
      * Configures if the card should remain open until the user clicks outside the card.
      */
@@ -193,17 +188,17 @@ export namespace people {
     /**
      * Configures how the card should be placed relative to the target.
      */
-    cardPlacementMode?: LivePersonaCardPlacementMode;
+    cardPlacementMode?: CardPlacementMode;
   }
 
   /**
-   * The parameters used by the live persona card package to configure the card.
+   * The parameters used by the persona card component to configure the card.
    */
-  export interface ILivePersonaCardParameters {
+  export interface CardParameters {
     /**
      * The information about the persona to open the card for.
      */
-    personaInfo: IHostAppProvidedPersona;
+    personaInfo: Persona;
 
     /**
      * Specifies which user interaction was used to trigger the API call.
@@ -213,7 +208,7 @@ export namespace people {
     /**
      * Optional configuration of the card behavior.
      */
-    behavior?: ILivePersonaCardBehavior;
+    behavior?: CardBehavior;
   }
 
   /**
@@ -226,8 +221,8 @@ export namespace people {
     targetBoundingRect: ClientRect;
 
     /**
-     * The parameters to provide to the live persona card component when opening the card.
+     * The parameters to provide to the persona card component when opening the card.
      */
-    cardParameters: ILivePersonaCardParameters;
+    cardParameters: CardParameters;
   }
 }

--- a/test/internal/mediaUtil.spec.ts
+++ b/test/internal/mediaUtil.spec.ts
@@ -1,5 +1,4 @@
-import { validateSelectMediaInputs, validateGetMediaInputs, validateViewImagesInput, decodeAttachment, createFile, validatePeoplePickerInput } from '../../src/internal/mediaUtil';
-import { people } from '../../src/public/people';
+import { validateSelectMediaInputs, validateGetMediaInputs, validateViewImagesInput, decodeAttachment, createFile } from '../../src/internal/mediaUtil';
 import { media } from '../../src/public/media';
 
 describe('mediaUtil', () => {
@@ -138,30 +137,6 @@ describe('mediaUtil', () => {
     }
     uriList.push(imageUri);
     const result = validateViewImagesInput(uriList);
-    expect(result).toBeTruthy();
-  });
-
- /**
-   * Validate People Picker selectPeople Input
-   */
-  it('test selectPeople success with null param', () => {
-    const result = validatePeoplePickerInput(null);
-    expect(result).toBeTruthy();
-  });
-
-  it('test selectPeople success with undefined param', () => {
-    const result = validatePeoplePickerInput(undefined);
-    expect(result).toBeTruthy();
-  });
-
-  it('test success case for selectPeople with valid input params', () => {
-    const peoplePickerInputs : people.PeoplePickerInputs = {
-      title: "Hello World",
-      setSelected: ["12345678"],
-      openOrgWideSearchInChatOrChannel: true,
-      singleSelect: true
-    }
-    const result = validatePeoplePickerInput(peoplePickerInputs);
     expect(result).toBeTruthy();
   });
 });

--- a/test/internal/peopleUtil.spec.ts
+++ b/test/internal/peopleUtil.spec.ts
@@ -29,7 +29,7 @@ describe('peopleUtil', () => {
   describe('validateOpenCardRequest', () => {
     const validInput: people.OpenCardRequest = {
       targetBoundingRect: { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 },
-      parameters: {
+      cardParameters: {
         personaInfo: { identifiers: { PersonaType: 'User', Smtp: 'test@microsoft.com' } },
         openCardTriggerType: 'MouseHover',
       },
@@ -40,7 +40,7 @@ describe('peopleUtil', () => {
     });
 
     it('should return false if targetBoundingRect property is missing', () => {
-      const missingTargetBoundingRect = { ...validInput.parameters } as any;
+      const missingTargetBoundingRect = { ...validInput.cardParameters } as any;
       expect(validateOpenCardRequest(missingTargetBoundingRect)).toBeFalsy();
     });
 
@@ -52,7 +52,7 @@ describe('peopleUtil', () => {
     it('should return false if openCardTriggerType property is missing', () => {
       const missingOpenCardTriggerType = {
         ...validInput.targetBoundingRect,
-        parameters: { ...validInput.parameters, openCardTriggerType: undefined },
+        parameters: { ...validInput.cardParameters, openCardTriggerType: undefined },
       } as any;
 
       expect(validateOpenCardRequest(missingOpenCardTriggerType)).toBeFalsy();
@@ -62,10 +62,10 @@ describe('peopleUtil', () => {
       const missingPersonaType = {
         ...validInput,
         parameters: {
-          ...validInput.parameters,
+          ...validInput.cardParameters,
           personaInfo: {
-            ...validInput.parameters.personaInfo,
-            identifiers: { ...validInput.parameters.personaInfo.identifiers, PersonaType: undefined },
+            ...validInput.cardParameters.personaInfo,
+            identifiers: { ...validInput.cardParameters.personaInfo.identifiers, PersonaType: undefined },
           },
         },
       } as any;
@@ -77,9 +77,9 @@ describe('peopleUtil', () => {
       const missingIdentifier = {
         ...validInput,
         parameters: {
-          ...validInput.parameters,
+          ...validInput.cardParameters,
           personaInfo: {
-            ...validInput.parameters.personaInfo,
+            ...validInput.cardParameters.personaInfo,
             identifiers: { PersonaType: 'User' },
           },
         },
@@ -91,7 +91,7 @@ describe('peopleUtil', () => {
     it('should return false if behavior is invalid', () => {
       const missingIdentifier = {
         ...validInput,
-        parameters: { ...validInput.parameters, behavior: 'invalid' },
+        parameters: { ...validInput.cardParameters, behavior: 'invalid' },
       } as any;
 
       expect(validateOpenCardRequest(missingIdentifier)).toBeFalsy();

--- a/test/internal/peopleUtil.spec.ts
+++ b/test/internal/peopleUtil.spec.ts
@@ -52,7 +52,7 @@ describe('peopleUtil', () => {
     it('should return false if openCardTriggerType property is missing', () => {
       const missingOpenCardTriggerType = {
         ...validInput.targetBoundingRect,
-        parameters: { ...validInput.cardParameters, openCardTriggerType: undefined },
+        cardParameters: { ...validInput.cardParameters, openCardTriggerType: undefined },
       } as any;
 
       expect(validateOpenCardRequest(missingOpenCardTriggerType)).toBeFalsy();
@@ -61,7 +61,7 @@ describe('peopleUtil', () => {
     it('should return false if PersonaType identifier is missing', () => {
       const missingPersonaType = {
         ...validInput,
-        parameters: {
+        cardParameters: {
           ...validInput.cardParameters,
           personaInfo: {
             ...validInput.cardParameters.personaInfo,
@@ -76,7 +76,7 @@ describe('peopleUtil', () => {
     it('should return false if no identifiers are provided', () => {
       const missingIdentifier = {
         ...validInput,
-        parameters: {
+        cardParameters: {
           ...validInput.cardParameters,
           personaInfo: {
             ...validInput.cardParameters.personaInfo,
@@ -91,7 +91,7 @@ describe('peopleUtil', () => {
     it('should return false if behavior is invalid', () => {
       const missingIdentifier = {
         ...validInput,
-        parameters: { ...validInput.cardParameters, behavior: 'invalid' },
+        cardParameters: { ...validInput.cardParameters, behavior: 'invalid' },
       } as any;
 
       expect(validateOpenCardRequest(missingIdentifier)).toBeFalsy();

--- a/test/internal/peopleUtil.spec.ts
+++ b/test/internal/peopleUtil.spec.ts
@@ -1,0 +1,104 @@
+import { validateOpenCardRequest, validatePeoplePickerInput } from '../../src/internal/peopleUtil';
+import { people } from '../../src/public/people';
+
+describe('peopleUtil', () => {
+  /**
+   * Validate People Picker selectPeople Input
+   */
+  it('test selectPeople success with null param', () => {
+    const result = validatePeoplePickerInput(null);
+    expect(result).toBeTruthy();
+  });
+
+  it('test selectPeople success with undefined param', () => {
+    const result = validatePeoplePickerInput(undefined);
+    expect(result).toBeTruthy();
+  });
+
+  it('test success case for selectPeople with valid input params', () => {
+    const peoplePickerInputs: people.PeoplePickerInputs = {
+      title: 'Hello World',
+      setSelected: ['12345678'],
+      openOrgWideSearchInChatOrChannel: true,
+      singleSelect: true,
+    };
+    const result = validatePeoplePickerInput(peoplePickerInputs);
+    expect(result).toBeTruthy();
+  });
+
+  describe('validateOpenCardRequest', () => {
+    const validInput: people.OpenCardRequest = {
+      targetBoundingRect: { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 },
+      parameters: {
+        personaInfo: { identifiers: { PersonaType: 'User', Smtp: 'test@microsoft.com' } },
+        openCardTriggerType: 'MouseHover',
+      },
+    };
+
+    it('should return false for empty input', () => {
+      expect(validateOpenCardRequest(null)).toBeFalsy();
+    });
+
+    it('should return false if targetBoundingRect property is missing', () => {
+      const missingTargetBoundingRect = { ...validInput.parameters } as any;
+      expect(validateOpenCardRequest(missingTargetBoundingRect)).toBeFalsy();
+    });
+
+    it('should return false if parameters property is missing', () => {
+      const missingParameters = { ...validInput.targetBoundingRect } as any;
+      expect(validateOpenCardRequest(missingParameters)).toBeFalsy();
+    });
+
+    it('should return false if openCardTriggerType property is missing', () => {
+      const missingOpenCardTriggerType = {
+        ...validInput.targetBoundingRect,
+        parameters: { ...validInput.parameters, openCardTriggerType: undefined },
+      } as any;
+
+      expect(validateOpenCardRequest(missingOpenCardTriggerType)).toBeFalsy();
+    });
+
+    it('should return false if PersonaType identifier is missing', () => {
+      const missingPersonaType = {
+        ...validInput,
+        parameters: {
+          ...validInput.parameters,
+          personaInfo: {
+            ...validInput.parameters.personaInfo,
+            identifiers: { ...validInput.parameters.personaInfo.identifiers, PersonaType: undefined },
+          },
+        },
+      } as any;
+
+      expect(validateOpenCardRequest(missingPersonaType)).toBeFalsy();
+    });
+
+    it('should return false if no identifiers are provided', () => {
+      const missingIdentifier = {
+        ...validInput,
+        parameters: {
+          ...validInput.parameters,
+          personaInfo: {
+            ...validInput.parameters.personaInfo,
+            identifiers: { PersonaType: 'User' },
+          },
+        },
+      } as any;
+
+      expect(validateOpenCardRequest(missingIdentifier)).toBeFalsy();
+    });
+
+    it('should return false if behavior is invalid', () => {
+      const missingIdentifier = {
+        ...validInput,
+        parameters: { ...validInput.parameters, behavior: 'invalid' },
+      } as any;
+
+      expect(validateOpenCardRequest(missingIdentifier)).toBeFalsy();
+    });
+
+    it('should return true for a valid input', () => {
+      expect(validateOpenCardRequest(validInput)).toBeTruthy();
+    });
+  });
+});

--- a/test/public/people.spec.ts
+++ b/test/public/people.spec.ts
@@ -4,166 +4,224 @@ import { FrameContexts } from '../../src/public/constants';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { SdkError, ErrorCode } from '../../src/public/interfaces';
 import { people } from '../../src/public/people';
+import { Utils } from '../utils';
 
-/**
- * Test cases for selectPeople API
- */
-describe('peoplePicker', () => {
-  const mobilePlatformMock = new FramelessPostMocks();
-  const minVersionForSelectPeople = '2.0.0';
-  const originalDefaultPlatformVersion = '1.6.0';
- 
-  beforeEach(() => {
-    mobilePlatformMock.messages = [];
-
-    // Set a mock window for testing
-    _initialize(mobilePlatformMock.mockWindow);
-  });
-
-  afterEach(() => {
-    // Reset the object since it's a singleton
-    if (_uninitialize) {
-      _uninitialize();
-    }
-  });
-
-  let emptyCallback = () => {};
-
+describe('people', () => {
   /**
-   * People Picker tests
+   * Test cases for selectPeople API
    */
-  it('should not allow selectPeople calls with null callback', () => {
-    expect(() => people.selectPeople(null)).toThrowError(
-      '[people picker] Callback cannot be null',
-    );
-  });
+  describe('peoplePicker', () => {
+    const mobilePlatformMock = new FramelessPostMocks();
+    const minVersionForSelectPeople = '2.0.0';
+    const originalDefaultPlatformVersion = '1.6.0';
+  
+    beforeEach(() => {
+      mobilePlatformMock.messages = [];
 
-  it('should allow selectPeople calls with null peoplePickerInputs', () => {
-    mobilePlatformMock.initializeWithContext(FrameContexts.task);
-    mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
-    let peoplePickerError: SdkError;
-    people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {
-      peoplePickerError = error;
-    }, null);
-    expect(peoplePickerError).toBeUndefined();
-  });
-
-  it('should allow selectPeople calls with no peoplePickerInputs', () => {
-    mobilePlatformMock.initializeWithContext(FrameContexts.task);
-    mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
-    let peoplePickerError: SdkError;
-    people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {
-      peoplePickerError = error;
-    });
-    expect(peoplePickerError).toBeUndefined();
-  });
-
-  it('should allow selectPeople calls with undefined peoplePickerInputs', () => {
-    mobilePlatformMock.initializeWithContext(FrameContexts.task);
-    mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
-    let peoplePickerError: SdkError;
-    people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {
-      peoplePickerError = error;
-    }, undefined);
-    expect(peoplePickerError).toBeUndefined();
-  });
-
-  it('selectPeople call in default version of platform support fails', () => {
-    mobilePlatformMock.initializeWithContext(FrameContexts.task);
-    mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-    let peoplePickerError: SdkError;
-    people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {
-      peoplePickerError = error;
-    });
-    expect(peoplePickerError).not.toBeNull();
-    expect(peoplePickerError.errorCode).toBe(ErrorCode.OLD_PLATFORM);
-  });
-
-  it('selectPeople call in task frameContext works', () => {
-    mobilePlatformMock.initializeWithContext(FrameContexts.task);
-    mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
-    people.selectPeople(emptyCallback);
-    const message = mobilePlatformMock.findMessageByFunc('people.selectPeople');
-    expect(message).not.toBeNull();
-    expect(message.args.length).toBe(1);
-  });
-
-  it('selectPeople call in content frameContext works', () => {
-    mobilePlatformMock.initializeWithContext(FrameContexts.content);
-    mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
-    people.selectPeople(emptyCallback);
-    const message = mobilePlatformMock.findMessageByFunc('people.selectPeople');
-    expect(message).not.toBeNull();
-    expect(message.args.length).toBe(1);
-  });
-
-  it('selectPeople calls with successful result', () => {
-    mobilePlatformMock.initializeWithContext(FrameContexts.content);
-    mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
-    let peoplePickerResult: people.PeoplePickerResult[], peoplePickerError: SdkError;
-    people.selectPeople((e: SdkError, m: people.PeoplePickerResult[]) => {
-      peoplePickerError = e;
-      peoplePickerResult = m;
+      // Set a mock window for testing
+      _initialize(mobilePlatformMock.mockWindow);
     });
 
-    const message = mobilePlatformMock.findMessageByFunc('people.selectPeople');
-    expect(message).not.toBeNull();
-    expect(message.args.length).toBe(1);
-
-    const callbackId = message.id;
-    const result = [{
-     objectId: "5842943a-aa5a-470a-bfdc-7311b9988962",
-     displayName: "Sonal Jha",
-     email: "sojh@m365x347208.onmicrosoft.com"
-    } as people.PeoplePickerResult];
-    mobilePlatformMock.respondToMessage({
-      data: {
-        id: callbackId,
-        args: [undefined, result]
+    afterEach(() => {
+      // Reset the object since it's a singleton
+      if (_uninitialize) {
+        _uninitialize();
       }
-    } as DOMMessageEvent)
+    });
 
-    expect(peoplePickerError).toBeFalsy();
-    expect(result.length).toBe(1);
-    const person = result[0];
-    expect(person).not.toBeNull();
-    expect(person.objectId).not.toBeNull();
-    expect(typeof person.objectId === 'string').toBeTruthy();
-    expect(typeof person.displayName === 'string').toBeTruthy();
-    expect(typeof person.email === 'string').toBeTruthy();
-    expect(person.objectId).toBe('5842943a-aa5a-470a-bfdc-7311b9988962');
-    expect(person.displayName).toBe('Sonal Jha');
-    expect(person.email).toBe('sojh@m365x347208.onmicrosoft.com');
+    let emptyCallback = () => {};
+
+    /**
+     * People Picker tests
+     */
+    it('should not allow selectPeople calls with null callback', () => {
+      expect(() => people.selectPeople(null)).toThrowError(
+        '[people picker] Callback cannot be null',
+      );
+    });
+
+    it('should allow selectPeople calls with null peoplePickerInputs', () => {
+      mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
+      let peoplePickerError: SdkError;
+      people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {
+        peoplePickerError = error;
+      }, null);
+      expect(peoplePickerError).toBeUndefined();
+    });
+
+    it('should allow selectPeople calls with no peoplePickerInputs', () => {
+      mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
+      let peoplePickerError: SdkError;
+      people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {
+        peoplePickerError = error;
+      });
+      expect(peoplePickerError).toBeUndefined();
+    });
+
+    it('should allow selectPeople calls with undefined peoplePickerInputs', () => {
+      mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
+      let peoplePickerError: SdkError;
+      people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {
+        peoplePickerError = error;
+      }, undefined);
+      expect(peoplePickerError).toBeUndefined();
+    });
+
+    it('selectPeople call in default version of platform support fails', () => {
+      mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+      let peoplePickerError: SdkError;
+      people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {
+        peoplePickerError = error;
+      });
+      expect(peoplePickerError).not.toBeNull();
+      expect(peoplePickerError.errorCode).toBe(ErrorCode.OLD_PLATFORM);
+    });
+
+    it('selectPeople call in task frameContext works', () => {
+      mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
+      people.selectPeople(emptyCallback);
+      const message = mobilePlatformMock.findMessageByFunc('people.selectPeople');
+      expect(message).not.toBeNull();
+      expect(message.args.length).toBe(1);
+    });
+
+    it('selectPeople call in content frameContext works', () => {
+      mobilePlatformMock.initializeWithContext(FrameContexts.content);
+      mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
+      people.selectPeople(emptyCallback);
+      const message = mobilePlatformMock.findMessageByFunc('people.selectPeople');
+      expect(message).not.toBeNull();
+      expect(message.args.length).toBe(1);
+    });
+
+    it('selectPeople calls with successful result', () => {
+      mobilePlatformMock.initializeWithContext(FrameContexts.content);
+      mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
+      let peoplePickerResult: people.PeoplePickerResult[], peoplePickerError: SdkError;
+      people.selectPeople((e: SdkError, m: people.PeoplePickerResult[]) => {
+        peoplePickerError = e;
+        peoplePickerResult = m;
+      });
+
+      const message = mobilePlatformMock.findMessageByFunc('people.selectPeople');
+      expect(message).not.toBeNull();
+      expect(message.args.length).toBe(1);
+
+      const callbackId = message.id;
+      const result = [{
+      objectId: "5842943a-aa5a-470a-bfdc-7311b9988962",
+      displayName: "Sonal Jha",
+      email: "sojh@m365x347208.onmicrosoft.com"
+      } as people.PeoplePickerResult];
+      mobilePlatformMock.respondToMessage({
+        data: {
+          id: callbackId,
+          args: [undefined, result]
+        }
+      } as DOMMessageEvent)
+
+      expect(peoplePickerError).toBeFalsy();
+      expect(result.length).toBe(1);
+      const person = result[0];
+      expect(person).not.toBeNull();
+      expect(person.objectId).not.toBeNull();
+      expect(typeof person.objectId === 'string').toBeTruthy();
+      expect(typeof person.displayName === 'string').toBeTruthy();
+      expect(typeof person.email === 'string').toBeTruthy();
+      expect(person.objectId).toBe('5842943a-aa5a-470a-bfdc-7311b9988962');
+      expect(person.displayName).toBe('Sonal Jha');
+      expect(person.email).toBe('sojh@m365x347208.onmicrosoft.com');
+    });
+
+    it('selectPeople calls with error', () => {
+      mobilePlatformMock.initializeWithContext(FrameContexts.content);
+      mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
+      let peoplePickerResult: people.PeoplePickerResult[], peoplePickerError: SdkError;
+      const peoplePickerInput: people.PeoplePickerInputs = {
+      title: "Hello World",
+      setSelected: null,
+      openOrgWideSearchInChatOrChannel: true,
+      singleSelect: true
+      };
+      people.selectPeople( (e: SdkError, m: people.PeoplePickerResult[]) => {
+        peoplePickerError = e;
+        peoplePickerResult = m;
+      }, peoplePickerInput);
+
+      const message = mobilePlatformMock.findMessageByFunc('people.selectPeople');
+      expect(message).not.toBeNull();
+      expect(message.args.length).toBe(1);
+
+      const callbackId = message.id;
+      mobilePlatformMock.respondToMessage({
+        data: {
+          id: callbackId,
+          args: [{ errorCode: ErrorCode.INTERNAL_ERROR }]
+        }
+      } as DOMMessageEvent)
+
+      expect(peoplePickerResult).toBeFalsy();
+      expect(peoplePickerError.errorCode).toBe(ErrorCode.INTERNAL_ERROR);
+    });
   });
 
-  it('selectPeople calls with error', () => {
-    mobilePlatformMock.initializeWithContext(FrameContexts.content);
-    mobilePlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
-    let peoplePickerResult: people.PeoplePickerResult[], peoplePickerError: SdkError;
-    const peoplePickerInput: people.PeoplePickerInputs = {
-     title: "Hello World",
-     setSelected: null,
-     openOrgWideSearchInChatOrChannel: true,
-     singleSelect: true
-    };
-    people.selectPeople( (e: SdkError, m: people.PeoplePickerResult[]) => {
-      peoplePickerError = e;
-      peoplePickerResult = m;
-    }, peoplePickerInput);
+  describe('openCard', () => {
+    const utils = new Utils();
 
-    const message = mobilePlatformMock.findMessageByFunc('people.selectPeople');
-    expect(message).not.toBeNull();
-    expect(message.args.length).toBe(1);
+    beforeEach(() => {
+      utils.processMessage = null;
+      utils.messages = [];
+      utils.childMessages = [];
+      utils.childWindow.closed = false;
 
-    const callbackId = message.id;
-    mobilePlatformMock.respondToMessage({
-      data: {
-        id: callbackId,
-        args: [{ errorCode: ErrorCode.INTERNAL_ERROR }]
+      // Set a mock window for testing
+      _initialize(utils.mockWindow);
+    });
+
+    afterEach(() => {
+      // Reset the object since it's a singleton
+      if (_uninitialize) {
+        _uninitialize();
       }
-    } as DOMMessageEvent)
+    });
 
-    expect(peoplePickerResult).toBeFalsy();
-    expect(peoplePickerError.errorCode).toBe(ErrorCode.INTERNAL_ERROR);
+    it('should return an error if validation fails', () => {
+      utils.initializeWithContext('content');
+
+      let error;
+      people.openCard(err => {
+        error = err;
+      });
+
+      expect(error).toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+    });
+
+    it('sends expected message', () => {
+      utils.initializeWithContext('content');
+
+      const request: people.OpenCardRequest = {
+        targetBoundingRect: { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 },
+        parameters: {
+          personaInfo: { identifiers: { PersonaType: 'User', Smtp: 'test@microsoft.com' } },
+          openCardTriggerType: 'MouseHover',
+        },
+      };
+
+      let error;
+      people.openCard(err => {
+        error = err;
+      }, request);
+
+      expect(error).toBeUndefined();
+      expect(utils.messages.length).toEqual(2);
+      expect(utils.messages[1].func).toEqual('people.openCard');
+      expect(utils.messages[1].args.length).toEqual(1);
+      expect(utils.messages[1].args[0]).toEqual(request);
+    });
   });
 });

--- a/test/public/people.spec.ts
+++ b/test/public/people.spec.ts
@@ -206,7 +206,7 @@ describe('people', () => {
 
       const request: people.OpenCardRequest = {
         targetBoundingRect: { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 },
-        parameters: {
+        cardParameters: {
           personaInfo: { identifiers: { PersonaType: 'User', Smtp: 'test@microsoft.com' } },
           openCardTriggerType: 'MouseHover',
         },


### PR DESCRIPTION
Adds an API for opening the [profile card](https://support.microsoft.com/en-us/office/profile-cards-in-microsoft-365-e80f931f-5fc4-4a59-ba6e-c1e35a85b501) inside Teams hosted apps. Teams will open the already existing profile card in the correct position over the top of the app according to the positional information provided in the API call.