### PR TITLE
Removed threadId from callback

### DIFF
--- a/src/private/teams.ts
+++ b/src/private/teams.ts
@@ -51,7 +51,7 @@ export namespace teams {
    * @param threadId ID of the thread where the app entity will be created; if threadId is not
    * provided, the threadId from route params will be used.
    */
-  export function refreshSiteUrl(threadId: string, callback: (threadId: string, error: SdkError) => void): void {
+  export function refreshSiteUrl(threadId: string, callback: (error: SdkError) => void): void {
     ensureInitialized();
 
     if (!threadId) {


### PR DESCRIPTION
Removed `threadId` from callback, which is no needed.