### PR TITLE
Rename @privateRemarks TSDoc tag to @hidden

### DIFF
--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -131,7 +131,7 @@ export function sendAndHandleSdkError<T>(actionName: string, ...args: any[]): Pr
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Send a message to parent. Uses nativeInterface on mobile to communicate with parent context
  *
  * @internal
@@ -154,7 +154,7 @@ function waitForResponse<T>(requestId: number): Promise<T> {
 export function sendMessageToParent(actionName: string, callback?: Function): void;
 
 /**
- * @privateRemarks
+ * @hidden
  * Send a message to parent. Uses nativeInterface on mobile to communicate with parent context
  *
  * @internal
@@ -225,7 +225,7 @@ export function processMessage(evt: DOMMessageEvent): void {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Validates the message source and origin, if it should be processed
  *
  * @internal
@@ -372,7 +372,7 @@ export function waitForMessageQueue(targetWindow: Window, callback: () => void):
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Send a response to child for a message request that was from child
  *
  * @internal
@@ -392,7 +392,7 @@ function sendMessageResponseToChild(
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Send a custom message object that can be sent to child window,
  * instead of a response message to a child
  *
@@ -438,7 +438,7 @@ function createMessageResponse(id: number, args: any[], isPartialResponse: boole
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Creates a message object without any id, used for custom actions being sent to child frame/window
  *
  * @internal

--- a/packages/teams-js/src/internal/constants.ts
+++ b/packages/teams-js/src/internal/constants.ts
@@ -1,6 +1,6 @@
 export const version = '2.0.0-beta.0';
 /**
- * @privateRemarks
+ * @hidden
  * The SDK version when all SDK APIs started to check platform compatibility for the APIs was 1.6.0.
  * Modified to 2.0.1 which is hightest till now so that if any client doesn't pass version in initialize function, it will be set to highest.
  * Mobile clients are passing versions, hence will be applicable to web and desktop clients only.
@@ -10,7 +10,7 @@ export const version = '2.0.0-beta.0';
 export const defaultSDKVersionForCompatCheck = '2.0.1';
 
 /**
- * @privateRemarks
+ * @hidden
  * This is the SDK version when selectMedia API - VideoAndImage is supported on mobile.
  *
  * @internal
@@ -18,7 +18,7 @@ export const defaultSDKVersionForCompatCheck = '2.0.1';
 export const videoAndImageMediaAPISupportVersion = '2.0.2';
 
 /**
- * @privateRemarks
+ * @hidden
  * Minimum required client supported version for {@link getUserJoinedTeams} to be supported on {@link HostClientType.android}
  *
  * @internal
@@ -26,7 +26,7 @@ export const videoAndImageMediaAPISupportVersion = '2.0.2';
 export const getUserJoinedTeamsSupportedAndroidClientVersion = '2.0.1';
 
 /**
- * @privateRemarks
+ * @hidden
  * This is the SDK version when location APIs (getLocation and showLocation) are supported.
  *
  * @internal
@@ -34,7 +34,7 @@ export const getUserJoinedTeamsSupportedAndroidClientVersion = '2.0.1';
 export const locationAPIsRequiredVersion = '1.9.0';
 
 /**
- * @privateRemarks
+ * @hidden
  * This is the SDK version when people picker API is supported on mobile.
  *
  * @internal
@@ -42,7 +42,7 @@ export const locationAPIsRequiredVersion = '1.9.0';
 export const peoplePickerRequiredVersion = '2.0.0';
 
 /**
- * @privateRemarks
+ * @hidden
  * This is the SDK version when captureImage API is supported on mobile.
  *
  * @internal
@@ -50,7 +50,7 @@ export const peoplePickerRequiredVersion = '2.0.0';
 export const captureImageMobileSupportVersion = '1.7.0';
 
 /**
- * @privateRemarks
+ * @hidden
  * This is the SDK version when media APIs are supported on all three platforms ios, android and web.
  *
  * @internal
@@ -58,7 +58,7 @@ export const captureImageMobileSupportVersion = '1.7.0';
 export const mediaAPISupportVersion = '1.8.0';
 
 /**
- * @privateRemarks
+ * @hidden
  * This is the SDK version when getMedia API is supported via Callbacks on all three platforms ios, android and web.
  *
  * @internal
@@ -66,7 +66,7 @@ export const mediaAPISupportVersion = '1.8.0';
 export const getMediaCallbackSupportVersion = '2.0.0';
 
 /**
- * @privateRemarks
+ * @hidden
  * This is the SDK version when scanBarCode API is supported on mobile.
  *
  * @internal
@@ -74,7 +74,7 @@ export const getMediaCallbackSupportVersion = '2.0.0';
 export const scanBarCodeAPIMobileSupportVersion = '1.9.0';
 
 /**
- * @privateRemarks
+ * @hidden
  * List of supported Host origins
  *
  * @internal
@@ -108,7 +108,7 @@ export const validOrigins = [
 ];
 
 /**
- * @privateRemarks
+ * @hidden
  * USer specified message origins should satisfy this test
  *
  * @internal

--- a/packages/teams-js/src/internal/interfaces.ts
+++ b/packages/teams-js/src/internal/interfaces.ts
@@ -1,5 +1,5 @@
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs
  * Shim in definitions used for browser-compat
  *
@@ -15,7 +15,7 @@ export interface DOMMessageEvent {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs
  *
  * @internal
@@ -25,7 +25,7 @@ export interface TeamsNativeClient {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs
  *
  * @internal
@@ -51,7 +51,7 @@ export interface MessageResponse {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Meant for Message objects that are sent to children without id
  *
  * @internal

--- a/packages/teams-js/src/internal/internalAPIs.ts
+++ b/packages/teams-js/src/internal/internalAPIs.ts
@@ -24,7 +24,7 @@ export function ensureInitialized(...expectedFrameContexts: string[]): void {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Checks whether the platform has knowledge of this API by doing a comparison
  * on API required version and platform supported version of the SDK
  *
@@ -41,7 +41,7 @@ export function isAPISupportedByPlatform(requiredVersion: string = defaultSDKVer
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Processes the valid origins specifuied by the user, de-duplicates and converts them into a regexp
  * which is used later for message source/origin validation
  *

--- a/packages/teams-js/src/internal/mediaUtil.ts
+++ b/packages/teams-js/src/internal/mediaUtil.ts
@@ -2,7 +2,7 @@ import { media } from '../public/media';
 import { people } from '../public/people';
 
 /**
- * @privateRemarks
+ * @hidden
  * Helper function to create a blob from media chunks based on their sequence
  *
  * @internal
@@ -28,7 +28,7 @@ export function createFile(assembleAttachment: media.AssembleAttachment[], mimeT
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Helper function to convert Media chunks into another object type which can be later assemebled
  * Converts base 64 encoded string to byte array and then into an array of blobs
  *
@@ -53,7 +53,7 @@ export function decodeAttachment(attachment: media.MediaChunk, mimeType: string)
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Returns true if the mediaInput params are valid and false otherwise
  *
  * @internal
@@ -66,7 +66,7 @@ export function validateSelectMediaInputs(mediaInputs: media.MediaInputs): boole
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Returns true if the mediaInput params are called for mediatype VideoAndImage and false otherwise
  *
  * @internal
@@ -81,7 +81,7 @@ export function isMediaCallForVideoAndImageInputs(mediaInputs: media.MediaInputs
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Returns true if the get Media params are valid and false otherwise
  *
  * @internal
@@ -94,7 +94,7 @@ export function validateGetMediaInputs(mimeType: string, format: media.FileForma
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Returns true if the view images param is valid and false otherwise
  *
  * @internal
@@ -107,7 +107,7 @@ export function validateViewImagesInput(uriList: media.ImageUri[]): boolean {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Returns true if the scan barcode param is valid and false otherwise
  *
  * @internal
@@ -126,7 +126,7 @@ export function validateScanBarCodeInput(barCodeConfig: media.BarCodeConfig): bo
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Returns true if the people picker params are valid and false otherwise
  *
  * @internal

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -65,7 +65,7 @@ export function getGenericOnCompleteHandler(errorMessage?: string): (success: bo
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Compares SDK versions.
  *
  * @param v1 - first version
@@ -122,7 +122,7 @@ export function compareSDKVersions(v1: string, v2: string): number {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Generates a GUID
  *
  * @internal
@@ -141,7 +141,7 @@ export function deepFreeze<T extends object>(obj: T): T {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * The following type definitions will be used in the
  * utility functions below, which help in transforming the
  * promises to support callbacks for backward compatibility

--- a/packages/teams-js/src/private/appEntity.ts
+++ b/packages/teams-js/src/private/appEntity.ts
@@ -3,14 +3,14 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { FrameContexts, SdkError } from '../public';
 import { runtime } from '../public/runtime';
 /**
- * @privateRemarks
+ * @hidden
  * Namespace to interact with the application entities specific part of the SDK.
  *
  * @alpha
  */
 export namespace appEntity {
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * --------
    * Information on an app entity
@@ -19,38 +19,38 @@ export namespace appEntity {
    */
   export interface AppEntity {
     /**
-     * @privateRemarks
+     * @hidden
      * App ID of the application
      */
     appId: string;
 
     /**
-     * @privateRemarks
+     * @hidden
      * URL for the application's icon
      */
     appIconUrl: string;
 
     /**
-     * @privateRemarks
+     * @hidden
      * Content URL for the app entity
      */
     contentUrl: string;
 
     /**
-     * @privateRemarks
+     * @hidden
      * The display name for the app entity
      */
     displayName: string;
 
     /**
-     * @privateRemarks
+     * @hidden
      * Website URL for the app entity. It is meant to be opened by the user in a browser.
      */
     websiteUrl: string;
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * --------
    * Open the Tab Gallery and retrieve the app entity

--- a/packages/teams-js/src/private/bot.ts
+++ b/packages/teams-js/src/private/bot.ts
@@ -5,14 +5,14 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { runtime } from '../public/runtime';
 
 /**
- * @privateRemarks
+ * @hidden
  * Namespace to interact with bots using the SDK.
  *
  * @alpha
  */
 export namespace bot {
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs until release.
    * ------
    * Sends query to bot in order to retrieve data.
@@ -38,7 +38,7 @@ export namespace bot {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs until release.
    * -----
    * Retrieves list of support commands from bot
@@ -62,7 +62,7 @@ export namespace bot {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs until release.
    * -----
    * Authenticates a user for json tab
@@ -89,7 +89,7 @@ export namespace bot {
 
   export interface QueryRequest {
     /**
-     * @privateRemarks
+     * @hidden
      * Query to search for
      */
     query: string;

--- a/packages/teams-js/src/private/chat.ts
+++ b/packages/teams-js/src/private/chat.ts
@@ -11,14 +11,14 @@ import { runtime } from '../public/runtime';
 import { ChatMembersInformation } from './interfaces';
 
 /**
- * @privateRemarks
+ * @hidden
  * Namespace to interact with the conversational subEntities inside the tab
  *
  * @alpha
  */
 export namespace chat {
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * --------------
    * Allows the user to start or continue a conversation with each subentity inside the tab
@@ -64,7 +64,7 @@ export namespace chat {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * --------------
    * Allows the user to close the conversation in the right pane
@@ -77,7 +77,7 @@ export namespace chat {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Allows an app to retrieve information of all chat members

--- a/packages/teams-js/src/private/files.ts
+++ b/packages/teams-js/src/private/files.ts
@@ -9,7 +9,7 @@ import { runtime } from '../public/runtime';
 import { FilePreviewParameters } from './interfaces';
 
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs
  * ------
  * Namespace to interact with the files specific part of the SDK.
@@ -18,7 +18,7 @@ import { FilePreviewParameters } from './interfaces';
  */
 export namespace files {
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Cloud storage providers registered with Microsoft Teams
@@ -32,7 +32,7 @@ export namespace files {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Cloud storage provider integration type
@@ -44,114 +44,114 @@ export namespace files {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Cloud storage folder interface
    */
   export interface CloudStorageFolder {
     /**
-     * @privateRemarks
+     * @hidden
      * ID of the cloud storage folder
      */
     id: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Display Name/Title of the cloud storage folder
      */
     title: string;
     /**
-     * @privateRemarks
+     * @hidden
      * ID of the cloud storage folder in the provider
      */
     folderId: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Type of the cloud storage folder provider integration
      */
     providerType: CloudStorageProviderType;
     /**
-     * @privateRemarks
+     * @hidden
      * Code of the supported cloud storage folder provider
      */
     providerCode: CloudStorageProvider;
     /**
-     * @privateRemarks
+     * @hidden
      * Display name of the owner of the cloud storage folder provider
      */
     ownerDisplayName: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Sharepoint specific siteURL of the folder
      */
     siteUrl?: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Sharepoint specific serverRelativeUrl of the folder
      */
     serverRelativeUrl?: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Sharepoint specific libraryType of the folder
      */
     libraryType?: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Sharepoint specific accessType of the folder
      */
     accessType?: string;
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Cloud storage item interface
    */
   export interface CloudStorageFolderItem {
     /**
-     * @privateRemarks
+     * @hidden
      * ID of the item in the provider
      */
     id: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Display name/title
      */
     title: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Key to differentiate files and subdirectory
      */
     isSubdirectory: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * File extension
      */
     type: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Last modifed time of the item
      */
     lastModifiedTime: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Display size of the items in bytes
      */
     size: number;
     /**
-     * @privateRemarks
+     * @hidden
      * URL of the file
      */
     objectUrl: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Temporary access token for the item
      */
     accessToken?: string;
   }
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Gets a list of cloud storage folders added to the channel
@@ -171,7 +171,7 @@ export namespace files {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Initiates the add cloud storage folder flow
@@ -196,7 +196,7 @@ export namespace files {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Deletes a cloud storage folder from channel
@@ -220,7 +220,7 @@ export namespace files {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Fetches the contents of a Cloud storage folder (CloudStorageFolder) / sub directory
@@ -249,7 +249,7 @@ export namespace files {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Open a cloud storage file in teams
@@ -277,7 +277,7 @@ export namespace files {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs.
    * ------
    * Opens a client-friendly preview of the specified file.

--- a/packages/teams-js/src/private/interfaces.ts
+++ b/packages/teams-js/src/private/interfaces.ts
@@ -1,6 +1,6 @@
 import { FileOpenPreference, TeamInformation } from '../public/interfaces';
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs
  * --------
  * Information about all members in a chat
@@ -12,7 +12,7 @@ export interface ChatMembersInformation {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs
  * --------
  * Information about a chat member
@@ -21,7 +21,7 @@ export interface ChatMembersInformation {
  */
 export interface ThreadMember {
   /**
-   * @privateRemarks
+   * @hidden
    * The member's user principal name in the current tenant.
    */
   upn: string;
@@ -44,7 +44,7 @@ export interface ShowNotificationParameters {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs.
  * ------
  * @alpha
@@ -56,7 +56,7 @@ export enum ViewerActionTypes {
 }
 
 /**
- * * @privateRemarks
+ * * @hidden
  * Hide from docs.
  * ------
  * User setting changes that can be subscribed to,
@@ -64,100 +64,100 @@ export enum ViewerActionTypes {
  */
 export enum UserSettingTypes {
   /**
-   * @privateRemarks
+   * @hidden
    * Use this key to subscribe to changes in user's file open preference
    */
   fileOpenPreference = 'fileOpenPreference',
   /**
-   * @privateRemarks
+   * @hidden
    * Use this key to subscribe to theme changes
    */
   theme = 'theme',
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs.
  * ------
  * @alpha
  */
 export interface FilePreviewParameters {
   /**
-   * @privateRemarks
+   * @hidden
    * The developer-defined unique ID for the file.
    */
   entityId: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The display name of the file.
    */
   title: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * An optional description of the file.
    */
   description?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The file extension; e.g. pptx, docx, etc.
    */
   type: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * A url to the source of the file, used to open the content in the user's default browser
    */
   objectUrl: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Optional; an alternate self-authenticating url used to preview the file in Mobile clients and offer it for download by the user
    */
   downloadUrl?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Optional; an alternate url optimized for previewing the file in web and desktop clients
    */
   webPreviewUrl?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Optional; an alternate url that allows editing of the file in web and desktop clients
    */
   webEditUrl?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Optional; the base url of the site where the file is hosted
    */
   baseUrl?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Deprecated; prefer using viewerAction instead
    * Optional; indicates whether the file should be opened in edit mode
    */
   editFile?: boolean;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Optional; the developer-defined unique ID for the sub-entity to return to when the file stage closes.
    * This field should be used to restore to a specific state within an entity, such as scrolling to or activating a specific piece of content.
    */
   subEntityId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Optional; indicates the mode in which file should be opened. Takes precedence over edit mode.
    */
   viewerAction?: ViewerActionTypes;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Optional; indicates how user prefers to open the file
    */
   fileOpenPreference?: FileOpenPreference;
@@ -169,7 +169,7 @@ export interface FilePreviewParameters {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs
  * --------
  * Query parameters used when fetching team information
@@ -177,14 +177,14 @@ export interface FilePreviewParameters {
  */
 export interface TeamInstanceParameters {
   /**
-   * @privateRemarks
+   * @hidden
    * Flag allowing to select favorite teams only
    */
   favoriteTeamsOnly?: boolean;
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs
  * --------
  * Information on userJoined Teams
@@ -192,7 +192,7 @@ export interface TeamInstanceParameters {
  */
 export interface UserJoinedTeamsInformation {
   /**
-   * @privateRemarks
+   * @hidden
    * List of team information
    */
   userJoinedTeams: TeamInformation[];

--- a/packages/teams-js/src/private/interfaces.ts
+++ b/packages/teams-js/src/private/interfaces.ts
@@ -56,7 +56,7 @@ export enum ViewerActionTypes {
 }
 
 /**
- * * @hidden
+ * @hidden
  * Hide from docs.
  * ------
  * User setting changes that can be subscribed to,

--- a/packages/teams-js/src/private/legacy.ts
+++ b/packages/teams-js/src/private/legacy.ts
@@ -13,7 +13,7 @@ import { TeamInstanceParameters, UserJoinedTeamsInformation } from './interfaces
 export namespace legacy {
   export namespace fullTrust {
     /**
-     * @privateRemarks
+     * @hidden
      * Hide from docs
      * ------
      * Allows an app to retrieve information of all user joined teams
@@ -43,7 +43,7 @@ export namespace legacy {
     }
 
     /**
-     * @privateRemarks
+     * @hidden
      * Hide from docs
      * ------
      * Allows an app to get the configuration setting value

--- a/packages/teams-js/src/private/logs.ts
+++ b/packages/teams-js/src/private/logs.ts
@@ -4,7 +4,7 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { runtime } from '../public/runtime';
 
 /**
- * @privateRemarks
+ * @hidden
  * Namespace to interact with the logging part of the SDK.
  * This object is used to send the app logs on demand to the host client
  *
@@ -14,7 +14,7 @@ import { runtime } from '../public/runtime';
  */
 export namespace logs {
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Registers a handler for getting app log

--- a/packages/teams-js/src/private/meetingRoom.ts
+++ b/packages/teams-js/src/private/meetingRoom.ts
@@ -8,153 +8,153 @@ import { runtime } from '../public/runtime';
  */
 export namespace meetingRoom {
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Data structure to represent a meeting room.
    */
   export interface MeetingRoomInfo {
     /**
-     * @privateRemarks
+     * @hidden
      * Endpoint id of the meeting room.
      */
     endpointId: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Device name of the meeting room.
      */
     deviceName: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Client type of the meeting room.
      */
     clientType: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Client version of the meeting room.
      */
     clientVersion: string;
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Enum used to indicate meeting room capabilities.
    */
   export enum Capability {
     /**
-     * @privateRemarks
+     * @hidden
      * Media control capability: toggle mute.
      */
     toggleMute = 'toggleMute',
     /**
-     * @privateRemarks
+     * @hidden
      * Media control capability: toggle camera.
      */
     toggleCamera = 'toggleCamera',
     /**
-     * @privateRemarks
+     * @hidden
      * Media control capability: toggle captions.
      */
     toggleCaptions = 'toggleCaptions',
     /**
-     * @privateRemarks
+     * @hidden
      * Media control capability: volume ajustion.
      */
     volume = 'volume',
     /**
-     * @privateRemarks
+     * @hidden
      * Stage layout control capability: show gallery mode.
      */
     showVideoGallery = 'showVideoGallery',
     /**
-     * @privateRemarks
+     * @hidden
      * Stage layout control capability: show content mode.
      */
     showContent = 'showContent',
     /**
-     * @privateRemarks
+     * @hidden
      * Stage layout control capability: show content + gallery mode.
      */
     showVideoGalleryAndContent = 'showVideoGalleryAndContent',
     /**
-     * @privateRemarks
+     * @hidden
      * Stage layout control capability: show laryge gallery mode.
      */
     showLargeGallery = 'showLargeGallery',
     /**
-     * @privateRemarks
+     * @hidden
      * Stage layout control capability: show together mode.
      */
     showTogether = 'showTogether',
     /**
-     * @privateRemarks
+     * @hidden
      * Meeting control capability: leave meeting.
      */
     leaveMeeting = 'leaveMeeting',
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Data structure to represent capabilities of a meeting room.
    */
   export interface MeetingRoomCapability {
     /**
-     * @privateRemarks
+     * @hidden
      * Media control capabilities, value can be "toggleMute", "toggleCamera", "toggleCaptions", "volume".
      */
     mediaControls: string[];
     /**
-     * @privateRemarks
+     * @hidden
      * Main stage layout control capabilities, value can be "showVideoGallery", "showContent", "showVideoGalleryAndContent", "showLargeGallery", "showTogether".
      */
     stageLayoutControls: string[];
     /**
-     * @privateRemarks
+     * @hidden
      * Meeting control capabilities, value can be "leaveMeeting".
      */
     meetingControls: string[];
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Data structure to represent states of a meeting room.
    */
   export interface MeetingRoomState {
     /**
-     * @privateRemarks
+     * @hidden
      * Current mute state, true: mute, false: unmute.
      */
     toggleMute: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * Current camera state, true: camera on, false: camera off.
      */
     toggleCamera: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * Current captions state, true: captions on, false: captions off.
      */
     toggleCaptions: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * Current main stage layout state, value can be one of "Gallery", "Content + gallery", "Content", "Large gallery" and "Together mode".
      */
     stageLayout: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Current leaveMeeting state, true: leave, false: no-op.
      */
     leaveMeeting: boolean;
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Fetch the meeting room info that paired with current client.
@@ -169,7 +169,7 @@ export namespace meetingRoom {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Send a command to paired meeting room.
@@ -188,7 +188,7 @@ export namespace meetingRoom {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Registers a handler for meeting room capabilities update.
@@ -210,7 +210,7 @@ export namespace meetingRoom {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * Registers a handler for meeting room states update.
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.

--- a/packages/teams-js/src/private/menus.ts
+++ b/packages/teams-js/src/private/menus.ts
@@ -4,7 +4,7 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { runtime } from '../public/runtime';
 
 /**
- * @privateRemarks
+ * @hidden
  * Namespace to interact with the menu-specific part of the SDK.
  * This object is used to show View Configuration, Action Menu and Navigation Bar Menu.
  *
@@ -13,98 +13,98 @@ import { runtime } from '../public/runtime';
  */
 export namespace menus {
   /**
-   * @privateRemarks
+   * @hidden
    * Represents information about item in View Configuration.
    */
   export interface ViewConfiguration {
     /**
-     * @privateRemarks
+     * @hidden
      * Unique identifier of view.
      */
     id: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Display title of the view.
      */
     title: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Additional information for accessibility.
      */
     contentDescription?: string;
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Represents information about menu item for Action Menu and Navigation Bar Menu.
    */
   export class MenuItem {
     /**
-     * @privateRemarks
+     * @hidden
      * Unique identifier for the menu item.
      */
     public id: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Display title of the menu item.
      */
     public title: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Display icon of the menu item. The icon value must be a string having SVG icon content.
      */
     public icon: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Selected state display icon of the menu item. The icon value must be a string having SVG icon content.
      */
     public iconSelected?: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Additional information for accessibility.
      */
     public contentDescription?: string;
     /**
-     * @privateRemarks
+     * @hidden
      * State of the menu item
      */
     public enabled = true;
     /**
-     * @privateRemarks
+     * @hidden
      * Interface to show list of items on selection of menu item.
      */
     public viewData: ViewData;
     /**
-     * @privateRemarks
+     * @hidden
      * Whether the menu item is selected or not
      */
     public selected = false;
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Represents information about view to show on Navigation Bar Menu item selection
    */
   export interface ViewData {
     /**
-     * @privateRemarks
+     * @hidden
      * Display header title of the item list.
      */
     listTitle?: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Type of the menu item.
      */
     listType: MenuListType;
     /**
-     * @privateRemarks
+     * @hidden
      * Array of MenuItem. Icon value will be required for all items in the list.
      */
     listItems: MenuItem[];
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Represents information about type of list to display in Navigation Bar Menu.
    */
   export enum MenuListType {
@@ -122,7 +122,7 @@ export namespace menus {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Registers list of view configurations and it's handler.
    * Handler is responsible for listening selection of View Configuration.
    *
@@ -143,7 +143,7 @@ export namespace menus {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Used to set menu items on the Navigation Bar. If icon is available, icon will be shown, otherwise title will be shown.
    *
    * @param items List of MenuItems for Navigation Bar Menu.
@@ -164,19 +164,19 @@ export namespace menus {
 
   export interface ActionMenuParameters {
     /**
-     * @privateRemarks
+     * @hidden
      * Display title for Action Menu
      */
     title: string;
     /**
-     * @privateRemarks
+     * @hidden
      * List of MenuItems for Action Menu
      */
     items: MenuItem[];
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Used to show Action Menu.
    *
    * @param params - Parameters for Menu Parameters

--- a/packages/teams-js/src/private/notifications.ts
+++ b/packages/teams-js/src/private/notifications.ts
@@ -6,7 +6,7 @@ import { ShowNotificationParameters } from './interfaces';
 
 export namespace notifications {
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs.
    * ------
    * display notification API.

--- a/packages/teams-js/src/private/privateAPIs.ts
+++ b/packages/teams-js/src/private/privateAPIs.ts
@@ -15,7 +15,7 @@ export function initializePrivateApis(): void {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs.
  * ------
  * Upload a custom App manifest directly to both team and personal scopes.
@@ -30,7 +30,7 @@ export function uploadCustomApp(manifestBlob: Blob, onComplete?: (status: boolea
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Internal use only
  * Sends a custom action MessageRequest to Teams or parent window
  *
@@ -54,7 +54,7 @@ export function sendCustomMessage(
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Internal use only
  * Sends a custom action MessageEvent to a child iframe/window, only if you are not using auth popup.
  * Otherwise it will go to the auth popup (which becomes the child)
@@ -80,7 +80,7 @@ export function sendCustomEvent(
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Internal use only
  * Adds a handler for an action sent by a child window or parent window
  *
@@ -103,7 +103,7 @@ export function registerCustomHandler(
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * register a handler to be called when a user setting changes. The changed setting type & value is provided in the callback.
  *
  * @param settingTypes - List of user setting changes to subscribe

--- a/packages/teams-js/src/private/remoteCamera.ts
+++ b/packages/teams-js/src/private/remoteCamera.ts
@@ -10,31 +10,31 @@ import { runtime } from '../public/runtime';
  */
 export namespace remoteCamera {
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Data structure to represent patricipant details needed to request control of camera.
    */
   export interface Participant {
     /**
-     * @privateRemarks
+     * @hidden
      * Id of participant.
      */
     id: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Display name of participant.
      */
     displayName?: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Active indicates whether the participant's device is actively being controlled.
      */
     active?: boolean;
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Enum used to indicate possible camera control commands.
@@ -50,61 +50,61 @@ export namespace remoteCamera {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Data structure to indicate the current state of the device.
    */
   export interface DeviceState {
     /**
-     * @privateRemarks
+     * @hidden
      * All operation are available to apply.
      */
     available: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * Either camera doesnt support to get state or It unable to apply command.
      */
     error: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * Reset max out or already applied. Client Disable Reset.
      */
     reset: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * ZoomIn maxed out.
      */
     zoomIn: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * ZoomOut maxed out.
      */
     zoomOut: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * PanLeft reached max left.
      */
     panLeft: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * PanRight reached max right.
      */
     panRight: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * TiltUp reached top.
      */
     tiltUp: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * TiltDown reached bottom.
      */
     tiltDown: boolean;
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Enum used to indicate the reason for the error.
@@ -121,26 +121,26 @@ export namespace remoteCamera {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Data structure to indicate the status of the current session.
    */
   export interface SessionStatus {
     /**
-     * @privateRemarks
+     * @hidden
      * Whether the far-end user is controlling a  device.
      */
     inControl: boolean;
     /**
-     * @privateRemarks
+     * @hidden
      * Reason the  control session was terminated.
      */
     terminatedReason?: SessionTerminatedReason;
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Enum used to indicate the reason the session was terminated.
@@ -160,7 +160,7 @@ export namespace remoteCamera {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Fetch a list of the participants with controllable-cameras in a meeting.
@@ -181,7 +181,7 @@ export namespace remoteCamera {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Request control of a participant's camera.
@@ -207,7 +207,7 @@ export namespace remoteCamera {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Send control command to the participant's camera.
@@ -227,7 +227,7 @@ export namespace remoteCamera {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Terminate the remote  session
@@ -243,7 +243,7 @@ export namespace remoteCamera {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Registers a handler for change in participants with controllable-cameras.
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *
@@ -260,7 +260,7 @@ export namespace remoteCamera {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Registers a handler for error.
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *
@@ -275,7 +275,7 @@ export namespace remoteCamera {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Registers a handler for device state change.
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *
@@ -290,7 +290,7 @@ export namespace remoteCamera {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Registers a handler for session status change.
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *

--- a/packages/teams-js/src/private/teams.ts
+++ b/packages/teams-js/src/private/teams.ts
@@ -5,7 +5,7 @@ import { SdkError } from '../public/interfaces';
 import { runtime } from '../public/runtime';
 
 /**
- * @privateRemarks
+ * @hidden
  * Namespace to interact with the `teams` specific part of the SDK.
  * ------
  * Hide from docs
@@ -28,7 +28,7 @@ export namespace teams {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * ------
    * Get a list of channels belong to a Team
@@ -50,7 +50,7 @@ export namespace teams {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Allow 1st party apps to call this function when they receive migrated errors to inform the Hub/Host to refresh the siteurl
    * when site admin renames siteurl.
    *

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -502,7 +502,7 @@ export namespace app {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs.
    * ------
    * Undocumented function used to set a mock window for unit tests
@@ -514,7 +514,7 @@ export namespace app {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs.
    * ------
    * Undocumented function used to clear state between unit tests
@@ -653,7 +653,7 @@ export namespace core {
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Transforms the Legacy Context object received from Messages to the structured app.Context object
  *
  * @internal

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -201,7 +201,7 @@ export namespace authentication {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs.
    * ------
    * Requests the decoded Azure AD user identity on behalf of the app.
@@ -215,7 +215,7 @@ export namespace authentication {
   /**
    * @deprecated with Teams JS v2 upgrades
    *
-   * @privateRemarks
+   * @hidden
    * Hide from docs.
    * ------
    * Requests the decoded Azure AD user identity on behalf of the app.
@@ -518,7 +518,7 @@ export namespace authentication {
   export type AuthTokenRequest = AuthTokenRequestParameters & LegacyCallBacks;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs.
    * ------
    *
@@ -526,52 +526,52 @@ export namespace authentication {
    */
   export interface UserProfile {
     /**
-     * @privateRemarks
+     * @hidden
      * The intended recipient of the token. The application that receives the token must verify that the audience
      * value is correct and reject any tokens intended for a different audience.
      */
     aud: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Identifies how the subject of the token was authenticated.
      */
     amr: string[];
     /**
-     * @privateRemarks
+     * @hidden
      * Stores the time at which the token was issued. It is often used to measure token freshness.
      */
     iat: number;
     /**
-     * @privateRemarks
+     * @hidden
      * Identifies the security token service (STS) that constructs and returns the token. In the tokens that Azure AD
      * returns, the issuer is sts.windows.net. The GUID in the issuer claim value is the tenant ID of the Azure AD
      * directory. The tenant ID is an immutable and reliable identifier of the directory.
      */
     iss: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Provides the last name, surname, or family name of the user as defined in the Azure AD user object.
      */
     family_name: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Provides the first or "given" name of the user, as set on the Azure AD user object.
      */
     given_name: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Provides a human-readable value that identifies the subject of the token. This value is not guaranteed to
      * be unique within a tenant and is designed to be used only for display purposes.
      */
     unique_name: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Contains a unique identifier of an object in Azure AD. This value is immutable and cannot be reassigned or
      * reused. Use the object ID to identify an object in queries to Azure AD.
      */
     oid: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Identifies the principal about which the token asserts information, such as the user of an application.
      * This value is immutable and cannot be reassigned or reused, so it can be used to perform authorization
      * checks safely. Because the subject is always present in the tokens the Azure AD issues, we recommended
@@ -579,14 +579,14 @@ export namespace authentication {
      */
     sub: string;
     /**
-     * @privateRemarks
+     * @hidden
      * An immutable, non-reusable identifier that identifies the directory tenant that issued the token. You can
      * use this value to access tenant-specific directory resources in a multitenant application. For example,
      * you can use this value to identify the tenant in a call to the Graph API.
      */
     tid: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Defines the end of the time interval within which a token is valid. The service that validates the token
      * should verify that the current date is within the token lifetime; otherwise it should reject the token. The
      * service might allow for up to five minutes beyond the token lifetime to account for any differences in clock
@@ -594,7 +594,7 @@ export namespace authentication {
      */
     exp: number;
     /**
-     * @privateRemarks
+     * @hidden
      * Defines the start of the time interval within which a token is valid. The service that validates the token
      * should verify that the current date is within the token lifetime; otherwise it should reject the token. The
      * service might allow for up to five minutes beyond the token lifetime to account for any differences in clock
@@ -602,12 +602,12 @@ export namespace authentication {
      */
     nbf: number;
     /**
-     * @privateRemarks
+     * @hidden
      * Stores the user name of the user principal.
      */
     upn: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Stores the version number of the token.
      */
     ver: string;
@@ -615,7 +615,7 @@ export namespace authentication {
 
   /**
    * @deprecated with TeamsJS v2 upgrades
-   * @privateRemarks
+   * @hidden
    * Hide from docs.
    * ------
    * @internal

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -173,50 +173,50 @@ export enum FileOpenPreference {
 
 export interface Context {
   /**
-   * @privateRemarks
+   * @hidden
    * The Office 365 group ID for the team with which the content is associated.
    * This field is available only when the identity permission is requested in the manifest.
    */
   groupId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The Microsoft Teams ID for the team with which the content is associated.
    */
   teamId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The name for the team with which the content is associated.
    */
   teamName?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The Microsoft Teams ID for the channel with which the content is associated.
    */
   channelId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The name for the channel with which the content is associated.
    */
   channelName?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The type of the channel with which the content is associated.
    */
   channelType?: ChannelType;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The developer-defined unique ID for the entity this content points to.
    */
   entityId: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The developer-defined unique ID for the sub-entity this content points to.
    * This field should be used to restore to a specific state within an entity,
    * such as scrolling to or activating a specific piece of content.
@@ -224,14 +224,14 @@ export interface Context {
   subEntityId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The current locale that the user has configured for the app formatted as
    * languageId-countryId (for example, en-us).
    */
   locale: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * More detailed locale info from the user's OS if available. Can be used together with
    * the @microsoft/globe NPM package to ensure your app respects the user's OS date and
    * time format configuration
@@ -239,7 +239,7 @@ export interface Context {
   osLocaleInfo?: LocaleInfo;
 
   /**
-   * @privateRemarks
+   * @hidden
    * @deprecated Use loginHint or userPrincipalName.
    * The UPN of the current user.
    * Because a malicious party can run your content in a browser, this value should
@@ -249,7 +249,7 @@ export interface Context {
   upn?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The Azure AD tenant ID of the current user.
    * Because a malicious party can run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
@@ -258,67 +258,67 @@ export interface Context {
   tid?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The current UI theme.
    */
   theme?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Indication whether the tab is in full-screen mode.
    */
   isFullScreen?: boolean;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The type of the team.
    */
   teamType?: TeamType;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The root SharePoint site associated with the team.
    */
   teamSiteUrl?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The domain of the root SharePoint site associated with the team.
    */
   teamSiteDomain?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The relative path to the SharePoint site associated with the team.
    */
   teamSitePath?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The tenant ID of the host team.
    */
   hostTeamTenantId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The AAD group ID of the host team.
    */
   hostTeamGroupId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The relative path to the SharePoint folder associated with the channel.
    */
   channelRelativeUrl?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Unique ID for the current Teams session for use in correlating telemetry data.
    */
   sessionId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The user's role in the team.
    * Because a malicious party can run your content in a browser, this value should
    * be used only as a hint as to the user's role, and never as proof of her role.
@@ -326,13 +326,13 @@ export interface Context {
   userTeamRole?: UserTeamRole;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The Microsoft Teams ID for the chat with which the content is associated.
    */
   chatId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * A value suitable for use as a login_hint when authenticating with Azure AD.
    * Because a malicious party can run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
@@ -341,7 +341,7 @@ export interface Context {
   loginHint?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The UPN of the current user. This may be an externally-authenticated UPN (e.g., guest users).
    * Because a malicious party run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
@@ -350,7 +350,7 @@ export interface Context {
   userPrincipalName?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The Azure AD object id of the current user.
    * Because a malicious party run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
@@ -359,142 +359,142 @@ export interface Context {
   userObjectId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Indicates whether team is archived.
    * Apps should use this as a signal to prevent any changes to content associated with archived teams.
    */
   isTeamArchived?: boolean;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The name of the host client. Possible values are: Office, Orange, Outlook, Teams
    */
   hostName?: HostName;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The type of the host client. Possible values are : android, ios, web, desktop, rigel (deprecated, use teamsRoomsWindows instead),
    * teamsRoomsWindows, teamsRoomsAndroid, teamsPhones, teamsDisplays
    */
   hostClientType?: HostClientType;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The context where tab url is loaded (content, task, setting, remove, sidePanel)
    */
   frameContext?: FrameContexts;
 
   /**
-   * @privateRemarks
+   * @hidden
    * SharePoint context. This is only available when hosted in SharePoint.
    */
   sharepoint?: any;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The type of license for the current users tenant.
    */
   tenantSKU?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The license type for the current user.
    */
   userLicenseType?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The ID of the parent message from which this task module was launched.
    * This is only available in task modules launched from bot cards.
    */
   parentMessageId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Current ring ID
    */
   ringId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Unique ID for the current session for use in correlating telemetry data.
    */
   appSessionId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * ID for the current visible app which is different for across cached sessions. Used for correlating telemetry data``
    */
   appLaunchId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Represents whether calling is allowed for the current logged in User
    */
   isCallingAllowed?: boolean;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Represents whether PSTN calling is allowed for the current logged in User
    */
   isPSTNCallingAllowed?: boolean;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Meeting Id used by tab when running in meeting context
    */
   meetingId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The OneNote section ID that is linked to the channel.
    */
   defaultOneNoteSectionId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Indication whether the tab is in a pop out window
    */
   isMultiWindow?: boolean;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Personal app icon y coordinate position
    */
   appIconPosition?: number;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Source origin from where the tab is opened
    */
   sourceOrigin?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Time when the user clicked on the tab
    */
   userClickTime?: number;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Team Template ID if there was a Team Template associated with the creation of the team.
    */
   teamTemplateId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Where the user prefers the file to be opened from by default during file open
    */
   userFileOpenPreference?: FileOpenPreference;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The address book name of the current user.
    */
   userDisplayName?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * Teamsite ID, aka sharepoint site id.
    */
   teamSiteId?: string;
@@ -564,7 +564,7 @@ export interface DialogInfo {
 export type TaskInfo = DialogInfo;
 
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs.
  * ------
  *
@@ -572,50 +572,50 @@ export type TaskInfo = DialogInfo;
  */
 export interface OpenConversationRequest {
   /**
-   * @privateRemarks
+   * @hidden
    * The Id of the subEntity where the conversation is taking place
    */
   subEntityId: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The title of the conversation
    */
   title: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The Id of the conversation. This is optional and should be specified whenever a previous conversation about a specific sub-entity has already been started before
    */
   conversationId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The Id of the channel. This is optional and should be specified whenever a conversation is started or opened in a personal app scope
    */
   channelId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The entity Id of the tab
    */
   entityId: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * A function that is called once the conversation Id has been created
    */
   onStartConversation?: (conversationResponse: ConversationResponse) => void;
 
   /**
-   * @privateRemarks
+   * @hidden
    * A function that is called if the pane is closed
    */
   onCloseConversation?: (conversationResponse: ConversationResponse) => void;
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs.
  * ------
  *
@@ -623,45 +623,45 @@ export interface OpenConversationRequest {
  */
 export interface ConversationResponse {
   /**
-   * @privateRemarks
+   * @hidden
    * The Id of the subEntity where the conversation is taking place
    */
   subEntityId: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The Id of the conversation. This is optional and should be specified whenever a previous conversation about a specific sub-entity has already been started before
    */
   conversationId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The Id of the channel. This is optional and should be specified whenever a conversation is started or opened in a personal app scope
    */
   channelId?: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The entity Id of the tab
    */
   entityId?: string;
 }
 
 /**
- * @privateRemarks
+ * @hidden
  * Hide from docs.
  *
  * @internal
  */
 export interface LoadContext {
   /**
-   * @privateRemarks
+   * @hidden
    * The entity that is requested to be loaded
    */
   entityId: string;
 
   /**
-   * @privateRemarks
+   * @hidden
    * The content URL that is requested to be loaded
    */
   contentUrl: string;

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -268,7 +268,7 @@ export namespace media {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * --------
    * All properties common to Image and Video Props
@@ -277,21 +277,21 @@ export namespace media {
    */
   interface MediaProps {
     /**
-     * @privateRemarks
+     * @hidden
      * Optional; Lets the developer specify the media source, more than one can be specified.
      * Default value is both camera and gallery
      */
     sources?: Source[];
 
     /**
-     * @privateRemarks
+     * @hidden
      * Optional; Specify in which mode the camera will be opened.
      * Default value is Photo
      */
     startMode?: CameraStartMode;
 
     /**
-     * @privateRemarks
+     * @hidden
      * Optional; indicate if user is allowed to move between front and back camera
      * Default value is true
      */
@@ -322,7 +322,7 @@ export namespace media {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * --------
    * All properties in VideoProps are optional and have default values in the platform
@@ -331,7 +331,7 @@ export namespace media {
    */
   interface VideoProps extends MediaProps {
     /**
-     * @privateRemarks
+     * @hidden
      * Optional; the maximum duration in minutes after which the recording should terminate automatically.
      * Default value is defined by the platform serving the API.
      */

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -14,7 +14,7 @@ import { runtime } from './runtime';
  */
 export namespace meeting {
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * Data structure to represent a meeting details.
    *
@@ -22,23 +22,23 @@ export namespace meeting {
    */
   export interface IMeetingDetails {
     /**
-     * @privateRemarks
+     * @hidden
      * details object
      */
     details: IDetails;
     /**
-     * @privateRemarks
+     * @hidden
      * conversation object
      */
     conversation: IConversation;
     /**
-     * @privateRemarks
+     * @hidden
      * organizer object
      */
     organizer: IOrganizer;
   }
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * Data structure to represent details.
    *
@@ -46,34 +46,34 @@ export namespace meeting {
    */
   export interface IDetails {
     /**
-     * @privateRemarks
+     * @hidden
      * Scheduled start time of the meeting
      */
     scheduledStartTime: string;
     /**
-     * @privateRemarks
+     * @hidden
      * Scheduled end time of the meeting
      */
     scheduledEndTime: string;
     /**
-     * @privateRemarks
+     * @hidden
      * url to join the current meeting
      */
     joinUrl?: string;
     /**
-     * @privateRemarks
+     * @hidden
      * meeting title name of the meeting
      */
     title?: string;
     /**
-     * @privateRemarks
+     * @hidden
      * type of the meeting
      */
     type?: MeetingType;
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * Data structure to represent a conversation object.
    *
@@ -81,14 +81,14 @@ export namespace meeting {
    */
   export interface IConversation {
     /**
-     * @privateRemarks
+     * @hidden
      * conversation id of the meeting
      */
     id: string;
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * Data structure to represent an organizer object.
    *
@@ -96,12 +96,12 @@ export namespace meeting {
    */
   export interface IOrganizer {
     /**
-     * @privateRemarks
+     * @hidden
      * organizer id of the meeting
      */
     id?: string;
     /**
-     * @privateRemarks
+     * @hidden
      * tenant id of the meeting
      */
     tenantId?: string;
@@ -222,7 +222,7 @@ export namespace meeting {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    *
    * Allows an app to get the meeting details for the meeting
@@ -235,7 +235,7 @@ export namespace meeting {
   /**
    * @deprecated with TeamsJS v2 upgrades
    *
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    *
    * Allows an app to get the meeting details for the meeting
@@ -272,7 +272,7 @@ export namespace meeting {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Allows an app to get the authentication token for the anonymous or guest user in the meeting
    *
    * @returns Promise containing the token or rejected promise containing SdkError details
@@ -283,7 +283,7 @@ export namespace meeting {
   /**
    * @deprecated with TeamsJS v2 upgrades
    *
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    *
    * Allows an app to get the authentication token for the anonymous or guest user in the meeting
@@ -381,7 +381,7 @@ export namespace meeting {
   ): Promise<void>;
 
   /**
-   * @privateRemarks
+   * @hidden
    * This function is the overloaded implementation of requestStartLiveStreaming.
    * Since the method signatures of the v1 callback and v2 promise differ in the type of the first parameter,
    * we need to do an extra check to know the typeof the @param1 to set the proper arguments of the utility function.
@@ -489,7 +489,7 @@ export namespace meeting {
   ): void;
 
   /**
-   * @privateRemarks
+   * @hidden
    * This function is the overloaded implementation of shareAppContentToStage.
    * Since the method signatures of the v1 callback and v2 promise differ in the type of the first parameter,
    * we need to do an extra check to know the typeof the @param1 to set the proper arguments of the utility function.
@@ -567,7 +567,7 @@ export namespace meeting {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs.
    * ------------------------------------------
    * Terminates current stage sharing session in meeting
@@ -579,7 +579,7 @@ export namespace meeting {
   /**
    * @deprecated with TeamsJS v2 upgrades
    *
-   * @privateRemarks
+   * @hidden
    * Hide from docs.
    * ------------------------------------------
    * Terminates current stage sharing session in meeting

--- a/packages/teams-js/src/public/monetization.ts
+++ b/packages/teams-js/src/public/monetization.ts
@@ -9,7 +9,7 @@ import { runtime } from './runtime';
  */
 export namespace monetization {
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * Data structure to represent a subscription plan.
    *
@@ -17,19 +17,19 @@ export namespace monetization {
    */
   export interface PlanInfo {
     /**
-     * @privateRemarks
+     * @hidden
      * plan id
      */
     planId: string;
     /**
-     * @privateRemarks
+     * @hidden
      * term of the plan
      */
     term: string;
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Hide from docs
    * Open dialog to start user's purchase experience
    *

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -286,7 +286,7 @@ export namespace pages {
     }
 
     /**
-     * @private
+     * @hidden
      * Hide from docs, since this class is not directly used.
      */
     class SaveEventImpl implements SaveEvent {
@@ -323,7 +323,7 @@ export namespace pages {
     }
 
     /**
-     * @private
+     * @hidden
      * Hide from docs, since this class is not directly used.
      */
     class RemoveEventImpl implements RemoveEvent {
@@ -407,7 +407,7 @@ export namespace pages {
 
   export namespace fullTrust {
     /**
-     * @private
+     * @hidden
      * Hide from docs
      * ------
      * Place the tab into full-screen mode.
@@ -418,7 +418,7 @@ export namespace pages {
     }
 
     /**
-     * @private
+     * @hidden
      * Hide from docs
      * ------
      * Reverts the tab into normal-screen mode.

--- a/packages/teams-js/src/public/people.ts
+++ b/packages/teams-js/src/public/people.ts
@@ -34,7 +34,7 @@ export namespace people {
     peoplePickerInputs?: PeoplePickerInputs,
   ): void;
   /**
-   * @privateRemarks
+   * @hidden
    * This function is the overloaded implementation of selectPeople.
    * Since the method signatures of the v1 callback and v2 promise differ in the type of the first parameter,
    * we need to do an extra check to know the typeof the @param1 to set the proper arguments of the utility function.

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -32,7 +32,7 @@ export function initialize(callback?: () => void, validMessageOrigins?: string[]
 /**
  * @deprecated with Teams JS v2 upgrades
  *
- * @privateRemarks
+ * @hidden
  * Hide from docs.
  * ------
  * Undocumented function used to set a mock window for unit tests
@@ -47,7 +47,7 @@ export function _initialize(hostWindow: any): void {
 /**
  * @deprecated with Teams JS v2 upgrades
  *
- * @privateRemarks
+ * @hidden
  * Hide from docs.
  * ------
  * Undocumented function used to clear state between unit tests
@@ -169,7 +169,7 @@ export function registerBackButtonHandler(handler: () => boolean): void {
 /**
  * @deprecated with Teams JS v2 upgrades
  *
- * @privateRemarks
+ * @hidden
  * Registers a handler to be called when the page has been requested to load.
  *
  * @param handler - The handler to invoke when the page is loaded.
@@ -181,7 +181,7 @@ export function registerOnLoadHandler(handler: (context: LoadContext) => void): 
 /**
  * @deprecated with Teams JS v2 upgrades
  *
- * @privateRemarks
+ * @hidden
  * Registers a handler to be called before the page is unloaded.
  *
  * @param handler - The handler to invoke before the page is unloaded. If this handler returns true the page should
@@ -194,7 +194,7 @@ export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void)
 /**
  * @deprecated with Teams JS v2 upgrades
  *
- * @privateRemarks
+ * @hidden
  * Registers a handler when focus needs to be passed from teams to the place of choice on app.
  *
  * @param handler - The handler to invoked by the app when they want the focus to be in the place of their choice.

--- a/packages/teams-js/src/public/sharing.ts
+++ b/packages/teams-js/src/public/sharing.ts
@@ -46,7 +46,7 @@ export namespace sharing {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Feature is under development
    * Opens a share dialog for web content
    *

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -38,7 +38,7 @@ export namespace teamsCore {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Registers a handler to be called when the page has been requested to load.
    *
    * @param handler - The handler to invoke when the page is loaded.
@@ -51,7 +51,7 @@ export namespace teamsCore {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Registers a handler to be called before the page is unloaded.
    *
    * @param handler - The handler to invoke before the page is unloaded. If this handler returns true the page should
@@ -65,7 +65,7 @@ export namespace teamsCore {
   }
 
   /**
-   * @privateRemarks
+   * @hidden
    * Registers a handler when focus needs to be passed from teams to the place of choice on app.
    *
    * @param handler - The handler to invoked by the app when they want the focus to be in the place of their choice.


### PR DESCRIPTION
Turns out that the @privateRemarks tag is not currently supported by TypeDoc generator used by MS Docs for TypeScript documentation. To suppress comments from publish on docs.microsoft.com, the recommendation is to use @hidden.