### PR TITLE
adding inline-souce-map to make dubgiing easier

### DIFF
--- a/apps/teams-test-app/webpack.config.js
+++ b/apps/teams-test-app/webpack.config.js
@@ -4,6 +4,7 @@ const HtmlWebPackPlugin = require('html-webpack-plugin');
 module.exports = {
   mode: 'production',
   entry: "./src/index.tsx",
+  devtool: 'inline-source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
Currently, we cannot debug source files in orange-hub by inspecting. Adding `devtool: 'inline-source-map',` in webpack in appSDk allows it to do so. 