### PR TITLE
New React components for TestApp with better input validation

### DIFF
--- a/apps/teams-test-app/README.md
+++ b/apps/teams-test-app/README.md
@@ -1,6 +1,6 @@
 # Teams Test App
 
-The Teams Test App is a React app used to test the Teams JavaScript client SDK and Host SDK. It is currently being developed to be used only for this testing and is not meant to serve as official guidance for SDK use for the time being. 
+The Teams Test App is a React app used to test the Teams JavaScript client SDK and Host SDK. It is currently being developed to be used only for this testing and is not meant to serve as official guidance for SDK use for the time being.
 
 ## Getting Started
 
@@ -23,6 +23,41 @@ or if you have already built the Teams JavaScript client SDK and would like to b
 
 ## Troubleshooting
 
-* If you see a directory view of some files after starting the app rather than the test app itself (which should simply be some boxes and buttons), please try removing all three node_modules folders from the repo (you can utilize our yarn clean:all command at the monorepo root) then redoing the yarn commands above.
+- If you see a directory view of some files after starting the app rather than the test app itself (which should simply be some boxes and buttons), please try removing all three node_modules folders from the repo (you can utilize our yarn clean:all command at the monorepo root) then redoing the yarn commands above.
 
-* Due to Windows loopback security features, you may see a warning from your browser when running the test app saying that your connection is not private. Click Advanced -> Continue to localhost to proceed to the app.
+- Due to Windows loopback security features, you may see a warning from your browser when running the test app saying that your connection is not private. Click Advanced -> Continue to localhost to proceed to the app.
+
+## Contributing
+
+### API Utility Components
+
+There's a set of helper React Components that can be used to add support to new APIs into the Test App.
+They are meant to keep the UI and generated HTML to be consistent, to allow for E2E scenario tests to be written against it.
+
+#### `ApiWithoutInput`
+
+Should be used to add support for an API which does not require any user input, e.g. `app.getContext()`.
+
+#### `ApiWithCheckboxInput`
+
+Should be used to add support for an API which requires a `true`/`false` input, e.g. `pages.returnFocus(navigateForward?: boolean)`.
+
+#### `ApiWithTextInput`
+
+Should be used to add support for an API which requires a more complex input, e.g. `calendar.composeMeeting(composeMeetingParams: ComposeMeetingParams)`.
+
+There are two possible ways to leverage `ApiWithTextInput` component:
+
+- APIs for which the input has no required properties and no validation is needed, a simple `onClick` callback can be provided.
+  In this case `ApiWithTextInput` will attempt to parse the input as JSON and call the provided callback.
+
+- For all other APIs `onClick` required two callbacks to be provided: `validateInput` and `submit`.
+  `ApiWithTextInput` component will attempt to parse the input as JSON and call `validateInput` to allow for input validation.
+  The validation function should throw an exception when the input requirements are not satisfied (e.g. a required property in not present).
+  If validation fails, the error will be shown in the Test App.
+  If validation passes, `submit` will be called.
+
+### Capability section
+
+For each capability a separate section should be added, which should consist of a header and a collection of the utility components described above.
+That section should be added in a separate file undef src\components, and referenced in the top-level `<App />` component.

--- a/apps/teams-test-app/src/components/AppAPIs.tsx
+++ b/apps/teams-test-app/src/components/AppAPIs.tsx
@@ -7,8 +7,8 @@ import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const GetContext = (): ReactElement =>
   ApiWithoutInput({
-    title: 'Get Context',
     name: 'getContextV2',
+    title: 'Get Context',
     onClick: async () => {
       const context = await app.getContext();
       return JSON.stringify(context);
@@ -17,8 +17,8 @@ const GetContext = (): ReactElement =>
 
 const ExecuteDeepLink = (): ReactElement =>
   ApiWithTextInput<string>({
-    title: 'Execute Deep Link',
     name: 'executeDeepLink2',
+    title: 'Execute Deep Link',
     onClick: {
       validateInput: input => {
         if (typeof input !== 'string') {
@@ -34,8 +34,8 @@ const ExecuteDeepLink = (): ReactElement =>
 
 const ShareDeepLink = (): ReactElement =>
   ApiWithTextInput<DeepLinkParameters>({
-    title: 'core.shareDeepLink',
     name: 'core.shareDeepLink',
+    title: 'core.shareDeepLink',
     onClick: {
       validateInput: input => {
         if (!input.subEntityId || !input.subEntityLabel) {

--- a/apps/teams-test-app/src/components/AppAPIs.tsx
+++ b/apps/teams-test-app/src/components/AppAPIs.tsx
@@ -3,12 +3,23 @@ import React, { ReactElement } from 'react';
 
 import { noHostSdkMsg } from '../App';
 import BoxAndButton from './BoxAndButton';
+import { ApiWithoutInput } from './utils/ApiWithoutInput';
+
+const RegisterOnThemeChangeHandler = (): ReactElement => (
+  <ApiWithoutInput
+    name="registerOnThemeChangeHandler"
+    title="Register On Theme Change Handler"
+    onClick={setResult => {
+      app.registerOnThemeChangeHandler(setResult);
+      return '';
+    }}
+  />
+);
 
 const AppAPIs = (): ReactElement => {
   const [getContextV2Res, setGetContextV2Res] = React.useState('');
   const [executeDeepLinkRes, setExecuteDeepLinkRes] = React.useState('');
   const [shareDeepLinkRes, setShareDeepLinkRes] = React.useState('');
-  const [registerOnThemeChangeHandlerRes, setRegisterOnThemeChangeHandlerRes] = React.useState('');
 
   const getContextV2 = (): void => {
     setGetContextV2Res('app.getContext()' + noHostSdkMsg);
@@ -29,12 +40,6 @@ const AppAPIs = (): ReactElement => {
     const deepLinkParams: DeepLinkParameters = JSON.parse(deepLinkParamsInput);
     core.shareDeepLink(deepLinkParams);
     setShareDeepLinkRes('called shareDeepLink.');
-  };
-
-  const registerOnThemeChangeHandler = (): void => {
-    app.registerOnThemeChangeHandler((theme: string) => {
-      setRegisterOnThemeChangeHandlerRes(theme);
-    });
   };
 
   return (
@@ -61,13 +66,7 @@ const AppAPIs = (): ReactElement => {
         title="core.shareDeepLink"
         name="core.shareDeepLink"
       />
-      <BoxAndButton
-        handleClick={registerOnThemeChangeHandler}
-        output={registerOnThemeChangeHandlerRes}
-        hasInput={false}
-        title="Register On Theme Change Handler"
-        name="registerOnThemeChangeHandler"
-      />
+      <RegisterOnThemeChangeHandler />
     </>
   );
 };

--- a/apps/teams-test-app/src/components/AppAPIs.tsx
+++ b/apps/teams-test-app/src/components/AppAPIs.tsx
@@ -1,6 +1,8 @@
 import { app, core, DeepLinkParameters } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
+import { noHostSdkMsg } from '../App';
+import BoxAndButton from './BoxAndButton';
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const GetContext = (): ReactElement =>
@@ -16,7 +18,7 @@ const GetContext = (): ReactElement =>
 const ExecuteDeepLink = (): ReactElement =>
   ApiWithTextInput<string>({
     title: 'Execute Deep Link',
-    name: 'executeDeepLink',
+    name: 'executeDeepLink2',
     onClick: {
       validateInput: input => {
         if (typeof input !== 'string') {
@@ -57,14 +59,36 @@ const RegisterOnThemeChangeHandler = (): ReactElement =>
     },
   });
 
-const AppAPIs = (): ReactElement => (
-  <>
-    <h1>app</h1>
-    <GetContext />
-    <ExecuteDeepLink />
-    <ShareDeepLink />
-    <RegisterOnThemeChangeHandler />
-  </>
-);
+const AppAPIs = (): ReactElement => {
+  // TODO: Remove once E2E scenario tests are updated to use the new version
+  const [executeDeepLinkRes, setExecuteDeepLinkRes] = React.useState('');
+
+  // TODO: Remove once E2E scenario tests are updated to use the new version
+  const executeDeepLink = (deepLink: string): void => {
+    setExecuteDeepLinkRes('core.executeDeepLink()' + noHostSdkMsg);
+    core
+      .executeDeepLink(deepLink)
+      .then(() => setExecuteDeepLinkRes('Completed'))
+      .catch(reason => setExecuteDeepLinkRes(reason));
+  };
+
+  return (
+    <>
+      <h1>app</h1>
+      <GetContext />
+      {/* TODO: Remove once E2E scenario tests are updated to use the new version */}
+      <BoxAndButton
+        handleClickWithInput={executeDeepLink}
+        output={executeDeepLinkRes}
+        hasInput={true}
+        title="Execute Deep Link"
+        name="executeDeepLink"
+      />
+      <ExecuteDeepLink />
+      <ShareDeepLink />
+      <RegisterOnThemeChangeHandler />
+    </>
+  );
+};
 
 export default AppAPIs;

--- a/apps/teams-test-app/src/components/AppAPIs.tsx
+++ b/apps/teams-test-app/src/components/AppAPIs.tsx
@@ -1,74 +1,70 @@
 import { app, core, DeepLinkParameters } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import { noHostSdkMsg } from '../App';
-import BoxAndButton from './BoxAndButton';
-import { ApiWithoutInput } from './utils/ApiWithoutInput';
+import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
-const RegisterOnThemeChangeHandler = (): ReactElement => (
-  <ApiWithoutInput
-    name="registerOnThemeChangeHandler"
-    title="Register On Theme Change Handler"
-    onClick={setResult => {
+const GetContext = (): ReactElement =>
+  ApiWithoutInput({
+    title: 'Get Context',
+    name: 'getContextV2',
+    onClick: async () => {
+      const context = await app.getContext();
+      return JSON.stringify(context);
+    },
+  });
+
+const ExecuteDeepLink = (): ReactElement =>
+  ApiWithTextInput<string>({
+    title: 'Execute Deep Link',
+    name: 'executeDeepLink',
+    onClick: {
+      validateInput: input => {
+        if (typeof input !== 'string') {
+          throw new Error('Input should be a string');
+        }
+      },
+      submit: async input => {
+        await core.executeDeepLink(input);
+        return 'Completed';
+      },
+    },
+  });
+
+const ShareDeepLink = (): ReactElement =>
+  ApiWithTextInput<DeepLinkParameters>({
+    title: 'core.shareDeepLink',
+    name: 'core.shareDeepLink',
+    onClick: {
+      validateInput: input => {
+        if (!input.subEntityId || !input.subEntityLabel) {
+          throw new Error('subEntityId and subEntityLabel are required.');
+        }
+      },
+      submit: async input => {
+        await core.shareDeepLink(input);
+        return 'called shareDeepLink';
+      },
+    },
+  });
+
+const RegisterOnThemeChangeHandler = (): ReactElement =>
+  ApiWithoutInput({
+    name: 'registerOnThemeChangeHandler',
+    title: 'Register On Theme Change Handler',
+    onClick: async setResult => {
       app.registerOnThemeChangeHandler(setResult);
       return '';
-    }}
-  />
+    },
+  });
+
+const AppAPIs = (): ReactElement => (
+  <>
+    <h1>app</h1>
+    <GetContext />
+    <ExecuteDeepLink />
+    <ShareDeepLink />
+    <RegisterOnThemeChangeHandler />
+  </>
 );
-
-const AppAPIs = (): ReactElement => {
-  const [getContextV2Res, setGetContextV2Res] = React.useState('');
-  const [executeDeepLinkRes, setExecuteDeepLinkRes] = React.useState('');
-  const [shareDeepLinkRes, setShareDeepLinkRes] = React.useState('');
-
-  const getContextV2 = (): void => {
-    setGetContextV2Res('app.getContext()' + noHostSdkMsg);
-    app.getContext().then((res: app.Context) => {
-      setGetContextV2Res(JSON.stringify(res));
-    });
-  };
-
-  const executeDeepLink = (deepLink: string): void => {
-    setExecuteDeepLinkRes('core.executeDeepLink()' + noHostSdkMsg);
-    core
-      .executeDeepLink(deepLink)
-      .then(() => setExecuteDeepLinkRes('Completed'))
-      .catch(reason => setExecuteDeepLinkRes(reason));
-  };
-
-  const shareDeepLink = (deepLinkParamsInput: string): void => {
-    const deepLinkParams: DeepLinkParameters = JSON.parse(deepLinkParamsInput);
-    core.shareDeepLink(deepLinkParams);
-    setShareDeepLinkRes('called shareDeepLink.');
-  };
-
-  return (
-    <>
-      <h1>app</h1>
-      <BoxAndButton
-        handleClick={getContextV2}
-        output={getContextV2Res}
-        hasInput={false}
-        title="Get Context"
-        name="getContextV2"
-      />
-      <BoxAndButton
-        handleClickWithInput={executeDeepLink}
-        output={executeDeepLinkRes}
-        hasInput={true}
-        title="Execute Deep Link"
-        name="executeDeepLink"
-      />
-      <BoxAndButton
-        handleClickWithInput={shareDeepLink}
-        output={shareDeepLinkRes}
-        hasInput={true}
-        title="core.shareDeepLink"
-        name="core.shareDeepLink"
-      />
-      <RegisterOnThemeChangeHandler />
-    </>
-  );
-};
 
 export default AppAPIs;

--- a/apps/teams-test-app/src/components/CalendarAPIs.tsx
+++ b/apps/teams-test-app/src/components/CalendarAPIs.tsx
@@ -1,14 +1,13 @@
 import { calendar } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import { ApiWithoutInput } from './utils/ApiWithoutInput';
-import { ApiWithTextInput } from './utils/ApiWithTextInput';
+import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const CheckCalendarCapability = (): React.ReactElement =>
   ApiWithoutInput({
     name: 'checkCapabilityCalendar',
     title: 'Check Calendar Capability',
-    onClick: () => `Calendar module ${calendar.isSupported() ? 'is' : 'is not'} supported`,
+    onClick: async () => `Calendar module ${calendar.isSupported() ? 'is' : 'is not'} supported`,
   });
 
 const ComposeMeeting = (): React.ReactElement =>

--- a/apps/teams-test-app/src/components/CalendarAPIs.tsx
+++ b/apps/teams-test-app/src/components/CalendarAPIs.tsx
@@ -1,11 +1,12 @@
 import { calendar } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
+import BoxAndButton from './BoxAndButton';
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const CheckCalendarCapability = (): React.ReactElement =>
   ApiWithoutInput({
-    name: 'checkCapabilityCalendar',
+    name: 'checkCalendarCapability',
     title: 'Check Calendar Capability',
     onClick: async () => `Calendar module ${calendar.isSupported() ? 'is' : 'is not'} supported`,
   });
@@ -37,13 +38,35 @@ const OpenCalendarItem = (): React.ReactElement =>
     },
   });
 
-const CalendarAPIs = (): ReactElement => (
-  <>
-    <h1>calendar</h1>
-    <CheckCalendarCapability />
-    <ComposeMeeting />
-    <OpenCalendarItem />
-  </>
-);
+const CalendarAPIs = (): ReactElement => {
+  // TODO: Remove once E2E scenario tests are updated to use the new version
+  const [capabilityCheckRes, setCapabilityCheckRes] = React.useState('');
+
+  // TODO: Remove once E2E scenario tests are updated to use the new version
+  const checkCalendarCapability = (): void => {
+    if (calendar.isSupported()) {
+      setCapabilityCheckRes('Calendar module is supported');
+    } else {
+      setCapabilityCheckRes('Calendar module is not supported');
+    }
+  };
+
+  return (
+    <>
+      <h1>calendar</h1>
+      {/* TODO: Remove once E2E scenario tests are updated to use the new version */}
+      <BoxAndButton
+        handleClick={checkCalendarCapability}
+        output={capabilityCheckRes}
+        hasInput={false}
+        title="Check Capability Calendar"
+        name="checkCapabilityCalendar"
+      />
+      <CheckCalendarCapability />
+      <ComposeMeeting />
+      <OpenCalendarItem />
+    </>
+  );
+};
 
 export default CalendarAPIs;

--- a/apps/teams-test-app/src/components/CalendarAPIs.tsx
+++ b/apps/teams-test-app/src/components/CalendarAPIs.tsx
@@ -1,64 +1,50 @@
 import { calendar } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import { noHostSdkMsg } from '../App';
-import BoxAndButton from './BoxAndButton';
+import { ApiWithoutInput } from './utils/ApiWithoutInput';
+import { ApiWithTextInput } from './utils/ApiWithTextInput';
 
-const CalendarAPIs = (): ReactElement => {
-  const [capabilityCheckRes, setCapabilityCheckRes] = React.useState('');
-  const [composeMeetingRes, setComposeMeetingRes] = React.useState('');
-  const [openCalendarItemRes, setOpenCalendarItemRes] = React.useState('');
+const CheckCalendarCapability = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'checkCapabilityCalendar',
+    title: 'Check Calendar Capability',
+    onClick: () => `Calendar module ${calendar.isSupported() ? 'is' : 'is not'} supported`,
+  });
 
-  const composeMeeting = (meetingParams: string): void => {
-    setComposeMeetingRes('calendar.composeMeeting()' + noHostSdkMsg);
-    calendar
-      .composeMeeting(JSON.parse(meetingParams))
-      .then(() => setComposeMeetingRes('Completed'))
-      .catch(reason => setComposeMeetingRes(reason));
-  };
+const ComposeMeeting = (): React.ReactElement =>
+  ApiWithTextInput<calendar.ComposeMeetingParams>({
+    name: 'composeMeeting',
+    title: 'Compose Meeting',
+    onClick: async input => {
+      await calendar.composeMeeting(input);
+      return 'Completed';
+    },
+  });
 
-  const openCalendarItem = (calendarParams: string): void => {
-    setOpenCalendarItemRes('calendar.openCalendarItem()' + noHostSdkMsg);
-    calendar
-      .openCalendarItem(JSON.parse(calendarParams))
-      .then(() => setOpenCalendarItemRes('Completed'))
-      .catch(reason => setOpenCalendarItemRes(reason));
-  };
+const OpenCalendarItem = (): React.ReactElement =>
+  ApiWithTextInput<calendar.OpenCalendarItemParams>({
+    name: 'openCalendarItem',
+    title: 'Open CalendarItem',
+    onClick: {
+      submit: async input => {
+        await calendar.openCalendarItem(input);
+        return 'Completed';
+      },
+      validateInput: x => {
+        if (!x.itemId) {
+          throw 'itemId is required';
+        }
+      },
+    },
+  });
 
-  const checkCalendarCapability = (): void => {
-    if (calendar.isSupported()) {
-      setCapabilityCheckRes('Calendar module is supported');
-    } else {
-      setCapabilityCheckRes('Calendar module is not supported');
-    }
-  };
-
-  return (
-    <>
-      <h1>calendar</h1>
-      <BoxAndButton
-        handleClick={checkCalendarCapability}
-        output={capabilityCheckRes}
-        hasInput={false}
-        title="Check Capability Calendar"
-        name="checkCapabilityCalendar"
-      />
-      <BoxAndButton
-        handleClickWithInput={openCalendarItem}
-        output={openCalendarItemRes}
-        hasInput={true}
-        title="Open Calendar Item"
-        name="openCalendarItem"
-      />
-      <BoxAndButton
-        handleClickWithInput={composeMeeting}
-        output={composeMeetingRes}
-        hasInput={true}
-        title="Compose Meeting"
-        name="composeMeeting"
-      />
-    </>
-  );
-};
+const CalendarAPIs = (): ReactElement => (
+  <>
+    <h1>calendar</h1>
+    <CheckCalendarCapability />
+    <ComposeMeeting />
+    <OpenCalendarItem />
+  </>
+);
 
 export default CalendarAPIs;

--- a/apps/teams-test-app/src/components/utils/ApiContainer.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiContainer.tsx
@@ -9,6 +9,10 @@ export interface ApiContainerProps {
 export const ApiContainer = (props: React.PropsWithChildren<ApiContainerProps>): React.ReactElement => {
   const { children, name, result } = props;
 
+  if (!name || !/^[a-zA-Z0-9]+$/.test(name)) {
+    throw new Error('name has to be set and it can only contain alphanumeric characters.');
+  }
+
   return (
     <div
       className="boxAndButton"

--- a/apps/teams-test-app/src/components/utils/ApiContainer.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiContainer.tsx
@@ -9,7 +9,7 @@ export interface ApiContainerProps {
 export const ApiContainer = (props: React.PropsWithChildren<ApiContainerProps>): React.ReactElement => {
   const { children, name, result } = props;
 
-  if (!name || !/^[a-zA-Z0-9]+$/.test(name)) {
+  if (!name || !/^[a-zA-Z0-9.]+$/.test(name)) {
     throw new Error('name has to be set and it can only contain alphanumeric characters.');
   }
 

--- a/apps/teams-test-app/src/components/utils/ApiContainer.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiContainer.tsx
@@ -10,7 +10,7 @@ export const ApiContainer = (props: React.PropsWithChildren<ApiContainerProps>):
   const { children, name, result } = props;
 
   if (!name || !/^[a-zA-Z0-9.]+$/.test(name)) {
-    throw new Error('name has to be set and it can only contain alphanumeric characters.');
+    throw new Error('name has to be set and it can only contain alphanumeric characters and dots.');
   }
 
   return (

--- a/apps/teams-test-app/src/components/utils/ApiContainer.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiContainer.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+export interface ApiContainerProps {
+  title: string;
+  name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
+  result?: string;
+}
+
+export const ApiContainer = (props: React.PropsWithChildren<ApiContainerProps>): React.ReactElement => {
+  const { children, name, result } = props;
+
+  return (
+    <div
+      className="boxAndButton"
+      style={{
+        display: 'inline-block',
+        height: 200,
+        width: 400,
+        border: '5px solid black',
+        textAlign: 'center',
+      }}
+      id={`box_${name}`}
+    >
+      {children}
+      <div
+        className="box"
+        style={{
+          border: '2px solid red',
+          height: 150,
+          width: 400,
+          overflow: 'auto',
+        }}
+      >
+        <span id={`text_${name}`} style={{ wordWrap: 'break-word' }}>
+          {result}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/apps/teams-test-app/src/components/utils/ApiWithCheckboxInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithCheckboxInput.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+
+import { noHostSdkMsg } from '../../App';
+
+export interface ApiWithCheckboxInputProps {
+  title: string;
+  name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
+  label: string;
+  onClick: (input: boolean) => Promise<string>;
+  defaultCheckboxState?: boolean;
+}
+
+export const ApiWithCheckboxInput = (props: ApiWithCheckboxInputProps): React.ReactElement => {
+  const { name, defaultCheckboxState = false, label, onClick, title } = props;
+  const [result, setResult] = React.useState('');
+  const [value, setValue] = React.useState(defaultCheckboxState);
+
+  const onClickCallback = React.useCallback(async () => {
+    setResult(noHostSdkMsg);
+
+    try {
+      const result = await onClick(value);
+      setResult(result);
+    } catch (err) {
+      setResult('Error: ' + err);
+    }
+  }, [value, setResult, onClick]);
+
+  return (
+    <div
+      className="boxAndButton"
+      style={{
+        display: 'inline-block',
+        height: 200,
+        width: 400,
+        border: '5px solid black',
+        textAlign: 'center',
+      }}
+      id={`box_${name}`}
+    >
+      <input name={`button_${name}`} type="button" value={title} onClick={onClickCallback} />
+      {label}
+      <input type="checkbox" name={label} onChange={e => setValue(e.target.checked)} />
+      <div
+        className="box"
+        style={{
+          border: '2px solid red',
+          height: 150,
+          width: 400,
+          overflow: 'auto',
+        }}
+      >
+        <span id={`text_${name}`} style={{ wordWrap: 'break-word' }}>
+          {result}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/apps/teams-test-app/src/components/utils/ApiWithCheckboxInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithCheckboxInput.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { noHostSdkMsg } from '../../App';
+import { ApiContainer } from './ApiContainer';
 
 export interface ApiWithCheckboxInputProps {
   title: string;
@@ -27,33 +28,10 @@ export const ApiWithCheckboxInput = (props: ApiWithCheckboxInputProps): React.Re
   }, [value, setResult, onClick]);
 
   return (
-    <div
-      className="boxAndButton"
-      style={{
-        display: 'inline-block',
-        height: 200,
-        width: 400,
-        border: '5px solid black',
-        textAlign: 'center',
-      }}
-      id={`box_${name}`}
-    >
+    <ApiContainer title={title} result={result} name={name}>
       <input name={`button_${name}`} type="button" value={title} onClick={onClickCallback} />
       {label}
       <input type="checkbox" name={label} onChange={e => setValue(e.target.checked)} />
-      <div
-        className="box"
-        style={{
-          border: '2px solid red',
-          height: 150,
-          width: 400,
-          overflow: 'auto',
-        }}
-      >
-        <span id={`text_${name}`} style={{ wordWrap: 'break-word' }}>
-          {result}
-        </span>
-      </div>
-    </div>
+    </ApiContainer>
   );
 };

--- a/apps/teams-test-app/src/components/utils/ApiWithTextInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithTextInput.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+
+import { noHostSdkMsg } from '../../App';
+
+export interface ApiWithTextInputProps<T> {
+  title: string;
+  name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
+  onClick:
+    | ((input: Partial<T>) => Promise<string>)
+    | {
+        validateInput: (input: Partial<T>) => void;
+        submit: (input: T) => Promise<string>;
+      };
+  defaultInput?: string;
+}
+
+export const ApiWithTextInput = <T extends unknown>(props: ApiWithTextInputProps<T>): React.ReactElement => {
+  const { name, defaultInput, onClick, title } = props;
+  const [result, setResult] = React.useState('');
+  const [input, setInput] = React.useState(defaultInput);
+
+  const onClickCallback = React.useCallback(async () => {
+    if (!input) {
+      return;
+    }
+
+    setResult(noHostSdkMsg);
+    try {
+      const partialInput = JSON.parse(input) as Partial<T>;
+      if (typeof onClick === 'function') {
+        const result = await onClick(partialInput);
+        setResult(result);
+      } else {
+        const { validateInput, submit } = onClick;
+        validateInput(partialInput);
+        const result = await submit(partialInput as T);
+        setResult(result);
+      }
+    } catch (err) {
+      setResult('Error: ' + err);
+    }
+  }, [input, setResult, onClick]);
+
+  return (
+    <div
+      className="boxAndButton"
+      style={{
+        display: 'inline-block',
+        height: 200,
+        width: 400,
+        border: '5px solid black',
+        textAlign: 'center',
+      }}
+      id={`box_${name}`}
+    >
+      <input type="text" name={`input_${name}`} value={input} onChange={e => setInput(e.target.value)} />
+      <input name={`button_${name}`} type="button" value={title} onClick={onClickCallback} />
+      <div
+        className="box"
+        style={{
+          border: '2px solid red',
+          height: 150,
+          width: 400,
+          overflow: 'auto',
+        }}
+      >
+        <span id={`text_${name}`} style={{ wordWrap: 'break-word' }}>
+          {result}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/apps/teams-test-app/src/components/utils/ApiWithTextInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithTextInput.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { noHostSdkMsg } from '../../App';
+import { ApiContainer } from './ApiContainer';
 
 export interface ApiWithTextInputProps<T> {
   title: string;
@@ -42,32 +43,9 @@ export const ApiWithTextInput = <T extends unknown>(props: ApiWithTextInputProps
   }, [input, setResult, onClick]);
 
   return (
-    <div
-      className="boxAndButton"
-      style={{
-        display: 'inline-block',
-        height: 200,
-        width: 400,
-        border: '5px solid black',
-        textAlign: 'center',
-      }}
-      id={`box_${name}`}
-    >
+    <ApiContainer title={title} result={result} name={name}>
       <input type="text" name={`input_${name}`} value={input} onChange={e => setInput(e.target.value)} />
       <input name={`button_${name}`} type="button" value={title} onClick={onClickCallback} />
-      <div
-        className="box"
-        style={{
-          border: '2px solid red',
-          height: 150,
-          width: 400,
-          overflow: 'auto',
-        }}
-      >
-        <span id={`text_${name}`} style={{ wordWrap: 'break-word' }}>
-          {result}
-        </span>
-      </div>
-    </div>
+    </ApiContainer>
   );
 };

--- a/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 export interface ApiWithoutInputProps {
   title: string;
   name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
-  onClick: () => string;
+  onClick: (setResult: (result: string) => void) => string;
 }
 
 export const ApiWithoutInput = (props: ApiWithoutInputProps): React.ReactElement => {
@@ -22,7 +22,7 @@ export const ApiWithoutInput = (props: ApiWithoutInputProps): React.ReactElement
       }}
       id={`box_${name}`}
     >
-      <input name={`button_${name}`} type="button" value={title} onClick={() => setResult(onClick())} />
+      <input name={`button_${name}`} type="button" value={title} onClick={() => setResult(onClick(setResult))} />
       <div
         className="box"
         style={{

--- a/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
+import { ApiContainer } from './ApiContainer';
 
 export interface ApiWithoutInputProps {
   title: string;
   name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
-  onClick: (setResult: (result: string) => void) => string;
+  onClick: (setResult: (result: string) => void) => Promise<string>;
 }
 
 export const ApiWithoutInput = (props: ApiWithoutInputProps): React.ReactElement => {
@@ -11,31 +12,13 @@ export const ApiWithoutInput = (props: ApiWithoutInputProps): React.ReactElement
   const [result, setResult] = React.useState('');
 
   return (
-    <div
-      className="boxAndButton"
-      style={{
-        display: 'inline-block',
-        height: 200,
-        width: 400,
-        border: '5px solid black',
-        textAlign: 'center',
-      }}
-      id={`box_${name}`}
-    >
-      <input name={`button_${name}`} type="button" value={title} onClick={() => setResult(onClick(setResult))} />
-      <div
-        className="box"
-        style={{
-          border: '2px solid red',
-          height: 150,
-          width: 400,
-          overflow: 'auto',
-        }}
-      >
-        <span id={`text_${name}`} style={{ wordWrap: 'break-word' }}>
-          {result}
-        </span>
-      </div>
-    </div>
+    <ApiContainer title={title} result={result} name={name}>
+      <input
+        name={`button_${name}`}
+        type="button"
+        value={title}
+        onClick={async () => setResult(await onClick(setResult))}
+      />
+    </ApiContainer>
   );
 };

--- a/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+export interface ApiWithoutInputProps {
+  title: string;
+  name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
+  onClick: () => string;
+}
+
+export const ApiWithoutInput = (props: ApiWithoutInputProps): React.ReactElement => {
+  const { name, onClick, title } = props;
+  const [result, setResult] = React.useState('');
+
+  return (
+    <div
+      className="boxAndButton"
+      style={{
+        display: 'inline-block',
+        height: 200,
+        width: 400,
+        border: '5px solid black',
+        textAlign: 'center',
+      }}
+      id={`box_${name}`}
+    >
+      <input name={`button_${name}`} type="button" value={title} onClick={() => setResult(onClick())} />
+      <div
+        className="box"
+        style={{
+          border: '2px solid red',
+          height: 150,
+          width: 400,
+          overflow: 'auto',
+        }}
+      >
+        <span id={`text_${name}`} style={{ wordWrap: 'break-word' }}>
+          {result}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import { ApiContainer } from './ApiContainer';
 
 export interface ApiWithoutInputProps {

--- a/apps/teams-test-app/src/components/utils/index.ts
+++ b/apps/teams-test-app/src/components/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './ApiWithCheckboxInput';
+export * from './ApiWithTextInput';
+export * from './ApiWithoutInput';


### PR DESCRIPTION
This PR adds a new set of utility React Components which should be used to add API support to Test App. These Components contain a bunch of shared logic around input parsing and handling. It also allows for better validation of said input using TypeScript's type system. This way a lot more errors we've seen only at runtime would show at compile time.

I also added a *Contributing* section in Readme which has a bit of information on how these should be used.


~Things I'd still like to do:~
 - ~move some of the shared HTML elements to a base component to make sure they stay consistent no matter what kind of input is expected for the API~
 - ~E2E scenario test validation~
 - ~documentation on how to use these when adding new API support to Test App~