### PR TITLE
Build pipeline yaml syntax correction

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,7 @@ steps:
   - task: PublishBuildArtifacts@1
     condition: and(
       in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-      ne(variables['Build.Reason'], 'PullRequest')
+      ne(variables['Build.Reason'], 'PullRequest'))
     inputs:
       PathtoPublish: './common/temp/bundleAnalysis'
       ArtifactName: '$(bundleArtifactName)'


### PR DESCRIPTION
Pipeline failed due to incorrect syntax of yaml. Did a no-brainer merge when saw all green.
Erin has updated policies and included our pipelines to check on every PR. Thank you Erin.