### PR TITLE
Include expected FrameContext in error message from ensureInitialized

### DIFF
--- a/packages/teams-js/src/internal/internalAPIs.ts
+++ b/packages/teams-js/src/internal/internalAPIs.ts
@@ -18,7 +18,10 @@ export function ensureInitialized(...expectedFrameContexts: string[]): void {
     }
 
     if (!found) {
-      throw new Error("This call is not allowed in the '" + GlobalVars.frameContext + "' context");
+      throw new Error(
+        `This call is only allowed in following contexts: ${JSON.stringify(expectedFrameContexts)}. ` +
+          `Current context: "${GlobalVars.frameContext}".`,
+      );
     }
   }
 }

--- a/packages/teams-js/test/private/chat.spec.ts
+++ b/packages/teams-js/test/private/chat.spec.ts
@@ -42,7 +42,7 @@ describe('chat', () => {
         entityId: 'someEntityId',
       };
       return expect(chat.openConversation(conversationRequest)).rejects.toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 
@@ -100,7 +100,9 @@ describe('chat', () => {
 
     it('should not allow calls from settings context', async () => {
       await utils.initializeWithContext('settings');
-      expect(() => chat.closeConversation()).toThrowError("This call is not allowed in the 'settings' context");
+      expect(() => chat.closeConversation()).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
+      );
     });
   });
 

--- a/packages/teams-js/test/private/files.spec.ts
+++ b/packages/teams-js/test/private/files.spec.ts
@@ -214,7 +214,9 @@ describe('files', () => {
       await utils.initializeWithContext('settings');
       return expect(
         files.getCloudStorageFolderContents(mockCloudStorageFolder, files.CloudStorageProvider.Box),
-      ).rejects.toThrowError("This call is not allowed in the 'settings' context");
+      ).rejects.toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
+      );
     });
 
     it('should not allow calls with null folder', async () => {
@@ -287,7 +289,7 @@ describe('files', () => {
     it('should not allow calls without frame context initialization', async () => {
       await utils.initializeWithContext('settings');
       expect(() => files.openCloudStorageFile(mockCloudStorageFolderItem, files.CloudStorageProvider.Box)).toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 

--- a/packages/teams-js/test/private/files.spec.ts
+++ b/packages/teams-js/test/private/files.spec.ts
@@ -35,7 +35,7 @@ describe('files', () => {
     it('should not allow calls without frame context initialization', async () => {
       await utils.initializeWithContext('settings');
       expect(files.getCloudStorageFolders('channelId')).rejects.toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 
@@ -84,7 +84,7 @@ describe('files', () => {
     it('should not allow calls without frame context initialization', async () => {
       await utils.initializeWithContext('settings');
       expect(files.addCloudStorageFolder('channelId')).rejects.toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 
@@ -142,7 +142,7 @@ describe('files', () => {
     it('should not allow calls without frame context initialization', async () => {
       await utils.initializeWithContext('settings');
       expect(files.deleteCloudStorageFolder('channelId', mockCloudStorageFolder)).rejects.toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 

--- a/packages/teams-js/test/private/pages.spec.ts
+++ b/packages/teams-js/test/private/pages.spec.ts
@@ -32,7 +32,7 @@ describe('AppSDK-TeamsAPIs', () => {
       await utils.initializeWithContext('settings');
 
       expect(() => pages.fullTrust.enterFullscreen()).toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 
@@ -40,20 +40,24 @@ describe('AppSDK-TeamsAPIs', () => {
       await utils.initializeWithContext('authentication');
 
       expect(() => pages.fullTrust.enterFullscreen()).toThrowError(
-        "This call is not allowed in the 'authentication' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "authentication".',
       );
     });
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
 
-      expect(() => pages.fullTrust.enterFullscreen()).toThrowError("This call is not allowed in the 'remove' context");
+      expect(() => pages.fullTrust.enterFullscreen()).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "remove".',
+      );
     });
 
     it('should not allow calls from task context', async () => {
       await utils.initializeWithContext('task');
 
-      expect(() => pages.fullTrust.enterFullscreen()).toThrowError("This call is not allowed in the 'task' context");
+      expect(() => pages.fullTrust.enterFullscreen()).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "task".',
+      );
     });
 
     it('should successfully enter fullscreen', async () => {
@@ -74,27 +78,33 @@ describe('AppSDK-TeamsAPIs', () => {
     it('should not allow calls from settings context', async () => {
       await utils.initializeWithContext('settings');
 
-      expect(() => pages.fullTrust.exitFullscreen()).toThrowError("This call is not allowed in the 'settings' context");
+      expect(() => pages.fullTrust.exitFullscreen()).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
+      );
     });
 
     it('should not allow calls from authentication context', async () => {
       await utils.initializeWithContext('authentication');
 
       expect(() => pages.fullTrust.exitFullscreen()).toThrowError(
-        "This call is not allowed in the 'authentication' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "authentication".',
       );
     });
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
 
-      expect(() => pages.fullTrust.exitFullscreen()).toThrowError("This call is not allowed in the 'remove' context");
+      expect(() => pages.fullTrust.exitFullscreen()).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "remove".',
+      );
     });
 
     it('should not allow calls from task context', async () => {
       await utils.initializeWithContext('task');
 
-      expect(() => pages.fullTrust.exitFullscreen()).toThrowError("This call is not allowed in the 'task' context");
+      expect(() => pages.fullTrust.exitFullscreen()).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "task".',
+      );
     });
 
     it('should successfully exit fullscreen', async () => {

--- a/packages/teams-js/test/private/teams.spec.ts
+++ b/packages/teams-js/test/private/teams.spec.ts
@@ -35,7 +35,7 @@ describe('AppSDK-privateAPIs', () => {
     it('should not allow calls without frame context initialization', async () => {
       await utils.initializeWithContext('settings');
       expect(() => teams.getTeamChannels('groupId', emptyCallback)).toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 
@@ -82,8 +82,9 @@ describe('AppSDK-privateAPIs', () => {
 
   describe('refreshSiteUrl', () => {
     it('should not allow calls before initialization', () => {
-      expect(() => teams.refreshSiteUrl('threadId', emptyCallback)).toThrowError('The library has not yet been initialized');
+      expect(() => teams.refreshSiteUrl('threadId', emptyCallback)).toThrowError(
+        'The library has not yet been initialized',
+      );
     });
   });
-
 });

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -463,7 +463,7 @@ describe('AppSDK-app', () => {
       await utils.initializeWithContext('authentication');
 
       return expect(pages.navigateCrossDomain('https://valid.origin.com')).rejects.toThrowError(
-        "This call is not allowed in the 'authentication' context",
+        'This call is only allowed in following contexts: ["content","sidePanel","settings","remove","task","stage","meetingStage"]. Current context: "authentication".',
       );
     });
 

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -45,7 +45,7 @@ describe('authentication', () => {
       };
 
       expect(() => authentication.authenticate(authenticationParams)).toThrowError(
-        "This call is not allowed in the 'authentication' context",
+        'This call is only allowed in following contexts: ["content","sidePanel","settings","remove","task","stage","meetingStage"]. Current context: "authentication".',
       );
     });
   });
@@ -674,7 +674,7 @@ describe('authentication', () => {
       'The library has not yet been initialized',
     );
   });
-  
+
   it('should successfully return getAuthToken in case of success in legacy flow', done => {
     utils.initializeWithContext('content').then(() => {
       const authTokenRequest = {

--- a/packages/teams-js/test/public/config.spec.ts
+++ b/packages/teams-js/test/public/config.spec.ts
@@ -24,7 +24,9 @@ describe('config', () => {
   it('should not allow calls from the wrong context', async () => {
     await utils.initializeWithContext('content');
 
-    expect(() => pages.config.setValidityState(true)).toThrowError("This call is not allowed in the 'content' context");
+    expect(() => pages.config.setValidityState(true)).toThrowError(
+      'This call is only allowed in following contexts: ["settings","remove"]. Current context: "content".',
+    );
   });
 
   it('should successfully notify success on save when there is no registered handler', async () => {

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -33,28 +33,36 @@ describe('Dialog', () => {
       await utils.initializeWithContext('settings');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.open(dialogInfo)).toThrowError("This call is not allowed in the 'settings' context");
+      expect(() => dialog.open(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "settings".',
+      );
     });
 
     it('should not allow calls from authentication context', async () => {
       await utils.initializeWithContext('authentication');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.open(dialogInfo)).toThrowError("This call is not allowed in the 'authentication' context");
+      expect(() => dialog.open(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "authentication".',
+      );
     });
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.open(dialogInfo)).toThrowError("This call is not allowed in the 'remove' context");
+      expect(() => dialog.open(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "remove".',
+      );
     });
 
     it('should not allow calls from task context', async () => {
       await utils.initializeWithContext('task');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.open(dialogInfo)).toThrowError("This call is not allowed in the 'task' context");
+      expect(() => dialog.open(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "task".',
+      );
     });
 
     it('should pass along entire DialogInfo parameter in sidePanel context', async () => {
@@ -146,21 +154,27 @@ describe('Dialog', () => {
       await utils.initializeWithContext('sidePanel');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.resize(dialogInfo)).toThrowError("This call is not allowed in the 'sidePanel' context");
+      expect(() => dialog.resize(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "sidePanel".',
+      );
     });
 
     it('should not allow calls from content context', async () => {
       await utils.initializeWithContext('content');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.resize(dialogInfo)).toThrowError("This call is not allowed in the 'content' context");
+      expect(() => dialog.resize(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "content".',
+      );
     });
-    
+
     it('should not allow calls from meetingStage context', async () => {
       await utils.initializeWithContext('meetingStage');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.resize(dialogInfo)).toThrowError("This call is not allowed in the 'meetingStage' context");
+      expect(() => dialog.resize(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "meetingStage".',
+      );
     });
 
     it('should successfully pass DialogInfo in Task context', async () => {
@@ -192,37 +206,49 @@ describe('Dialog', () => {
     it('should not allow calls from settings context', async () => {
       await utils.initializeWithContext('settings');
 
-      expect(() => dialog.submit()).toThrowError("This call is not allowed in the 'settings' context");
+      expect(() => dialog.submit()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "settings".',
+      );
     });
 
     it('should not allow calls from authentication context', async () => {
       await utils.initializeWithContext('authentication');
 
-      expect(() => dialog.submit()).toThrowError("This call is not allowed in the 'authentication' context");
+      expect(() => dialog.submit()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "authentication".',
+      );
     });
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
 
-      expect(() => dialog.submit()).toThrowError("This call is not allowed in the 'remove' context");
+      expect(() => dialog.submit()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "remove".',
+      );
     });
 
     it('should not allow calls from content context', async () => {
       await utils.initializeWithContext('content');
 
-      expect(() => dialog.submit()).toThrowError("This call is not allowed in the 'content' context");
+      expect(() => dialog.submit()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "content".',
+      );
     });
 
     it('should not allow calls from meetingStage context', async () => {
       await utils.initializeWithContext('meetingStage');
 
-      expect(() => dialog.submit()).toThrowError("This call is not allowed in the 'meetingStage' context");
+      expect(() => dialog.submit()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "meetingStage".',
+      );
     });
 
     it('should not allow calls from sidePanel context', async () => {
       await utils.initializeWithContext('sidePanel');
 
-      expect(() => dialog.submit()).toThrowError("This call is not allowed in the 'sidePanel' context");
+      expect(() => dialog.submit()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "sidePanel".',
+      );
     });
 
     it('should successfully pass result and appIds parameters when called from Task context', async () => {

--- a/packages/teams-js/test/public/locationLegacy.spec.ts
+++ b/packages/teams-js/test/public/locationLegacy.spec.ts
@@ -56,21 +56,21 @@ describe('location_V1', () => {
     await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
     mobilePlatformMock.setClientSupportedSDKVersion(minVersionForLocationAPIs);
     expect(() => location.getLocation(defaultLocationProps, emptyCallback)).toThrowError(
-      "This call is not allowed in the 'authentication' context",
+      'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
     );
   });
   it('should not allow getLocation calls for remove frame context', async () => {
     await mobilePlatformMock.initializeWithContext(FrameContexts.remove);
     mobilePlatformMock.setClientSupportedSDKVersion(minVersionForLocationAPIs);
     expect(() => location.getLocation(defaultLocationProps, emptyCallback)).toThrowError(
-      "This call is not allowed in the 'remove' context",
+      'This call is only allowed in following contexts: ["content","task"]. Current context: "remove".',
     );
   });
   it('should not allow getLocation calls for settings frame context', async () => {
     await mobilePlatformMock.initializeWithContext(FrameContexts.settings);
     mobilePlatformMock.setClientSupportedSDKVersion(minVersionForLocationAPIs);
     expect(() => location.getLocation(defaultLocationProps, emptyCallback)).toThrowError(
-      "This call is not allowed in the 'settings' context",
+      'This call is only allowed in following contexts: ["content","task"]. Current context: "settings".',
     );
   });
   it('should not allow getLocation calls without props', done => {
@@ -184,21 +184,21 @@ describe('location_V1', () => {
     await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
     mobilePlatformMock.setClientSupportedSDKVersion(minVersionForLocationAPIs);
     expect(() => location.showLocation(defaultLocation, emptyCallback)).toThrowError(
-      "This call is not allowed in the 'authentication' context",
+      'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
     );
   });
   it('should not allow showLocation calls for remove frame context', async () => {
     await mobilePlatformMock.initializeWithContext(FrameContexts.remove);
     mobilePlatformMock.setClientSupportedSDKVersion(minVersionForLocationAPIs);
     expect(() => location.showLocation(defaultLocation, emptyCallback)).toThrowError(
-      "This call is not allowed in the 'remove' context",
+      'This call is only allowed in following contexts: ["content","task"]. Current context: "remove".',
     );
   });
   it('should not allow showLocation calls for settings frame context', async () => {
     await mobilePlatformMock.initializeWithContext(FrameContexts.settings);
     mobilePlatformMock.setClientSupportedSDKVersion(minVersionForLocationAPIs);
     expect(() => location.showLocation(defaultLocation, emptyCallback)).toThrowError(
-      "This call is not allowed in the 'settings' context",
+      'This call is only allowed in following contexts: ["content","task"]. Current context: "settings".',
     );
   });
   it('should not allow showLocation calls without props', done => {

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -59,21 +59,21 @@ describe('media', () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
         mobilePlatformMock.setClientSupportedSDKVersion(minVersionForCaptureImage);
         expect(() => media.captureImage(emptyCallback)).toThrowError(
-          "This call is not allowed in the 'authentication' context",
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
         );
       });
       it('should not allow captureImage calls for remove frame context', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.remove);
         mobilePlatformMock.setClientSupportedSDKVersion(minVersionForCaptureImage);
         expect(() => media.captureImage(emptyCallback)).toThrowError(
-          "This call is not allowed in the 'remove' context",
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "remove".',
         );
       });
       it('should not allow captureImage calls for settings frame context', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.settings);
         mobilePlatformMock.setClientSupportedSDKVersion(minVersionForCaptureImage);
         expect(() => media.captureImage(emptyCallback)).toThrowError(
-          "This call is not allowed in the 'settings' context",
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "settings".',
         );
       });
       it('should not allow captureImage calls in desktop', done => {
@@ -174,18 +174,22 @@ describe('media', () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
         mobilePlatformMock.setClientSupportedSDKVersion(minVersionForCaptureImage);
         return expect(() => media.captureImage()).toThrowError(
-          "This call is not allowed in the 'authentication' context",
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
         );
       });
       it('should not allow captureImage calls for remove frame context', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.remove);
         mobilePlatformMock.setClientSupportedSDKVersion(minVersionForCaptureImage);
-        return expect(() => media.captureImage()).toThrowError("This call is not allowed in the 'remove' context");
+        return expect(() => media.captureImage()).toThrowError(
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "remove".',
+        );
       });
       it('should not allow captureImage calls for settings frame context', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.settings);
         mobilePlatformMock.setClientSupportedSDKVersion(minVersionForCaptureImage);
-        return expect(() => media.captureImage()).toThrowError("This call is not allowed in the 'settings' context");
+        return expect(() => media.captureImage()).toThrowError(
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "settings".',
+        );
       });
       it('should not allow captureImage calls in desktop', async () => {
         await desktopPlatformMock.initializeWithContext(FrameContexts.content);
@@ -1369,7 +1373,7 @@ describe('media', () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
         mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
         return expect(() => media.scanBarCode()).toThrowError(
-          "This call is not allowed in the 'authentication' context",
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
         );
       });
 

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -1232,7 +1232,7 @@ describe('media', () => {
         mobilePlatformMock.initializeWithContext(FrameContexts.authentication).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
           expect(() => media.scanBarCode(emptyCallback, null)).toThrowError(
-            "This call is not allowed in the 'authentication' context",
+            'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
           );
         });
       });

--- a/packages/teams-js/test/public/navigation.spec.ts
+++ b/packages/teams-js/test/public/navigation.spec.ts
@@ -43,7 +43,7 @@ describe('MicrosoftTeams-Navigation', () => {
       await utils.initializeWithContext('authentication');
 
       expect(() => navigateCrossDomain('https://valid.origin.com')).toThrowError(
-        "This call is not allowed in the 'authentication' context",
+        'This call is only allowed in following contexts: ["content","sidePanel","settings","remove","task","stage","meetingStage"]. Current context: "authentication".',
       );
     });
 

--- a/packages/teams-js/test/public/settings.spec.ts
+++ b/packages/teams-js/test/public/settings.spec.ts
@@ -23,7 +23,9 @@ describe('settings', () => {
 
   it('should not allow calls from the wrong context', () => {
     utils.initializeWithContext('content').then(() => {
-      expect(() => settings.setValidityState(true)).toThrowError("This call is not allowed in the 'content' context");
+      expect(() => settings.setValidityState(true)).toThrowError(
+        'This call is only allowed in following contexts: ["settings","remove"]. Current context: "content".',
+      );
     });
   });
 

--- a/packages/teams-js/test/public/tasks.spec.ts
+++ b/packages/teams-js/test/public/tasks.spec.ts
@@ -33,28 +33,36 @@ describe('tasks', () => {
       await utils.initializeWithContext('settings');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'settings' context");
+      expect(() => tasks.startTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "settings".',
+      );
     });
 
     it('should not allow calls from authentication context', async () => {
       await utils.initializeWithContext('authentication');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'authentication' context");
+      expect(() => tasks.startTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "authentication".',
+      );
     });
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'remove' context");
+      expect(() => tasks.startTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "remove".',
+      );
     });
 
     it('should not allow calls from task context', async () => {
       await utils.initializeWithContext('task');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'task' context");
+      expect(() => tasks.startTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "task".',
+      );
     });
 
     it('should pass along entire TaskInfo parameter in sidePanel context', async () => {
@@ -146,23 +154,29 @@ describe('tasks', () => {
       await utils.initializeWithContext('content');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.updateTask(taskInfo)).toThrowError("This call is not allowed in the 'content' context");
+      expect(() => tasks.updateTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "content".',
+      );
     });
 
     it('should not allow calls from sidePanel context', async () => {
       await utils.initializeWithContext('sidePanel');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.updateTask(taskInfo)).toThrowError("This call is not allowed in the 'sidePanel' context");
+      expect(() => tasks.updateTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "sidePanel".',
+      );
     });
 
     it('should not allow calls from meetingStage context', async () => {
       await utils.initializeWithContext('meetingStage');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.updateTask(taskInfo)).toThrowError("This call is not allowed in the 'meetingStage' context");
+      expect(() => tasks.updateTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "meetingStage".',
+      );
     });
-    
+
     it('should successfully pass taskInfo in task context', async () => {
       await utils.initializeWithContext('task');
       const taskInfo = { width: 10, height: 10 };
@@ -192,37 +206,49 @@ describe('tasks', () => {
     it('should not allow calls from settings context', async () => {
       await utils.initializeWithContext('settings');
 
-      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'settings' context");
+      expect(() => tasks.submitTask()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "settings".',
+      );
     });
 
     it('should not allow calls from content context', async () => {
       await utils.initializeWithContext('content');
 
-      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'content' context");
+      expect(() => tasks.submitTask()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "content".',
+      );
     });
 
     it('should not allow calls from sidePanel context', async () => {
       await utils.initializeWithContext('sidePanel');
 
-      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'sidePanel' context");
+      expect(() => tasks.submitTask()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "sidePanel".',
+      );
     });
 
     it('should not allow calls from meetingStage context', async () => {
       await utils.initializeWithContext('meetingStage');
 
-      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'meetingStage' context");
+      expect(() => tasks.submitTask()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "meetingStage".',
+      );
     });
 
     it('should not allow calls from authentication context', async () => {
       await utils.initializeWithContext('authentication');
 
-      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'authentication' context");
+      expect(() => tasks.submitTask()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "authentication".',
+      );
     });
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
 
-      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'remove' context");
+      expect(() => tasks.submitTask()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "remove".',
+      );
     });
 
     it('should successfully pass result and appIds parameters when called from task context', async () => {

--- a/packages/teams-js/test/public/video.spec.ts
+++ b/packages/teams-js/test/public/video.spec.ts
@@ -35,11 +35,11 @@ describe('video', () => {
   it('should not allow calls from the wrong context', async () => {
     await utils.initializeWithContext('content');
     expect(() => video.registerForVideoFrame(emptyVideoEffectCallback, videoFrameConfig)).toThrowError(
-      "This call is not allowed in the 'content' context",
+      'This call is only allowed in following contexts: ["sidePanel"]. Current context: "content".',
     );
     expect(() =>
       video.notifySelectedVideoEffectChanged(video.EffectChangeType.EffectChanged, 'sample effect config'),
-    ).toThrowError("This call is not allowed in the 'content' context");
+    ).toThrowError('This call is only allowed in following contexts: ["sidePanel"]. Current context: "content".');
   });
 
   it('register for video frame event', async () => {


### PR DESCRIPTION
This fixes a recent suggestion: https://github.com/OfficeDev/microsoft-teams-library-js/issues/688

Sample error message with the change:

> Uncaught Error: This call is only allowed in following contexts: ["settings"]. Current context: "content".