### PR TITLE
Update each @deprecated tag to point to the replaced API

### DIFF
--- a/packages/teams-js/src/public/appInitialization.ts
+++ b/packages/teams-js/src/public/appInitialization.ts
@@ -1,35 +1,42 @@
 import { app } from './app';
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link app} namespace instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link app} namespace instead.
  */
 export namespace appInitialization {
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.Messages} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link app.Messages} instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export import Messages = app.Messages;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.FailedReason} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link app.FailedReason} instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export import FailedReason = app.FailedReason;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.ExpectedFailureReason} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link app.ExpectedFailureReason} instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export import ExpectedFailureReason = app.ExpectedFailureReason;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.IFailedRequest} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link app.IFailedRequest} instead.
    */
   export import IFailedRequest = app.IFailedRequest;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.IExpectedFailureRequest} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link app.IExpectedFailureRequest} instead.
    */
   export import IExpectedFailureRequest = app.IExpectedFailureRequest;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifyAppLoaded app.notifyAppLoaded(): void} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link app.notifyAppLoaded app.notifyAppLoaded(): void} instead.
    * Notifies the frame that app has loaded and to hide the loading indicator if one is shown.
    */
   export function notifyAppLoaded(): void {
@@ -37,7 +44,8 @@ export namespace appInitialization {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifySuccess app.notifySuccess(): void} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link app.notifySuccess app.notifySuccess(): void} instead.
    * Notifies the frame that app initialization is successful and is ready for user interaction.
    */
   export function notifySuccess(): void {
@@ -45,7 +53,8 @@ export namespace appInitialization {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifyFailure app.notifyFailure(appInitializationFailedRequest: IFailedRequest): void} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link app.notifyFailure app.notifyFailure(appInitializationFailedRequest: IFailedRequest): void} instead.
    * Notifies the frame that app initialization has failed and to show an error page in its place.
    */
   export function notifyFailure(appInitializationFailedRequest: IFailedRequest): void {
@@ -53,7 +62,8 @@ export namespace appInitialization {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifyExpectedFailure app.notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link app.notifyExpectedFailure app.notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void} instead.
    * Notifies the frame that app initialized with some expected errors.
    */
   export function notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void {

--- a/packages/teams-js/src/public/appInitialization.ts
+++ b/packages/teams-js/src/public/appInitialization.ts
@@ -1,35 +1,35 @@
 import { app } from './app';
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'app' namespace instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link app} namespace instead.
  */
 export namespace appInitialization {
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'app.Messages' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.Messages} instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export import Messages = app.Messages;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'app.FailedReason' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.FailedReason} instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export import FailedReason = app.FailedReason;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'app.ExpectedFailureReason' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.ExpectedFailureReason} instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export import ExpectedFailureReason = app.ExpectedFailureReason;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'app.IFailedRequest' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.IFailedRequest} instead.
    */
   export import IFailedRequest = app.IFailedRequest;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'app.IExpectedFailureRequest' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.IExpectedFailureRequest} instead.
    */
   export import IExpectedFailureRequest = app.IExpectedFailureRequest;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'app.notifyAppLoaded(): void' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifyAppLoaded(): void} instead.
    * Notifies the frame that app has loaded and to hide the loading indicator if one is shown.
    */
   export function notifyAppLoaded(): void {
@@ -37,7 +37,7 @@ export namespace appInitialization {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'app.notifySuccess(): void' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifySuccess(): void} instead.
    * Notifies the frame that app initialization is successful and is ready for user interaction.
    */
   export function notifySuccess(): void {
@@ -45,7 +45,7 @@ export namespace appInitialization {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'app.notifyFailure(appInitializationFailedRequest: IFailedRequest): void' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifyFailure(appInitializationFailedRequest: IFailedRequest): void} instead.
    * Notifies the frame that app initialization has failed and to show an error page in its place.
    */
   export function notifyFailure(appInitializationFailedRequest: IFailedRequest): void {
@@ -53,7 +53,7 @@ export namespace appInitialization {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'app.notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void} instead.
    * Notifies the frame that app initialized with some expected errors.
    */
   export function notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void {

--- a/packages/teams-js/src/public/appInitialization.ts
+++ b/packages/teams-js/src/public/appInitialization.ts
@@ -29,7 +29,7 @@ export namespace appInitialization {
   export import IExpectedFailureRequest = app.IExpectedFailureRequest;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifyAppLoaded(): void} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifyAppLoaded app.notifyAppLoaded(): void} instead.
    * Notifies the frame that app has loaded and to hide the loading indicator if one is shown.
    */
   export function notifyAppLoaded(): void {
@@ -37,7 +37,7 @@ export namespace appInitialization {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifySuccess(): void} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifySuccess app.notifySuccess(): void} instead.
    * Notifies the frame that app initialization is successful and is ready for user interaction.
    */
   export function notifySuccess(): void {
@@ -45,7 +45,7 @@ export namespace appInitialization {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifyFailure(appInitializationFailedRequest: IFailedRequest): void} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifyFailure app.notifyFailure(appInitializationFailedRequest: IFailedRequest): void} instead.
    * Notifies the frame that app initialization has failed and to show an error page in its place.
    */
   export function notifyFailure(appInitializationFailedRequest: IFailedRequest): void {
@@ -53,7 +53,7 @@ export namespace appInitialization {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link app.notifyExpectedFailure app.notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void} instead.
    * Notifies the frame that app initialized with some expected errors.
    */
   export function notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void {

--- a/packages/teams-js/src/public/appInitialization.ts
+++ b/packages/teams-js/src/public/appInitialization.ts
@@ -1,35 +1,35 @@
 import { app } from './app';
 
 /**
- * @deprecated with TeamsJS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'app' namespace instead.
  */
 export namespace appInitialization {
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'app.Messages' instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export import Messages = app.Messages;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'app.FailedReason' instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export import FailedReason = app.FailedReason;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'app.ExpectedFailureReason' instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export import ExpectedFailureReason = app.ExpectedFailureReason;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'app.IFailedRequest' instead.
    */
   export import IFailedRequest = app.IFailedRequest;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'app.IExpectedFailureRequest' instead.
    */
   export import IExpectedFailureRequest = app.IExpectedFailureRequest;
 
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'app.notifyAppLoaded(): void' instead.
    * Notifies the frame that app has loaded and to hide the loading indicator if one is shown.
    */
   export function notifyAppLoaded(): void {
@@ -37,7 +37,7 @@ export namespace appInitialization {
   }
 
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'app.notifySuccess(): void' instead.
    * Notifies the frame that app initialization is successful and is ready for user interaction.
    */
   export function notifySuccess(): void {
@@ -45,7 +45,7 @@ export namespace appInitialization {
   }
 
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'app.notifyFailure(appInitializationFailedRequest: IFailedRequest): void' instead.
    * Notifies the frame that app initialization has failed and to show an error page in its place.
    */
   export function notifyFailure(appInitializationFailedRequest: IFailedRequest): void {
@@ -53,7 +53,7 @@ export namespace appInitialization {
   }
 
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'app.notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void' instead.
    * Notifies the frame that app initialized with some expected errors.
    */
   export function notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void {

--- a/packages/teams-js/src/public/appWindow.ts
+++ b/packages/teams-js/src/public/appWindow.ts
@@ -17,7 +17,7 @@ export interface IAppWindow {
    */
   postMessage(message: any): Promise<void>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'postMessage(message: any): Promise<void>' instead.
    * @param message - The message to send
    * @param onComplete - The deprecated way of invoking a callback to know if the postMessage has been success/failed.
    */
@@ -40,7 +40,7 @@ export class ChildAppWindow implements IAppWindow {
    */
   public postMessage(message: any): Promise<void>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'postMessage(message: any): Promise<void>' instead.
    * @param message - The message to send
    * @param onComplete - The deprecated way of invoking a callback to know if the postMessage has been success/failed.
    */
@@ -88,7 +88,7 @@ export class ParentAppWindow implements IAppWindow {
    */
   public postMessage(message: any): Promise<void>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'postMessage(message: any): Promise<void>' instead.
    * @param message - The message to send
    * @param onComplete - The deprecated way of invoking a callback to know if the postMessage has been success/failed.
    */

--- a/packages/teams-js/src/public/appWindow.ts
+++ b/packages/teams-js/src/public/appWindow.ts
@@ -17,7 +17,7 @@ export interface IAppWindow {
    */
   postMessage(message: any): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'postMessage(message: any): Promise<void>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link postMessage(message: any): Promise<void>} instead.
    * @param message - The message to send
    * @param onComplete - The deprecated way of invoking a callback to know if the postMessage has been success/failed.
    */
@@ -40,7 +40,7 @@ export class ChildAppWindow implements IAppWindow {
    */
   public postMessage(message: any): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'postMessage(message: any): Promise<void>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link postMessage(message: any): Promise<void>} instead.
    * @param message - The message to send
    * @param onComplete - The deprecated way of invoking a callback to know if the postMessage has been success/failed.
    */
@@ -88,7 +88,7 @@ export class ParentAppWindow implements IAppWindow {
    */
   public postMessage(message: any): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'postMessage(message: any): Promise<void>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link postMessage(message: any): Promise<void>} instead.
    * @param message - The message to send
    * @param onComplete - The deprecated way of invoking a callback to know if the postMessage has been success/failed.
    */

--- a/packages/teams-js/src/public/appWindow.ts
+++ b/packages/teams-js/src/public/appWindow.ts
@@ -17,7 +17,7 @@ export interface IAppWindow {
    */
   postMessage(message: any): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link postMessage(message: any): Promise<void>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link IAppWindow.postMessage IAppWindow.postMessage(message: any): Promise\<void\>} instead.
    * @param message - The message to send
    * @param onComplete - The deprecated way of invoking a callback to know if the postMessage has been success/failed.
    */
@@ -40,7 +40,7 @@ export class ChildAppWindow implements IAppWindow {
    */
   public postMessage(message: any): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link postMessage(message: any): Promise<void>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link ChildAppWindow.postMessage ChildAppWindow.postMessage(message: any): Promise\<void\>} instead.
    * @param message - The message to send
    * @param onComplete - The deprecated way of invoking a callback to know if the postMessage has been success/failed.
    */
@@ -88,7 +88,7 @@ export class ParentAppWindow implements IAppWindow {
    */
   public postMessage(message: any): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link postMessage(message: any): Promise<void>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link ParentAppWindow.postMessage ParentAppWindow.postMessage(message: any): Promise\<void\>} instead.
    * @param message - The message to send
    * @param onComplete - The deprecated way of invoking a callback to know if the postMessage has been success/failed.
    */

--- a/packages/teams-js/src/public/appWindow.ts
+++ b/packages/teams-js/src/public/appWindow.ts
@@ -17,7 +17,8 @@ export interface IAppWindow {
    */
   postMessage(message: any): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link IAppWindow.postMessage IAppWindow.postMessage(message: any): Promise\<void\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link IAppWindow.postMessage IAppWindow.postMessage(message: any): Promise\<void\>} instead.
    * @param message - The message to send
    * @param onComplete - The deprecated way of invoking a callback to know if the postMessage has been success/failed.
    */
@@ -40,7 +41,8 @@ export class ChildAppWindow implements IAppWindow {
    */
   public postMessage(message: any): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link ChildAppWindow.postMessage ChildAppWindow.postMessage(message: any): Promise\<void\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link ChildAppWindow.postMessage ChildAppWindow.postMessage(message: any): Promise\<void\>} instead.
    * @param message - The message to send
    * @param onComplete - The deprecated way of invoking a callback to know if the postMessage has been success/failed.
    */
@@ -88,7 +90,8 @@ export class ParentAppWindow implements IAppWindow {
    */
   public postMessage(message: any): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link ParentAppWindow.postMessage ParentAppWindow.postMessage(message: any): Promise\<void\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link ParentAppWindow.postMessage ParentAppWindow.postMessage(message: any): Promise\<void\>} instead.
    * @param message - The message to send
    * @param onComplete - The deprecated way of invoking a callback to know if the postMessage has been success/failed.
    */

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -39,16 +39,6 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise<string>} instead.
-   *
-   * Initiates an authentication request, which opens a new window with the specified settings.
-   *
-   * @param authenticateParameters - The parameters for the authentication request.
-   *
-   */
-  export function authenticate(authenticateParameters?: AuthenticateParameters): void;
-
-  /**
    * Initiates an authentication request, which opens a new window with the specified settings.
    *
    * @param authenticateParameters - The parameters for the authentication request. It is a required parameter since v2 upgrade
@@ -59,6 +49,15 @@ export namespace authentication {
    *
    */
   export function authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise<string>;
+  /**
+   * @deprecated As of 2.0.0-beta.1. Please use {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} instead.
+   *
+   * Initiates an authentication request, which opens a new window with the specified settings.
+   *
+   * @param authenticateParameters - The parameters for the authentication request.
+   *
+   */
+  export function authenticate(authenticateParameters?: AuthenticateParameters): void;
   export function authenticate(authenticateParameters?: AuthenticateParameters): Promise<string> {
     const isDifferentParamsInCall: boolean = authenticateParameters !== undefined;
     const authenticateParams: AuthenticateParameters = isDifferentParamsInCall ? authenticateParameters : authParams;
@@ -144,17 +143,6 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise<string>} instead.
-   *
-   * Requests an Azure AD token to be issued on behalf of the app. The token is acquired from the cache
-   * if it is not expired. Otherwise a request is sent to Azure AD to obtain a new token.
-   *
-   * @param authTokenRequest - A set of values that configure the token request.
-   * It contains callbacks to call in case of success/failure
-   */
-  export function getAuthToken(authTokenRequest: AuthTokenRequest): void;
-
-  /**
    * Requests an Azure AD token to be issued on behalf of the app. The token is acquired from the cache
    * if it is not expired. Otherwise a request is sent to Azure AD to obtain a new token.
    *
@@ -163,6 +151,16 @@ export namespace authentication {
    * @returns Promise that will be fulfilled with the token if successful.
    */
   export function getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise<string>;
+  /**
+   * @deprecated As of 2.0.0-beta.1. Please use {@link authentication.getAuthToken authentication.getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise\<string\>} instead.
+   *
+   * Requests an Azure AD token to be issued on behalf of the app. The token is acquired from the cache
+   * if it is not expired. Otherwise a request is sent to Azure AD to obtain a new token.
+   *
+   * @param authTokenRequest - A set of values that configure the token request.
+   * It contains callbacks to call in case of success/failure
+   */
+  export function getAuthToken(authTokenRequest: AuthTokenRequest): void;
   export function getAuthToken(authTokenRequest: AuthTokenRequest): Promise<string> {
     ensureInitialized();
     return getAuthTokenHelper(authTokenRequest)
@@ -211,9 +209,8 @@ export namespace authentication {
    * @internal
    */
   export function getUser(): Promise<UserProfile>;
-
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link getUser(): Promise<UserProfile>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link authentication.getUser authentication.getUser(): Promise\<UserProfile\>} instead.
    *
    * @hidden
    * Hide from docs.

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -28,7 +28,7 @@ export namespace authentication {
 
   let authParams: AuthenticateParameters;
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1.
    *
    * Registers the authentication Communication.handlers
    *
@@ -39,7 +39,7 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise<string>' instead.
    *
    * Initiates an authentication request, which opens a new window with the specified settings.
    *
@@ -144,7 +144,7 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise<string>' instead.
    *
    * Requests an Azure AD token to be issued on behalf of the app. The token is acquired from the cache
    * if it is not expired. Otherwise a request is sent to Azure AD to obtain a new token.
@@ -213,7 +213,7 @@ export namespace authentication {
   export function getUser(): Promise<UserProfile>;
 
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'getUser(): Promise<UserProfile>' instead.
    *
    * @hidden
    * Hide from docs.
@@ -462,16 +462,16 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1.
    */
   interface LegacyCallBacks {
     /**
-     * @deprecated with TeamsJS v2 upgrades
+     * @deprecated As of 2.0.0-beta.1.
      * A function that is called if the request succeeds.
      */
     successCallback?: (result: string) => void;
     /**
-     * @deprecated with TeamsJS v2 upgrades
+     * @deprecated As of 2.0.0-beta.1.
      * A function that is called if the request fails, with the reason for the failure.
      */
     failureCallback?: (reason: string) => void;
@@ -493,7 +493,7 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use'AuthenticatePopUpParameters' instead.
    */
   export type AuthenticateParameters = AuthenticatePopUpParameters & LegacyCallBacks;
 
@@ -513,7 +513,7 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'AuthTokenRequestParameters' instead.
    */
   export type AuthTokenRequest = AuthTokenRequestParameters & LegacyCallBacks;
 
@@ -614,7 +614,7 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1.
    * @hidden
    * Hide from docs.
    * ------

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -28,7 +28,8 @@ export namespace authentication {
 
   let authParams: AuthenticateParameters;
   /**
-   * @deprecated As of 2.0.0-beta.1.
+   * @deprecated
+   * As of 2.0.0-beta.1.
    *
    * Registers the authentication Communication.handlers
    *
@@ -50,7 +51,8 @@ export namespace authentication {
    */
   export function authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise<string>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} instead.
    *
    * Initiates an authentication request, which opens a new window with the specified settings.
    *
@@ -152,7 +154,8 @@ export namespace authentication {
    */
   export function getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise<string>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link authentication.getAuthToken authentication.getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise\<string\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link authentication.getAuthToken authentication.getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise\<string\>} instead.
    *
    * Requests an Azure AD token to be issued on behalf of the app. The token is acquired from the cache
    * if it is not expired. Otherwise a request is sent to Azure AD to obtain a new token.
@@ -210,7 +213,8 @@ export namespace authentication {
    */
   export function getUser(): Promise<UserProfile>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link authentication.getUser authentication.getUser(): Promise\<UserProfile\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link authentication.getUser authentication.getUser(): Promise\<UserProfile\>} instead.
    *
    * @hidden
    * Hide from docs.
@@ -459,16 +463,19 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1.
+   * @deprecated
+   * As of 2.0.0-beta.1.
    */
   interface LegacyCallBacks {
     /**
-     * @deprecated As of 2.0.0-beta.1.
+     * @deprecated
+     * As of 2.0.0-beta.1.
      * A function that is called if the request succeeds.
      */
     successCallback?: (result: string) => void;
     /**
-     * @deprecated As of 2.0.0-beta.1.
+     * @deprecated
+     * As of 2.0.0-beta.1.
      * A function that is called if the request fails, with the reason for the failure.
      */
     failureCallback?: (reason: string) => void;
@@ -490,7 +497,8 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link AuthenticatePopUpParameters} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link AuthenticatePopUpParameters} instead.
    */
   export type AuthenticateParameters = AuthenticatePopUpParameters & LegacyCallBacks;
 
@@ -510,7 +518,8 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link AuthTokenRequestParameters} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link AuthTokenRequestParameters} instead.
    */
   export type AuthTokenRequest = AuthTokenRequestParameters & LegacyCallBacks;
 
@@ -611,7 +620,8 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1.
+   * @deprecated
+   * As of 2.0.0-beta.1.
    * @hidden
    * Hide from docs.
    * ------

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -39,7 +39,7 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise<string>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise<string>} instead.
    *
    * Initiates an authentication request, which opens a new window with the specified settings.
    *
@@ -144,7 +144,7 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise<string>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise<string>} instead.
    *
    * Requests an Azure AD token to be issued on behalf of the app. The token is acquired from the cache
    * if it is not expired. Otherwise a request is sent to Azure AD to obtain a new token.
@@ -213,7 +213,7 @@ export namespace authentication {
   export function getUser(): Promise<UserProfile>;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'getUser(): Promise<UserProfile>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link getUser(): Promise<UserProfile>} instead.
    *
    * @hidden
    * Hide from docs.
@@ -493,7 +493,7 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use'AuthenticatePopUpParameters' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link AuthenticatePopUpParameters} instead.
    */
   export type AuthenticateParameters = AuthenticatePopUpParameters & LegacyCallBacks;
 
@@ -513,7 +513,7 @@ export namespace authentication {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'AuthTokenRequestParameters' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link AuthTokenRequestParameters} instead.
    */
   export type AuthTokenRequest = AuthTokenRequestParameters & LegacyCallBacks;
 

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -4,7 +4,7 @@ export enum HostClientType {
   android = 'android',
   ios = 'ios',
   /**
-   * @deprecated Use teamsRoomsWindows instead.
+   * @deprecated As of 2.0.0-beta.1. Please use 'teamsRoomsWindows' instead.
    */
   rigel = 'rigel',
   surfaceHub = 'surfaceHub',
@@ -64,7 +64,7 @@ export enum DialogDimension {
 }
 
 /**
- * @deprecated with TeamsJS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'DialogDimension' instead.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export import TaskModuleDimension = DialogDimension;

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -4,7 +4,8 @@ export enum HostClientType {
   android = 'android',
   ios = 'ios',
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link teamsRoomsWindows} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link teamsRoomsWindows} instead.
    */
   rigel = 'rigel',
   surfaceHub = 'surfaceHub',
@@ -64,7 +65,8 @@ export enum DialogDimension {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link DialogDimension} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link DialogDimension} instead.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export import TaskModuleDimension = DialogDimension;

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -4,7 +4,7 @@ export enum HostClientType {
   android = 'android',
   ios = 'ios',
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'teamsRoomsWindows' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link teamsRoomsWindows} instead.
    */
   rigel = 'rigel',
   surfaceHub = 'surfaceHub',
@@ -64,7 +64,7 @@ export enum DialogDimension {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'DialogDimension' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link DialogDimension} instead.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export import TaskModuleDimension = DialogDimension;

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -39,11 +39,11 @@ export { video } from './video';
 export { sharing } from './sharing';
 export { call } from './call';
 /**
- * @deprecated with TeamsJS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1.
  */
 export { appInitialization } from './appInitialization';
 /**
- * @deprecated with TeamsJS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1.
  */
 export {
   enablePrintCapability,
@@ -68,14 +68,14 @@ export {
   shareDeepLink,
 } from './publicAPIs';
 /**
- * @deprecated with TeamsJS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1.
  */
 export { returnFocus, navigateBack, navigateCrossDomain, navigateToTab } from './navigation';
 /**
- * @deprecated with TeamsJS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1.
  */
 export { settings } from './settings';
 /**
- * @deprecated with TeamsJS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1.
  */
 export { tasks } from './tasks';

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -39,11 +39,13 @@ export { video } from './video';
 export { sharing } from './sharing';
 export { call } from './call';
 /**
- * @deprecated As of 2.0.0-beta.1.
+ * @deprecated
+ * As of 2.0.0-beta.1.
  */
 export { appInitialization } from './appInitialization';
 /**
- * @deprecated As of 2.0.0-beta.1.
+ * @deprecated
+ * As of 2.0.0-beta.1.
  */
 export {
   enablePrintCapability,
@@ -68,14 +70,17 @@ export {
   shareDeepLink,
 } from './publicAPIs';
 /**
- * @deprecated As of 2.0.0-beta.1.
+ * @deprecated
+ * As of 2.0.0-beta.1.
  */
 export { returnFocus, navigateBack, navigateCrossDomain, navigateToTab } from './navigation';
 /**
- * @deprecated As of 2.0.0-beta.1.
+ * @deprecated
+ * As of 2.0.0-beta.1.
  */
 export { settings } from './settings';
 /**
- * @deprecated As of 2.0.0-beta.1.
+ * @deprecated
+ * As of 2.0.0-beta.1.
  */
 export { tasks } from './tasks';

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -240,7 +240,7 @@ export interface Context {
 
   /**
    * @hidden
-   * @deprecated Use loginHint or userPrincipalName.
+   * @deprecated As of 2.0.0-beta.1. Please use 'loginHint' or 'userPrincipalName' instead.
    * The UPN of the current user.
    * Because a malicious party can run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
@@ -559,7 +559,7 @@ export interface DialogInfo {
 }
 
 /**
- * @deprecated with TeamsJS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'DialogInfo' instead.
  */
 export type TaskInfo = DialogInfo;
 
@@ -680,7 +680,7 @@ export interface FrameInfo {
 }
 
 /**
- * @deprecated with TeamsJS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'FrameInfo' instead.
  */
 export type FrameContext = FrameInfo;
 

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -240,7 +240,7 @@ export interface Context {
 
   /**
    * @hidden
-   * @deprecated As of 2.0.0-beta.1. Please use 'loginHint' or 'userPrincipalName' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link loginHint} or {@link userPrincipalName} instead.
    * The UPN of the current user.
    * Because a malicious party can run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
@@ -559,7 +559,7 @@ export interface DialogInfo {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'DialogInfo' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link DialogInfo} instead.
  */
 export type TaskInfo = DialogInfo;
 
@@ -680,7 +680,7 @@ export interface FrameInfo {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'FrameInfo' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link FrameInfo} instead.
  */
 export type FrameContext = FrameInfo;
 

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -240,7 +240,8 @@ export interface Context {
 
   /**
    * @hidden
-   * @deprecated As of 2.0.0-beta.1. Please use {@link loginHint} or {@link userPrincipalName} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link loginHint} or {@link userPrincipalName} instead.
    * The UPN of the current user.
    * Because a malicious party can run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
@@ -559,7 +560,8 @@ export interface DialogInfo {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link DialogInfo} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link DialogInfo} instead.
  */
 export type TaskInfo = DialogInfo;
 
@@ -680,7 +682,8 @@ export interface FrameInfo {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link FrameInfo} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link FrameInfo} instead.
  */
 export type FrameContext = FrameInfo;
 

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -55,7 +55,8 @@ export namespace location {
    */
   export function getLocation(props: LocationProps): Promise<Location>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link location.getLocation location.getLocation(props: LocationProps): Promise\<Location\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link location.getLocation location.getLocation(props: LocationProps): Promise\<Location\>} instead.
    * @param props {@link LocationProps} - Specifying how the location request is handled
    * @param callback - Callback to invoke when current user location is fetched
    */
@@ -88,7 +89,8 @@ export namespace location {
    */
   export function showLocation(location: Location): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link location.showLocation location.showLocation(location: Location): Promise\<void\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link location.showLocation location.showLocation(location: Location): Promise\<void\>} instead.
    * Shows the location on map corresponding to the given coordinates
    * @param location {@link Location} - which needs to be shown on map
    * @param callback - Callback to invoke when the location is opened on map

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -55,7 +55,7 @@ export namespace location {
    */
   export function getLocation(props: LocationProps): Promise<Location>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'location.getLocation(props: LocationProps): Promise<Location>' instead.
    * @param props {@link LocationProps} - Specifying how the location request is handled
    * @param callback - Callback to invoke when current user location is fetched
    */
@@ -88,7 +88,7 @@ export namespace location {
    */
   export function showLocation(location: Location): Promise<void>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'location.showLocation(location: Location): Promise<void>' instead.
    * Shows the location on map corresponding to the given coordinates
    * @param location {@link Location} - which needs to be shown on map
    * @param callback - Callback to invoke when the location is opened on map

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -55,7 +55,7 @@ export namespace location {
    */
   export function getLocation(props: LocationProps): Promise<Location>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link location.getLocation(props: LocationProps): Promise<Location>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link location.getLocation location.getLocation(props: LocationProps): Promise\<Location\>} instead.
    * @param props {@link LocationProps} - Specifying how the location request is handled
    * @param callback - Callback to invoke when current user location is fetched
    */
@@ -88,7 +88,7 @@ export namespace location {
    */
   export function showLocation(location: Location): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link location.showLocation(location: Location): Promise<void>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link location.showLocation location.showLocation(location: Location): Promise\<void\>} instead.
    * Shows the location on map corresponding to the given coordinates
    * @param location {@link Location} - which needs to be shown on map
    * @param callback - Callback to invoke when the location is opened on map

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -55,7 +55,7 @@ export namespace location {
    */
   export function getLocation(props: LocationProps): Promise<Location>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'location.getLocation(props: LocationProps): Promise<Location>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link location.getLocation(props: LocationProps): Promise<Location>} instead.
    * @param props {@link LocationProps} - Specifying how the location request is handled
    * @param callback - Callback to invoke when current user location is fetched
    */
@@ -88,7 +88,7 @@ export namespace location {
    */
   export function showLocation(location: Location): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'location.showLocation(location: Location): Promise<void>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link location.showLocation(location: Location): Promise<void>} instead.
    * Shows the location on map corresponding to the given coordinates
    * @param location {@link Location} - which needs to be shown on map
    * @param callback - Callback to invoke when the location is opened on map

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -89,7 +89,7 @@ export namespace media {
    *
    * @param callback - Callback to invoke when the image is captured.
    *
-   * @deprecated As of 2.0.0-beta.1. Please use 'media.captureImage(): Promise<File[]>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link media.captureImage(): Promise<File[]>} instead.
    *
    * @remarks
    * Note: Currently we support getting one File through this API, i.e. the file arrays size will be one.
@@ -147,7 +147,7 @@ export namespace media {
     /**
      * Gets the media in chunks irrespective of size, these chunks are assembled and sent back to the webapp as file/blob
      *
-     * @deprecated As of 2.0.0-beta.1. Please use 'media.Media.getMedia(): Promise<Blob>' instead.
+     * @deprecated As of 2.0.0-beta.1. Please use {@link media.Media.getMedia(): Promise<Blob>} instead.
      *
      * @param callback - returns blob of media
      */
@@ -454,7 +454,7 @@ export namespace media {
   /**
    * Select an attachment using camera/gallery
    *
-   * @deprecated As of 2.0.0-beta.1. Please use 'media.selectMedia(mediaInputs: MediaInputs): Promise<Media[]>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link media.selectMedia(mediaInputs: MediaInputs): Promise<Media[]>} instead.
    *
    * @param mediaInputs - The input params to customize the media to be selected
    * @param callback - The callback to invoke after fetching the media
@@ -509,7 +509,7 @@ export namespace media {
   /**
    * View images using native image viewer
    *
-   * @deprecated As of 2.0.0-beta.1. Please use 'media.viewImages(uriList: ImageUri[]): Promise<void>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link media.viewImages(uriList: ImageUri[]): Promise<void>} instead.
    *
    * @param uriList - list of URIs for images to be viewed - can be content URI or server URL. Supports up to 10 Images in a single call
    * @param callback - returns back error if encountered, returns null in case of success
@@ -561,7 +561,7 @@ export namespace media {
    * @remarks
    * Note: For desktop and web, this API is not supported. Callback will be resolved with ErrorCode.NotSupported.
    *
-   * @deprecated As of 2.0.0-beta.1. Please use 'media.scanBarCode(config?: BarCodeConfig): Promise<string>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link media.scanBarCode(config?: BarCodeConfig): Promise<string>} instead.
    *
    * @param callback - callback to invoke after scanning the barcode
    * @param config - optional input configuration to customize the barcode scanning experience

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -89,7 +89,7 @@ export namespace media {
    *
    * @param callback - Callback to invoke when the image is captured.
    *
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'media.captureImage(): Promise<File[]>' instead.
    *
    * @remarks
    * Note: Currently we support getting one File through this API, i.e. the file arrays size will be one.
@@ -147,7 +147,7 @@ export namespace media {
     /**
      * Gets the media in chunks irrespective of size, these chunks are assembled and sent back to the webapp as file/blob
      *
-     * @deprecated with TeamsJS v2 upgrades
+     * @deprecated As of 2.0.0-beta.1. Please use 'media.Media.getMedia(): Promise<Blob>' instead.
      *
      * @param callback - returns blob of media
      */
@@ -454,7 +454,7 @@ export namespace media {
   /**
    * Select an attachment using camera/gallery
    *
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'media.selectMedia(mediaInputs: MediaInputs): Promise<Media[]>' instead.
    *
    * @param mediaInputs - The input params to customize the media to be selected
    * @param callback - The callback to invoke after fetching the media
@@ -509,7 +509,7 @@ export namespace media {
   /**
    * View images using native image viewer
    *
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'media.viewImages(uriList: ImageUri[]): Promise<void>' instead.
    *
    * @param uriList - list of URIs for images to be viewed - can be content URI or server URL. Supports up to 10 Images in a single call
    * @param callback - returns back error if encountered, returns null in case of success
@@ -561,7 +561,7 @@ export namespace media {
    * @remarks
    * Note: For desktop and web, this API is not supported. Callback will be resolved with ErrorCode.NotSupported.
    *
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'media.scanBarCode(config?: BarCodeConfig): Promise<string>' instead.
    *
    * @param callback - callback to invoke after scanning the barcode
    * @param config - optional input configuration to customize the barcode scanning experience

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -89,7 +89,7 @@ export namespace media {
    *
    * @param callback - Callback to invoke when the image is captured.
    *
-   * @deprecated As of 2.0.0-beta.1. Please use {@link media.captureImage(): Promise<File[]>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link media.captureImage media.captureImage(): Promise\<File[]\>} instead.
    *
    * @remarks
    * Note: Currently we support getting one File through this API, i.e. the file arrays size will be one.
@@ -147,7 +147,7 @@ export namespace media {
     /**
      * Gets the media in chunks irrespective of size, these chunks are assembled and sent back to the webapp as file/blob
      *
-     * @deprecated As of 2.0.0-beta.1. Please use {@link media.Media.getMedia(): Promise<Blob>} instead.
+     * @deprecated As of 2.0.0-beta.1. Please use {@link media.Media.getMedia media.Media.getMedia(): Promise\<Blob\>} instead.
      *
      * @param callback - returns blob of media
      */
@@ -454,7 +454,7 @@ export namespace media {
   /**
    * Select an attachment using camera/gallery
    *
-   * @deprecated As of 2.0.0-beta.1. Please use {@link media.selectMedia(mediaInputs: MediaInputs): Promise<Media[]>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link media.selectMedia media.selectMedia(mediaInputs: MediaInputs): Promise\<Media[]\>} instead.
    *
    * @param mediaInputs - The input params to customize the media to be selected
    * @param callback - The callback to invoke after fetching the media
@@ -509,7 +509,7 @@ export namespace media {
   /**
    * View images using native image viewer
    *
-   * @deprecated As of 2.0.0-beta.1. Please use {@link media.viewImages(uriList: ImageUri[]): Promise<void>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link media.viewImages media.viewImages(uriList: ImageUri[]): Promise\<void\>} instead.
    *
    * @param uriList - list of URIs for images to be viewed - can be content URI or server URL. Supports up to 10 Images in a single call
    * @param callback - returns back error if encountered, returns null in case of success
@@ -561,7 +561,7 @@ export namespace media {
    * @remarks
    * Note: For desktop and web, this API is not supported. Callback will be resolved with ErrorCode.NotSupported.
    *
-   * @deprecated As of 2.0.0-beta.1. Please use {@link media.scanBarCode(config?: BarCodeConfig): Promise<string>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link media.scanBarCode media.scanBarCode(config?: BarCodeConfig): Promise\<string\>} instead.
    *
    * @param callback - callback to invoke after scanning the barcode
    * @param config - optional input configuration to customize the barcode scanning experience

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -89,7 +89,8 @@ export namespace media {
    *
    * @param callback - Callback to invoke when the image is captured.
    *
-   * @deprecated As of 2.0.0-beta.1. Please use {@link media.captureImage media.captureImage(): Promise\<File[]\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link media.captureImage media.captureImage(): Promise\<File[]\>} instead.
    *
    * @remarks
    * Note: Currently we support getting one File through this API, i.e. the file arrays size will be one.
@@ -147,7 +148,8 @@ export namespace media {
     /**
      * Gets the media in chunks irrespective of size, these chunks are assembled and sent back to the webapp as file/blob
      *
-     * @deprecated As of 2.0.0-beta.1. Please use {@link media.Media.getMedia media.Media.getMedia(): Promise\<Blob\>} instead.
+     * @deprecated
+     * As of 2.0.0-beta.1, please use {@link media.Media.getMedia media.Media.getMedia(): Promise\<Blob\>} instead.
      *
      * @param callback - returns blob of media
      */
@@ -454,7 +456,8 @@ export namespace media {
   /**
    * Select an attachment using camera/gallery
    *
-   * @deprecated As of 2.0.0-beta.1. Please use {@link media.selectMedia media.selectMedia(mediaInputs: MediaInputs): Promise\<Media[]\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link media.selectMedia media.selectMedia(mediaInputs: MediaInputs): Promise\<Media[]\>} instead.
    *
    * @param mediaInputs - The input params to customize the media to be selected
    * @param callback - The callback to invoke after fetching the media
@@ -509,7 +512,8 @@ export namespace media {
   /**
    * View images using native image viewer
    *
-   * @deprecated As of 2.0.0-beta.1. Please use {@link media.viewImages media.viewImages(uriList: ImageUri[]): Promise\<void\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link media.viewImages media.viewImages(uriList: ImageUri[]): Promise\<void\>} instead.
    *
    * @param uriList - list of URIs for images to be viewed - can be content URI or server URL. Supports up to 10 Images in a single call
    * @param callback - returns back error if encountered, returns null in case of success
@@ -561,7 +565,8 @@ export namespace media {
    * @remarks
    * Note: For desktop and web, this API is not supported. Callback will be resolved with ErrorCode.NotSupported.
    *
-   * @deprecated As of 2.0.0-beta.1. Please use {@link media.scanBarCode media.scanBarCode(config?: BarCodeConfig): Promise\<string\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link media.scanBarCode media.scanBarCode(config?: BarCodeConfig): Promise\<string\>} instead.
    *
    * @param callback - callback to invoke after scanning the barcode
    * @param config - optional input configuration to customize the barcode scanning experience

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -158,7 +158,7 @@ export namespace meeting {
    */
   export function getIncomingClientAudioState(): Promise<boolean>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getIncomingClientAudioState(): Promise<boolean>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getIncomingClientAudioState meeting.getIncomingClientAudioState(): Promise\<boolean\>} instead.
    *
    * Allows an app to get the incoming audio speaker setting for the meeting user
    *
@@ -168,7 +168,6 @@ export namespace meeting {
    * result: True means incoming audio is muted and false means incoming audio is unmuted
    */
   export function getIncomingClientAudioState(callback: (error: SdkError | null, result: boolean | null) => void): void;
-
   export function getIncomingClientAudioState(
     callback?: (error: SdkError | null, result: boolean | null) => void,
   ): Promise<boolean> {
@@ -196,7 +195,7 @@ export namespace meeting {
    */
   export function toggleIncomingClientAudio(): Promise<boolean>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.toggleIncomingClientAudio(): Promise<boolean>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.toggleIncomingClientAudio meeting.toggleIncomingClientAudio(): Promise\<boolean\>} instead.
    *
    * @param callback - Callback contains 2 parameters, error and result.
    * error can either contain an error of type SdkError, incase of an error, or null when toggle is successful
@@ -204,7 +203,6 @@ export namespace meeting {
    * result: True means incoming audio is muted and false means incoming audio is unmuted
    */
   export function toggleIncomingClientAudio(callback: (error: SdkError | null, result: boolean | null) => void): void;
-
   export function toggleIncomingClientAudio(
     callback?: (error: SdkError | null, result: boolean | null) => void,
   ): Promise<boolean> {
@@ -233,7 +231,7 @@ export namespace meeting {
    */
   export function getMeetingDetails(): Promise<IMeetingDetails>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getMeetingDetails(): Promise<IMeetingDetails>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getMeetingDetails meeting.getMeetingDetails(): Promise\<IMeetingDetails\>} instead.
    *
    * @hidden
    * Hide from docs
@@ -249,7 +247,6 @@ export namespace meeting {
   export function getMeetingDetails(
     callback: (error: SdkError | null, meetingDetails: IMeetingDetails | null) => void,
   ): void;
-
   export function getMeetingDetails(
     callback?: (error: SdkError | null, meetingDetails: IMeetingDetails | null) => void,
   ): Promise<IMeetingDetails> {
@@ -281,7 +278,7 @@ export namespace meeting {
    */
   export function getAuthenticationTokenForAnonymousUser(): Promise<string>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getAuthenticationTokenForAnonymousUser(): Promise<string>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getAuthenticationTokenForAnonymousUser meeting.getAuthenticationTokenForAnonymousUser(): Promise\<string\>} instead.
    *
    * @hidden
    * Hide from docs
@@ -296,7 +293,6 @@ export namespace meeting {
   export function getAuthenticationTokenForAnonymousUser(
     callback: (error: SdkError | null, authenticationTokenOfAnonymousUser: string | null) => void,
   ): void;
-
   export function getAuthenticationTokenForAnonymousUser(
     callback?: (error: SdkError | null, authenticationTokenOfAnonymousUser: string | null) => void,
   ): Promise<string> {
@@ -324,7 +320,7 @@ export namespace meeting {
    */
   export function getLiveStreamState(): Promise<LiveStreamState>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getLiveStreamState(): Promise<LiveStreamState>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getLiveStreamState meeting.getLiveStreamState(): Promise\<LiveStreamState\>} instead.
    *
    * Allows an app to get the state of the live stream in the current meeting
    *
@@ -335,7 +331,6 @@ export namespace meeting {
   export function getLiveStreamState(
     callback: (error: SdkError | null, liveStreamState: LiveStreamState | null) => void,
   ): void;
-
   export function getLiveStreamState(
     callback?: (error: SdkError | null, liveStreamState: LiveStreamState | null) => void,
   ): Promise<LiveStreamState> {
@@ -364,7 +359,7 @@ export namespace meeting {
    */
   export function requestStartLiveStreaming(streamUrl: string, streamKey?: string): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.requestStartLiveStreaming(streamUrl: string, streamKey?: string): Promise<void>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.requestStartLiveStreaming meeting.requestStartLiveStreaming(streamUrl: string, streamKey?: string): Promise\<void\>} instead.
    *
    * Allows an app to request the live streaming be started at the given streaming url
    *
@@ -379,7 +374,6 @@ export namespace meeting {
     streamUrl: string,
     streamKey?: string,
   ): Promise<void>;
-
   /**
    * @hidden
    * This function is the overloaded implementation of requestStartLiveStreaming.
@@ -429,7 +423,7 @@ export namespace meeting {
    */
   export function requestStopLiveStreaming(): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.requestStopLiveStreaming(): Promise<void>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.requestStopLiveStreaming meeting.requestStopLiveStreaming(): Promise\<void\>} instead.
    *
    * Allows an app to request the live streaming be stopped at the given streaming url
    * @param callback - Callback contains error parameter which can be of type SdkError in case of an error, or null when operation is successful
@@ -437,7 +431,6 @@ export namespace meeting {
    * Use getLiveStreamState or registerLiveStreamChangedHandler to get updates on the live stream state
    */
   export function requestStopLiveStreaming(callback: (error: SdkError | null) => void): void;
-
   export function requestStopLiveStreaming(callback?: (error: SdkError | null) => void): Promise<void> {
     ensureInitialized(FrameContexts.sidePanel);
     return callCallbackWithSdkErrorFromPromiseAndReturnPromise(requestStopLiveStreamingHelper, callback);
@@ -474,7 +467,7 @@ export namespace meeting {
    */
   export function shareAppContentToStage(appContentUrl: string): Promise<boolean>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.shareAppContentToStage(appContentUrl: string): Promise<boolean>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.shareAppContentToStage meeting.shareAppContentToStage(appContentUrl: string): Promise\<boolean\>} instead.
    *
    * Allows an app to share contents in the meeting
    *
@@ -487,7 +480,6 @@ export namespace meeting {
     callback: (error: SdkError | null, result: boolean | null) => void,
     appContentUrl: string,
   ): void;
-
   /**
    * @hidden
    * This function is the overloaded implementation of shareAppContentToStage.
@@ -531,7 +523,7 @@ export namespace meeting {
    */
   export function getAppContentStageSharingCapabilities(): Promise<IAppContentStageSharingCapabilities>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getAppContentStageSharingCapabilities(): Promise<IAppContentStageSharingCapabilities>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getAppContentStageSharingCapabilities meeting.getAppContentStageSharingCapabilities(): Promise\<IAppContentStageSharingCapabilities\>} instead.
    *
    * Provides information related to app's in-meeting sharing capabilities
    *
@@ -546,7 +538,6 @@ export namespace meeting {
       appContentStageSharingCapabilities: IAppContentStageSharingCapabilities | null,
     ) => void,
   ): void;
-
   export function getAppContentStageSharingCapabilities(
     callback?: (
       error: SdkError | null,
@@ -577,7 +568,7 @@ export namespace meeting {
    */
   export function stopSharingAppContentToStage(): Promise<boolean>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.stopSharingAppContentToStage(): Promise<boolean>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.stopSharingAppContentToStage meeting.stopSharingAppContentToStage(): Promise\<boolean\>} instead.
    *
    * @hidden
    * Hide from docs.
@@ -591,7 +582,6 @@ export namespace meeting {
   export function stopSharingAppContentToStage(
     callback: (error: SdkError | null, result: boolean | null) => void,
   ): void;
-
   export function stopSharingAppContentToStage(
     callback?: (error: SdkError | null, result: boolean | null) => void,
   ): Promise<boolean> {
@@ -615,7 +605,7 @@ export namespace meeting {
    */
   export function getAppContentStageSharingState(): Promise<IAppContentStageSharingState>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getAppContentStageSharingState(): Promise<IAppContentStageSharingState>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getAppContentStageSharingState meeting.getAppContentStageSharingState(): Promise\<IAppContentStageSharingState\>} instead.
    *
    * Provides information related to current stage sharing state for app
    * @param callback - Callback contains 2 parameters, error and result.
@@ -626,7 +616,6 @@ export namespace meeting {
   export function getAppContentStageSharingState(
     callback: (error: SdkError | null, appContentStageSharingState: IAppContentStageSharingState | null) => void,
   ): void;
-
   export function getAppContentStageSharingState(
     callback?: (error: SdkError | null, appContentStageSharingState: IAppContentStageSharingState | null) => void,
   ): Promise<IAppContentStageSharingState> {

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -158,7 +158,7 @@ export namespace meeting {
    */
   export function getIncomingClientAudioState(): Promise<boolean>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.getIncomingClientAudioState(): Promise<boolean>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getIncomingClientAudioState(): Promise<boolean>} instead.
    *
    * Allows an app to get the incoming audio speaker setting for the meeting user
    *
@@ -196,7 +196,7 @@ export namespace meeting {
    */
   export function toggleIncomingClientAudio(): Promise<boolean>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.toggleIncomingClientAudio(): Promise<boolean>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.toggleIncomingClientAudio(): Promise<boolean>} instead.
    *
    * @param callback - Callback contains 2 parameters, error and result.
    * error can either contain an error of type SdkError, incase of an error, or null when toggle is successful
@@ -233,7 +233,7 @@ export namespace meeting {
    */
   export function getMeetingDetails(): Promise<IMeetingDetails>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.getMeetingDetails(): Promise<IMeetingDetails>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getMeetingDetails(): Promise<IMeetingDetails>} instead.
    *
    * @hidden
    * Hide from docs
@@ -281,7 +281,7 @@ export namespace meeting {
    */
   export function getAuthenticationTokenForAnonymousUser(): Promise<string>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.getAuthenticationTokenForAnonymousUser(): Promise<string>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getAuthenticationTokenForAnonymousUser(): Promise<string>} instead.
    *
    * @hidden
    * Hide from docs
@@ -324,7 +324,7 @@ export namespace meeting {
    */
   export function getLiveStreamState(): Promise<LiveStreamState>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.getLiveStreamState(): Promise<LiveStreamState>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getLiveStreamState(): Promise<LiveStreamState>} instead.
    *
    * Allows an app to get the state of the live stream in the current meeting
    *
@@ -364,7 +364,7 @@ export namespace meeting {
    */
   export function requestStartLiveStreaming(streamUrl: string, streamKey?: string): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.requestStartLiveStreaming(streamUrl: string, streamKey?: string): Promise<void>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.requestStartLiveStreaming(streamUrl: string, streamKey?: string): Promise<void>} instead.
    *
    * Allows an app to request the live streaming be started at the given streaming url
    *
@@ -429,7 +429,7 @@ export namespace meeting {
    */
   export function requestStopLiveStreaming(): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.requestStopLiveStreaming(): Promise<void>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.requestStopLiveStreaming(): Promise<void>} instead.
    *
    * Allows an app to request the live streaming be stopped at the given streaming url
    * @param callback - Callback contains error parameter which can be of type SdkError in case of an error, or null when operation is successful
@@ -474,7 +474,7 @@ export namespace meeting {
    */
   export function shareAppContentToStage(appContentUrl: string): Promise<boolean>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.shareAppContentToStage(appContentUrl: string): Promise<boolean>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.shareAppContentToStage(appContentUrl: string): Promise<boolean>} instead.
    *
    * Allows an app to share contents in the meeting
    *
@@ -531,7 +531,7 @@ export namespace meeting {
    */
   export function getAppContentStageSharingCapabilities(): Promise<IAppContentStageSharingCapabilities>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.getAppContentStageSharingCapabilities(): Promise<IAppContentStageSharingCapabilities>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getAppContentStageSharingCapabilities(): Promise<IAppContentStageSharingCapabilities>} instead.
    *
    * Provides information related to app's in-meeting sharing capabilities
    *
@@ -577,7 +577,7 @@ export namespace meeting {
    */
   export function stopSharingAppContentToStage(): Promise<boolean>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.stopSharingAppContentToStage(): Promise<boolean>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.stopSharingAppContentToStage(): Promise<boolean>} instead.
    *
    * @hidden
    * Hide from docs.
@@ -615,7 +615,7 @@ export namespace meeting {
    */
   export function getAppContentStageSharingState(): Promise<IAppContentStageSharingState>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.getAppContentStageSharingState(): Promise<IAppContentStageSharingState>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getAppContentStageSharingState(): Promise<IAppContentStageSharingState>} instead.
    *
    * Provides information related to current stage sharing state for app
    * @param callback - Callback contains 2 parameters, error and result.

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -158,7 +158,8 @@ export namespace meeting {
    */
   export function getIncomingClientAudioState(): Promise<boolean>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getIncomingClientAudioState meeting.getIncomingClientAudioState(): Promise\<boolean\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link meeting.getIncomingClientAudioState meeting.getIncomingClientAudioState(): Promise\<boolean\>} instead.
    *
    * Allows an app to get the incoming audio speaker setting for the meeting user
    *
@@ -195,7 +196,8 @@ export namespace meeting {
    */
   export function toggleIncomingClientAudio(): Promise<boolean>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.toggleIncomingClientAudio meeting.toggleIncomingClientAudio(): Promise\<boolean\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link meeting.toggleIncomingClientAudio meeting.toggleIncomingClientAudio(): Promise\<boolean\>} instead.
    *
    * @param callback - Callback contains 2 parameters, error and result.
    * error can either contain an error of type SdkError, incase of an error, or null when toggle is successful
@@ -231,7 +233,8 @@ export namespace meeting {
    */
   export function getMeetingDetails(): Promise<IMeetingDetails>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getMeetingDetails meeting.getMeetingDetails(): Promise\<IMeetingDetails\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link meeting.getMeetingDetails meeting.getMeetingDetails(): Promise\<IMeetingDetails\>} instead.
    *
    * @hidden
    * Hide from docs
@@ -278,7 +281,8 @@ export namespace meeting {
    */
   export function getAuthenticationTokenForAnonymousUser(): Promise<string>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getAuthenticationTokenForAnonymousUser meeting.getAuthenticationTokenForAnonymousUser(): Promise\<string\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link meeting.getAuthenticationTokenForAnonymousUser meeting.getAuthenticationTokenForAnonymousUser(): Promise\<string\>} instead.
    *
    * @hidden
    * Hide from docs
@@ -320,7 +324,8 @@ export namespace meeting {
    */
   export function getLiveStreamState(): Promise<LiveStreamState>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getLiveStreamState meeting.getLiveStreamState(): Promise\<LiveStreamState\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link meeting.getLiveStreamState meeting.getLiveStreamState(): Promise\<LiveStreamState\>} instead.
    *
    * Allows an app to get the state of the live stream in the current meeting
    *
@@ -359,7 +364,8 @@ export namespace meeting {
    */
   export function requestStartLiveStreaming(streamUrl: string, streamKey?: string): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.requestStartLiveStreaming meeting.requestStartLiveStreaming(streamUrl: string, streamKey?: string): Promise\<void\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link meeting.requestStartLiveStreaming meeting.requestStartLiveStreaming(streamUrl: string, streamKey?: string): Promise\<void\>} instead.
    *
    * Allows an app to request the live streaming be started at the given streaming url
    *
@@ -423,7 +429,8 @@ export namespace meeting {
    */
   export function requestStopLiveStreaming(): Promise<void>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.requestStopLiveStreaming meeting.requestStopLiveStreaming(): Promise\<void\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link meeting.requestStopLiveStreaming meeting.requestStopLiveStreaming(): Promise\<void\>} instead.
    *
    * Allows an app to request the live streaming be stopped at the given streaming url
    * @param callback - Callback contains error parameter which can be of type SdkError in case of an error, or null when operation is successful
@@ -467,7 +474,8 @@ export namespace meeting {
    */
   export function shareAppContentToStage(appContentUrl: string): Promise<boolean>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.shareAppContentToStage meeting.shareAppContentToStage(appContentUrl: string): Promise\<boolean\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link meeting.shareAppContentToStage meeting.shareAppContentToStage(appContentUrl: string): Promise\<boolean\>} instead.
    *
    * Allows an app to share contents in the meeting
    *
@@ -523,7 +531,8 @@ export namespace meeting {
    */
   export function getAppContentStageSharingCapabilities(): Promise<IAppContentStageSharingCapabilities>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getAppContentStageSharingCapabilities meeting.getAppContentStageSharingCapabilities(): Promise\<IAppContentStageSharingCapabilities\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link meeting.getAppContentStageSharingCapabilities meeting.getAppContentStageSharingCapabilities(): Promise\<IAppContentStageSharingCapabilities\>} instead.
    *
    * Provides information related to app's in-meeting sharing capabilities
    *
@@ -568,7 +577,8 @@ export namespace meeting {
    */
   export function stopSharingAppContentToStage(): Promise<boolean>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.stopSharingAppContentToStage meeting.stopSharingAppContentToStage(): Promise\<boolean\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link meeting.stopSharingAppContentToStage meeting.stopSharingAppContentToStage(): Promise\<boolean\>} instead.
    *
    * @hidden
    * Hide from docs.
@@ -605,7 +615,8 @@ export namespace meeting {
    */
   export function getAppContentStageSharingState(): Promise<IAppContentStageSharingState>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link meeting.getAppContentStageSharingState meeting.getAppContentStageSharingState(): Promise\<IAppContentStageSharingState\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link meeting.getAppContentStageSharingState meeting.getAppContentStageSharingState(): Promise\<IAppContentStageSharingState\>} instead.
    *
    * Provides information related to current stage sharing state for app
    * @param callback - Callback contains 2 parameters, error and result.

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -158,7 +158,7 @@ export namespace meeting {
    */
   export function getIncomingClientAudioState(): Promise<boolean>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.getIncomingClientAudioState(): Promise<boolean>' instead.
    *
    * Allows an app to get the incoming audio speaker setting for the meeting user
    *
@@ -196,7 +196,7 @@ export namespace meeting {
    */
   export function toggleIncomingClientAudio(): Promise<boolean>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.toggleIncomingClientAudio(): Promise<boolean>' instead.
    *
    * @param callback - Callback contains 2 parameters, error and result.
    * error can either contain an error of type SdkError, incase of an error, or null when toggle is successful
@@ -233,7 +233,7 @@ export namespace meeting {
    */
   export function getMeetingDetails(): Promise<IMeetingDetails>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.getMeetingDetails(): Promise<IMeetingDetails>' instead.
    *
    * @hidden
    * Hide from docs
@@ -281,7 +281,7 @@ export namespace meeting {
    */
   export function getAuthenticationTokenForAnonymousUser(): Promise<string>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.getAuthenticationTokenForAnonymousUser(): Promise<string>' instead.
    *
    * @hidden
    * Hide from docs
@@ -324,7 +324,7 @@ export namespace meeting {
    */
   export function getLiveStreamState(): Promise<LiveStreamState>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.getLiveStreamState(): Promise<LiveStreamState>' instead.
    *
    * Allows an app to get the state of the live stream in the current meeting
    *
@@ -364,7 +364,7 @@ export namespace meeting {
    */
   export function requestStartLiveStreaming(streamUrl: string, streamKey?: string): Promise<void>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.requestStartLiveStreaming(streamUrl: string, streamKey?: string): Promise<void>' instead.
    *
    * Allows an app to request the live streaming be started at the given streaming url
    *
@@ -429,7 +429,7 @@ export namespace meeting {
    */
   export function requestStopLiveStreaming(): Promise<void>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.requestStopLiveStreaming(): Promise<void>' instead.
    *
    * Allows an app to request the live streaming be stopped at the given streaming url
    * @param callback - Callback contains error parameter which can be of type SdkError in case of an error, or null when operation is successful
@@ -474,7 +474,7 @@ export namespace meeting {
    */
   export function shareAppContentToStage(appContentUrl: string): Promise<boolean>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.shareAppContentToStage(appContentUrl: string): Promise<boolean>' instead.
    *
    * Allows an app to share contents in the meeting
    *
@@ -531,7 +531,7 @@ export namespace meeting {
    */
   export function getAppContentStageSharingCapabilities(): Promise<IAppContentStageSharingCapabilities>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.getAppContentStageSharingCapabilities(): Promise<IAppContentStageSharingCapabilities>' instead.
    *
    * Provides information related to app's in-meeting sharing capabilities
    *
@@ -577,7 +577,7 @@ export namespace meeting {
    */
   export function stopSharingAppContentToStage(): Promise<boolean>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.stopSharingAppContentToStage(): Promise<boolean>' instead.
    *
    * @hidden
    * Hide from docs.
@@ -615,7 +615,7 @@ export namespace meeting {
    */
   export function getAppContentStageSharingState(): Promise<IAppContentStageSharingState>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'meeting.getAppContentStageSharingState(): Promise<IAppContentStageSharingState>' instead.
    *
    * Provides information related to current stage sharing state for app
    * @param callback - Callback contains 2 parameters, error and result.

--- a/packages/teams-js/src/public/navigation.ts
+++ b/packages/teams-js/src/public/navigation.ts
@@ -7,7 +7,7 @@ import { pages } from './pages';
  */
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.returnFocus(navigateForward?: boolean): void' instead.
  *
  * Return focus to the main Teams app. Will focus search bar if navigating foward and app bar if navigating back.
  *
@@ -18,7 +18,7 @@ export function returnFocus(navigateForward?: boolean): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.tabs.navigateToTab(tabInstance: TabInstance): Promise<void>' instead.
  *
  * Navigates the Microsoft Teams app to the specified tab instance.
  *
@@ -42,7 +42,7 @@ export function navigateToTab(tabInstance: TabInstance, onComplete?: (status: bo
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.navigateCrossDomain(url: string): Promise<void>' instead.
  *
  * Navigates the frame to a new cross-domain URL. The domain of this URL must match at least one of the
  * valid domains specified in the validDomains block of the manifest; otherwise, an exception will be
@@ -78,7 +78,7 @@ export function navigateCrossDomain(url: string, onComplete?: (status: boolean, 
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.backStack.navigateBack(): Promise<void>' instead.
  *
  * Navigates back in the Teams client.
  * See registerBackButtonHandler for more information on when it's appropriate to use this method.

--- a/packages/teams-js/src/public/navigation.ts
+++ b/packages/teams-js/src/public/navigation.ts
@@ -7,7 +7,7 @@ import { pages } from './pages';
  */
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.returnFocus(navigateForward?: boolean): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.returnFocus pages.returnFocus(navigateForward?: boolean): void} instead.
  *
  * Return focus to the main Teams app. Will focus search bar if navigating foward and app bar if navigating back.
  *
@@ -18,7 +18,7 @@ export function returnFocus(navigateForward?: boolean): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.tabs.navigateToTab(tabInstance: TabInstance): Promise<void>} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.tabs.navigateToTab pages.tabs.navigateToTab(tabInstance: TabInstance): Promise\<void\>} instead.
  *
  * Navigates the Microsoft Teams app to the specified tab instance.
  *
@@ -42,7 +42,7 @@ export function navigateToTab(tabInstance: TabInstance, onComplete?: (status: bo
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.navigateCrossDomain(url: string): Promise<void>} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.navigateCrossDomain pages.navigateCrossDomain(url: string): Promise\<void\>} instead.
  *
  * Navigates the frame to a new cross-domain URL. The domain of this URL must match at least one of the
  * valid domains specified in the validDomains block of the manifest; otherwise, an exception will be
@@ -78,7 +78,7 @@ export function navigateCrossDomain(url: string, onComplete?: (status: boolean, 
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.backStack.navigateBack(): Promise<void>} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.backStack.navigateBack pages.backStack.navigateBack(): Promise\<void\>} instead.
  *
  * Navigates back in the Teams client.
  * See registerBackButtonHandler for more information on when it's appropriate to use this method.

--- a/packages/teams-js/src/public/navigation.ts
+++ b/packages/teams-js/src/public/navigation.ts
@@ -7,7 +7,8 @@ import { pages } from './pages';
  */
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.returnFocus pages.returnFocus(navigateForward?: boolean): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.returnFocus pages.returnFocus(navigateForward?: boolean): void} instead.
  *
  * Return focus to the main Teams app. Will focus search bar if navigating foward and app bar if navigating back.
  *
@@ -18,7 +19,8 @@ export function returnFocus(navigateForward?: boolean): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.tabs.navigateToTab pages.tabs.navigateToTab(tabInstance: TabInstance): Promise\<void\>} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.tabs.navigateToTab pages.tabs.navigateToTab(tabInstance: TabInstance): Promise\<void\>} instead.
  *
  * Navigates the Microsoft Teams app to the specified tab instance.
  *
@@ -42,7 +44,8 @@ export function navigateToTab(tabInstance: TabInstance, onComplete?: (status: bo
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.navigateCrossDomain pages.navigateCrossDomain(url: string): Promise\<void\>} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.navigateCrossDomain pages.navigateCrossDomain(url: string): Promise\<void\>} instead.
  *
  * Navigates the frame to a new cross-domain URL. The domain of this URL must match at least one of the
  * valid domains specified in the validDomains block of the manifest; otherwise, an exception will be
@@ -78,7 +81,8 @@ export function navigateCrossDomain(url: string, onComplete?: (status: boolean, 
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.backStack.navigateBack pages.backStack.navigateBack(): Promise\<void\>} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.backStack.navigateBack pages.backStack.navigateBack(): Promise\<void\>} instead.
  *
  * Navigates back in the Teams client.
  * See registerBackButtonHandler for more information on when it's appropriate to use this method.

--- a/packages/teams-js/src/public/navigation.ts
+++ b/packages/teams-js/src/public/navigation.ts
@@ -7,7 +7,7 @@ import { pages } from './pages';
  */
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.returnFocus(navigateForward?: boolean): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.returnFocus(navigateForward?: boolean): void} instead.
  *
  * Return focus to the main Teams app. Will focus search bar if navigating foward and app bar if navigating back.
  *
@@ -18,7 +18,7 @@ export function returnFocus(navigateForward?: boolean): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.tabs.navigateToTab(tabInstance: TabInstance): Promise<void>' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.tabs.navigateToTab(tabInstance: TabInstance): Promise<void>} instead.
  *
  * Navigates the Microsoft Teams app to the specified tab instance.
  *
@@ -42,7 +42,7 @@ export function navigateToTab(tabInstance: TabInstance, onComplete?: (status: bo
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.navigateCrossDomain(url: string): Promise<void>' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.navigateCrossDomain(url: string): Promise<void>} instead.
  *
  * Navigates the frame to a new cross-domain URL. The domain of this URL must match at least one of the
  * valid domains specified in the validDomains block of the manifest; otherwise, an exception will be
@@ -78,7 +78,7 @@ export function navigateCrossDomain(url: string, onComplete?: (status: boolean, 
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.backStack.navigateBack(): Promise<void>' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.backStack.navigateBack(): Promise<void>} instead.
  *
  * Navigates back in the Teams client.
  * See registerBackButtonHandler for more information on when it's appropriate to use this method.

--- a/packages/teams-js/src/public/people.ts
+++ b/packages/teams-js/src/public/people.ts
@@ -21,7 +21,7 @@ export namespace people {
    */
   export function selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise<PeoplePickerResult[]>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link people.selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise<PeoplePickerResult[]>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link people.selectPeople people.selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise\<PeoplePickerResult[]\>} instead.
    *
    * Launches a people picker and allows the user to select one or more people from the list
    * If the app is added to personal app scope the people picker launched is org wide and if the app is added to a chat/channel, people picker launched is also limited to the members of chat/channel

--- a/packages/teams-js/src/public/people.ts
+++ b/packages/teams-js/src/public/people.ts
@@ -21,7 +21,8 @@ export namespace people {
    */
   export function selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise<PeoplePickerResult[]>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link people.selectPeople people.selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise\<PeoplePickerResult[]\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link people.selectPeople people.selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise\<PeoplePickerResult[]\>} instead.
    *
    * Launches a people picker and allows the user to select one or more people from the list
    * If the app is added to personal app scope the people picker launched is org wide and if the app is added to a chat/channel, people picker launched is also limited to the members of chat/channel

--- a/packages/teams-js/src/public/people.ts
+++ b/packages/teams-js/src/public/people.ts
@@ -21,7 +21,7 @@ export namespace people {
    */
   export function selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise<PeoplePickerResult[]>;
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'people.selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise<PeoplePickerResult[]>' instead.
    *
    * Launches a people picker and allows the user to select one or more people from the list
    * If the app is added to personal app scope the people picker launched is org wide and if the app is added to a chat/channel, people picker launched is also limited to the members of chat/channel

--- a/packages/teams-js/src/public/people.ts
+++ b/packages/teams-js/src/public/people.ts
@@ -21,7 +21,7 @@ export namespace people {
    */
   export function selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise<PeoplePickerResult[]>;
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'people.selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise<PeoplePickerResult[]>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link people.selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise<PeoplePickerResult[]>} instead.
    *
    * Launches a people picker and allows the user to select one or more people from the list
    * If the app is added to personal app scope the people picker launched is org wide and if the app is added to a chat/channel, people picker launched is also limited to the members of chat/channel

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -13,7 +13,7 @@ import { pages } from './pages';
 import { teamsCore } from './teamsAPIs';
 
 /**
- * @deprecated with TeamsJS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'app.initialize(validMessageOrigins?: string[]): Promise<void>' instead.
  *
  * Initializes the library. This must be called before any other SDK calls
  * but after the frame is loaded successfully.
@@ -30,7 +30,7 @@ export function initialize(callback?: () => void, validMessageOrigins?: string[]
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'app._initialize(hostWindow: any): void' instead.
  *
  * @hidden
  * Hide from docs.
@@ -45,7 +45,7 @@ export function _initialize(hostWindow: any): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'app._uninitialize(): void' instead.
  *
  * @hidden
  * Hide from docs.
@@ -59,7 +59,7 @@ export function _uninitialize(): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'teamsCore.enablePrintCapability(): void' instead.
  *
  * Enable print capability to support printing page using Ctrl+P and cmd+P
  */
@@ -68,7 +68,7 @@ export function enablePrintCapability(): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'teamsCore.print(): void' instead.
  *
  * Default print handler
  */
@@ -77,7 +77,7 @@ export function print(): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'app.getContext(): Promise<app.Context>' instead.
  *
  * Retrieves the current context the frame is running in.
  *
@@ -93,7 +93,7 @@ export function getContext(callback: (context: Context) => void): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'app.registerOnThemeChangeHandler(handler: (theme: string) => void): void' instead.
  *
  * Registers a handler for theme changes.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -105,7 +105,7 @@ export function registerOnThemeChangeHandler(handler: (theme: string) => void): 
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.registerFullScreenHandler(handler: (isFullScreen: boolean) => void): void' instead.
  *
  * Registers a handler for changes from or to full-screen view for a tab.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -117,7 +117,7 @@ export function registerFullScreenHandler(handler: (isFullScreen: boolean) => vo
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.appButton.onClick(handler: () => void): void' instead.
  *
  * Registers a handler for clicking the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -129,7 +129,7 @@ export function registerAppButtonClickHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.appButton.onHoverEnter(handler: () => void): void' instead.
  *
  * Registers a handler for entering hover of the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -141,7 +141,7 @@ export function registerAppButtonHoverEnterHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.appButton.onHoverLeave(handler: () => void): void' instead.
  *
  * Registers a handler for exiting hover of the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -153,7 +153,7 @@ export function registerAppButtonHoverLeaveHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.backStack.registerBackButtonHandler(handler: () => boolean): void' instead.
  *
  * Registers a handler for user presses of the Team client's back button. Experiences that maintain an internal
  * navigation stack should use this handler to navigate the user back within their frame. If an app finds
@@ -167,7 +167,7 @@ export function registerBackButtonHandler(handler: () => boolean): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'teamsCore.registerOnLoadHandler(handler: (context: LoadContext) => void): void' instead.
  *
  * @hidden
  * Registers a handler to be called when the page has been requested to load.
@@ -179,7 +179,7 @@ export function registerOnLoadHandler(handler: (context: LoadContext) => void): 
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'teamsCore.registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void' instead.
  *
  * @hidden
  * Registers a handler to be called before the page is unloaded.
@@ -192,7 +192,7 @@ export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void)
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'teamsCore.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void' instead.
  *
  * @hidden
  * Registers a handler when focus needs to be passed from teams to the place of choice on app.
@@ -204,7 +204,7 @@ export function registerFocusEnterHandler(handler: (navigateForward: boolean) =>
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.registerChangeConfigHandler(handler: () => void): void' instead.
  *
  * Registers a handler for when the user reconfigurated tab.
  *
@@ -215,7 +215,7 @@ export function registerEnterSettingsHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.tabs.getTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise<TabInformation>' instead.
  *
  * Allows an app to retrieve for this user tabs that are owned by this app.
  * If no TabInstanceParameters are passed, the app defaults to favorite teams and favorite channels.
@@ -234,7 +234,7 @@ export function getTabInstances(
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.tabs.getMruTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise<TabInformation>' instead.
  *
  * Allows an app to retrieve the most recently used tabs for this user.
  *
@@ -252,7 +252,7 @@ export function getMruTabInstances(
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'core.shareDeepLink(deepLinkParameters: DeepLinkParameters): void' instead.
  *
  * Shares a deep link that a user can use to navigate back to a specific state in this page.
  *
@@ -263,7 +263,7 @@ export function shareDeepLink(deepLinkParameters: DeepLinkParameters): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'core.executeDeepLink(deepLink: string): Promise<void>' instead.
  *
  * Execute deep link API.
  *
@@ -293,7 +293,7 @@ export function executeDeepLink(deepLink: string, onComplete?: (status: boolean,
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.setCurrentFrame(frameInfo: FrameInfo): void' instead.
  *
  * Set the current Frame Context
  *
@@ -304,7 +304,7 @@ export function setFrameContext(frameContext: FrameContext): void {
 }
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.initializeWithFrameContext(frameInfo: FrameInfo, callback?: () => void, validMessageOrigins?: string[],): void' instead.
  *
  * Initilize with FrameContext
  *

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -13,7 +13,7 @@ import { pages } from './pages';
 import { teamsCore } from './teamsAPIs';
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link app.initialize(validMessageOrigins?: string[]): Promise<void>} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link app.initialize app.initialize(validMessageOrigins?: string[]): Promise\<void\>} instead.
  *
  * Initializes the library. This must be called before any other SDK calls
  * but after the frame is loaded successfully.
@@ -30,7 +30,7 @@ export function initialize(callback?: () => void, validMessageOrigins?: string[]
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link app._initialize(hostWindow: any): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link app._initialize app._initialize(hostWindow: any): void} instead.
  *
  * @hidden
  * Hide from docs.
@@ -45,7 +45,7 @@ export function _initialize(hostWindow: any): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link app._uninitialize(): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link app._uninitialize app._uninitialize(): void} instead.
  *
  * @hidden
  * Hide from docs.
@@ -59,7 +59,7 @@ export function _uninitialize(): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.enablePrintCapability(): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.enablePrintCapability teamsCore.enablePrintCapability(): void} instead.
  *
  * Enable print capability to support printing page using Ctrl+P and cmd+P
  */
@@ -68,7 +68,7 @@ export function enablePrintCapability(): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.print(): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.print teamsCore.print(): void} instead.
  *
  * Default print handler
  */
@@ -77,7 +77,7 @@ export function print(): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link app.getContext(): Promise<app.Context>} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link app.getContext app.getContext(): Promise\<app.Context\>} instead.
  *
  * Retrieves the current context the frame is running in.
  *
@@ -93,7 +93,7 @@ export function getContext(callback: (context: Context) => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link app.registerOnThemeChangeHandler(handler: (theme: string) => void): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link app.registerOnThemeChangeHandler app.registerOnThemeChangeHandler(handler: (theme: string) => void): void} instead.
  *
  * Registers a handler for theme changes.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -105,7 +105,7 @@ export function registerOnThemeChangeHandler(handler: (theme: string) => void): 
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.registerFullScreenHandler(handler: (isFullScreen: boolean) => void): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.registerFullScreenHandler pages.registerFullScreenHandler(handler: (isFullScreen: boolean) => void): void} instead.
  *
  * Registers a handler for changes from or to full-screen view for a tab.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -117,7 +117,7 @@ export function registerFullScreenHandler(handler: (isFullScreen: boolean) => vo
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.appButton.onClick(handler: () => void): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.appButton.onClick pages.appButton.onClick(handler: () => void): void} instead.
  *
  * Registers a handler for clicking the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -129,7 +129,7 @@ export function registerAppButtonClickHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.appButton.onHoverEnter(handler: () => void): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.appButton.onHoverEnter pages.appButton.onHoverEnter(handler: () => void): void} instead.
  *
  * Registers a handler for entering hover of the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -141,7 +141,7 @@ export function registerAppButtonHoverEnterHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.appButton.onHoverLeave(handler: () => void): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.appButton.onHoverLeave pages.appButton.onHoverLeave(handler: () => void): void} instead.
  *
  * Registers a handler for exiting hover of the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -153,7 +153,7 @@ export function registerAppButtonHoverLeaveHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.backStack.registerBackButtonHandler(handler: () => boolean): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.backStack.registerBackButtonHandler pages.backStack.registerBackButtonHandler(handler: () => boolean): void} instead.
  *
  * Registers a handler for user presses of the Team client's back button. Experiences that maintain an internal
  * navigation stack should use this handler to navigate the user back within their frame. If an app finds
@@ -167,7 +167,7 @@ export function registerBackButtonHandler(handler: () => boolean): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.registerOnLoadHandler(handler: (context: LoadContext) => void): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.registerOnLoadHandler teamsCore.registerOnLoadHandler(handler: (context: LoadContext) => void): void} instead.
  *
  * @hidden
  * Registers a handler to be called when the page has been requested to load.
@@ -179,7 +179,7 @@ export function registerOnLoadHandler(handler: (context: LoadContext) => void): 
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.registerBeforeUnloadHandler teamsCore.registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void} instead.
  *
  * @hidden
  * Registers a handler to be called before the page is unloaded.
@@ -192,7 +192,7 @@ export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void)
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.registerFocusEnterHandler teamsCore.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void} instead.
  *
  * @hidden
  * Registers a handler when focus needs to be passed from teams to the place of choice on app.
@@ -204,7 +204,7 @@ export function registerFocusEnterHandler(handler: (navigateForward: boolean) =>
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.registerChangeConfigHandler(handler: () => void): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.registerChangeConfigHandler pages.config.registerChangeConfigHandler(handler: () => void): void} instead.
  *
  * Registers a handler for when the user reconfigurated tab.
  *
@@ -215,7 +215,7 @@ export function registerEnterSettingsHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.tabs.getTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise<TabInformation>} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.tabs.getTabInstances pages.tabs.getTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise\<TabInformation\>} instead.
  *
  * Allows an app to retrieve for this user tabs that are owned by this app.
  * If no TabInstanceParameters are passed, the app defaults to favorite teams and favorite channels.
@@ -234,7 +234,7 @@ export function getTabInstances(
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.tabs.getMruTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise<TabInformation>} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.tabs.getMruTabInstances pages.tabs.getMruTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise\<TabInformation\>} instead.
  *
  * Allows an app to retrieve the most recently used tabs for this user.
  *
@@ -252,7 +252,7 @@ export function getMruTabInstances(
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link core.shareDeepLink(deepLinkParameters: DeepLinkParameters): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link core.shareDeepLink core.shareDeepLink(deepLinkParameters: DeepLinkParameters): void} instead.
  *
  * Shares a deep link that a user can use to navigate back to a specific state in this page.
  *
@@ -263,7 +263,7 @@ export function shareDeepLink(deepLinkParameters: DeepLinkParameters): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link core.executeDeepLink(deepLink: string): Promise<void>} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link core.executeDeepLink core.executeDeepLink(deepLink: string): Promise\<void\>} instead.
  *
  * Execute deep link API.
  *
@@ -293,7 +293,7 @@ export function executeDeepLink(deepLink: string, onComplete?: (status: boolean,
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.setCurrentFrame(frameInfo: FrameInfo): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.setCurrentFrame pages.setCurrentFrame(frameInfo: FrameInfo): void} instead.
  *
  * Set the current Frame Context
  *
@@ -304,7 +304,7 @@ export function setFrameContext(frameContext: FrameContext): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.initializeWithFrameContext(frameInfo: FrameInfo, callback?: () => void, validMessageOrigins?: string[],): void} instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.initializeWithFrameContext pages.initializeWithFrameContext(frameInfo: FrameInfo, callback?: () => void, validMessageOrigins?: string[],): void} instead.
  *
  * Initilize with FrameContext
  *

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -13,7 +13,8 @@ import { pages } from './pages';
 import { teamsCore } from './teamsAPIs';
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link app.initialize app.initialize(validMessageOrigins?: string[]): Promise\<void\>} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link app.initialize app.initialize(validMessageOrigins?: string[]): Promise\<void\>} instead.
  *
  * Initializes the library. This must be called before any other SDK calls
  * but after the frame is loaded successfully.
@@ -30,7 +31,8 @@ export function initialize(callback?: () => void, validMessageOrigins?: string[]
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link app._initialize app._initialize(hostWindow: any): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link app._initialize app._initialize(hostWindow: any): void} instead.
  *
  * @hidden
  * Hide from docs.
@@ -45,7 +47,8 @@ export function _initialize(hostWindow: any): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link app._uninitialize app._uninitialize(): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link app._uninitialize app._uninitialize(): void} instead.
  *
  * @hidden
  * Hide from docs.
@@ -59,7 +62,8 @@ export function _uninitialize(): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.enablePrintCapability teamsCore.enablePrintCapability(): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link teamsCore.enablePrintCapability teamsCore.enablePrintCapability(): void} instead.
  *
  * Enable print capability to support printing page using Ctrl+P and cmd+P
  */
@@ -68,7 +72,8 @@ export function enablePrintCapability(): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.print teamsCore.print(): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link teamsCore.print teamsCore.print(): void} instead.
  *
  * Default print handler
  */
@@ -77,7 +82,8 @@ export function print(): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link app.getContext app.getContext(): Promise\<app.Context\>} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link app.getContext app.getContext(): Promise\<app.Context\>} instead.
  *
  * Retrieves the current context the frame is running in.
  *
@@ -93,7 +99,8 @@ export function getContext(callback: (context: Context) => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link app.registerOnThemeChangeHandler app.registerOnThemeChangeHandler(handler: (theme: string) => void): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link app.registerOnThemeChangeHandler app.registerOnThemeChangeHandler(handler: (theme: string) => void): void} instead.
  *
  * Registers a handler for theme changes.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -105,7 +112,8 @@ export function registerOnThemeChangeHandler(handler: (theme: string) => void): 
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.registerFullScreenHandler pages.registerFullScreenHandler(handler: (isFullScreen: boolean) => void): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.registerFullScreenHandler pages.registerFullScreenHandler(handler: (isFullScreen: boolean) => void): void} instead.
  *
  * Registers a handler for changes from or to full-screen view for a tab.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -117,7 +125,8 @@ export function registerFullScreenHandler(handler: (isFullScreen: boolean) => vo
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.appButton.onClick pages.appButton.onClick(handler: () => void): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.appButton.onClick pages.appButton.onClick(handler: () => void): void} instead.
  *
  * Registers a handler for clicking the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -129,7 +138,8 @@ export function registerAppButtonClickHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.appButton.onHoverEnter pages.appButton.onHoverEnter(handler: () => void): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.appButton.onHoverEnter pages.appButton.onHoverEnter(handler: () => void): void} instead.
  *
  * Registers a handler for entering hover of the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -141,7 +151,8 @@ export function registerAppButtonHoverEnterHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.appButton.onHoverLeave pages.appButton.onHoverLeave(handler: () => void): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.appButton.onHoverLeave pages.appButton.onHoverLeave(handler: () => void): void} instead.
  *
  * Registers a handler for exiting hover of the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -153,7 +164,8 @@ export function registerAppButtonHoverLeaveHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.backStack.registerBackButtonHandler pages.backStack.registerBackButtonHandler(handler: () => boolean): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.backStack.registerBackButtonHandler pages.backStack.registerBackButtonHandler(handler: () => boolean): void} instead.
  *
  * Registers a handler for user presses of the Team client's back button. Experiences that maintain an internal
  * navigation stack should use this handler to navigate the user back within their frame. If an app finds
@@ -167,7 +179,8 @@ export function registerBackButtonHandler(handler: () => boolean): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.registerOnLoadHandler teamsCore.registerOnLoadHandler(handler: (context: LoadContext) => void): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link teamsCore.registerOnLoadHandler teamsCore.registerOnLoadHandler(handler: (context: LoadContext) => void): void} instead.
  *
  * @hidden
  * Registers a handler to be called when the page has been requested to load.
@@ -179,7 +192,8 @@ export function registerOnLoadHandler(handler: (context: LoadContext) => void): 
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.registerBeforeUnloadHandler teamsCore.registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link teamsCore.registerBeforeUnloadHandler teamsCore.registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void} instead.
  *
  * @hidden
  * Registers a handler to be called before the page is unloaded.
@@ -192,7 +206,8 @@ export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void)
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.registerFocusEnterHandler teamsCore.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link teamsCore.registerFocusEnterHandler teamsCore.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void} instead.
  *
  * @hidden
  * Registers a handler when focus needs to be passed from teams to the place of choice on app.
@@ -204,7 +219,8 @@ export function registerFocusEnterHandler(handler: (navigateForward: boolean) =>
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.registerChangeConfigHandler pages.config.registerChangeConfigHandler(handler: () => void): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.config.registerChangeConfigHandler pages.config.registerChangeConfigHandler(handler: () => void): void} instead.
  *
  * Registers a handler for when the user reconfigurated tab.
  *
@@ -215,7 +231,8 @@ export function registerEnterSettingsHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.tabs.getTabInstances pages.tabs.getTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise\<TabInformation\>} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.tabs.getTabInstances pages.tabs.getTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise\<TabInformation\>} instead.
  *
  * Allows an app to retrieve for this user tabs that are owned by this app.
  * If no TabInstanceParameters are passed, the app defaults to favorite teams and favorite channels.
@@ -234,7 +251,8 @@ export function getTabInstances(
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.tabs.getMruTabInstances pages.tabs.getMruTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise\<TabInformation\>} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.tabs.getMruTabInstances pages.tabs.getMruTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise\<TabInformation\>} instead.
  *
  * Allows an app to retrieve the most recently used tabs for this user.
  *
@@ -252,7 +270,8 @@ export function getMruTabInstances(
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link core.shareDeepLink core.shareDeepLink(deepLinkParameters: DeepLinkParameters): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link core.shareDeepLink core.shareDeepLink(deepLinkParameters: DeepLinkParameters): void} instead.
  *
  * Shares a deep link that a user can use to navigate back to a specific state in this page.
  *
@@ -263,7 +282,8 @@ export function shareDeepLink(deepLinkParameters: DeepLinkParameters): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link core.executeDeepLink core.executeDeepLink(deepLink: string): Promise\<void\>} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link core.executeDeepLink core.executeDeepLink(deepLink: string): Promise\<void\>} instead.
  *
  * Execute deep link API.
  *
@@ -293,7 +313,8 @@ export function executeDeepLink(deepLink: string, onComplete?: (status: boolean,
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.setCurrentFrame pages.setCurrentFrame(frameInfo: FrameInfo): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.setCurrentFrame pages.setCurrentFrame(frameInfo: FrameInfo): void} instead.
  *
  * Set the current Frame Context
  *
@@ -304,7 +325,8 @@ export function setFrameContext(frameContext: FrameContext): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.initializeWithFrameContext pages.initializeWithFrameContext(frameInfo: FrameInfo, callback?: () => void, validMessageOrigins?: string[],): void} instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.initializeWithFrameContext pages.initializeWithFrameContext(frameInfo: FrameInfo, callback?: () => void, validMessageOrigins?: string[],): void} instead.
  *
  * Initilize with FrameContext
  *

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -13,7 +13,7 @@ import { pages } from './pages';
 import { teamsCore } from './teamsAPIs';
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'app.initialize(validMessageOrigins?: string[]): Promise<void>' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link app.initialize(validMessageOrigins?: string[]): Promise<void>} instead.
  *
  * Initializes the library. This must be called before any other SDK calls
  * but after the frame is loaded successfully.
@@ -30,7 +30,7 @@ export function initialize(callback?: () => void, validMessageOrigins?: string[]
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'app._initialize(hostWindow: any): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link app._initialize(hostWindow: any): void} instead.
  *
  * @hidden
  * Hide from docs.
@@ -45,7 +45,7 @@ export function _initialize(hostWindow: any): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'app._uninitialize(): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link app._uninitialize(): void} instead.
  *
  * @hidden
  * Hide from docs.
@@ -59,7 +59,7 @@ export function _uninitialize(): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'teamsCore.enablePrintCapability(): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.enablePrintCapability(): void} instead.
  *
  * Enable print capability to support printing page using Ctrl+P and cmd+P
  */
@@ -68,7 +68,7 @@ export function enablePrintCapability(): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'teamsCore.print(): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.print(): void} instead.
  *
  * Default print handler
  */
@@ -77,7 +77,7 @@ export function print(): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'app.getContext(): Promise<app.Context>' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link app.getContext(): Promise<app.Context>} instead.
  *
  * Retrieves the current context the frame is running in.
  *
@@ -93,7 +93,7 @@ export function getContext(callback: (context: Context) => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'app.registerOnThemeChangeHandler(handler: (theme: string) => void): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link app.registerOnThemeChangeHandler(handler: (theme: string) => void): void} instead.
  *
  * Registers a handler for theme changes.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -105,7 +105,7 @@ export function registerOnThemeChangeHandler(handler: (theme: string) => void): 
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.registerFullScreenHandler(handler: (isFullScreen: boolean) => void): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.registerFullScreenHandler(handler: (isFullScreen: boolean) => void): void} instead.
  *
  * Registers a handler for changes from or to full-screen view for a tab.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -117,7 +117,7 @@ export function registerFullScreenHandler(handler: (isFullScreen: boolean) => vo
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.appButton.onClick(handler: () => void): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.appButton.onClick(handler: () => void): void} instead.
  *
  * Registers a handler for clicking the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -129,7 +129,7 @@ export function registerAppButtonClickHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.appButton.onHoverEnter(handler: () => void): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.appButton.onHoverEnter(handler: () => void): void} instead.
  *
  * Registers a handler for entering hover of the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -141,7 +141,7 @@ export function registerAppButtonHoverEnterHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.appButton.onHoverLeave(handler: () => void): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.appButton.onHoverLeave(handler: () => void): void} instead.
  *
  * Registers a handler for exiting hover of the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -153,7 +153,7 @@ export function registerAppButtonHoverLeaveHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.backStack.registerBackButtonHandler(handler: () => boolean): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.backStack.registerBackButtonHandler(handler: () => boolean): void} instead.
  *
  * Registers a handler for user presses of the Team client's back button. Experiences that maintain an internal
  * navigation stack should use this handler to navigate the user back within their frame. If an app finds
@@ -167,7 +167,7 @@ export function registerBackButtonHandler(handler: () => boolean): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'teamsCore.registerOnLoadHandler(handler: (context: LoadContext) => void): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.registerOnLoadHandler(handler: (context: LoadContext) => void): void} instead.
  *
  * @hidden
  * Registers a handler to be called when the page has been requested to load.
@@ -179,7 +179,7 @@ export function registerOnLoadHandler(handler: (context: LoadContext) => void): 
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'teamsCore.registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void} instead.
  *
  * @hidden
  * Registers a handler to be called before the page is unloaded.
@@ -192,7 +192,7 @@ export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void)
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'teamsCore.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link teamsCore.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void} instead.
  *
  * @hidden
  * Registers a handler when focus needs to be passed from teams to the place of choice on app.
@@ -204,7 +204,7 @@ export function registerFocusEnterHandler(handler: (navigateForward: boolean) =>
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.registerChangeConfigHandler(handler: () => void): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.registerChangeConfigHandler(handler: () => void): void} instead.
  *
  * Registers a handler for when the user reconfigurated tab.
  *
@@ -215,7 +215,7 @@ export function registerEnterSettingsHandler(handler: () => void): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.tabs.getTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise<TabInformation>' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.tabs.getTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise<TabInformation>} instead.
  *
  * Allows an app to retrieve for this user tabs that are owned by this app.
  * If no TabInstanceParameters are passed, the app defaults to favorite teams and favorite channels.
@@ -234,7 +234,7 @@ export function getTabInstances(
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.tabs.getMruTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise<TabInformation>' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.tabs.getMruTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise<TabInformation>} instead.
  *
  * Allows an app to retrieve the most recently used tabs for this user.
  *
@@ -252,7 +252,7 @@ export function getMruTabInstances(
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'core.shareDeepLink(deepLinkParameters: DeepLinkParameters): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link core.shareDeepLink(deepLinkParameters: DeepLinkParameters): void} instead.
  *
  * Shares a deep link that a user can use to navigate back to a specific state in this page.
  *
@@ -263,7 +263,7 @@ export function shareDeepLink(deepLinkParameters: DeepLinkParameters): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'core.executeDeepLink(deepLink: string): Promise<void>' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link core.executeDeepLink(deepLink: string): Promise<void>} instead.
  *
  * Execute deep link API.
  *
@@ -293,7 +293,7 @@ export function executeDeepLink(deepLink: string, onComplete?: (status: boolean,
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.setCurrentFrame(frameInfo: FrameInfo): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.setCurrentFrame(frameInfo: FrameInfo): void} instead.
  *
  * Set the current Frame Context
  *
@@ -304,7 +304,7 @@ export function setFrameContext(frameContext: FrameContext): void {
 }
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.initializeWithFrameContext(frameInfo: FrameInfo, callback?: () => void, validMessageOrigins?: string[],): void' instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.initializeWithFrameContext(frameInfo: FrameInfo, callback?: () => void, validMessageOrigins?: string[],): void} instead.
  *
  * Initilize with FrameContext
  *

--- a/packages/teams-js/src/public/settings.ts
+++ b/packages/teams-js/src/public/settings.ts
@@ -3,35 +3,35 @@ import { FrameContexts } from './constants';
 import { pages } from './pages';
 
 /**
- * @deprecated with Teams JS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'pages.config' namespace instead.
  *
  * Namespace to interact with the settings-specific part of the SDK.
  * This object is usable only on the settings frame.
  */
 export namespace settings {
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.Config' instead.
    * @remarks
    * Renamed to config in pages.Config
    */
   export import Settings = pages.config.Config;
 
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.SaveEvent' instead.
    * @remarks
    * See pages.SaveEvent
    */
   export import SaveEvent = pages.config.SaveEvent;
 
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.RemoveEvent' instead.
    * @remarks
    * See pages.RemoveEvent
    */
   export import RemoveEvent = pages.config.RemoveEvent;
 
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.SaveParameters' instead.
    * @remarks
    * See pages.SaveParameters
    */
@@ -39,7 +39,7 @@ export namespace settings {
   export import SaveParameters = pages.config.SaveParameters;
 
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.setValidityState(validityState: boolean): void' instead.
    *
    * Sets the validity state for the settings.
    * The initial value is false, so the user cannot save the settings until this is called with true.
@@ -51,7 +51,7 @@ export namespace settings {
   }
 
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.getConfig(): Promise<Config>' instead.
    *
    * Gets the settings for the current instance.
    *
@@ -65,7 +65,7 @@ export namespace settings {
   }
 
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.setConfig(instanceSettings: Config): Promise<void>' instead.
    *
    * Sets the settings for the current instance.
    * This is an asynchronous operation; calls to getSettings are not guaranteed to reflect the changed state.
@@ -92,7 +92,7 @@ export namespace settings {
   }
 
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.registerOnSaveHandler(handler: (evt: SaveEvent) => void): void' instead.
    *
    * Registers a handler for when the user attempts to save the settings. This handler should be used
    * to create or update the underlying resource powering the content.
@@ -106,7 +106,7 @@ export namespace settings {
   }
 
   /**
-   * @deprecated with Teams JS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void' instead.
    *
    * Registers a handler for user attempts to remove content. This handler should be used
    * to remove the underlying resource powering the content.

--- a/packages/teams-js/src/public/settings.ts
+++ b/packages/teams-js/src/public/settings.ts
@@ -3,35 +3,40 @@ import { FrameContexts } from './constants';
 import { pages } from './pages';
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config} namespace instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link pages.config} namespace instead.
  *
  * Namespace to interact with the settings-specific part of the SDK.
  * This object is usable only on the settings frame.
  */
 export namespace settings {
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.Config} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link pages.config.Config} instead.
    * @remarks
    * Renamed to config in pages.Config
    */
   export import Settings = pages.config.Config;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.SaveEvent} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link pages.config.SaveEvent} instead.
    * @remarks
    * See pages.SaveEvent
    */
   export import SaveEvent = pages.config.SaveEvent;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.RemoveEvent} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link pages.config.RemoveEvent} instead.
    * @remarks
    * See pages.RemoveEvent
    */
   export import RemoveEvent = pages.config.RemoveEvent;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.SaveParameters} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link pages.config.SaveParameters} instead.
    * @remarks
    * See pages.SaveParameters
    */
@@ -39,7 +44,8 @@ export namespace settings {
   export import SaveParameters = pages.config.SaveParameters;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.setValidityState pages.config.setValidityState(validityState: boolean): void} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link pages.config.setValidityState pages.config.setValidityState(validityState: boolean): void} instead.
    *
    * Sets the validity state for the settings.
    * The initial value is false, so the user cannot save the settings until this is called with true.
@@ -51,7 +57,8 @@ export namespace settings {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.getConfig pages.config.getConfig(): Promise\<Config\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link pages.config.getConfig pages.config.getConfig(): Promise\<Config\>} instead.
    *
    * Gets the settings for the current instance.
    *
@@ -65,7 +72,8 @@ export namespace settings {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.setConfig pages.config.setConfig(instanceSettings: Config): Promise\<void\>} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link pages.config.setConfig pages.config.setConfig(instanceSettings: Config): Promise\<void\>} instead.
    *
    * Sets the settings for the current instance.
    * This is an asynchronous operation; calls to getSettings are not guaranteed to reflect the changed state.
@@ -92,7 +100,8 @@ export namespace settings {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.registerOnSaveHandler pages.config.registerOnSaveHandler(handler: (evt: SaveEvent) => void): void} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link pages.config.registerOnSaveHandler pages.config.registerOnSaveHandler(handler: (evt: SaveEvent) => void): void} instead.
    *
    * Registers a handler for when the user attempts to save the settings. This handler should be used
    * to create or update the underlying resource powering the content.
@@ -106,7 +115,8 @@ export namespace settings {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.registerOnRemoveHandler pages.config.registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link pages.config.registerOnRemoveHandler pages.config.registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void} instead.
    *
    * Registers a handler for user attempts to remove content. This handler should be used
    * to remove the underlying resource powering the content.

--- a/packages/teams-js/src/public/settings.ts
+++ b/packages/teams-js/src/public/settings.ts
@@ -3,35 +3,35 @@ import { FrameContexts } from './constants';
 import { pages } from './pages';
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'pages.config' namespace instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config} namespace instead.
  *
  * Namespace to interact with the settings-specific part of the SDK.
  * This object is usable only on the settings frame.
  */
 export namespace settings {
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.Config' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.Config} instead.
    * @remarks
    * Renamed to config in pages.Config
    */
   export import Settings = pages.config.Config;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.SaveEvent' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.SaveEvent} instead.
    * @remarks
    * See pages.SaveEvent
    */
   export import SaveEvent = pages.config.SaveEvent;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.RemoveEvent' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.RemoveEvent} instead.
    * @remarks
    * See pages.RemoveEvent
    */
   export import RemoveEvent = pages.config.RemoveEvent;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.SaveParameters' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.SaveParameters} instead.
    * @remarks
    * See pages.SaveParameters
    */
@@ -39,7 +39,7 @@ export namespace settings {
   export import SaveParameters = pages.config.SaveParameters;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.setValidityState(validityState: boolean): void' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.setValidityState(validityState: boolean): void} instead.
    *
    * Sets the validity state for the settings.
    * The initial value is false, so the user cannot save the settings until this is called with true.
@@ -51,7 +51,7 @@ export namespace settings {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.getConfig(): Promise<Config>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.getConfig(): Promise<Config>} instead.
    *
    * Gets the settings for the current instance.
    *
@@ -65,7 +65,7 @@ export namespace settings {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.setConfig(instanceSettings: Config): Promise<void>' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.setConfig(instanceSettings: Config): Promise<void>} instead.
    *
    * Sets the settings for the current instance.
    * This is an asynchronous operation; calls to getSettings are not guaranteed to reflect the changed state.
@@ -92,7 +92,7 @@ export namespace settings {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.registerOnSaveHandler(handler: (evt: SaveEvent) => void): void' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.registerOnSaveHandler(handler: (evt: SaveEvent) => void): void} instead.
    *
    * Registers a handler for when the user attempts to save the settings. This handler should be used
    * to create or update the underlying resource powering the content.
@@ -106,7 +106,7 @@ export namespace settings {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'pages.config.registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void} instead.
    *
    * Registers a handler for user attempts to remove content. This handler should be used
    * to remove the underlying resource powering the content.

--- a/packages/teams-js/src/public/settings.ts
+++ b/packages/teams-js/src/public/settings.ts
@@ -39,7 +39,7 @@ export namespace settings {
   export import SaveParameters = pages.config.SaveParameters;
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.setValidityState(validityState: boolean): void} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.setValidityState pages.config.setValidityState(validityState: boolean): void} instead.
    *
    * Sets the validity state for the settings.
    * The initial value is false, so the user cannot save the settings until this is called with true.
@@ -51,7 +51,7 @@ export namespace settings {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.getConfig(): Promise<Config>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.getConfig pages.config.getConfig(): Promise\<Config\>} instead.
    *
    * Gets the settings for the current instance.
    *
@@ -65,7 +65,7 @@ export namespace settings {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.setConfig(instanceSettings: Config): Promise<void>} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.setConfig pages.config.setConfig(instanceSettings: Config): Promise\<void\>} instead.
    *
    * Sets the settings for the current instance.
    * This is an asynchronous operation; calls to getSettings are not guaranteed to reflect the changed state.
@@ -92,7 +92,7 @@ export namespace settings {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.registerOnSaveHandler(handler: (evt: SaveEvent) => void): void} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.registerOnSaveHandler pages.config.registerOnSaveHandler(handler: (evt: SaveEvent) => void): void} instead.
    *
    * Registers a handler for when the user attempts to save the settings. This handler should be used
    * to create or update the underlying resource powering the content.
@@ -106,7 +106,7 @@ export namespace settings {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link pages.config.registerOnRemoveHandler pages.config.registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void} instead.
    *
    * Registers a handler for user attempts to remove content. This handler should be used
    * to remove the underlying resource powering the content.

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -4,7 +4,7 @@ import { dialog } from './dialog';
 import { TaskInfo } from './interfaces';
 
 /**
- * @deprecated with TeamsJS v2 upgrades
+ * @deprecated As of 2.0.0-beta.1. Please use 'dialog' namespace instead.
  *
  * Namespace to interact with the task module-specific part of the SDK.
  * This object is usable only on the content frame.
@@ -12,7 +12,7 @@ import { TaskInfo } from './interfaces';
  */
 export namespace tasks {
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'dialog.open(dialogInfo: DialogInfo, submitHandler?: (err: string, result: string) => void): IAppWindow' instead.
    *
    * Allows an app to open the task module.
    *
@@ -24,7 +24,7 @@ export namespace tasks {
   }
 
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'dialog.resize(dialogInfo: DialogInfo): void' instead.
    *
    * Update height/width task info properties.
    *
@@ -35,7 +35,7 @@ export namespace tasks {
   }
 
   /**
-   * @deprecated with TeamsJS v2 upgrades
+   * @deprecated As of 2.0.0-beta.1. Please use 'dialog.submit(result?: string | object, appIds?: string | string[]): void' instead.
    *
    * Submit the task module.
    *

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -12,7 +12,7 @@ import { TaskInfo } from './interfaces';
  */
 export namespace tasks {
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link dialog.open(dialogInfo: DialogInfo, submitHandler?: (err: string, result: string) => void): IAppWindow} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link dialog.open dialog.open(dialogInfo: DialogInfo, submitHandler?: (err: string, result: string) => void): IAppWindow} instead.
    *
    * Allows an app to open the task module.
    *
@@ -24,7 +24,7 @@ export namespace tasks {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link dialog.resize(dialogInfo: DialogInfo): void} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link dialog.resize dialog.resize(dialogInfo: DialogInfo): void} instead.
    *
    * Update height/width task info properties.
    *
@@ -35,7 +35,7 @@ export namespace tasks {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link dialog.submit(result?: string | object, appIds?: string | string[]): void} instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link dialog.submit dialog.submit(result?: string | object, appIds?: string | string[]): void} instead.
    *
    * Submit the task module.
    *

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -4,7 +4,7 @@ import { dialog } from './dialog';
 import { TaskInfo } from './interfaces';
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use 'dialog' namespace instead.
+ * @deprecated As of 2.0.0-beta.1. Please use {@link dialog} namespace instead.
  *
  * Namespace to interact with the task module-specific part of the SDK.
  * This object is usable only on the content frame.
@@ -12,7 +12,7 @@ import { TaskInfo } from './interfaces';
  */
 export namespace tasks {
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'dialog.open(dialogInfo: DialogInfo, submitHandler?: (err: string, result: string) => void): IAppWindow' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link dialog.open(dialogInfo: DialogInfo, submitHandler?: (err: string, result: string) => void): IAppWindow} instead.
    *
    * Allows an app to open the task module.
    *
@@ -24,7 +24,7 @@ export namespace tasks {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'dialog.resize(dialogInfo: DialogInfo): void' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link dialog.resize(dialogInfo: DialogInfo): void} instead.
    *
    * Update height/width task info properties.
    *
@@ -35,7 +35,7 @@ export namespace tasks {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use 'dialog.submit(result?: string | object, appIds?: string | string[]): void' instead.
+   * @deprecated As of 2.0.0-beta.1. Please use {@link dialog.submit(result?: string | object, appIds?: string | string[]): void} instead.
    *
    * Submit the task module.
    *

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -4,7 +4,8 @@ import { dialog } from './dialog';
 import { TaskInfo } from './interfaces';
 
 /**
- * @deprecated As of 2.0.0-beta.1. Please use {@link dialog} namespace instead.
+ * @deprecated
+ * As of 2.0.0-beta.1, please use {@link dialog} namespace instead.
  *
  * Namespace to interact with the task module-specific part of the SDK.
  * This object is usable only on the content frame.
@@ -12,7 +13,8 @@ import { TaskInfo } from './interfaces';
  */
 export namespace tasks {
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link dialog.open dialog.open(dialogInfo: DialogInfo, submitHandler?: (err: string, result: string) => void): IAppWindow} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link dialog.open dialog.open(dialogInfo: DialogInfo, submitHandler?: (err: string, result: string) => void): IAppWindow} instead.
    *
    * Allows an app to open the task module.
    *
@@ -24,7 +26,8 @@ export namespace tasks {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link dialog.resize dialog.resize(dialogInfo: DialogInfo): void} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link dialog.resize dialog.resize(dialogInfo: DialogInfo): void} instead.
    *
    * Update height/width task info properties.
    *
@@ -35,7 +38,8 @@ export namespace tasks {
   }
 
   /**
-   * @deprecated As of 2.0.0-beta.1. Please use {@link dialog.submit dialog.submit(result?: string | object, appIds?: string | string[]): void} instead.
+   * @deprecated
+   * As of 2.0.0-beta.1, please use {@link dialog.submit dialog.submit(result?: string | object, appIds?: string | string[]): void} instead.
    *
    * Submit the task module.
    *


### PR DESCRIPTION
Update each @deprecated tag to point to the replaced API and use the @link tag inside the @deprecated comments with full signature.
For example:
` @deprecated As of 2.0.0-beta.1. Please use {@link app.initialize app.initialize(validMessageOrigins?: string[]): Promise\<void\>} instead.`