### PR TITLE
Type `result` as `string | object` in `dialog.submitHandler`

### DIFF
--- a/apps/teams-test-app/src/components/DialogAPIs.tsx
+++ b/apps/teams-test-app/src/components/DialogAPIs.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import { dialog, DialogInfo } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
@@ -12,7 +13,7 @@ const DialogAPIs = (): ReactElement => {
 
   const openDialog = (dialogInfoInput: string): void => {
     const dialogInfo: DialogInfo = JSON.parse(dialogInfoInput);
-    const onComplete = (err: string, result: string): void => {
+    const onComplete = (err: string, result: string | object): void => {
       setOpenRes('Error: ' + err + '\nResult: ' + result);
     };
     setOpenRes('dialog.open' + noHostSdkMsg);

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -23,7 +23,10 @@ export namespace dialog {
    * @param dialogInfo - An object containing the parameters of the dialog module
    * @param submitHandler - Handler to call when the task module is completed
    */
-  export function open(dialogInfo: DialogInfo, submitHandler?: (err: string, result: string) => void): IAppWindow {
+  export function open(
+    dialogInfo: DialogInfo,
+    submitHandler?: (err: string, result: string | object) => void,
+  ): IAppWindow {
     ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
 
     sendMessageToParent('tasks.startTask', [dialogInfo], submitHandler);

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
 import { IAppWindow } from './appWindow';
 import { TaskModuleDimension } from './constants';
 import { dialog } from './dialog';
@@ -19,7 +21,10 @@ export namespace tasks {
    * @param taskInfo - An object containing the parameters of the task module
    * @param submitHandler - Handler to call when the task module is completed
    */
-  export function startTask(taskInfo: TaskInfo, submitHandler?: (err: string, result: string) => void): IAppWindow {
+  export function startTask(
+    taskInfo: TaskInfo,
+    submitHandler?: (err: string, result: string | object) => void,
+  ): IAppWindow {
     return dialog.open(getDialogInfoFromTaskInfo(taskInfo), submitHandler);
   }
 
@@ -42,7 +47,6 @@ export namespace tasks {
    * @param result - Contains the result to be sent to the bot or the app. Typically a JSON object or a serialized version of it
    * @param appIds - Helps to validate that the call originates from the same appId as the one that invoked the task module
    */
-  // eslint-disable-next-line
   export function submitTask(result?: string | object, appIds?: string | string[]): void {
     dialog.submit(result, appIds);
   }


### PR DESCRIPTION
Addresses https://github.com/OfficeDev/microsoft-teams-library-js/issues/444 in 2.0-preview branch for both the new `dialog.open` and backwards-compatible `tasks.startTask`.