### PR TITLE
Add missing yarn install line to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This JavaScript library is part of the [Microsoft Teams developer platform](http
 ## Getting Started
 
 1. Clone the repo
+2. `yarn install` from repo root
 2. `yarn build` from repo root
 3. to run Unit test `yarn test`
 


### PR DESCRIPTION
Root readme and readme in package folder don't match, and this one was missing a required step.

Also, I *think* this one should pass all the checks finally since it's no longer a personal fork merging back into the main repo. I hope.