### PR TITLE
Stop generating blank documentation files with weird titles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,13 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Run current file",
+      "program": "${file}",
+      "cwd": "${fileDirname}"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Launch yarn command",
       "runtimeExecutable": "yarn",
       "cwd": "${workspaceFolder}",

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This JavaScript library is part of the [Microsoft Teams developer platform](http
 ## Getting Started
 
 1. Clone the repo
+2. `yarn install` from repo root
 2. `yarn build` from repo root
 3. to run Unit test `yarn test`
 

--- a/apps/teams-test-app/README.md
+++ b/apps/teams-test-app/README.md
@@ -1,6 +1,6 @@
 # Teams Test App
 
-The Teams Test App is a React app used to test the Teams JavaScript client SDK and Host SDK. It is currently being developed to be used only for this testing and is not meant to serve as official guidance for SDK use for the time being. 
+The Teams Test App is a React app used to test the Teams JavaScript client SDK and Host SDK. It is currently being developed to be used only for this testing and is not meant to serve as official guidance for SDK use for the time being.
 
 ## Getting Started
 
@@ -23,6 +23,41 @@ or if you have already built the Teams JavaScript client SDK and would like to b
 
 ## Troubleshooting
 
-* If you see a directory view of some files after starting the app rather than the test app itself (which should simply be some boxes and buttons), please try removing all three node_modules folders from the repo (you can utilize our yarn clean:all command at the monorepo root) then redoing the yarn commands above.
+- If you see a directory view of some files after starting the app rather than the test app itself (which should simply be some boxes and buttons), please try removing all three node_modules folders from the repo (you can utilize our yarn clean:all command at the monorepo root) then redoing the yarn commands above.
 
-* Due to Windows loopback security features, you may see a warning from your browser when running the test app saying that your connection is not private. Click Advanced -> Continue to localhost to proceed to the app.
+- Due to Windows loopback security features, you may see a warning from your browser when running the test app saying that your connection is not private. Click Advanced -> Continue to localhost to proceed to the app.
+
+## Contributing
+
+### API Utility Components
+
+There's a set of helper React Components that can be used to add support to new APIs into the Test App.
+They are meant to keep the UI and generated HTML to be consistent, to allow for E2E scenario tests to be written against it.
+
+#### `ApiWithoutInput`
+
+Should be used to add support for an API which does not require any user input, e.g. `app.getContext()`.
+
+#### `ApiWithCheckboxInput`
+
+Should be used to add support for an API which requires a `true`/`false` input, e.g. `pages.returnFocus(navigateForward?: boolean)`.
+
+#### `ApiWithTextInput`
+
+Should be used to add support for an API which requires a more complex input, e.g. `calendar.composeMeeting(composeMeetingParams: ComposeMeetingParams)`.
+
+There are two possible ways to leverage `ApiWithTextInput` component:
+
+- APIs for which the input has no required properties and no validation is needed, a simple `onClick` callback can be provided.
+  In this case `ApiWithTextInput` will attempt to parse the input as JSON and call the provided callback.
+
+- For all other APIs `onClick` required two callbacks to be provided: `validateInput` and `submit`.
+  `ApiWithTextInput` component will attempt to parse the input as JSON and call `validateInput` to allow for input validation.
+  The validation function should throw an exception when the input requirements are not satisfied (e.g. a required property in not present).
+  If validation fails, the error will be shown in the Test App.
+  If validation passes, `submit` will be called.
+
+### Capability section
+
+For each capability a separate section should be added, which should consist of a header and a collection of the utility components described above.
+That section should be added in a separate file undef src\components, and referenced in the top-level `<App />` component.

--- a/apps/teams-test-app/src/components/AppAPIs.tsx
+++ b/apps/teams-test-app/src/components/AppAPIs.tsx
@@ -3,20 +3,67 @@ import React, { ReactElement } from 'react';
 
 import { noHostSdkMsg } from '../App';
 import BoxAndButton from './BoxAndButton';
+import { ApiWithoutInput, ApiWithTextInput } from './utils';
+
+const GetContext = (): ReactElement =>
+  ApiWithoutInput({
+    name: 'getContextV2',
+    title: 'Get Context',
+    onClick: async () => {
+      const context = await app.getContext();
+      return JSON.stringify(context);
+    },
+  });
+
+const ExecuteDeepLink = (): ReactElement =>
+  ApiWithTextInput<string>({
+    name: 'executeDeepLink2',
+    title: 'Execute Deep Link',
+    onClick: {
+      validateInput: input => {
+        if (typeof input !== 'string') {
+          throw new Error('Input should be a string');
+        }
+      },
+      submit: async input => {
+        await core.executeDeepLink(input);
+        return 'Completed';
+      },
+    },
+  });
+
+const ShareDeepLink = (): ReactElement =>
+  ApiWithTextInput<DeepLinkParameters>({
+    name: 'core.shareDeepLink',
+    title: 'core.shareDeepLink',
+    onClick: {
+      validateInput: input => {
+        if (!input.subEntityId || !input.subEntityLabel) {
+          throw new Error('subEntityId and subEntityLabel are required.');
+        }
+      },
+      submit: async input => {
+        await core.shareDeepLink(input);
+        return 'called shareDeepLink';
+      },
+    },
+  });
+
+const RegisterOnThemeChangeHandler = (): ReactElement =>
+  ApiWithoutInput({
+    name: 'registerOnThemeChangeHandler',
+    title: 'Register On Theme Change Handler',
+    onClick: async setResult => {
+      app.registerOnThemeChangeHandler(setResult);
+      return '';
+    },
+  });
 
 const AppAPIs = (): ReactElement => {
-  const [getContextV2Res, setGetContextV2Res] = React.useState('');
+  // TODO: Remove once E2E scenario tests are updated to use the new version
   const [executeDeepLinkRes, setExecuteDeepLinkRes] = React.useState('');
-  const [shareDeepLinkRes, setShareDeepLinkRes] = React.useState('');
-  const [registerOnThemeChangeHandlerRes, setRegisterOnThemeChangeHandlerRes] = React.useState('');
 
-  const getContextV2 = (): void => {
-    setGetContextV2Res('app.getContext()' + noHostSdkMsg);
-    app.getContext().then((res: app.Context) => {
-      setGetContextV2Res(JSON.stringify(res));
-    });
-  };
-
+  // TODO: Remove once E2E scenario tests are updated to use the new version
   const executeDeepLink = (deepLink: string): void => {
     setExecuteDeepLinkRes('core.executeDeepLink()' + noHostSdkMsg);
     core
@@ -25,28 +72,11 @@ const AppAPIs = (): ReactElement => {
       .catch(reason => setExecuteDeepLinkRes(reason));
   };
 
-  const shareDeepLink = (deepLinkParamsInput: string): void => {
-    const deepLinkParams: DeepLinkParameters = JSON.parse(deepLinkParamsInput);
-    core.shareDeepLink(deepLinkParams);
-    setShareDeepLinkRes('called shareDeepLink.');
-  };
-
-  const registerOnThemeChangeHandler = (): void => {
-    app.registerOnThemeChangeHandler((theme: string) => {
-      setRegisterOnThemeChangeHandlerRes(theme);
-    });
-  };
-
   return (
     <>
       <h1>app</h1>
-      <BoxAndButton
-        handleClick={getContextV2}
-        output={getContextV2Res}
-        hasInput={false}
-        title="Get Context"
-        name="getContextV2"
-      />
+      <GetContext />
+      {/* TODO: Remove once E2E scenario tests are updated to use the new version */}
       <BoxAndButton
         handleClickWithInput={executeDeepLink}
         output={executeDeepLinkRes}
@@ -54,20 +84,9 @@ const AppAPIs = (): ReactElement => {
         title="Execute Deep Link"
         name="executeDeepLink"
       />
-      <BoxAndButton
-        handleClickWithInput={shareDeepLink}
-        output={shareDeepLinkRes}
-        hasInput={true}
-        title="core.shareDeepLink"
-        name="core.shareDeepLink"
-      />
-      <BoxAndButton
-        handleClick={registerOnThemeChangeHandler}
-        output={registerOnThemeChangeHandlerRes}
-        hasInput={false}
-        title="Register On Theme Change Handler"
-        name="registerOnThemeChangeHandler"
-      />
+      <ExecuteDeepLink />
+      <ShareDeepLink />
+      <RegisterOnThemeChangeHandler />
     </>
   );
 };

--- a/apps/teams-test-app/src/components/AppInitialization.tsx
+++ b/apps/teams-test-app/src/components/AppInitialization.tsx
@@ -2,22 +2,55 @@ import { app } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
 import BoxAndButton from './BoxAndButton';
+import { ApiWithoutInput, ApiWithTextInput } from './utils';
+
+const NotifyLoaded = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'appInitializationAppLoaded',
+    title: 'appInitialization.appLoaded',
+    onClick: async () => {
+      app.notifyAppLoaded();
+      return 'called';
+    },
+  });
+
+const NotifySuccess = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'appInitializationSuccess',
+    title: 'appInitialization.success',
+    onClick: async () => {
+      app.notifySuccess();
+      return 'called';
+    },
+  });
+
+const NotifyFailure = (): React.ReactElement =>
+  ApiWithTextInput<app.FailedReason>({
+    name: 'appInitializationFailure2',
+    title: 'appInitialization.failure',
+    onClick: {
+      validateInput: input => {
+        if (!input) {
+          // this API actually allow for the input not to be provided
+          return;
+        }
+        const acceptableValues = Object.values(app.FailedReason);
+        if (!acceptableValues.includes(input)) {
+          throw new Error(`input must be one of: ${JSON.stringify(acceptableValues)}`);
+        }
+      },
+      submit: async input => {
+        app.notifyFailure({ reason: input || app.FailedReason.Other });
+        return 'called';
+      },
+    },
+  });
 
 const AppInitializationAPIs = (): ReactElement => {
-  const [notifyLoadedRes, setNotifyLoadedRes] = React.useState('');
-  const [notifySuccessRes, setNotifySuccessRes] = React.useState('');
+  // TODO: Remove once E2E scenario tests are updated to use the new version
   const [notifyFailureRes, setNotifyFailureRes] = React.useState('');
 
-  const notifyLoaded = (): void => {
-    app.notifyAppLoaded();
-    setNotifyLoadedRes('called');
-  };
-
-  const notifySuccess = (): void => {
-    app.notifySuccess();
-    setNotifySuccessRes('called');
-  };
-
+  // TODO: Remove once E2E scenario tests are updated to use the new version
   const notifyFailure = (reason?: string): void => {
     app.notifyFailure({
       reason: (reason as app.FailedReason) || app.FailedReason.Other,
@@ -28,20 +61,10 @@ const AppInitializationAPIs = (): ReactElement => {
   return (
     <>
       <h1>appInitialization</h1>
-      <BoxAndButton
-        handleClick={notifyLoaded}
-        output={notifyLoadedRes}
-        hasInput={false}
-        title="appInitialization.appLoaded"
-        name="appInitializationAppLoaded"
-      />
-      <BoxAndButton
-        handleClick={notifySuccess}
-        output={notifySuccessRes}
-        hasInput={false}
-        title="appInitialization.success"
-        name="appInitializationSuccess"
-      />
+      <NotifyLoaded />
+      <NotifySuccess />
+      <NotifyFailure />
+      {/* TODO: Remove once E2E scenario tests are updated to use the new version */}
       <BoxAndButton
         handleClickWithInput={notifyFailure}
         output={notifyFailureRes}

--- a/apps/teams-test-app/src/components/AppInstallDialog.tsx
+++ b/apps/teams-test-app/src/components/AppInstallDialog.tsx
@@ -1,48 +1,38 @@
 import { appInstallDialog } from '@microsoft/teams-js';
 import React from 'react';
 
-import { noHostSdkMsg } from '../App';
-import BoxAndButton from './BoxAndButton';
+import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
-const AppInstallDialogAPIs: React.FC = () => {
-  const [openAppInstallDialogRes, setOpenAppInstallDialogRes] = React.useState('');
-  const [checkAppInstallDialogCapabilityRes, setCheckAppInstallDialogCapabilityRes] = React.useState('');
+const CheckAppInstallDialogCapability = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'checkCapabilityAppInstallDialog',
+    title: 'Check Capability App Install Dialog',
+    onClick: async () => `AppInstallDialog module ${appInstallDialog.isSupported() ? 'is' : 'is not'} supported`,
+  });
 
-  const openAppInstallDialog = (openAppInstallDialogParams: string): void => {
-    setOpenAppInstallDialogRes('appInstallDialog.openAppInstallDialog()' + noHostSdkMsg);
-    appInstallDialog
-      .openAppInstallDialog(JSON.parse(openAppInstallDialogParams))
-      .then(() => setOpenAppInstallDialogRes('called'))
-      .catch(reason => setOpenAppInstallDialogRes(JSON.stringify(reason)));
-  };
+const OpenAppInstallDialog = (): React.ReactElement =>
+  ApiWithTextInput<appInstallDialog.OpenAppInstallDialogParams>({
+    name: 'openAppInstallDialog',
+    title: 'Open App Install Dialog',
+    onClick: {
+      validateInput: input => {
+        if (!input.appId) {
+          throw new Error('appId is required');
+        }
+      },
+      submit: async input => {
+        await appInstallDialog.openAppInstallDialog(input);
+        return 'called';
+      },
+    },
+  });
 
-  const checkAppInstallDialogCapability = (): void => {
-    if (appInstallDialog.isSupported()) {
-      setCheckAppInstallDialogCapabilityRes('AppInstallDialog module is supported');
-    } else {
-      setCheckAppInstallDialogCapabilityRes('AppInstallDialog module is not supported');
-    }
-  };
-
-  return (
-    <>
-      <h1>appInstallDialog</h1>
-      <BoxAndButton
-        handleClickWithInput={openAppInstallDialog}
-        output={openAppInstallDialogRes}
-        hasInput={true}
-        title="Open App Install Dialog"
-        name="openAppInstallDialog"
-      />
-      <BoxAndButton
-        handleClick={checkAppInstallDialogCapability}
-        output={checkAppInstallDialogCapabilityRes}
-        hasInput={false}
-        title="Check Capability App Install Dialog"
-        name="checkCapabilityAppInstallDialog"
-      />
-    </>
-  );
-};
+const AppInstallDialogAPIs: React.FC = () => (
+  <>
+    <h1>appInstallDialog</h1>
+    <OpenAppInstallDialog />
+    <CheckAppInstallDialogCapability />
+  </>
+);
 
 export default AppInstallDialogAPIs;

--- a/apps/teams-test-app/src/components/AuthenticationAPIs.tsx
+++ b/apps/teams-test-app/src/components/AuthenticationAPIs.tsx
@@ -3,47 +3,95 @@ import React, { ReactElement } from 'react';
 
 import { noHostSdkMsg } from '../App';
 import BoxAndButton from './BoxAndButton';
+import { ApiWithoutInput, ApiWithTextInput } from './utils';
+
+const Initialize = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'initialize',
+    title: 'Initialize',
+    onClick: async () => {
+      await app.initialize();
+      return 'called';
+    },
+  });
+
+const GetAuthToken = (): React.ReactElement =>
+  ApiWithTextInput<authentication.AuthTokenRequestParameters>({
+    name: 'getAuthToken',
+    title: 'Get Auth Token',
+    onClick: async authParams => {
+      const result = await authentication.getAuthToken(authParams);
+      return 'Success: ' + JSON.stringify(result);
+    },
+  });
+
+const GetUser = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'getUser',
+    title: 'Get User',
+    onClick: async () => {
+      const user = await authentication.getUser();
+      return 'Success: ' + JSON.stringify(user);
+    },
+  });
+
+const NotifyFailure = (): React.ReactElement =>
+  ApiWithTextInput<string>({
+    name: 'authentication.notifyFailure2',
+    title: 'authentication.notifyFailure',
+    onClick: async input => {
+      authentication.notifyFailure(input);
+      return 'called';
+    },
+  });
+
+const NotifySuccess = (): React.ReactElement =>
+  ApiWithTextInput<string>({
+    name: 'authentication.notifySuccess2',
+    title: 'authentication.notifySuccess',
+    onClick: async input => {
+      authentication.notifySuccess(input);
+      return 'called';
+    },
+  });
+
+const Authenticate = (): React.ReactElement =>
+  ApiWithTextInput<authentication.AuthenticatePopUpParameters>({
+    name: 'authentication.authenticate2',
+    title: 'authentication.authenticate',
+    onClick: {
+      validateInput: input => {
+        if (!input.url) {
+          throw new Error('url is required');
+        }
+      },
+      submit: async authParams => {
+        const token = await authentication.authenticate(authParams);
+        return 'Success: ' + token;
+      },
+    },
+  });
 
 const AuthenticationAPIs = (): ReactElement => {
-  const [getTokenRes, setGetTokenRes] = React.useState('');
-  const [getUserRes, setGetUserRes] = React.useState('');
+  // TODO: Remove once E2E scenario tests are updated to use the new version
+
   const [notifyFailureRes, setNotifyFailureRes] = React.useState('');
   const [notifySuccessRes, setNotifySuccessRes] = React.useState('');
   const [authenticateRes, setAuthenticateRes] = React.useState('');
-  const [initializeRes, setInitializeRes] = React.useState('');
 
-  const authGetToken = (unformattedAuthParams: string): void => {
-    setGetTokenRes('authentication.getToken()' + noHostSdkMsg);
-    const authParams: authentication.AuthTokenRequestParameters = JSON.parse(unformattedAuthParams);
-    authentication
-      .getAuthToken(authParams)
-      .then(result => setGetTokenRes('Success: ' + result))
-      .catch(reason => setGetTokenRes('Failure: ' + reason));
-  };
-
-  const authGetUser = (): void => {
-    setGetUserRes('authentication.getUser()' + noHostSdkMsg);
-    authentication
-      .getUser()
-      .then(user => setGetUserRes('Success: ' + JSON.stringify(user)))
-      .catch(reason => setGetUserRes('Failure: ' + reason));
-  };
-
+  // TODO: Remove once E2E scenario tests are updated to use the new version
   const authNotifyFailure = (reason: string): void => {
     authentication.notifyFailure(reason);
     setNotifyFailureRes('called');
   };
 
+  // TODO: Remove once E2E scenario tests are updated to use the new version
   const authNotifySuccess = (result: string): void => {
     authentication.notifySuccess(result);
     setNotifySuccessRes('called');
   };
 
-  const initialize = (): void => {
-    app.initialize();
-    setInitializeRes('called');
-  };
-
+  // TODO: Remove once E2E scenario tests are updated to use the new version
   const authAuthenticate = (unformattedAuthParams: string): void => {
     setAuthenticateRes('authentication.authenticate()' + noHostSdkMsg);
     const authParams: authentication.AuthenticatePopUpParameters = JSON.parse(unformattedAuthParams);
@@ -52,25 +100,15 @@ const AuthenticationAPIs = (): ReactElement => {
       .then(token => setAuthenticateRes('Success: ' + token))
       .catch((reason: Error) => setAuthenticateRes('Failure: ' + reason.message));
   };
-
   return (
     <>
       <h1>authentication</h1>
-      <BoxAndButton
-        handleClick={initialize}
-        output={initializeRes}
-        hasInput={false}
-        title="Initialize"
-        name="initialize"
-      />
-      <BoxAndButton
-        handleClickWithInput={authGetToken}
-        output={getTokenRes}
-        hasInput={true}
-        title="Get Auth Token"
-        name="getAuthToken"
-      />
-      <BoxAndButton handleClick={authGetUser} output={getUserRes} hasInput={false} title="Get User" name="getUser" />
+      <Initialize />
+      <GetAuthToken />
+      <GetUser />
+      <NotifyFailure />
+      <NotifySuccess />
+      {/* TODO: Remove once E2E scenario tests are updated to use the new version */}
       <BoxAndButton
         handleClickWithInput={authNotifyFailure}
         output={notifyFailureRes}
@@ -78,6 +116,7 @@ const AuthenticationAPIs = (): ReactElement => {
         title="authentication.notifyFailure"
         name="authentication.notifyFailure"
       />
+      {/* TODO: Remove once E2E scenario tests are updated to use the new version */}
       <BoxAndButton
         handleClickWithInput={authNotifySuccess}
         output={notifySuccessRes}
@@ -85,6 +124,8 @@ const AuthenticationAPIs = (): ReactElement => {
         title="authentication.notifySuccess"
         name="authentication.notifySuccess"
       />
+      <Authenticate />
+      {/* TODO: Remove once E2E scenario tests are updated to use the new version */}
       <BoxAndButton
         handleClickWithInput={authAuthenticate}
         output={authenticateRes}

--- a/apps/teams-test-app/src/components/CalendarAPIs.tsx
+++ b/apps/teams-test-app/src/components/CalendarAPIs.tsx
@@ -1,30 +1,48 @@
 import { calendar } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import { noHostSdkMsg } from '../App';
 import BoxAndButton from './BoxAndButton';
+import { ApiWithoutInput, ApiWithTextInput } from './utils';
+
+const CheckCalendarCapability = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'checkCalendarCapability',
+    title: 'Check Calendar Capability',
+    onClick: async () => `Calendar module ${calendar.isSupported() ? 'is' : 'is not'} supported`,
+  });
+
+const ComposeMeeting = (): React.ReactElement =>
+  ApiWithTextInput<calendar.ComposeMeetingParams>({
+    name: 'composeMeeting',
+    title: 'Compose Meeting',
+    onClick: async input => {
+      await calendar.composeMeeting(input);
+      return 'Completed';
+    },
+  });
+
+const OpenCalendarItem = (): React.ReactElement =>
+  ApiWithTextInput<calendar.OpenCalendarItemParams>({
+    name: 'openCalendarItem',
+    title: 'Open CalendarItem',
+    onClick: {
+      submit: async input => {
+        await calendar.openCalendarItem(input);
+        return 'Completed';
+      },
+      validateInput: x => {
+        if (!x.itemId) {
+          throw 'itemId is required';
+        }
+      },
+    },
+  });
 
 const CalendarAPIs = (): ReactElement => {
+  // TODO: Remove once E2E scenario tests are updated to use the new version
   const [capabilityCheckRes, setCapabilityCheckRes] = React.useState('');
-  const [composeMeetingRes, setComposeMeetingRes] = React.useState('');
-  const [openCalendarItemRes, setOpenCalendarItemRes] = React.useState('');
 
-  const composeMeeting = (meetingParams: string): void => {
-    setComposeMeetingRes('calendar.composeMeeting()' + noHostSdkMsg);
-    calendar
-      .composeMeeting(JSON.parse(meetingParams))
-      .then(() => setComposeMeetingRes('Completed'))
-      .catch(reason => setComposeMeetingRes(reason));
-  };
-
-  const openCalendarItem = (calendarParams: string): void => {
-    setOpenCalendarItemRes('calendar.openCalendarItem()' + noHostSdkMsg);
-    calendar
-      .openCalendarItem(JSON.parse(calendarParams))
-      .then(() => setOpenCalendarItemRes('Completed'))
-      .catch(reason => setOpenCalendarItemRes(reason));
-  };
-
+  // TODO: Remove once E2E scenario tests are updated to use the new version
   const checkCalendarCapability = (): void => {
     if (calendar.isSupported()) {
       setCapabilityCheckRes('Calendar module is supported');
@@ -36,6 +54,7 @@ const CalendarAPIs = (): ReactElement => {
   return (
     <>
       <h1>calendar</h1>
+      {/* TODO: Remove once E2E scenario tests are updated to use the new version */}
       <BoxAndButton
         handleClick={checkCalendarCapability}
         output={capabilityCheckRes}
@@ -43,20 +62,9 @@ const CalendarAPIs = (): ReactElement => {
         title="Check Capability Calendar"
         name="checkCapabilityCalendar"
       />
-      <BoxAndButton
-        handleClickWithInput={openCalendarItem}
-        output={openCalendarItemRes}
-        hasInput={true}
-        title="Open Calendar Item"
-        name="openCalendarItem"
-      />
-      <BoxAndButton
-        handleClickWithInput={composeMeeting}
-        output={composeMeetingRes}
-        hasInput={true}
-        title="Compose Meeting"
-        name="composeMeeting"
-      />
+      <CheckCalendarCapability />
+      <ComposeMeeting />
+      <OpenCalendarItem />
     </>
   );
 };

--- a/apps/teams-test-app/src/components/CallAPIs.tsx
+++ b/apps/teams-test-app/src/components/CallAPIs.tsx
@@ -1,47 +1,44 @@
 import { call } from '@microsoft/teams-js';
 import React from 'react';
 
-import { noHostSdkMsg } from '../App';
-import BoxAndButton from './BoxAndButton';
+import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
-const CallAPIs: React.FC = () => {
-  const [startCallRes, setStartCallRes] = React.useState('');
-  const [capabilityCheckRes, setCapabilityCheckRes] = React.useState('');
+const CheckCallCapability = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'checkCapabilityCall',
+    title: 'Check Capability Call',
+    onClick: async () => `Call module ${call.isSupported() ? 'is' : 'is not'} supported`,
+  });
 
-  const startCall = (callParams: string): void => {
-    setStartCallRes('call.startCall()' + noHostSdkMsg);
-    call
-      .startCall(JSON.parse(callParams))
-      .then(success => setStartCallRes('result: ' + success))
-      .catch(reason => setStartCallRes(reason));
-  };
+const StartCall = (): React.ReactElement =>
+  ApiWithTextInput<call.StartCallParams>({
+    name: 'startCall',
+    title: 'Start Call',
+    onClick: {
+      validateInput: () => {
+        // TODO: uncomment below once the test is updated to reflect the proper input type
+        /*
+        if (!input.targets) {
+          throw new Error('targets is required');
+        }
+        if (!Array.isArray(input) || input.length === 0 || input.some(x => typeof x !== x)) {
+          throw new Error('targets has to be a non-empty array of strings');
+        }
+        */
+      },
+      submit: async callParams => {
+        const result = await call.startCall(callParams);
+        return 'result: ' + result;
+      },
+    },
+  });
 
-  const checkCallCapability = (): void => {
-    if (call.isSupported()) {
-      setCapabilityCheckRes('Call module is supported');
-    } else {
-      setCapabilityCheckRes('Call module is not supported');
-    }
-  };
-  return (
-    <>
-      <h1>call</h1>
-      <BoxAndButton
-        handleClickWithInput={startCall}
-        output={startCallRes}
-        hasInput={true}
-        title="Start Call"
-        name="startCall"
-      />
-      <BoxAndButton
-        handleClick={checkCallCapability}
-        output={capabilityCheckRes}
-        hasInput={false}
-        title="Check Capability Call"
-        name="checkCapabilityCall"
-      />
-    </>
-  );
-};
+const CallAPIs: React.FC = () => (
+  <>
+    <h1>call</h1>
+    <StartCall />
+    <CheckCallCapability />
+  </>
+);
 
 export default CallAPIs;

--- a/apps/teams-test-app/src/components/LocationAPIs.tsx
+++ b/apps/teams-test-app/src/components/LocationAPIs.tsx
@@ -1,66 +1,56 @@
 import { location } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import { noHostSdkMsg } from '../App';
-import BoxAndButton from './BoxAndButton';
+import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
-const LocationAPIs = (): ReactElement => {
-  const [getLocationRes, setGetLocationRes] = React.useState('');
-  const [showLocationRes, setShowLocationRes] = React.useState('');
-  const [checkLocationCapabilityRes, setCheckLocationCapabilityRes] = React.useState('');
+const CheckLocationCapability = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'checkLocationCapability',
+    title: 'Check Location Capability',
+    onClick: async () => `Location module ${location.isSupported() ? 'is' : 'is not'} supported`,
+  });
 
-  const getLocation = (locationPropsInput: string): void => {
-    const locationProps: location.LocationProps = JSON.parse(locationPropsInput);
-    setGetLocationRes('location.getLocation()' + noHostSdkMsg);
-    location
-      .getLocation(locationProps)
-      .then(location => setGetLocationRes(JSON.stringify(location)))
-      .catch(err => setGetLocationRes(err.errorCode.toString + ' ' + err.message));
-  };
+const GetLocation = (): React.ReactElement =>
+  ApiWithTextInput<location.LocationProps>({
+    name: 'getLocation',
+    title: 'Get Location',
+    onClick: {
+      validateInput: input => {
+        if (input.allowChooseLocation === undefined) {
+          throw new Error('allowChooseLocation is required');
+        }
+      },
+      submit: async locationProps => {
+        const result = await location.getLocation(locationProps);
+        return JSON.stringify(result);
+      },
+    },
+  });
 
-  const showLocation = (locationInput: string): void => {
-    const locationParam: location.Location = JSON.parse(locationInput);
-    setShowLocationRes('location.showLocation()' + noHostSdkMsg);
-    location
-      .showLocation(locationParam)
-      .then(() => setShowLocationRes('Completed'))
-      .catch(err => setShowLocationRes(err.errorCode.toString + ' ' + err.message));
-  };
+const ShowLocation = (): React.ReactElement =>
+  ApiWithTextInput<location.Location>({
+    name: 'showLocation',
+    title: 'Show Location',
+    onClick: {
+      validateInput: input => {
+        if (!input.latitude || !input.longitude) {
+          throw new Error('latitude and longitude are required');
+        }
+      },
+      submit: async locationProps => {
+        await location.showLocation(locationProps);
+        return 'Completed';
+      },
+    },
+  });
 
-  const locationCapabilityCheck = (): void => {
-    if (location.isSupported()) {
-      setCheckLocationCapabilityRes('Location module is supported');
-    } else {
-      setCheckLocationCapabilityRes('Location module is not supported');
-    }
-  };
-
-  return (
-    <>
-      <h1>location</h1>
-      <BoxAndButton
-        handleClickWithInput={getLocation}
-        output={getLocationRes}
-        hasInput={true}
-        title="Get Location"
-        name="getLocation"
-      />
-      <BoxAndButton
-        handleClickWithInput={showLocation}
-        output={showLocationRes}
-        hasInput={true}
-        title="Show Location"
-        name="showLocation"
-      />
-      <BoxAndButton
-        handleClick={locationCapabilityCheck}
-        output={checkLocationCapabilityRes}
-        hasInput={false}
-        title="Check Location Capability"
-        name="checkLocationCapability"
-      />
-    </>
-  );
-};
+const LocationAPIs = (): ReactElement => (
+  <>
+    <h1>location</h1>
+    <GetLocation />
+    <ShowLocation />
+    <CheckLocationCapability />
+  </>
+);
 
 export default LocationAPIs;

--- a/apps/teams-test-app/src/components/LogsAPIs.tsx
+++ b/apps/teams-test-app/src/components/LogsAPIs.tsx
@@ -2,33 +2,26 @@ import { logs } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
 import { generateRegistrationMsg } from '../App';
-import BoxAndButton from './BoxAndButton';
+import { ApiWithoutInput } from './utils';
 
-const LogsAPIs = (): ReactElement => {
-  const [registerGetLogHandlerRes, setRegisterGetLogHandlerRes] = React.useState('');
+const RegisterGetLogHandler = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'registerGetLogHandler',
+    title: 'Register Get Log Handler',
+    onClick: async setResult => {
+      logs.registerGetLogHandler(() => {
+        setResult('Success');
+        return 'App log string';
+      });
+      return generateRegistrationMsg('it is invoked to get the app log');
+    },
+  });
 
-  const registerGetLogHandler = (): void => {
-    setRegisterGetLogHandlerRes(generateRegistrationMsg('it is invoked to get the app log'));
-    const log = 'App log string';
-    const handler = (): string => {
-      setRegisterGetLogHandlerRes('Success');
-      return log;
-    };
-    logs.registerGetLogHandler(handler);
-  };
-
-  return (
-    <>
-      <h1>logs</h1>
-      <BoxAndButton
-        handleClick={registerGetLogHandler}
-        output={registerGetLogHandlerRes}
-        hasInput={false}
-        title="Register Get Log Handler"
-        name="registerGetLogHandler"
-      />
-    </>
-  );
-};
+const LogsAPIs = (): ReactElement => (
+  <>
+    <h1>logs</h1>
+    <RegisterGetLogHandler />
+  </>
+);
 
 export default LogsAPIs;

--- a/apps/teams-test-app/src/components/SharingAPIs.tsx
+++ b/apps/teams-test-app/src/components/SharingAPIs.tsx
@@ -6,11 +6,11 @@ import BoxAndButton from './BoxAndButton';
 
 const SharingAPIs = (): ReactElement => {
   const [shareWebContentRes, setShareWebContentRes] = React.useState('');
+  const [capabilityCheckRes, setCapabilityCheckRes] = React.useState('');
 
-  const shareWebContent = (): void => {
-    const shareRequest: sharing.IShareRequest<sharing.IURLContent> = {
-      content: [{ type: 'URL', url: 'https://bing.com' }],
-    };
+  const shareWebContent = (input: string): void => {
+    const shareRequest: sharing.IShareRequest<sharing.IShareRequestContentType> = JSON.parse(input);
+
     const callback = (err?: SdkError): void => {
       if (err) {
         setShareWebContentRes(JSON.stringify(err));
@@ -22,15 +22,30 @@ const SharingAPIs = (): ReactElement => {
     sharing.shareWebContent(shareRequest, callback);
   };
 
+  const checkSharingCapability = (): void => {
+    if (sharing.isSupported()) {
+      setCapabilityCheckRes('Sharing is supported');
+    } else {
+      setCapabilityCheckRes('Sharing is not supported');
+    }
+  };
+
   return (
     <>
       <h1>sharing</h1>
       <BoxAndButton
-        handleClick={shareWebContent}
+        handleClickWithInput={shareWebContent}
         output={shareWebContentRes}
-        hasInput={false}
+        hasInput={true}
         title="Share web content"
         name="share_shareWebContent"
+      />
+      <BoxAndButton
+        handleClick={checkSharingCapability}
+        output={capabilityCheckRes}
+        hasInput={false}
+        title="Check Sharing Capability"
+        name="checkSharingCapability"
       />
     </>
   );

--- a/apps/teams-test-app/src/components/utils/ApiContainer.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiContainer.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+
+export interface ApiContainerProps {
+  title: string;
+  name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
+  result?: string;
+}
+
+export const ApiContainer = (props: React.PropsWithChildren<ApiContainerProps>): React.ReactElement => {
+  const { children, name, result } = props;
+
+  if (!name || !/^[a-zA-Z0-9.]+$/.test(name)) {
+    throw new Error('name has to be set and it can only contain alphanumeric characters and dots.');
+  }
+
+  return (
+    <div
+      className="boxAndButton"
+      style={{
+        display: 'inline-block',
+        height: 200,
+        width: 400,
+        border: '5px solid black',
+        textAlign: 'center',
+      }}
+      id={`box_${name}`}
+    >
+      {children}
+      <div
+        className="box"
+        style={{
+          border: '2px solid red',
+          height: 150,
+          width: 400,
+          overflow: 'auto',
+        }}
+      >
+        <span id={`text_${name}`} style={{ wordWrap: 'break-word' }}>
+          {result}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/apps/teams-test-app/src/components/utils/ApiContainer.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiContainer.tsx
@@ -9,8 +9,8 @@ export interface ApiContainerProps {
 export const ApiContainer = (props: React.PropsWithChildren<ApiContainerProps>): React.ReactElement => {
   const { children, name, result } = props;
 
-  if (!name || !/^[a-zA-Z0-9.]+$/.test(name)) {
-    throw new Error('name has to be set and it can only contain alphanumeric characters and dots.');
+  if (!name || !/^[a-zA-Z0-9._]+$/.test(name)) {
+    throw new Error('name has to be set and it can only contain alphanumeric characters, dots and underscores.');
   }
 
   return (

--- a/apps/teams-test-app/src/components/utils/ApiWithCheckboxInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithCheckboxInput.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import { noHostSdkMsg } from '../../App';
+import { ApiContainer } from './ApiContainer';
+
+export interface ApiWithCheckboxInputProps {
+  title: string;
+  name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
+  label: string;
+  onClick: (input: boolean) => Promise<string>;
+  defaultCheckboxState?: boolean;
+}
+
+export const ApiWithCheckboxInput = (props: ApiWithCheckboxInputProps): React.ReactElement => {
+  const { name, defaultCheckboxState = false, label, onClick, title } = props;
+  const [result, setResult] = React.useState('');
+  const [value, setValue] = React.useState(defaultCheckboxState);
+
+  const onClickCallback = React.useCallback(async () => {
+    setResult(noHostSdkMsg);
+
+    try {
+      const result = await onClick(value);
+      setResult(result);
+    } catch (err) {
+      setResult('Error: ' + err);
+    }
+  }, [value, setResult, onClick]);
+
+  return (
+    <ApiContainer title={title} result={result} name={name}>
+      <input name={`button_${name}`} type="button" value={title} onClick={onClickCallback} />
+      {label}
+      <input type="checkbox" name={label} onChange={e => setValue(e.target.checked)} />
+    </ApiContainer>
+  );
+};

--- a/apps/teams-test-app/src/components/utils/ApiWithTextInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithTextInput.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+import { noHostSdkMsg } from '../../App';
+import { ApiContainer } from './ApiContainer';
+
+export interface ApiWithTextInputProps<T> {
+  title: string;
+  name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
+  onClick:
+    | ((input: Partial<T>) => Promise<string>)
+    | {
+        validateInput: (input: Partial<T>) => void;
+        submit: (input: T) => Promise<string>;
+      };
+  defaultInput?: string;
+}
+
+export const ApiWithTextInput = <T extends unknown>(props: ApiWithTextInputProps<T>): React.ReactElement => {
+  const { name, defaultInput, onClick, title } = props;
+  const [result, setResult] = React.useState('');
+  const [input, setInput] = React.useState(defaultInput);
+
+  const onClickCallback = React.useCallback(async () => {
+    if (!input) {
+      return;
+    }
+
+    setResult(noHostSdkMsg);
+    try {
+      const partialInput = JSON.parse(input) as Partial<T>;
+      if (typeof onClick === 'function') {
+        const result = await onClick(partialInput);
+        setResult(result);
+      } else {
+        const { validateInput, submit } = onClick;
+        validateInput(partialInput);
+        const result = await submit(partialInput as T);
+        setResult(result);
+      }
+    } catch (err) {
+      setResult('Error: ' + err);
+    }
+  }, [input, setResult, onClick]);
+
+  return (
+    <ApiContainer title={title} result={result} name={name}>
+      <input type="text" name={`input_${name}`} value={input} onChange={e => setInput(e.target.value)} />
+      <input name={`button_${name}`} type="button" value={title} onClick={onClickCallback} />
+    </ApiContainer>
+  );
+};

--- a/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+import { ApiContainer } from './ApiContainer';
+
+export interface ApiWithoutInputProps {
+  title: string;
+  name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
+  onClick: (setResult: (result: string) => void) => Promise<string>;
+}
+
+export const ApiWithoutInput = (props: ApiWithoutInputProps): React.ReactElement => {
+  const { name, onClick, title } = props;
+  const [result, setResult] = React.useState('');
+
+  return (
+    <ApiContainer title={title} result={result} name={name}>
+      <input
+        name={`button_${name}`}
+        type="button"
+        value={title}
+        onClick={async () => setResult(await onClick(setResult))}
+      />
+    </ApiContainer>
+  );
+};

--- a/apps/teams-test-app/src/components/utils/index.ts
+++ b/apps/teams-test-app/src/components/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './ApiWithCheckboxInput';
+export * from './ApiWithTextInput';
+export * from './ApiWithoutInput';

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,16 @@ steps:
       Arguments: 'install'
     displayName: 'yarn install'
 
+  - script: 'node prepNextDevRelease.js'
+    workingDirectory: '$(System.DefaultWorkingDirectory)\packages\teams-js'
+    condition: and(
+      eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'),
+      in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
+      ne(variables['Build.Reason'], 'PullRequest'),
+      ne(variables['Build.Reason'], 'Manual')
+      )
+    displayName: 'node prepNextDevRelease.js'
+
   - task: ESLint@1
     inputs:
       Configuration: 'required'
@@ -198,11 +208,11 @@ steps:
       WebAppName: 'cloudroll'
       package: '$(Build.ArtifactStagingDirectory)\teams-test-app\$(Build.BuildId).zip'
     displayName: 'Deploy to cloudroll'
-
+    
   # TODO - delete after release pipeline creation
   - task: CmdLine@1
     condition: and(
-      startsWith(variables['Build.SourceBranch'], 'refs/tags/v'),
+      or(startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview')),
       in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
       ne(variables['Build.Reason'], 'PullRequest'),
       ne(variables['Build.Reason'], 'Manual'))
@@ -211,29 +221,8 @@ steps:
       arguments: publish.js
       workingFolder: '$(System.DefaultWorkingDirectory)\packages\teams-js'
       failOnStandardError: true
-    displayName: 'Publish Npm Package (release)'
+    displayName: 'Publish Npm Package'
 
-  # TODO - reenable after PP
-  # - script: 'node prepNextDevRelease.js'
-  #   workingDirectory: '$(System.DefaultWorkingDirectory)/tools/cli'
-  #   condition: and(
-  #     eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'),
-  #     in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-  #     ne(variables['Build.Reason'], 'PullRequest'),
-  #     ne(variables['Build.Reason'], 'Manual')
-  #     )
-  #   displayName: 'node prepNextDevRelease.js'
-
-  # - task: Yarn@3
-  #   condition: and(
-  #     eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'),
-  #     in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-  #     ne(variables['Build.Reason'], 'PullRequest'),
-  #     ne(variables['Build.Reason'], 'Manual'))
-  #   inputs:
-  #     Arguments: 'publish-sdk --tag next-dev'
-  #   displayName: 'yarn publish-sdk (dev commit)'
-  
   - powershell: |
       $npmVer=$(node -p "require('./packages/teams-js/package.json').version") 
       Write-Host "##vso[task.setvariable variable=Version;isOutput=true]$npmVer"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/webpack": "^5.10.0",
-    "@types/webpack-dev-server": "^3.11.1",
+    "@types/webpack-dev-server": "^4.5.0",
     "@typescript-eslint/eslint-plugin": "^4.29.0",
     "@typescript-eslint/parser": "^4.29.0",
     "azure-keyvault": "^3.0.4",

--- a/packages/teams-js/src/internal/internalAPIs.ts
+++ b/packages/teams-js/src/internal/internalAPIs.ts
@@ -18,7 +18,10 @@ export function ensureInitialized(...expectedFrameContexts: string[]): void {
     }
 
     if (!found) {
-      throw new Error("This call is not allowed in the '" + GlobalVars.frameContext + "' context");
+      throw new Error(
+        `This call is only allowed in following contexts: ${JSON.stringify(expectedFrameContexts)}. ` +
+          `Current context: "${GlobalVars.frameContext}".`,
+      );
     }
   }
 }

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -464,7 +464,7 @@ export namespace authentication {
   /**
    * @deprecated with TeamsJS v2 upgrades
    */
-  interface LegacyCallBacks {
+  export interface LegacyCallBacks {
     /**
      * @deprecated with TeamsJS v2 upgrades
      * A function that is called if the request succeeds.

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -7,6 +7,7 @@ export {
   TeamType,
   UserTeamRole,
   ChannelType,
+  HostName,
 } from './constants';
 export {
   Context,
@@ -21,6 +22,8 @@ export {
   TeamInformation,
   FileOpenPreference,
   OpenConversationRequest,
+  LocaleInfo,
+  FrameInfo,
 } from './interfaces';
 export { app, core } from './app';
 export { appInstallDialog } from './appInstallDialog';

--- a/packages/teams-js/src/public/video.ts
+++ b/packages/teams-js/src/public/video.ts
@@ -75,7 +75,7 @@ export namespace video {
   /**
    *  Video frame call back function definition
    */
-  type VideoFrameCallback = (
+  export type VideoFrameCallback = (
     frame: VideoFrame,
     notifyVideoFrameProcessed: () => void,
     notifyError: (errorMessage: string) => void,
@@ -84,7 +84,7 @@ export namespace video {
   /**
    *  Video effect change call back function definition
    */
-  type VideoEffectCallBack = (effectId: string | undefined) => void;
+  export type VideoEffectCallBack = (effectId: string | undefined) => void;
 
   /**
    * register to read the video frames in Permissions section.

--- a/packages/teams-js/test/private/chat.spec.ts
+++ b/packages/teams-js/test/private/chat.spec.ts
@@ -42,7 +42,7 @@ describe('chat', () => {
         entityId: 'someEntityId',
       };
       return expect(chat.openConversation(conversationRequest)).rejects.toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 
@@ -100,7 +100,9 @@ describe('chat', () => {
 
     it('should not allow calls from settings context', async () => {
       await utils.initializeWithContext('settings');
-      expect(() => chat.closeConversation()).toThrowError("This call is not allowed in the 'settings' context");
+      expect(() => chat.closeConversation()).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
+      );
     });
   });
 

--- a/packages/teams-js/test/private/files.spec.ts
+++ b/packages/teams-js/test/private/files.spec.ts
@@ -35,7 +35,7 @@ describe('files', () => {
     it('should not allow calls without frame context initialization', async () => {
       await utils.initializeWithContext('settings');
       expect(files.getCloudStorageFolders('channelId')).rejects.toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 
@@ -84,7 +84,7 @@ describe('files', () => {
     it('should not allow calls without frame context initialization', async () => {
       await utils.initializeWithContext('settings');
       expect(files.addCloudStorageFolder('channelId')).rejects.toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 
@@ -142,7 +142,7 @@ describe('files', () => {
     it('should not allow calls without frame context initialization', async () => {
       await utils.initializeWithContext('settings');
       expect(files.deleteCloudStorageFolder('channelId', mockCloudStorageFolder)).rejects.toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 
@@ -214,7 +214,9 @@ describe('files', () => {
       await utils.initializeWithContext('settings');
       return expect(
         files.getCloudStorageFolderContents(mockCloudStorageFolder, files.CloudStorageProvider.Box),
-      ).rejects.toThrowError("This call is not allowed in the 'settings' context");
+      ).rejects.toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
+      );
     });
 
     it('should not allow calls with null folder', async () => {
@@ -287,7 +289,7 @@ describe('files', () => {
     it('should not allow calls without frame context initialization', async () => {
       await utils.initializeWithContext('settings');
       expect(() => files.openCloudStorageFile(mockCloudStorageFolderItem, files.CloudStorageProvider.Box)).toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 

--- a/packages/teams-js/test/private/pages.spec.ts
+++ b/packages/teams-js/test/private/pages.spec.ts
@@ -32,7 +32,7 @@ describe('AppSDK-TeamsAPIs', () => {
       await utils.initializeWithContext('settings');
 
       expect(() => pages.fullTrust.enterFullscreen()).toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 
@@ -40,20 +40,24 @@ describe('AppSDK-TeamsAPIs', () => {
       await utils.initializeWithContext('authentication');
 
       expect(() => pages.fullTrust.enterFullscreen()).toThrowError(
-        "This call is not allowed in the 'authentication' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "authentication".',
       );
     });
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
 
-      expect(() => pages.fullTrust.enterFullscreen()).toThrowError("This call is not allowed in the 'remove' context");
+      expect(() => pages.fullTrust.enterFullscreen()).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "remove".',
+      );
     });
 
     it('should not allow calls from task context', async () => {
       await utils.initializeWithContext('task');
 
-      expect(() => pages.fullTrust.enterFullscreen()).toThrowError("This call is not allowed in the 'task' context");
+      expect(() => pages.fullTrust.enterFullscreen()).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "task".',
+      );
     });
 
     it('should successfully enter fullscreen', async () => {
@@ -74,27 +78,33 @@ describe('AppSDK-TeamsAPIs', () => {
     it('should not allow calls from settings context', async () => {
       await utils.initializeWithContext('settings');
 
-      expect(() => pages.fullTrust.exitFullscreen()).toThrowError("This call is not allowed in the 'settings' context");
+      expect(() => pages.fullTrust.exitFullscreen()).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
+      );
     });
 
     it('should not allow calls from authentication context', async () => {
       await utils.initializeWithContext('authentication');
 
       expect(() => pages.fullTrust.exitFullscreen()).toThrowError(
-        "This call is not allowed in the 'authentication' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "authentication".',
       );
     });
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
 
-      expect(() => pages.fullTrust.exitFullscreen()).toThrowError("This call is not allowed in the 'remove' context");
+      expect(() => pages.fullTrust.exitFullscreen()).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "remove".',
+      );
     });
 
     it('should not allow calls from task context', async () => {
       await utils.initializeWithContext('task');
 
-      expect(() => pages.fullTrust.exitFullscreen()).toThrowError("This call is not allowed in the 'task' context");
+      expect(() => pages.fullTrust.exitFullscreen()).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "task".',
+      );
     });
 
     it('should successfully exit fullscreen', async () => {

--- a/packages/teams-js/test/private/teams.spec.ts
+++ b/packages/teams-js/test/private/teams.spec.ts
@@ -35,7 +35,7 @@ describe('AppSDK-privateAPIs', () => {
     it('should not allow calls without frame context initialization', async () => {
       await utils.initializeWithContext('settings');
       expect(() => teams.getTeamChannels('groupId', emptyCallback)).toThrowError(
-        "This call is not allowed in the 'settings' context",
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings".',
       );
     });
 
@@ -82,8 +82,9 @@ describe('AppSDK-privateAPIs', () => {
 
   describe('refreshSiteUrl', () => {
     it('should not allow calls before initialization', () => {
-      expect(() => teams.refreshSiteUrl('threadId', emptyCallback)).toThrowError('The library has not yet been initialized');
+      expect(() => teams.refreshSiteUrl('threadId', emptyCallback)).toThrowError(
+        'The library has not yet been initialized',
+      );
     });
   });
-
 });

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -463,7 +463,7 @@ describe('AppSDK-app', () => {
       await utils.initializeWithContext('authentication');
 
       return expect(pages.navigateCrossDomain('https://valid.origin.com')).rejects.toThrowError(
-        "This call is not allowed in the 'authentication' context",
+        'This call is only allowed in following contexts: ["content","sidePanel","settings","remove","task","stage","meetingStage"]. Current context: "authentication".',
       );
     });
 

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -45,7 +45,7 @@ describe('authentication', () => {
       };
 
       expect(() => authentication.authenticate(authenticationParams)).toThrowError(
-        "This call is not allowed in the 'authentication' context",
+        'This call is only allowed in following contexts: ["content","sidePanel","settings","remove","task","stage","meetingStage"]. Current context: "authentication".',
       );
     });
   });
@@ -674,7 +674,7 @@ describe('authentication', () => {
       'The library has not yet been initialized',
     );
   });
-  
+
   it('should successfully return getAuthToken in case of success in legacy flow', done => {
     utils.initializeWithContext('content').then(() => {
       const authTokenRequest = {

--- a/packages/teams-js/test/public/config.spec.ts
+++ b/packages/teams-js/test/public/config.spec.ts
@@ -24,7 +24,9 @@ describe('config', () => {
   it('should not allow calls from the wrong context', async () => {
     await utils.initializeWithContext('content');
 
-    expect(() => pages.config.setValidityState(true)).toThrowError("This call is not allowed in the 'content' context");
+    expect(() => pages.config.setValidityState(true)).toThrowError(
+      'This call is only allowed in following contexts: ["settings","remove"]. Current context: "content".',
+    );
   });
 
   it('should successfully notify success on save when there is no registered handler', async () => {

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -33,28 +33,36 @@ describe('Dialog', () => {
       await utils.initializeWithContext('settings');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.open(dialogInfo)).toThrowError("This call is not allowed in the 'settings' context");
+      expect(() => dialog.open(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "settings".',
+      );
     });
 
     it('should not allow calls from authentication context', async () => {
       await utils.initializeWithContext('authentication');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.open(dialogInfo)).toThrowError("This call is not allowed in the 'authentication' context");
+      expect(() => dialog.open(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "authentication".',
+      );
     });
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.open(dialogInfo)).toThrowError("This call is not allowed in the 'remove' context");
+      expect(() => dialog.open(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "remove".',
+      );
     });
 
     it('should not allow calls from task context', async () => {
       await utils.initializeWithContext('task');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.open(dialogInfo)).toThrowError("This call is not allowed in the 'task' context");
+      expect(() => dialog.open(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "task".',
+      );
     });
 
     it('should pass along entire DialogInfo parameter in sidePanel context', async () => {
@@ -146,21 +154,27 @@ describe('Dialog', () => {
       await utils.initializeWithContext('sidePanel');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.resize(dialogInfo)).toThrowError("This call is not allowed in the 'sidePanel' context");
+      expect(() => dialog.resize(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "sidePanel".',
+      );
     });
 
     it('should not allow calls from content context', async () => {
       await utils.initializeWithContext('content');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.resize(dialogInfo)).toThrowError("This call is not allowed in the 'content' context");
+      expect(() => dialog.resize(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "content".',
+      );
     });
-    
+
     it('should not allow calls from meetingStage context', async () => {
       await utils.initializeWithContext('meetingStage');
 
       const dialogInfo: DialogInfo = {};
-      expect(() => dialog.resize(dialogInfo)).toThrowError("This call is not allowed in the 'meetingStage' context");
+      expect(() => dialog.resize(dialogInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "meetingStage".',
+      );
     });
 
     it('should successfully pass DialogInfo in Task context', async () => {
@@ -192,37 +206,49 @@ describe('Dialog', () => {
     it('should not allow calls from settings context', async () => {
       await utils.initializeWithContext('settings');
 
-      expect(() => dialog.submit()).toThrowError("This call is not allowed in the 'settings' context");
+      expect(() => dialog.submit()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "settings".',
+      );
     });
 
     it('should not allow calls from authentication context', async () => {
       await utils.initializeWithContext('authentication');
 
-      expect(() => dialog.submit()).toThrowError("This call is not allowed in the 'authentication' context");
+      expect(() => dialog.submit()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "authentication".',
+      );
     });
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
 
-      expect(() => dialog.submit()).toThrowError("This call is not allowed in the 'remove' context");
+      expect(() => dialog.submit()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "remove".',
+      );
     });
 
     it('should not allow calls from content context', async () => {
       await utils.initializeWithContext('content');
 
-      expect(() => dialog.submit()).toThrowError("This call is not allowed in the 'content' context");
+      expect(() => dialog.submit()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "content".',
+      );
     });
 
     it('should not allow calls from meetingStage context', async () => {
       await utils.initializeWithContext('meetingStage');
 
-      expect(() => dialog.submit()).toThrowError("This call is not allowed in the 'meetingStage' context");
+      expect(() => dialog.submit()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "meetingStage".',
+      );
     });
 
     it('should not allow calls from sidePanel context', async () => {
       await utils.initializeWithContext('sidePanel');
 
-      expect(() => dialog.submit()).toThrowError("This call is not allowed in the 'sidePanel' context");
+      expect(() => dialog.submit()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "sidePanel".',
+      );
     });
 
     it('should successfully pass result and appIds parameters when called from Task context', async () => {

--- a/packages/teams-js/test/public/locationLegacy.spec.ts
+++ b/packages/teams-js/test/public/locationLegacy.spec.ts
@@ -56,21 +56,21 @@ describe('location_V1', () => {
     await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
     mobilePlatformMock.setClientSupportedSDKVersion(minVersionForLocationAPIs);
     expect(() => location.getLocation(defaultLocationProps, emptyCallback)).toThrowError(
-      "This call is not allowed in the 'authentication' context",
+      'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
     );
   });
   it('should not allow getLocation calls for remove frame context', async () => {
     await mobilePlatformMock.initializeWithContext(FrameContexts.remove);
     mobilePlatformMock.setClientSupportedSDKVersion(minVersionForLocationAPIs);
     expect(() => location.getLocation(defaultLocationProps, emptyCallback)).toThrowError(
-      "This call is not allowed in the 'remove' context",
+      'This call is only allowed in following contexts: ["content","task"]. Current context: "remove".',
     );
   });
   it('should not allow getLocation calls for settings frame context', async () => {
     await mobilePlatformMock.initializeWithContext(FrameContexts.settings);
     mobilePlatformMock.setClientSupportedSDKVersion(minVersionForLocationAPIs);
     expect(() => location.getLocation(defaultLocationProps, emptyCallback)).toThrowError(
-      "This call is not allowed in the 'settings' context",
+      'This call is only allowed in following contexts: ["content","task"]. Current context: "settings".',
     );
   });
   it('should not allow getLocation calls without props', done => {
@@ -184,21 +184,21 @@ describe('location_V1', () => {
     await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
     mobilePlatformMock.setClientSupportedSDKVersion(minVersionForLocationAPIs);
     expect(() => location.showLocation(defaultLocation, emptyCallback)).toThrowError(
-      "This call is not allowed in the 'authentication' context",
+      'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
     );
   });
   it('should not allow showLocation calls for remove frame context', async () => {
     await mobilePlatformMock.initializeWithContext(FrameContexts.remove);
     mobilePlatformMock.setClientSupportedSDKVersion(minVersionForLocationAPIs);
     expect(() => location.showLocation(defaultLocation, emptyCallback)).toThrowError(
-      "This call is not allowed in the 'remove' context",
+      'This call is only allowed in following contexts: ["content","task"]. Current context: "remove".',
     );
   });
   it('should not allow showLocation calls for settings frame context', async () => {
     await mobilePlatformMock.initializeWithContext(FrameContexts.settings);
     mobilePlatformMock.setClientSupportedSDKVersion(minVersionForLocationAPIs);
     expect(() => location.showLocation(defaultLocation, emptyCallback)).toThrowError(
-      "This call is not allowed in the 'settings' context",
+      'This call is only allowed in following contexts: ["content","task"]. Current context: "settings".',
     );
   });
   it('should not allow showLocation calls without props', done => {

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -59,21 +59,21 @@ describe('media', () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
         mobilePlatformMock.setClientSupportedSDKVersion(minVersionForCaptureImage);
         expect(() => media.captureImage(emptyCallback)).toThrowError(
-          "This call is not allowed in the 'authentication' context",
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
         );
       });
       it('should not allow captureImage calls for remove frame context', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.remove);
         mobilePlatformMock.setClientSupportedSDKVersion(minVersionForCaptureImage);
         expect(() => media.captureImage(emptyCallback)).toThrowError(
-          "This call is not allowed in the 'remove' context",
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "remove".',
         );
       });
       it('should not allow captureImage calls for settings frame context', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.settings);
         mobilePlatformMock.setClientSupportedSDKVersion(minVersionForCaptureImage);
         expect(() => media.captureImage(emptyCallback)).toThrowError(
-          "This call is not allowed in the 'settings' context",
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "settings".',
         );
       });
       it('should not allow captureImage calls in desktop', done => {
@@ -174,18 +174,22 @@ describe('media', () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
         mobilePlatformMock.setClientSupportedSDKVersion(minVersionForCaptureImage);
         return expect(() => media.captureImage()).toThrowError(
-          "This call is not allowed in the 'authentication' context",
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
         );
       });
       it('should not allow captureImage calls for remove frame context', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.remove);
         mobilePlatformMock.setClientSupportedSDKVersion(minVersionForCaptureImage);
-        return expect(() => media.captureImage()).toThrowError("This call is not allowed in the 'remove' context");
+        return expect(() => media.captureImage()).toThrowError(
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "remove".',
+        );
       });
       it('should not allow captureImage calls for settings frame context', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.settings);
         mobilePlatformMock.setClientSupportedSDKVersion(minVersionForCaptureImage);
-        return expect(() => media.captureImage()).toThrowError("This call is not allowed in the 'settings' context");
+        return expect(() => media.captureImage()).toThrowError(
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "settings".',
+        );
       });
       it('should not allow captureImage calls in desktop', async () => {
         await desktopPlatformMock.initializeWithContext(FrameContexts.content);
@@ -1228,7 +1232,7 @@ describe('media', () => {
         mobilePlatformMock.initializeWithContext(FrameContexts.authentication).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
           expect(() => media.scanBarCode(emptyCallback, null)).toThrowError(
-            "This call is not allowed in the 'authentication' context",
+            'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
           );
         });
       });
@@ -1369,7 +1373,7 @@ describe('media', () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
         mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
         return expect(() => media.scanBarCode()).toThrowError(
-          "This call is not allowed in the 'authentication' context",
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
         );
       });
 

--- a/packages/teams-js/test/public/navigation.spec.ts
+++ b/packages/teams-js/test/public/navigation.spec.ts
@@ -43,7 +43,7 @@ describe('MicrosoftTeams-Navigation', () => {
       await utils.initializeWithContext('authentication');
 
       expect(() => navigateCrossDomain('https://valid.origin.com')).toThrowError(
-        "This call is not allowed in the 'authentication' context",
+        'This call is only allowed in following contexts: ["content","sidePanel","settings","remove","task","stage","meetingStage"]. Current context: "authentication".',
       );
     });
 

--- a/packages/teams-js/test/public/settings.spec.ts
+++ b/packages/teams-js/test/public/settings.spec.ts
@@ -23,7 +23,9 @@ describe('settings', () => {
 
   it('should not allow calls from the wrong context', () => {
     utils.initializeWithContext('content').then(() => {
-      expect(() => settings.setValidityState(true)).toThrowError("This call is not allowed in the 'content' context");
+      expect(() => settings.setValidityState(true)).toThrowError(
+        'This call is only allowed in following contexts: ["settings","remove"]. Current context: "content".',
+      );
     });
   });
 

--- a/packages/teams-js/test/public/tasks.spec.ts
+++ b/packages/teams-js/test/public/tasks.spec.ts
@@ -33,28 +33,36 @@ describe('tasks', () => {
       await utils.initializeWithContext('settings');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'settings' context");
+      expect(() => tasks.startTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "settings".',
+      );
     });
 
     it('should not allow calls from authentication context', async () => {
       await utils.initializeWithContext('authentication');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'authentication' context");
+      expect(() => tasks.startTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "authentication".',
+      );
     });
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'remove' context");
+      expect(() => tasks.startTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "remove".',
+      );
     });
 
     it('should not allow calls from task context', async () => {
       await utils.initializeWithContext('task');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.startTask(taskInfo)).toThrowError("This call is not allowed in the 'task' context");
+      expect(() => tasks.startTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "task".',
+      );
     });
 
     it('should pass along entire TaskInfo parameter in sidePanel context', async () => {
@@ -146,23 +154,29 @@ describe('tasks', () => {
       await utils.initializeWithContext('content');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.updateTask(taskInfo)).toThrowError("This call is not allowed in the 'content' context");
+      expect(() => tasks.updateTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "content".',
+      );
     });
 
     it('should not allow calls from sidePanel context', async () => {
       await utils.initializeWithContext('sidePanel');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.updateTask(taskInfo)).toThrowError("This call is not allowed in the 'sidePanel' context");
+      expect(() => tasks.updateTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "sidePanel".',
+      );
     });
 
     it('should not allow calls from meetingStage context', async () => {
       await utils.initializeWithContext('meetingStage');
 
       const taskInfo: TaskInfo = {};
-      expect(() => tasks.updateTask(taskInfo)).toThrowError("This call is not allowed in the 'meetingStage' context");
+      expect(() => tasks.updateTask(taskInfo)).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "meetingStage".',
+      );
     });
-    
+
     it('should successfully pass taskInfo in task context', async () => {
       await utils.initializeWithContext('task');
       const taskInfo = { width: 10, height: 10 };
@@ -192,37 +206,49 @@ describe('tasks', () => {
     it('should not allow calls from settings context', async () => {
       await utils.initializeWithContext('settings');
 
-      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'settings' context");
+      expect(() => tasks.submitTask()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "settings".',
+      );
     });
 
     it('should not allow calls from content context', async () => {
       await utils.initializeWithContext('content');
 
-      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'content' context");
+      expect(() => tasks.submitTask()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "content".',
+      );
     });
 
     it('should not allow calls from sidePanel context', async () => {
       await utils.initializeWithContext('sidePanel');
 
-      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'sidePanel' context");
+      expect(() => tasks.submitTask()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "sidePanel".',
+      );
     });
 
     it('should not allow calls from meetingStage context', async () => {
       await utils.initializeWithContext('meetingStage');
 
-      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'meetingStage' context");
+      expect(() => tasks.submitTask()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "meetingStage".',
+      );
     });
 
     it('should not allow calls from authentication context', async () => {
       await utils.initializeWithContext('authentication');
 
-      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'authentication' context");
+      expect(() => tasks.submitTask()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "authentication".',
+      );
     });
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
 
-      expect(() => tasks.submitTask()).toThrowError("This call is not allowed in the 'remove' context");
+      expect(() => tasks.submitTask()).toThrowError(
+        'This call is only allowed in following contexts: ["task"]. Current context: "remove".',
+      );
     });
 
     it('should successfully pass result and appIds parameters when called from task context', async () => {

--- a/packages/teams-js/test/public/video.spec.ts
+++ b/packages/teams-js/test/public/video.spec.ts
@@ -35,11 +35,11 @@ describe('video', () => {
   it('should not allow calls from the wrong context', async () => {
     await utils.initializeWithContext('content');
     expect(() => video.registerForVideoFrame(emptyVideoEffectCallback, videoFrameConfig)).toThrowError(
-      "This call is not allowed in the 'content' context",
+      'This call is only allowed in following contexts: ["sidePanel"]. Current context: "content".',
     );
     expect(() =>
       video.notifySelectedVideoEffectChanged(video.EffectChangeType.EffectChanged, 'sample effect config'),
-    ).toThrowError("This call is not allowed in the 'content' context");
+    ).toThrowError('This call is only allowed in following contexts: ["sidePanel"]. Current context: "content".');
   });
 
   it('register for video frame event', async () => {

--- a/packages/teams-js/webpack.config.js
+++ b/packages/teams-js/webpack.config.js
@@ -50,6 +50,7 @@ module.exports = {
       main: 'dts/index.d.ts',
       out: '~/dist/MicrosoftTeams.d.ts',
       removeSource: true,
+      outputAsModuleFolder: true,
     }),
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,7 +1974,7 @@
     write-file-atomic "^2.3.0"
 
 "@microsoft/teams-js@file:packages/teams-js":
-  version "2.0.0-beta.0"
+  version "2.0.0-beta.1"
 
 "@mixer/webpack-bundle-compare@^0.1.0":
   version "0.1.0"
@@ -2214,6 +2214,13 @@
   integrity sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==
   dependencies:
     "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/bonjour@*":
+  version "3.5.9"
+  resolved "https://registry.yarnpkg.com/@types/bonjour/-/bonjour-3.5.9.tgz#3cc4e5135dbb5940fc6051604809234612f89cb4"
+  integrity sha512-VkZUiYevvtPyFu5XtpYw9a8moCSzxgjs5PAFF4yXjA7eYHvzBlXe+eJdqBBNWWVzI1r7Ki0KxMYvaQuhm+6f5A==
+  dependencies:
     "@types/node" "*"
 
 "@types/connect-history-api-fallback@*":
@@ -2463,6 +2470,13 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/serve-index@*":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.1.tgz#1b5e85370a192c01ec6cec4735cf2917337a6278"
+  integrity sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==
+  dependencies:
+    "@types/express" "*"
+
 "@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
@@ -2493,16 +2507,29 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/webpack-dev-server@^3.11.1":
-  version "3.11.6"
-  resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-3.11.6.tgz#d8888cfd2f0630203e13d3ed7833a4d11b8a34dc"
-  integrity sha512-XCph0RiiqFGetukCTC3KVnY1jwLcZ84illFRMbyFzCcWl90B/76ew0tSqF46oBhnLC4obNDG7dMO0JfTN0MgMQ==
+"@types/webpack-dev-middleware@*":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@types/webpack-dev-middleware/-/webpack-dev-middleware-5.0.2.tgz#0f66566c2ca7d484891b4552c8a7b64a3044e3e2"
+  integrity sha512-S3WUtef//Vx6WETyWZkM45WqgRxWSaqbpWtPcKySNRhiQNyhCqM9EueggaMX3L9N2IbG4dJIK5PgYcAWUifUbA==
   dependencies:
+    "@types/connect" "*"
+    tapable "^2.1.1"
+    webpack "^5.38.1"
+
+"@types/webpack-dev-server@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-4.5.0.tgz#52a983de97db81a38b7309a8cf8a730c3e02f28e"
+  integrity sha512-HMb6pZPANObue3LwbdpQLWzQyF9O0wntiPyXj4vGutlAbNKTXH4hDCHaZyfvfZDmFn+5HprrWHm1TGt3awNr/A==
+  dependencies:
+    "@types/bonjour" "*"
     "@types/connect-history-api-fallback" "*"
     "@types/express" "*"
+    "@types/serve-index" "*"
     "@types/serve-static" "*"
-    "@types/webpack" "^4"
-    http-proxy-middleware "^1.0.0"
+    "@types/webpack-dev-middleware" "*"
+    chokidar "^3.5.1"
+    http-proxy-middleware "^2.0.0"
+    webpack "*"
 
 "@types/webpack-sources@*":
   version "3.2.0"
@@ -2513,7 +2540,7 @@
     "@types/source-list-map" "*"
     source-map "^0.7.3"
 
-"@types/webpack@^4", "@types/webpack@^4.41.8":
+"@types/webpack@^4.41.8":
   version "4.41.31"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.31.tgz#c35f252a3559ddf9c85c0d8b0b42019025e581aa"
   integrity sha512-/i0J7sepXFIp1ZT7FjUGi1eXMCg8HCCzLJEQkKsOtbJFontsJLolBcDC+3qxn5pPwiCt1G0ZdRmYRzNBtvpuGQ==
@@ -2988,7 +3015,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.0.0, anymatch@^3.0.3:
+anymatch@^3.0.0, anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
   integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
@@ -3397,6 +3424,11 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
+binary-extensions@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
 bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
@@ -3466,7 +3498,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -3742,6 +3774,21 @@ chokidar@^2.1.8:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
+
+chokidar@^3.5.1:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.4:
   version "1.1.4"
@@ -4751,7 +4798,7 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^5.0.0, enhanced-resolve@^5.8.0:
+enhanced-resolve@^5.0.0, enhanced-resolve@^5.8.0, enhanced-resolve@^5.8.3:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
   integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
@@ -4828,6 +4875,11 @@ es-module-lexer@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.7.1.tgz#c2c8e0f46f2df06274cdaf0dd3f3b33e0a0b267d"
   integrity sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==
+
+es-module-lexer@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
+  integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -5545,7 +5597,7 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-fsevents@^2.3.2:
+fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -5720,7 +5772,7 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.2:
+glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -6108,10 +6160,10 @@ http-proxy-middleware@0.19.1:
     lodash "^4.17.11"
     micromatch "^3.1.10"
 
-http-proxy-middleware@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz#43700d6d9eecb7419bf086a128d0f7205d9eb665"
-  integrity sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==
+http-proxy-middleware@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz#7ef3417a479fb7666a571e09966c66a39bd2c15f"
+  integrity sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==
   dependencies:
     "@types/http-proxy" "^1.17.5"
     http-proxy "^1.18.1"
@@ -6424,6 +6476,13 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-boolean-object@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
@@ -6555,6 +6614,13 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-glob@~4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -8341,7 +8407,7 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -8973,7 +9039,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.2.3:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
@@ -9523,6 +9589,13 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
+
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
 
 recast@^0.20.3:
   version "0.20.5"
@@ -11452,6 +11525,41 @@ webpack-sources@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.1.tgz#251a7d9720d75ada1469ca07dbb62f3641a05b6d"
   integrity sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==
+
+webpack-sources@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.2.tgz#d88e3741833efec57c4c789b6010db9977545260"
+  integrity sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw==
+
+webpack@*, webpack@^5.38.1:
+  version "5.64.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.64.1.tgz#fd59840c16f04fe315f2b2598a85026f12dfa1bb"
+  integrity sha512-b4FHmRgaaAjP+aVOVz41a9Qa5SmkUPQ+u8FntTQ1roPHahSComB6rXnLwc976VhUY4CqTaLu5mCswuHiNhOfVw==
+  dependencies:
+    "@types/eslint-scope" "^3.7.0"
+    "@types/estree" "^0.0.50"
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/wasm-edit" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    acorn "^8.4.1"
+    acorn-import-assertions "^1.7.6"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.8.3"
+    es-module-lexer "^0.9.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.4"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.1.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.2.0"
+    webpack-sources "^3.2.2"
 
 webpack@^5, webpack@^5.10.0:
   version "5.53.0"


### PR DESCRIPTION
Our MicrosoftTeams.d.ts file was getting generated with module declarations around each item (and those modules had names like @microsoft/teams-js...). These modules weren't really doing anything, and after talking with coshaw added this line to our webpack.config.js file:

![image](https://user-images.githubusercontent.com/18446904/142485137-41699c24-910c-430b-8fa4-bc2edba86477.png)

This stops generating the outer module declarations which means that generating documentation using MicrosoftTeams.d.ts works correctly again because the typedoc decorations are at the correct level again.