### PR TITLE
Remove unnecessary deprecated tags from index

### DIFF
--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -41,13 +41,7 @@ export { people } from './people';
 export { video } from './video';
 export { sharing } from './sharing';
 export { call } from './call';
-/**
- * @deprecated with TeamsJS v2 upgrades
- */
 export { appInitialization } from './appInitialization';
-/**
- * @deprecated with TeamsJS v2 upgrades
- */
 export {
   enablePrintCapability,
   executeDeepLink,
@@ -70,15 +64,6 @@ export {
   setFrameContext,
   shareDeepLink,
 } from './publicAPIs';
-/**
- * @deprecated with TeamsJS v2 upgrades
- */
 export { returnFocus, navigateBack, navigateCrossDomain, navigateToTab } from './navigation';
-/**
- * @deprecated with TeamsJS v2 upgrades
- */
 export { settings } from './settings';
-/**
- * @deprecated with TeamsJS v2 upgrades
- */
 export { tasks } from './tasks';


### PR DESCRIPTION
These tags caused a warning during doc generation because in the MicrosoftTeams.d.ts file the things they were referencing were removed, which meant we just had 5 deprecated comments in a row at the top of the file. I checked, and each function/module marked as deprecated in index are ALSO marked as deprecated in their actual files, and removing the deprecated tags from index appears to have no impact on the actual documentation (other than fixing the warning)

If the @deprecated tags in index are doing something else that I don't know about let me know!