### PR TITLE
Fixing StatesHandler in MeetingRoom

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/MeetingRoomAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/MeetingRoomAPIs.tsx
@@ -57,10 +57,10 @@ const RegisterMeetingRoomStatesUpdateHandler = (): React.ReactElement =>
     name: 'registerMeetingRoomStatesUpdateHandler',
     title: 'Register MeetingRoom States UpdateHandler',
     onClick: async setResult => {
-      const handler = (meetingRoomCapability: meetingRoom.MeetingRoomCapability): void => {
-        setResult(`Capabilities of meeting room update ${JSON.stringify(meetingRoomCapability)}`);
+      const handler = (meetingRoomState: meetingRoom.MeetingRoomState): void => {
+        setResult(`States of meeting room update ${JSON.stringify(meetingRoomState)}`);
       };
-      meetingRoom.registerMeetingRoomCapabilitiesUpdateHandler(handler);
+      meetingRoom.registerMeetingRoomStatesUpdateHandler(handler);
 
       return generateRegistrationMsg('the meeting room states update');
     },


### PR DESCRIPTION
I fixed meetingAPI in my last PR where instead of calling states update handler, we were calling capabilities handler for states. It was most likely a typo).  But somehow, we are back to the previous errors stage (A new push (https://github.com/OfficeDev/microsoft-teams-library-js/commit/bb52fd3ea108e84195094ef6a5eafd6755865e1d#diff-2fe57e8385413dc51d9a46541abea26d2919811b266f80e28a143a6bb1285d7c
reverted these changes back to the error state. 