### PR TITLE
NavigateToApp API and tests

### DIFF
--- a/apps/teams-test-app/src/components/PagesAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesAPIs.tsx
@@ -20,6 +20,23 @@ const NavigateCrossDomain = (): React.ReactElement =>
     },
   });
 
+const NavigateToApp = (): React.ReactElement =>
+  ApiWithTextInput<pages.NavigateToAppParams>({
+    name: 'navigateToApp',
+    title: 'Navigate To App',
+    onClick: {
+      validateInput: input => {
+        if (!input.appId || !input.pageId) {
+          throw new Error('AppID and PageID are required.');
+        }
+      },
+      submit: async input => {
+        await pages.navigateToApp(input);
+        return 'Completed';
+      },
+    },
+  });
+
 const ReturnFocus = (): React.ReactElement =>
   ApiWithCheckboxInput({
     name: 'returnFocus',
@@ -71,6 +88,7 @@ const PagesAPIs = (): ReactElement => (
   <>
     <h1>pages</h1>
     <NavigateCrossDomain />
+    <NavigateToApp />
     <ReturnFocus />
     <SetCurrentFrame />
     <RegisterFullScreenChangeHandler />

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -269,23 +269,18 @@ export function callCallbackWithErrorOrResultOrNullFromPromiseAndReturnPromise<T
 }
 
 export function createTeamsAppLink(params: pages.NavigateToAppParams): string {
-  let url =
+  const url = new URL(
     'https://teams.microsoft.com/l/entity/' +
-    encodeURIComponent(params.appId) +
-    '/' +
-    encodeURIComponent(params.pageId);
+      encodeURIComponent(params.appId) +
+      '/' +
+      encodeURIComponent(params.pageId),
+  );
 
-  const queryParams = {};
   if (params.webUrl) {
-    queryParams['webUrl'] = params.webUrl;
+    url.searchParams.append('webUrl', params.webUrl);
   }
   if (params.channelId || params.subPageId) {
-    queryParams['context'] = JSON.stringify({ channelId: params.channelId, subEntityId: params.subPageId });
+    url.searchParams.append('context', JSON.stringify({ channelId: params.channelId, subEntityId: params.subPageId }));
   }
-  let addedParam = false;
-  for (const key in queryParams) {
-    url += (addedParam ? '&' : '?') + key + '=' + encodeURIComponent(queryParams[key]);
-    addedParam = true;
-  }
-  return url;
+  return url.toString();
 }

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -4,6 +4,7 @@ import * as uuid from 'uuid';
 
 import { GlobalVars } from '../internal/globalVars';
 import { SdkError } from '../public/interfaces';
+import { pages } from '../public/pages';
 import { validOrigins } from './constants';
 
 /**
@@ -265,4 +266,26 @@ export function callCallbackWithErrorOrResultOrNullFromPromiseAndReturnPromise<T
     }
   });
   return p;
+}
+
+export function createTeamsAppLink(params: pages.NavigateToAppParams): string {
+  let url =
+    'https://teams.microsoft.com/l/entity/' +
+    encodeURIComponent(params.appId) +
+    '/' +
+    encodeURIComponent(params.pageId);
+
+  const queryParams = {};
+  if (params.webUrl) {
+    queryParams['webUrl'] = params.webUrl;
+  }
+  if (params.channelId || params.subPageId) {
+    queryParams['context'] = JSON.stringify({ channelId: params.channelId, subEntityId: params.subPageId });
+  }
+  let addedParam = false;
+  for (const key in queryParams) {
+    url += (addedParam ? '&' : '?') + key + '=' + encodeURIComponent(queryParams[key]);
+    addedParam = true;
+  }
+  return url;
 }

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -6,6 +6,7 @@ import {
 } from '../internal/communication';
 import { registerHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
+import { createTeamsAppLink } from '../internal/utils';
 import { app } from './app';
 import { FrameContexts } from './constants';
 import { FrameInfo, TabInformation, TabInstance, TabInstanceParameters } from './interfaces';
@@ -69,6 +70,24 @@ export namespace pages {
     });
   }
 
+  export function navigateToApp(params: NavigateToAppParams): Promise<void> {
+    return new Promise<void>(resolve => {
+      ensureInitialized(
+        FrameContexts.content,
+        FrameContexts.sidePanel,
+        FrameContexts.settings,
+        FrameContexts.task,
+        FrameContexts.stage,
+        FrameContexts.meetingStage,
+      );
+      if (runtime.isLegacyTeams) {
+        resolve(send('executeDeepLink', createTeamsAppLink(params)));
+      } else {
+        resolve(send('pages.navigateToApp', params));
+      }
+    });
+  }
+
   /**
    * Registers a handler for changes from or to full-screen view for a tab.
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -84,6 +103,14 @@ export namespace pages {
    */
   export function isSupported(): boolean {
     return runtime.supports.pages ? true : false;
+  }
+
+  export interface NavigateToAppParams {
+    appId: string;
+    pageId: string;
+    webUrl?: string;
+    subPageId?: string;
+    channelId?: string;
   }
 
   /**

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -70,6 +70,15 @@ export namespace pages {
     });
   }
 
+  /**
+   * Navigate to the given App ID and Page ID, with optional parameters for a WebURL (if the app cannot
+   * be navigated to, such as if it is not installed), Channel ID (for apps installed as a channel tab), and
+   * Sub-page ID (for navigating to specific content within the page). This is equivalent to navigating to
+   * a deep link with the above data, but does not require the app to build a URL or worry about different
+   * deep link formats for different hosts.
+   * @param params Parameters for the navigation
+   * @returns a promise that will resolve if the navigation was successful
+   */
   export function navigateToApp(params: NavigateToAppParams): Promise<void> {
     return new Promise<void>(resolve => {
       ensureInitialized(
@@ -105,11 +114,34 @@ export namespace pages {
     return runtime.supports.pages ? true : false;
   }
 
+  /**
+   * Parameters for the NavigateToApp API
+   */
   export interface NavigateToAppParams {
+    /**
+     * ID of the App to navigate to
+     */
     appId: string;
+
+    /**
+     * Developer-defined ID of the Page to navigate to within the app (Formerly EntityID)
+     */
     pageId: string;
+
+    /**
+     * Optional URL to open if the navigation cannot be completed within the host
+     */
     webUrl?: string;
+
+    /**
+     * Optional developer-defined ID describing the content to navigate to within the Page. This will be passed
+     * back to the App via the Context object.
+     */
     subPageId?: string;
+
+    /**
+     * Optional ID of the Teams Channel where the app should be opened
+     */
     channelId?: string;
   }
 

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -3,6 +3,7 @@
 import { deepFreeze } from '../internal/utils';
 export interface IRuntime {
   readonly apiVersion: number;
+  readonly isLegacyTeams?: boolean;
   readonly supports: {
     readonly appInstallDialog?: {};
     readonly appEntity?: {};
@@ -77,6 +78,7 @@ export let runtime: IRuntime = {
 
 export const teamsRuntimeConfig: IRuntime = {
   apiVersion: 1,
+  isLegacyTeams: true,
   supports: {
     appInstallDialog: {},
     appEntity: {},

--- a/packages/teams-js/test/internal/utils.spec.ts
+++ b/packages/teams-js/test/internal/utils.spec.ts
@@ -1,5 +1,6 @@
 import { GlobalVars } from '../../src/internal/globalVars';
-import { compareSDKVersions, validateOrigin } from '../../src/internal/utils';
+import { compareSDKVersions, createTeamsAppLink, validateOrigin } from '../../src/internal/utils';
+import { pages } from '../../src/public';
 
 describe('utils', () => {
   test('compareSDKVersions', () => {
@@ -88,26 +89,78 @@ describe('utils', () => {
     const result = validateOrigin(messageOrigin);
     expect(result).toBe(false);
   });
-  it("validateOrigin returns false if first end of origin is not matched valid subdomains in teams pre-known allowlist", () => {
+  it('validateOrigin returns false if first end of origin is not matched valid subdomains in teams pre-known allowlist', () => {
     const messageOrigin = new URL('https://myteams.microsoft.com');
     const result = validateOrigin(messageOrigin);
     expect(result).toBe(false);
   });
-  it("validateOrigin returns false if first end of origin is not matched valid subdomains in the user supplied list", () => {
+  it('validateOrigin returns false if first end of origin is not matched valid subdomains in the user supplied list', () => {
     const messageOrigin = new URL('https://myteams.microsoft.com');
     const result = validateOrigin(messageOrigin);
     GlobalVars.additionalValidOrigins = ['https://*.teams.microsoft.com'];
     expect(result).toBe(false);
   });
-  it("validateOrigin returns false if origin for subdomains does not match in teams pre-known allowlist", () => {
+  it('validateOrigin returns false if origin for subdomains does not match in teams pre-known allowlist', () => {
     const messageOrigin = new URL('https://a.b.sharepoint.com');
     const result = validateOrigin(messageOrigin);
     expect(result).toBe(false);
   });
-  it("validateOrigin returns false if origin for subdomains does not match in the user supplied list", () => {
+  it('validateOrigin returns false if origin for subdomains does not match in the user supplied list', () => {
     const messageOrigin = new URL('https://a.b.testdomain.com');
     const result = validateOrigin(messageOrigin);
     GlobalVars.additionalValidOrigins = ['https://*.testdomain.com'];
     expect(result).toBe(false);
+  });
+  describe('createTeamsAppLink', () => {
+    it('builds a basic URL with an appId and pageId', () => {
+      const params: pages.NavigateToAppParams = {
+        appId: 'fe4a8eba-2a31-4737-8e33-e5fae6fee194',
+        pageId: 'tasklist123',
+      };
+      const expected = 'https://teams.microsoft.com/l/entity/fe4a8eba-2a31-4737-8e33-e5fae6fee194/tasklist123';
+      expect(createTeamsAppLink(params)).toBe(expected);
+    });
+    it('builds a URL with a webUrl parameter', () => {
+      const params: pages.NavigateToAppParams = {
+        appId: 'fe4a8eba-2a31-4737-8e33-e5fae6fee194',
+        pageId: 'tasklist123',
+        webUrl: 'https://tasklist.example.com/123',
+      };
+      const expected =
+        'https://teams.microsoft.com/l/entity/fe4a8eba-2a31-4737-8e33-e5fae6fee194/tasklist123?webUrl=https%3A%2F%2Ftasklist.example.com%2F123';
+      expect(createTeamsAppLink(params)).toBe(expected);
+    });
+    it('builds a URL with a subPageUrl parameter', () => {
+      const params: pages.NavigateToAppParams = {
+        appId: 'fe4a8eba-2a31-4737-8e33-e5fae6fee194',
+        pageId: 'tasklist123',
+        subPageId: 'task456',
+      };
+      const expected =
+        'https://teams.microsoft.com/l/entity/fe4a8eba-2a31-4737-8e33-e5fae6fee194/tasklist123?context=%7B%22subEntityId%22%3A%22task456%22%7D';
+      expect(createTeamsAppLink(params)).toBe(expected);
+    });
+    it('builds a URL with a channelId parameter', () => {
+      const params: pages.NavigateToAppParams = {
+        appId: 'fe4a8eba-2a31-4737-8e33-e5fae6fee194',
+        pageId: 'tasklist123',
+        channelId: '19:cbe3683f25094106b826c9cada3afbe0@thread.skype',
+      };
+      const expected =
+        'https://teams.microsoft.com/l/entity/fe4a8eba-2a31-4737-8e33-e5fae6fee194/tasklist123?context=%7B%22channelId%22%3A%2219%3Acbe3683f25094106b826c9cada3afbe0%40thread.skype%22%7D';
+      expect(createTeamsAppLink(params)).toBe(expected);
+    });
+    it('builds a URL with all optional properties', () => {
+      const params: pages.NavigateToAppParams = {
+        appId: 'fe4a8eba-2a31-4737-8e33-e5fae6fee194',
+        pageId: 'tasklist123',
+        webUrl: 'https://tasklist.example.com/123',
+        channelId: '19:cbe3683f25094106b826c9cada3afbe0@thread.skype',
+        subPageId: 'task456',
+      };
+      const expected =
+        'https://teams.microsoft.com/l/entity/fe4a8eba-2a31-4737-8e33-e5fae6fee194/tasklist123?webUrl=https%3A%2F%2Ftasklist.example.com%2F123&context=%7B%22channelId%22%3A%2219%3Acbe3683f25094106b826c9cada3afbe0%40thread.skype%22%2C%22subEntityId%22%3A%22task456%22%7D';
+      expect(createTeamsAppLink(params)).toBe(expected);
+    });
   });
 });

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -1,0 +1,78 @@
+import { app } from '../../src/public/app';
+import { pages } from '../../src/public/pages';
+import { Utils } from '../utils';
+
+describe('AppSDK-TeamsAPIs', () => {
+  // Use to send a mock message from the app.
+  const utils = new Utils();
+
+  beforeEach(() => {
+    utils.processMessage = null;
+    utils.messages = [];
+    utils.childMessages = [];
+    utils.childWindow.closed = false;
+
+    // Set a mock window for testing
+    app._initialize(utils.mockWindow);
+  });
+
+  afterEach(() => {
+    // Reset the object since it's a singleton
+    if (app._uninitialize) {
+      app._uninitialize();
+    }
+  });
+
+  describe('navigateToApp', () => {
+    const navigateToAppParams: pages.NavigateToAppParams = {
+      appId: 'fe4a8eba-2a31-4737-8e33-e5fae6fee194',
+      pageId: 'tasklist123',
+      webUrl: 'https://tasklist.example.com/123',
+      channelId: '19:cbe3683f25094106b826c9cada3afbe0@thread.skype',
+      subPageId: 'task456',
+    };
+
+    it('should not allow calls before initialization', () => {
+      expect(() => pages.navigateToApp(navigateToAppParams)).rejects.toThrowError(
+        'The library has not yet been initialized',
+      );
+    });
+
+    it('should not allow calls from authentication context', async () => {
+      await utils.initializeWithContext('authentication');
+
+      expect(() => pages.navigateToApp(navigateToAppParams)).rejects.toThrowError(
+        'This call is only allowed in following contexts: ["content","sidePanel","settings","task","stage","meetingStage"]. Current context: "authentication".',
+      );
+    });
+
+    it('should successfully send the navigateToApp message', async () => {
+      await utils.initializeWithContext('content');
+      utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: {} } });
+
+      const promise = pages.navigateToApp(navigateToAppParams);
+
+      const navigateToAppMessage = utils.findMessageByFunc('pages.navigateToApp');
+      utils.respondToMessage(navigateToAppMessage, true);
+      await promise;
+
+      expect(navigateToAppMessage).not.toBeNull();
+      expect(navigateToAppMessage.args[0]).toStrictEqual(navigateToAppParams);
+    });
+
+    it('should successfully send an executeDeepLink message for legacy teams clients', async () => {
+      await utils.initializeWithContext('content');
+
+      const promise = pages.navigateToApp(navigateToAppParams);
+
+      const executeDeepLinkMessage = utils.findMessageByFunc('executeDeepLink');
+      utils.respondToMessage(executeDeepLinkMessage, true);
+      await promise;
+
+      expect(executeDeepLinkMessage).not.toBeNull();
+      expect(executeDeepLinkMessage.args[0]).toBe(
+        'https://teams.microsoft.com/l/entity/fe4a8eba-2a31-4737-8e33-e5fae6fee194/tasklist123?webUrl=https%3A%2F%2Ftasklist.example.com%2F123&context=%7B%22channelId%22%3A%2219%3Acbe3683f25094106b826c9cada3afbe0%40thread.skype%22%2C%22subEntityId%22%3A%22task456%22%7D',
+      );
+    });
+  });
+});


### PR DESCRIPTION
* Create new NavigateToApp API that can navigate to a given App ID, Page ID, and with an optional Web URL, Sub-page ID and Channel ID
* Detect if we are running against a legacy Teams client, and if so, build the corresponding deep link and call the ExecuteDeepLink API instead
* Tests for both flows