### PR TITLE
Update v2 with getGenericOnCompleteHandler when the user didn't provide a callback.

### DIFF
--- a/packages/teams-js/src/public/navigation.ts
+++ b/packages/teams-js/src/public/navigation.ts
@@ -1,4 +1,5 @@
 import { ensureInitialized } from '../internal/internalAPIs';
+import { getGenericOnCompleteHandler } from '../internal/utils';
 import { FrameContexts } from './constants';
 import { TabInstance } from './interfaces';
 import { pages } from './pages';
@@ -29,17 +30,14 @@ export function returnFocus(navigateForward?: boolean): void {
  */
 export function navigateToTab(tabInstance: TabInstance, onComplete?: (status: boolean, reason?: string) => void): void {
   ensureInitialized();
+  onComplete = onComplete ? onComplete : getGenericOnCompleteHandler();
   pages.tabs
     .navigateToTab(tabInstance)
     .then(() => {
-      if (onComplete) {
-        onComplete(true);
-      }
+      onComplete(true);
     })
     .catch((error: Error) => {
-      if (onComplete) {
-        onComplete(false, error.message);
-      }
+      onComplete(false, error.message);
     });
 }
 
@@ -66,17 +64,14 @@ export function navigateCrossDomain(url: string, onComplete?: (status: boolean, 
     FrameContexts.stage,
     FrameContexts.meetingStage,
   );
+  onComplete = onComplete ? onComplete : getGenericOnCompleteHandler();
   pages
     .navigateCrossDomain(url)
     .then(() => {
-      if (onComplete) {
-        onComplete(true);
-      }
+      onComplete(true);
     })
     .catch((error: Error) => {
-      if (onComplete) {
-        onComplete(false, error.message);
-      }
+      onComplete(false, error.message);
     });
 }
 
@@ -91,16 +86,13 @@ export function navigateCrossDomain(url: string, onComplete?: (status: boolean, 
  */
 export function navigateBack(onComplete?: (status: boolean, reason?: string) => void): void {
   ensureInitialized();
+  onComplete = onComplete ? onComplete : getGenericOnCompleteHandler();
   pages.backStack
     .navigateBack()
     .then(() => {
-      if (onComplete) {
-        onComplete(true);
-      }
+      onComplete(true);
     })
     .catch((error: Error) => {
-      if (onComplete) {
-        onComplete(false, error.message);
-      }
+      onComplete(false, error.message);
     });
 }

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -1,4 +1,5 @@
 import { ensureInitialized } from '../internal/internalAPIs';
+import { getGenericOnCompleteHandler } from '../internal/utils';
 import { app, core } from './app';
 import { FrameContexts } from './constants';
 import {
@@ -298,17 +299,14 @@ export function executeDeepLink(deepLink: string, onComplete?: (status: boolean,
     FrameContexts.stage,
     FrameContexts.meetingStage,
   );
+  onComplete = onComplete ? onComplete : getGenericOnCompleteHandler();
   core
     .executeDeepLink(deepLink)
     .then(() => {
-      if (onComplete) {
-        onComplete(true);
-      }
+      onComplete(true);
     })
     .catch((err: Error) => {
-      if (onComplete) {
-        onComplete(false, err.message);
-      }
+      onComplete(false, err.message);
     });
 }
 

--- a/packages/teams-js/src/public/settings.ts
+++ b/packages/teams-js/src/public/settings.ts
@@ -1,4 +1,5 @@
 import { ensureInitialized } from '../internal/internalAPIs';
+import { getGenericOnCompleteHandler } from '../internal/utils';
 import { FrameContexts } from './constants';
 import { pages } from './pages';
 
@@ -85,17 +86,14 @@ export namespace settings {
     onComplete?: (status: boolean, reason?: string) => void,
   ): void {
     ensureInitialized(FrameContexts.content, FrameContexts.settings, FrameContexts.sidePanel);
+    onComplete = onComplete ? onComplete : getGenericOnCompleteHandler();
     pages.config
       .setConfig(instanceSettings)
       .then(() => {
-        if (onComplete) {
-          onComplete(true);
-        }
+        onComplete(true);
       })
       .catch((error: Error) => {
-        if (onComplete) {
-          onComplete(false, error.message);
-        }
+        onComplete(false, error.message);
       });
   }
 

--- a/packages/teams-js/test/public/navigation.spec.ts
+++ b/packages/teams-js/test/public/navigation.spec.ts
@@ -1,3 +1,4 @@
+import * as utilFunc from '../../src/internal/utils';
 import { navigateBack, navigateCrossDomain, navigateToTab, returnFocus } from '../../src/public/navigation';
 import { _uninitialize } from '../../src/public/publicAPIs';
 import { Utils } from '../utils';
@@ -112,24 +113,37 @@ describe('MicrosoftTeams-Navigation', () => {
         utils.respondToMessage(navigateCrossDomainMessage, false);
       });
     });
-    it('should throw on invalid cross-origin navigation request', () => {
-      utils.initializeWithContext('settings').then(async () => {
-        const p = navigateCrossDomain('https://invalid.origin.com');
+
+    it('should call getGenericOnCompleteHandler when no callback is provided.', done => {
+      utils.initializeWithContext('settings').then(() => {
+        jest.spyOn(utilFunc, 'getGenericOnCompleteHandler').mockImplementation(() => {
+          return (success: boolean, reason: string): void => {
+            if (!success) {
+              expect(reason).toBe(
+                'Cross-origin navigation is only supported for URLs matching the pattern registered in the manifest.',
+              );
+              done();
+            }
+          };
+        });
+        navigateCrossDomain('https://invalid.origin.com');
 
         const navigateCrossDomainMessage = utils.findMessageByFunc('navigateCrossDomain');
         expect(navigateCrossDomainMessage).not.toBeNull();
         expect(navigateCrossDomainMessage.args.length).toBe(1);
         expect(navigateCrossDomainMessage.args[0]).toBe('https://invalid.origin.com');
+
         utils.respondToMessage(navigateCrossDomainMessage, false);
-        await expect(p).rejects.toEqual('Cross-origin navigation is only supported for URLs matching the pattern registered in the manifest.');
       });
     });
+
     it('should register the navigateBack action', () => {
       utils.initializeWithContext('content');
       navigateBack();
       const navigateBackMessage = utils.findMessageByFunc('navigateBack');
       expect(navigateBackMessage).not.toBeNull();
     });
+
     it('should register the navigateToTab action', () => {
       utils.initializeWithContext('content');
       navigateToTab(null);

--- a/packages/teams-js/test/public/navigation.spec.ts
+++ b/packages/teams-js/test/public/navigation.spec.ts
@@ -1,10 +1,6 @@
-import process from 'process';
-
 import { navigateBack, navigateCrossDomain, navigateToTab, returnFocus } from '../../src/public/navigation';
 import { _uninitialize } from '../../src/public/publicAPIs';
 import { Utils } from '../utils';
-
-
 
 describe('MicrosoftTeams-Navigation', () => {
   // Use to send a mock message from the app.

--- a/packages/teams-js/test/public/navigation.spec.ts
+++ b/packages/teams-js/test/public/navigation.spec.ts
@@ -1,6 +1,10 @@
+import process from 'process';
+
 import { navigateBack, navigateCrossDomain, navigateToTab, returnFocus } from '../../src/public/navigation';
 import { _uninitialize } from '../../src/public/publicAPIs';
 import { Utils } from '../utils';
+
+
 
 describe('MicrosoftTeams-Navigation', () => {
   // Use to send a mock message from the app.
@@ -110,6 +114,18 @@ describe('MicrosoftTeams-Navigation', () => {
         expect(navigateCrossDomainMessage.args[0]).toBe('https://invalid.origin.com');
 
         utils.respondToMessage(navigateCrossDomainMessage, false);
+      });
+    });
+    it('should throw on invalid cross-origin navigation request', () => {
+      utils.initializeWithContext('settings').then(async () => {
+        const p = navigateCrossDomain('https://invalid.origin.com');
+
+        const navigateCrossDomainMessage = utils.findMessageByFunc('navigateCrossDomain');
+        expect(navigateCrossDomainMessage).not.toBeNull();
+        expect(navigateCrossDomainMessage.args.length).toBe(1);
+        expect(navigateCrossDomainMessage.args[0]).toBe('https://invalid.origin.com');
+        utils.respondToMessage(navigateCrossDomainMessage, false);
+        await expect(p).rejects.toEqual('Cross-origin navigation is only supported for URLs matching the pattern registered in the manifest.');
       });
     });
     it('should register the navigateBack action', () => {

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -1,4 +1,5 @@
 import { version } from '../../src/internal/constants';
+import * as utilFunc from '../../src/internal/utils';
 import { HostClientType, TeamType, UserTeamRole } from '../../src/public/constants';
 import { FrameContexts } from '../../src/public/constants';
 import { Context, FrameContext, TabInstanceParameters } from '../../src/public/interfaces';
@@ -405,6 +406,37 @@ describe('MicrosoftTeams-publicAPIs', () => {
 
         // send message request
         executeDeepLink(request, onComplete);
+
+        // find message request in jest
+        const message = utils.findMessageByFunc('executeDeepLink');
+
+        // check message is sending correct data
+        expect(message).not.toBeUndefined();
+        expect(message.args).toContain(request);
+
+        // simulate response
+        const data = {
+          success: false,
+          error: 'Something went wrong...',
+        };
+        utils.respondToMessage(message, data.success, data.error);
+      });
+    });
+
+    it('should invoke getGenericOnCompleteHandler when no callback is provided.', done => {
+      utils.initializeWithContext('content').then(() => {
+        const request = 'dummyDeepLink';
+        jest.spyOn(utilFunc, 'getGenericOnCompleteHandler').mockImplementation(() => {
+          return (success: boolean, reason: string): void => {
+            if (!success) {
+              expect(reason).toBe('Something went wrong...');
+              done();
+            }
+          };
+        });
+
+        // send message request
+        executeDeepLink(request);
 
         // find message request in jest
         const message = utils.findMessageByFunc('executeDeepLink');


### PR DESCRIPTION
There are few places in v1(master) where the return of the method getGenericOnCompleteHandler used when the user doesn't provide a callback.
appWindow.ts
 - ChildAppWindow.postMessage
 - ParentAppWindow.postMessage
navigation.ts (deprecated)
- navigateToTab
- navigateCrossDomain
- navigateBack
publicAPIs.ts (deprecated)
- executeDeepLink
settings.ts (deprecated)
- setSettings
I have updated the deprecated code with the generic handler. 
For appWindow.ts functions, they throw an error when the promise fails, so no need to update it.
