### PR TITLE
navigateToApp e2e test

### DIFF
--- a/apps/bundle-analysis-app/package.json
+++ b/apps/bundle-analysis-app/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "webpack",
+    "build:dev": "webpack",
     "clean": "rimraf ./dist ./bundleAnalysis",
     "eslint-fix-build": "yarn eslint ./src --fix && webpack",
     "webpack:profile": "webpack"

--- a/apps/teams-perf-test-app/package.json
+++ b/apps/teams-perf-test-app/package.json
@@ -6,6 +6,7 @@
   "version": "0.0.1",
   "scripts": {
     "build": "yarn eslint ./src/**/*.tsx && webpack",
+    "build:dev": "yarn eslint ./src/**/*.tsx && webpack",
     "clean": "rimraf ./build",
     "eslint-fix-build": "yarn eslint --fix --ext .tsx ./src && webpack",
     "start": "webpack serve"

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -6,6 +6,7 @@
   "version": "2.0.0-beta.2",
   "scripts": {
     "build":"yarn build:bundle",
+    "build:dev":"yarn build:bundle",
     "build:bundle": "yarn eslint ./src/**/*.tsx && webpack",
     "build:CDN": "yarn eslint ./src/**/*.tsx && webpack --config webpack.cdn.config.js",
     "build:local": "yarn eslint ./src/**/*.tsx && webpack --config webpack.local.config.js && yarn copy",

--- a/azure-pipelines-with-e2etests.yml
+++ b/azure-pipelines-with-e2etests.yml
@@ -44,7 +44,7 @@ steps:
   - task: Yarn@2
     displayName: 'Build client sdk'
     inputs:
-      Arguments: 'build'
+      Arguments: 'build:dev'
       ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
   - task: CmdLine@2

--- a/azure-pipelines-with-e2etests_localScriptTag.yml
+++ b/azure-pipelines-with-e2etests_localScriptTag.yml
@@ -44,7 +44,7 @@ steps:
   - task: Yarn@2
     displayName: 'Build client sdk'
     inputs:
-      Arguments: 'build'
+      Arguments: 'build:dev'
       ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
   - task: Yarn@2

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "lerna run build --stream",
+    "build:dev": "lerna run build:dev --stream",
     "build:clean": "yarn clean && yarn build",
     "bundleAnalyze": "yarn workspace @microsoft/bundle-analysis-app webpack:profile",
     "bundleAnalyze:collect": "yarn bundleAnalyze && node tools/cli/collectBundleAnalysis.js --folderName bundleAnalysis",

--- a/packages/bundle-size-tools/package.json
+++ b/packages/bundle-size-tools/package.json
@@ -8,6 +8,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "yarn clean && yarn tsc",
+    "build:dev": "yarn clean && yarn tsc",
     "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
     "eslint-fix-build": "yarn eslint ./src --fix && yarn build"
   },

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -11,6 +11,7 @@
   "typings": "./dist/MicrosoftTeams.d.ts",
   "scripts": {
     "build": "yarn lint && webpack",
+    "build:dev": "yarn lint && webpack --env dev",
     "clean": "rimraf ./dist",
     "doctor": "yarn lint --fix",
     "eslint-fix-build": "yarn eslint ./src --fix && yarn build",

--- a/packages/teams-js/src/env.d.ts
+++ b/packages/teams-js/src/env.d.ts
@@ -1,0 +1,1 @@
+declare const __DEV__: boolean | undefined;

--- a/packages/teams-js/src/env.ts
+++ b/packages/teams-js/src/env.ts
@@ -1,0 +1,3 @@
+declare const __DEV__: boolean | undefined;
+const dev = __DEV__;
+export { dev as __DEV__ };

--- a/packages/teams-js/src/env.ts
+++ b/packages/teams-js/src/env.ts
@@ -1,3 +1,0 @@
-declare const __DEV__: boolean | undefined;
-const dev = __DEV__;
-export { dev as __DEV__ };

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { __DEV__ } from '../env';
 import {
   Communication,
   initializeCommunication,
@@ -493,6 +494,14 @@ export namespace app {
               } else {
                 // If it's any error that's not a JSON parsing error, we want the program to fail.
                 throw e;
+              }
+            }
+            if (__DEV__) {
+              const urlParams = new URLSearchParams(window.location.search);
+              console.info('Running DEV build');
+              if (urlParams.has('legacyTeams') && urlParams.get('legacyTeams')) {
+                console.info('Applying legacy Teams runtime config');
+                applyRuntimeConfig(teamsRuntimeConfig);
               }
             }
 

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { __DEV__ } from '../env';
 import {
   Communication,
   initializeCommunication,
@@ -496,7 +495,8 @@ export namespace app {
                 throw e;
               }
             }
-            if (__DEV__) {
+            const is_dev = typeof __DEV__ !== 'undefined' ? __DEV__ : undefined;
+            if (is_dev) {
               const urlParams = new URLSearchParams(window.location.search);
               console.info('Running DEV build');
               if (urlParams.has('legacyTeams') && urlParams.get('legacyTeams')) {

--- a/packages/teams-js/webpack.config.js
+++ b/packages/teams-js/webpack.config.js
@@ -9,78 +9,83 @@ const WebpackAssetsManifest = require('webpack-assets-manifest');
 const libraryName = 'microsoftTeams';
 const expect = require('expect');
 const path = require('path');
+const webpack = require('webpack');
 
-module.exports = {
-  entry: {
-    MicrosoftTeams: './src/index.ts',
-    'MicrosoftTeams.min': './src/index.ts',
-  },
-  output: {
-    filename: '[name].js',
-    // the following setting is required for SRI to work
-    crossOriginLoading: 'anonymous',
-    path: path.resolve(__dirname, 'dist'),
-    library: {
-      name: libraryName,
-      type: 'umd',
-      umdNamedDefine: true,
+module.exports = function(env) {
+  return {
+    entry: {
+      MicrosoftTeams: './src/index.ts',
+      'MicrosoftTeams.min': './src/index.ts',
     },
-  },
-  devtool: 'source-map',
-  resolve: {
-    extensions: ['.tsx', '.ts', '.js'],
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        use: 'ts-loader',
-        exclude: /node_modules/,
+    output: {
+      filename: '[name].js',
+      // the following setting is required for SRI to work
+      crossOriginLoading: 'anonymous',
+      path: path.resolve(__dirname, 'dist'),
+      library: {
+        name: libraryName,
+        type: 'umd',
+        umdNamedDefine: true,
       },
-    ],
-  },
-  optimization: {
-    minimize: true,
-    minimizer: [
-      new TerserPlugin({
-        terserOptions: {
-          compress: {
-            reduce_funcs: false,
-            inline: false,
-          },
+    },
+    devtool: 'source-map',
+    resolve: {
+      extensions: ['.tsx', '.ts', '.js'],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          use: 'ts-loader',
+          exclude: /node_modules/,
         },
-        include: /\.min\.js$/,
-      }),
-    ],
-  },
-  // webpack.production.config.js
-  mode: 'production',
-  plugins: [
-    new DtsBundleWebpack({
-      name: '@microsoft/teams-js',
-      main: 'dts/index.d.ts',
-      out: '~/dist/MicrosoftTeams.d.ts',
-      removeSource: true,
-      outputAsModuleFolder: true,
-    }),
-
-    // https://www.npmjs.com/package/webpack-subresource-integrity
-    new SubresourceIntegrityPlugin({ enabled: true }),
-
-    // Webpackmanifest produces the json file containing asset(JS file) and its corresponding hash values(Example: https://github.com/waysact/webpack-subresource-integrity/blob/main/examples/webpack-assets-manifest/webpack.config.js)
-    new WebpackAssetsManifest({
-      integrity: true,
-      integrityHashes: ['sha384'],
-      output: 'MicrosoftTeams-manifest.json',
-    }),
-    {
-      apply: compiler => {
-        compiler.hooks.done.tap('wsi-test', () => {
-          const manifest = JSON.parse(readFileSync(join(__dirname, 'dist/MicrosoftTeams-manifest.json'), 'utf-8'));
-          // If for some reason hash was not generated for the assets, this test will fail in build.
-          expect(manifest['MicrosoftTeams.min.js'].integrity).toMatch(/sha384-.*/);
-        });
-      },
+      ],
     },
-  ],
+    optimization: {
+      minimize: true,
+      minimizer: [
+        new TerserPlugin({
+          terserOptions: {
+            compress: {
+              reduce_funcs: false,
+              inline: false,
+            },
+          },
+          include: /\.min\.js$/,
+        }),
+      ],
+    },
+    // webpack.production.config.js
+    mode: 'production',
+    plugins: [
+      new webpack.DefinePlugin({ __DEV__: env.dev ? JSON.stringify(true) : JSON.stringify(false) }),
+
+      new DtsBundleWebpack({
+        name: '@microsoft/teams-js',
+        main: 'dts/index.d.ts',
+        out: '~/dist/MicrosoftTeams.d.ts',
+        removeSource: true,
+        outputAsModuleFolder: true,
+      }),
+
+      // https://www.npmjs.com/package/webpack-subresource-integrity
+      new SubresourceIntegrityPlugin({ enabled: true }),
+
+      // Webpackmanifest produces the json file containing asset(JS file) and its corresponding hash values(Example: https://github.com/waysact/webpack-subresource-integrity/blob/main/examples/webpack-assets-manifest/webpack.config.js)
+      new WebpackAssetsManifest({
+        integrity: true,
+        integrityHashes: ['sha384'],
+        output: 'MicrosoftTeams-manifest.json',
+      }),
+      {
+        apply: compiler => {
+          compiler.hooks.done.tap('wsi-test', () => {
+            const manifest = JSON.parse(readFileSync(join(__dirname, 'dist/MicrosoftTeams-manifest.json'), 'utf-8'));
+            // If for some reason hash was not generated for the assets, this test will fail in build.
+            expect(manifest['MicrosoftTeams.min.js'].integrity).toMatch(/sha384-.*/);
+          });
+        },
+      },
+    ],
+  };
 };


### PR DESCRIPTION
Add webpack environment variable to teams-js to enable URL parameters on dev builds only
Add legacyTeams URL parameter to force teams-js to use legacyTeams runtime config
This will allow us to write an e2e test that verifies navigateToApp calls executeDeepLink when running legacyTeams config