### PR TITLE
Update cdn url in readme to also update version in script src

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,12 +109,6 @@ jobs:
 
       - script: 'node prepNewReadme.js'
         workingDirectory: '$(System.DefaultWorkingDirectory)\packages\teams-js'
-        condition: and(
-          startsWith(variables['Build.SourceBranch'], 'refs/tags/v'),
-          in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-          ne(variables['Build.Reason'], 'PullRequest'),
-          ne(variables['Build.Reason'], 'Manual')
-          )
         displayName: 'node prepNewReadme.js'
 
       - task: Yarn@3

--- a/packages/teams-js/prepNewReadme.js
+++ b/packages/teams-js/prepNewReadme.js
@@ -3,6 +3,12 @@ const path = require('path');
 
 const relativePathToManifestJson = './dist/MicrosoftTeams-manifest.json';
 const relativePathToReadmeTemplate = './Readme.md';
+const version = require('./package.json').version;
+
+const createUrl = () => {
+  const isDev = version.includes('dev');
+  return `https://res${isDev ? '-sdf' : ''}.cdn.office.net/teams-js/${version}/js/MicrosoftTeams.min.js`;
+}
 
 const getIntegrityHash = () => {
   const absolutePathToManifestJson = path.resolve(__dirname, relativePathToManifestJson);
@@ -18,19 +24,23 @@ const getIntegrityHash = () => {
   return integrityHash;
 };
 
-const updateReadmeWithIntegrityHash = (integrityHash) => {
+const updateReadme = (integrityHash) => {
   const absolutePathToReadmeTemplate = path.resolve(__dirname, relativePathToReadmeTemplate);
   if(!fs.existsSync(absolutePathToReadmeTemplate)) {
     throw(`ERROR: Readme-template.md at ${absolutePathToReadmeTemplate} was not found.`);
   }
   const readme = fs.readFileSync(absolutePathToReadmeTemplate, 'utf8');
-  const result = readme.replace(/integrity=\".*?\"/, `integrity="${integrityHash}"`);
+  const readmeWithIntegrity = readme.replace(/integrity=\".*?\"/, `integrity="${integrityHash}"`);
+  const result = readmeWithIntegrity.replace(
+    /src=\"https:\/\/res.*?\/js\/MicrosoftTeams.min.js\"/,
+    `src="${createUrl()}"`);
+
   fs.writeFileSync(absolutePathToReadmeTemplate, result);
 };
 
 (() => {
   console.log('readme-generator is running');
   const integrityHash = getIntegrityHash();
-  updateReadmeWithIntegrityHash(integrityHash);
+  updateReadme(integrityHash);
   console.log('readme-generator completed successfully!');
 })();

--- a/tools/cli/prepNextRelease.js
+++ b/tools/cli/prepNextRelease.js
@@ -88,7 +88,7 @@ const updatePackageVersion = async () => {
 };
 
 const buildAndUpdateIntegrityHash = async () => {
-  console.log('Updating integrity hash');
+  console.log('Updating readme with new script src');
   await execShellCommand('cd packages/teams-js & yarn build & node prepNewReadme.js');
 };
 


### PR DESCRIPTION
This will modify the readme for both next-dev and next releases as build artifacts get prepared. 
The next-dev versions will point to the respective sdf cdn endpoint and the integrity hash for that dev release.

We can also be running this on every build moving forward.