### PR TITLE
Added DisplayMode Property to MenuItem as part of setNavBarMenu API

### DIFF
--- a/src/private/menus.ts
+++ b/src/private/menus.ts
@@ -26,6 +26,23 @@ export namespace menus {
      */
     contentDescription?: string;
   }
+
+  /**
+   * Defines how a menu item should appear in the NavBar.
+   */
+  export enum DisplayMode {
+    /**
+     * Only place this item in the NavBar if there's room for it.
+     * If there's no room, item is shown in the overflow menu.
+     */
+    ifRoom = 0,
+    /**
+     * Never place this item in the NavBar.
+     * The item would always be shown in NavBar's overflow menu.
+     */
+    never = 1,
+  }
+
   /**
    * Represents information about menu item for Action Menu and Navigation Bar Menu.
    */
@@ -62,6 +79,12 @@ export namespace menus {
      * Whether the menu item is selected or not
      */
     public selected = false;
+    /**
+     * The Display Mode of the menu item.
+     * Default Behaviour would be DisplayMode.ifRoom if null.
+     * Refer {@link DisplayMode}
+     */
+    public displayMode?: DisplayMode;
   }
   /**
    * Represents information about view to show on Navigation Bar Menu item selection

--- a/src/private/menus.ts
+++ b/src/private/menus.ts
@@ -40,7 +40,7 @@ export namespace menus {
      * Never place this item in the NavBar.
      * The item would always be shown in NavBar's overflow menu.
      */
-    never = 1,
+    overflowOnly = 1,
   }
 
   /**


### PR DESCRIPTION
Introduced Display Mode Enum & corresponding property to `MenuItem` part of `setNavBarMenu` 

- This feature is required by both iOS and Android platforms as part of **setNavBarMenu** API
- Adding capability for Web Apps to define how a menu items should appear in the NavBar, either on the NavBar or inside the Overflow Menu.​
- JS SDK Changes
  - Added DisplayMode enum, consisting of the following options.
    - ifRoom – Only place this item in the NavBar if there's room for it. If there's no room, item is shown in the overflow menu.​
    - never - Never place this item in the NavBar. The item would always be shown in NavBar's overflow menu. ​
  - Adding new property displayMode as part of MenuItem.​
  - If null, the behavior would default to ifRoom.​
- API is modelled on similar lines as showAsAction for TitleBar on Android platform

@reenudeswal @ydogandjiev @aeunms 
