### PR TITLE
Add trace logging to TeamsJs

### DIFF
--- a/apps/teams-test-app/tsconfig.json
+++ b/apps/teams-test-app/tsconfig.json
@@ -14,7 +14,8 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "jsx": "react"
+    "jsx": "react",
+    "sourceMap": true
   },
   "include": [
     "src"

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -18,6 +18,12 @@
     "prettier": "prettier --write '**/*.{ts,js,css,html}'",
     "test": "jest"
   },
+  "dependencies": {
+    "debug": "4.3.3"
+  },
+  "devDependencies": {
+    "@types/debug": "4.1.7"
+  },
   "license": "MIT",
   "files": [
     "dist/**",

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -1,0 +1,12 @@
+import { debug as registerLogger, Debugger } from 'debug';
+
+const topLevelLogger = registerLogger('teamsJs');
+
+/**
+ * @internal
+ *
+ * Returns a logger for a given namespace, within the pre-defined top-level teamsJs namespace
+ */
+export function getLogger(namespace: string): Debugger {
+  return topLevelLogger.extend(namespace);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1975,6 +1975,8 @@
 
 "@microsoft/teams-js@file:packages/teams-js":
   version "2.0.0-beta.2"
+  dependencies:
+    debug "4.3.3"
 
 "@mixer/webpack-bundle-compare@^0.1.0":
   version "0.1.0"
@@ -2238,6 +2240,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/debug@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/detect-indent@0.1.30":
   version "0.1.30"
   resolved "https://registry.yarnpkg.com/@types/detect-indent/-/detect-indent-0.1.30.tgz#dc682bb412b4e65ba098e70edad73b4833fb910d"
@@ -2391,6 +2400,11 @@
   version "0.3.29"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
   integrity sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY=
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/msgpack-lite@^0.1.7":
   version "0.1.8"
@@ -4372,6 +4386,13 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
 


### PR DESCRIPTION
This change is a first stab at adding trace logging to TeamsJs v2. It integrates [debug ](https://www.npmjs.com/package/debug) package and uses it to add trace logging around app->parent communication: sending, queuing, receiving and handling messages between the application and the parent host.

The logging is disabled by default and can be turned on by setting a logging pattern in local storage:

```
localStorage.debug = "teamsJs:*"
```

Sample output for a test app loaded successfully, followed by `getContext` call, `registerThemeChanged` and host notifying the application about the theme changing:

![image](https://user-images.githubusercontent.com/6841973/147472278-38f01495-734d-4908-bcf3-45d9bf42fe52.png)

In subsequent changes, assuming there's an agreement around this change, I'll add similar trace logging around app->child communication and other important aspects of the SDK.

Open questions:

- [ ] is there any sort of attribution we need to do for debug package usage?
- [ ] where should I add documentation around this new functionality?
- [ ] how do I let the support folks know that this will be a thing, so they can ask the customers reporting issues to enable trace logging and share the logs, if appropriate?