### PR TITLE
Modified ApiWithoutInput to account for callbacks

### DIFF
--- a/apps/teams-test-app/src/components/AppAPIs.tsx
+++ b/apps/teams-test-app/src/components/AppAPIs.tsx
@@ -1,4 +1,4 @@
-import { app, Context, core, DeepLinkParameters, getContext } from '@microsoft/teams-js';
+import { app, Context, getContext } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
 import { noHostSdkMsg } from '../App';

--- a/apps/teams-test-app/src/components/AppAPIs.tsx
+++ b/apps/teams-test-app/src/components/AppAPIs.tsx
@@ -1,4 +1,4 @@
-import { app, core, DeepLinkParameters } from '@microsoft/teams-js';
+import { app, Context, core, DeepLinkParameters, getContext } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
@@ -7,9 +7,18 @@ const GetContext = (): ReactElement =>
   ApiWithoutInput({
     name: 'getContextV2',
     title: 'Get Context',
-    onClick: async () => {
-      const context = await app.getContext();
-      return JSON.stringify(context);
+    onClick: {
+      withPromise: async () => {
+        const context = await app.getContext();
+        return JSON.stringify(context);
+      },
+      withCallback: setResult => {
+        const callback = (context: Context): void => {
+          setResult(JSON.stringify(context));
+        };
+        const context = getContext(callback);
+        return JSON.stringify(context);
+      },
     },
   });
 

--- a/apps/teams-test-app/src/components/AppAPIs.tsx
+++ b/apps/teams-test-app/src/components/AppAPIs.tsx
@@ -1,6 +1,7 @@
 import { app, Context, core, DeepLinkParameters, getContext } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
+import { noHostSdkMsg } from '../App';
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const GetContext = (): ReactElement =>
@@ -16,8 +17,8 @@ const GetContext = (): ReactElement =>
         const callback = (context: Context): void => {
           setResult(JSON.stringify(context));
         };
-        const context = getContext(callback);
-        return JSON.stringify(context);
+        getContext(callback);
+        return 'getContext()' + noHostSdkMsg;
       },
     },
   });

--- a/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
@@ -25,7 +25,7 @@ export const ApiWithoutInput = (props: ApiWithoutInputProps): React.ReactElement
         type="button"
         value={title}
         onClick={async () => {
-          if (typeof onClick == 'function') {
+          if (typeof onClick === 'function') {
             setResult(await onClick(setResult));
           } else {
             if (getTestBackCompat()) {

--- a/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react';
 
 import { ApiContainer } from './ApiContainer';
+import { getTestBackCompat } from './getTestBackCompat';
 
 export interface ApiWithoutInputProps {
   title: string;
   name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
-  onClick: (setResult: (result: string) => void) => Promise<string>;
+  onClick:
+    | ((setResult: (result: string) => void) => Promise<string>)
+    | {
+        withPromise: (setResult: (result: string) => void) => Promise<string>;
+        withCallback: (setResult: (result: string) => void) => string;
+      };
 }
 
 export const ApiWithoutInput = (props: ApiWithoutInputProps): React.ReactElement => {
@@ -18,7 +24,17 @@ export const ApiWithoutInput = (props: ApiWithoutInputProps): React.ReactElement
         name={`button_${name}`}
         type="button"
         value={title}
-        onClick={async () => setResult(await onClick(setResult))}
+        onClick={async () => {
+          if (typeof onClick == 'function') {
+            setResult(await onClick(setResult));
+          } else {
+            if (getTestBackCompat()) {
+              setResult(onClick.withCallback(setResult));
+            } else {
+              setResult(await onClick.withPromise(setResult));
+            }
+          }
+        }}
       />
     </ApiContainer>
   );


### PR DESCRIPTION
Modified the onClick property to contain to separate function handlers, withPromise and withCallback. withPromise will function as it currently does, while withCallbacks will be used by API's that are run in backwards compatibility mode