### PR TITLE
Backwards compatibility for navigation API and update pages.appButton title

### DIFF
--- a/apps/teams-test-app/src/components/PagesAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesAPIs.tsx
@@ -24,6 +24,8 @@ const NavigateCrossDomain = (): React.ReactElement =>
             if (!status) {
               if (reason) {
                 setResult(JSON.stringify(reason));
+              } else {
+                setResult("Status is false but there's not reason?! This shouldn't happen.");
               }
             } else {
               setResult('Completed');

--- a/apps/teams-test-app/src/components/PagesAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesAPIs.tsx
@@ -32,7 +32,6 @@ const NavigateCrossDomain = (): React.ReactElement =>
             }
           };
           navigateCrossDomain(input, onComplete);
-          return 'navigateCrossDomain()' + noHostSdkMsg;
         },
       },
     },

--- a/apps/teams-test-app/src/components/PagesAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesAPIs.tsx
@@ -1,7 +1,6 @@
 import { DeepLinkParameters, FrameInfo, navigateCrossDomain, pages, returnFocus } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import { noHostSdkMsg } from '../App';
 import { ApiWithCheckboxInput, ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const NavigateCrossDomain = (): React.ReactElement =>

--- a/apps/teams-test-app/src/components/PagesAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesAPIs.tsx
@@ -1,6 +1,7 @@
-import { DeepLinkParameters, FrameInfo, pages } from '@microsoft/teams-js';
+import { DeepLinkParameters, FrameInfo, navigateCrossDomain, pages } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
+import { noHostSdkMsg } from '../App';
 import { ApiWithCheckboxInput, ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const NavigateCrossDomain = (): React.ReactElement =>
@@ -13,9 +14,24 @@ const NavigateCrossDomain = (): React.ReactElement =>
           throw new Error('Target URL is required.');
         }
       },
-      submit: async input => {
-        await pages.navigateCrossDomain(input);
-        return 'Completed';
+      submit: {
+        withPromise: async input => {
+          await pages.navigateCrossDomain(input);
+          return 'Completed';
+        },
+        withCallback: (input, setResult) => {
+          const onComplete = (status: boolean, reason?: string): void => {
+            if (!status) {
+              if (reason) {
+                setResult(JSON.stringify(reason));
+              }
+            } else {
+              setResult('Completed');
+            }
+          };
+          navigateCrossDomain(input, onComplete);
+          return 'navigateCrossDomain()' + noHostSdkMsg;
+        },
       },
     },
   });

--- a/apps/teams-test-app/src/components/PagesAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesAPIs.tsx
@@ -1,4 +1,5 @@
 import { DeepLinkParameters, FrameInfo, navigateCrossDomain, pages, returnFocus } from '@microsoft/teams-js';
+import React, { ReactElement } from 'react';
 
 import { noHostSdkMsg } from '../App';
 import { ApiWithCheckboxInput, ApiWithoutInput, ApiWithTextInput } from './utils';

--- a/apps/teams-test-app/src/components/PagesAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesAPIs.tsx
@@ -1,4 +1,4 @@
-import { DeepLinkParameters, FrameInfo, navigateCrossDomain, pages, returnFocus, setting } from '@microsoft/teams-js';
+import { DeepLinkParameters, FrameInfo, navigateCrossDomain, pages, returnFocus, settings } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
 import { ApiWithCheckboxInput, ApiWithoutInput, ApiWithTextInput } from './utils';

--- a/apps/teams-test-app/src/components/PagesAppButtonAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesAppButtonAPIs.tsx
@@ -41,7 +41,7 @@ const RegisterAppButtonHoverLeaveHandler = (): React.ReactElement =>
 
 const PagesAppButtonAPIs = (): ReactElement => (
   <>
-    <h1>pages.tabs</h1>
+    <h1>pages.appButton</h1>
     <RegisterAppButtonClickHandler />
     <RegisterAppButtonHoverEnterHandler />
     <RegisterAppButtonHoverLeaveHandler />

--- a/apps/teams-test-app/src/components/PagesBackStackAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesBackStackAPIs.tsx
@@ -27,7 +27,6 @@ const NavigateBack = (): React.ReactElement =>
           }
         };
         navigateBack(onComplete);
-        return 'navigateBack()' + noHostSdkMsg;
       },
     },
   });

--- a/apps/teams-test-app/src/components/PagesBackStackAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesBackStackAPIs.tsx
@@ -1,7 +1,6 @@
 import { navigateBack, pages } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import { noHostSdkMsg } from '../App';
 import { ApiWithoutInput } from './utils';
 import { ApiContainer } from './utils/ApiContainer';
 

--- a/apps/teams-test-app/src/components/PagesBackStackAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesBackStackAPIs.tsx
@@ -19,6 +19,8 @@ const NavigateBack = (): React.ReactElement =>
           if (!status) {
             if (reason) {
               setResult(JSON.stringify(reason));
+            } else {
+              setResult("Status is false but there's not reason?! This shouldn't happen.");
             }
           } else {
             setResult('Completed');

--- a/apps/teams-test-app/src/components/PagesBackStackAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesBackStackAPIs.tsx
@@ -1,6 +1,7 @@
-import { pages } from '@microsoft/teams-js';
+import { navigateBack, pages } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
+import { noHostSdkMsg } from '../App';
 import { ApiWithoutInput } from './utils';
 import { ApiContainer } from './utils/ApiContainer';
 
@@ -8,9 +9,24 @@ const NavigateBack = (): React.ReactElement =>
   ApiWithoutInput({
     name: 'navigateBack',
     title: 'Navigate Back',
-    onClick: async () => {
-      await pages.backStack.navigateBack();
-      return 'Completed';
+    onClick: {
+      withPromise: async () => {
+        await pages.backStack.navigateBack();
+        return 'Completed';
+      },
+      withCallback: setResult => {
+        const onComplete = (status: boolean, reason?: string): void => {
+          if (!status) {
+            if (reason) {
+              setResult(JSON.stringify(reason));
+            }
+          } else {
+            setResult('Completed');
+          }
+        };
+        navigateBack(onComplete);
+        return 'navigateBack()' + noHostSdkMsg;
+      },
     },
   });
 

--- a/apps/teams-test-app/src/components/PagesTabsAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesTabsAPIs.tsx
@@ -1,7 +1,6 @@
 import { navigateToTab, pages, TabInstance, TabInstanceParameters } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import { noHostSdkMsg } from '../App';
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const NavigateToTab = (): React.ReactElement =>

--- a/apps/teams-test-app/src/components/PagesTabsAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesTabsAPIs.tsx
@@ -1,6 +1,7 @@
-import { pages, TabInstance, TabInstanceParameters } from '@microsoft/teams-js';
+import { navigateToTab, pages, TabInstance, TabInstanceParameters } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
+import { noHostSdkMsg } from '../App';
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const NavigateToTab = (): React.ReactElement =>
@@ -13,9 +14,24 @@ const NavigateToTab = (): React.ReactElement =>
           throw new Error('tabName is required');
         }
       },
-      submit: async input => {
-        await pages.tabs.navigateToTab(input);
-        return 'Completed';
+      submit: {
+        withPromise: async input => {
+          await pages.tabs.navigateToTab(input);
+          return 'Completed';
+        },
+        withCallback: (input, setResult) => {
+          const onComplete = (status: boolean, reason?: string): void => {
+            if (!status) {
+              if (reason) {
+                setResult(JSON.stringify(reason));
+              }
+            } else {
+              setResult('Completed');
+            }
+          };
+          navigateToTab(input, onComplete);
+          return 'navigateToTab()' + noHostSdkMsg;
+        },
       },
     },
   });

--- a/apps/teams-test-app/src/components/PagesTabsAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesTabsAPIs.tsx
@@ -24,6 +24,8 @@ const NavigateToTab = (): React.ReactElement =>
             if (!status) {
               if (reason) {
                 setResult(JSON.stringify(reason));
+              } else {
+                setResult("Status is false but there's not reason?! This shouldn't happen.");
               }
             } else {
               setResult('Completed');

--- a/apps/teams-test-app/src/components/PagesTabsAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesTabsAPIs.tsx
@@ -32,7 +32,6 @@ const NavigateToTab = (): React.ReactElement =>
             }
           };
           navigateToTab(input, onComplete);
-          return 'navigateToTab()' + noHostSdkMsg;
         },
       },
     },


### PR DESCRIPTION
Added in callback capability for the navigation API depending on if we are in Teams JS v1 mode or TeamsJSv2 mode.
Update one of `pages.tabs` titles to `pages.appButton` since `RegisterAppButtonClickHandler`, `RegisterAppButtonHoverEnterHandler`, and `RegisterAppButtonHoverLeaveHandler` have been moved to a new sub-capability pages.appButton.