### PR TITLE
Setting version constant in one place

### DIFF
--- a/packages/teams-js/jest.config.js
+++ b/packages/teams-js/jest.config.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const commonSettings = require('../../jest.config.common.js');
+const packageVersion = require('./package.json').version;
 
 module.exports = {
   ...commonSettings,
@@ -9,5 +10,6 @@ module.exports = {
         downlevelIteration: true,
       },
     },
+    PACKAGE_VERSION: packageVersion,
   },
 };

--- a/packages/teams-js/prepNextDevRelease.js
+++ b/packages/teams-js/prepNextDevRelease.js
@@ -167,26 +167,10 @@ function getNewPkgJsonContent(currNextDevVer) {
   return packageJson;
 }
 
-/**
- * Replaces the version declared in internal/constants.ts with the given version.
- * @param {string} newVersion the new version to replace the version in the constants.ts file with.
- */
-function saveNewConstantsContent(newVersion) {
-  let constantsFileContent = getFileContent(internalConstantsFilePath);
-  const pattern = 'const version = ';
-  const verDeclarationIndex = constantsFileContent.indexOf(pattern);
-  const endVerDeclarationIndex = constantsFileContent.indexOf(';', verDeclarationIndex);
-  // whole substring consisting of the declaration to be replaced.
-  const verDeclaration = constantsFileContent.substring(verDeclarationIndex, endVerDeclarationIndex);
-  const newConstantsFileContent = constantsFileContent.replace(verDeclaration, `${pattern}'${newVersion}'`);
-  saveFile(internalConstantsFilePath, newConstantsFileContent);
-}
-
 function prepNewDevRelease(devStdout) {
   const newPackageJson = getNewPkgJsonContent(devStdout);
   const newVersion = newPackageJson.version;
   saveJsonFile(newPackageJson);
-  saveNewConstantsContent(newVersion);
   return newVersion;
 }
 

--- a/packages/teams-js/src/internal/constants.ts
+++ b/packages/teams-js/src/internal/constants.ts
@@ -1,4 +1,6 @@
-export const version = '2.0.0-beta.2';
+declare const PACKAGE_VERSION: string;
+export const version = PACKAGE_VERSION;
+
 /**
  * @hidden
  * The SDK version when all SDK APIs started to check platform compatibility for the APIs was 1.6.0.

--- a/packages/teams-js/webpack.config.js
+++ b/packages/teams-js/webpack.config.js
@@ -9,6 +9,9 @@ const WebpackAssetsManifest = require('webpack-assets-manifest');
 const libraryName = 'microsoftTeams';
 const expect = require('expect');
 const path = require('path');
+const { DefinePlugin } = require('webpack');
+const packageVersion = require('./package.json').version;
+
 
 module.exports = {
   entry: {
@@ -56,6 +59,10 @@ module.exports = {
   // webpack.production.config.js
   mode: 'production',
   plugins: [
+    new DefinePlugin({
+      PACKAGE_VERSION: JSON.stringify(packageVersion),
+    }),
+
     new DtsBundleWebpack({
       name: '@microsoft/teams-js',
       main: 'dts/index.d.ts',


### PR DESCRIPTION
Instead of having the version set in two places, we can rely on webpack to pull the value from package.json and inject it in the constants file during build time.

This makes life easier when bumping versions. Only one value will need to be updated.