### PR TITLE
Update withCallback utils

### DIFF
--- a/apps/teams-test-app/src/components/AppAPIs.tsx
+++ b/apps/teams-test-app/src/components/AppAPIs.tsx
@@ -1,7 +1,6 @@
 import { app, Context, getContext } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import { noHostSdkMsg } from '../App';
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const GetContext = (): ReactElement =>
@@ -18,7 +17,6 @@ const GetContext = (): ReactElement =>
           setResult(JSON.stringify(context));
         };
         getContext(callback);
-        return 'getContext()' + noHostSdkMsg;
       },
     },
   });

--- a/apps/teams-test-app/src/components/LocationAPIs.tsx
+++ b/apps/teams-test-app/src/components/LocationAPIs.tsx
@@ -1,7 +1,6 @@
 import { location, SdkError } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import { noHostSdkMsg } from '../App';
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const CheckLocationCapability = (): React.ReactElement =>
@@ -35,7 +34,6 @@ const GetLocation = (): React.ReactElement =>
             }
           };
           location.getLocation(locationProps, callback);
-          return 'location.getLocation()' + noHostSdkMsg;
         },
       },
     },
@@ -65,7 +63,6 @@ const ShowLocation = (): React.ReactElement =>
             }
           };
           location.showLocation(locationProps, callback);
-          return 'location.showLocation()' + noHostSdkMsg;
         },
       },
     },

--- a/apps/teams-test-app/src/components/privateApis/MonetizationAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/MonetizationAPIs.tsx
@@ -38,7 +38,6 @@ const OpenPurchaseExperience = (): React.ReactElement =>
             }
           };
           monetization.openPurchaseExperience(callback, planInfo);
-          return 'monetization.openPurchaseExperience()' + noHostSdkMsg;
         },
       },
     },

--- a/apps/teams-test-app/src/components/utils/ApiWithTextInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithTextInput.tsx
@@ -15,7 +15,7 @@ export interface ApiWithTextInputProps<T> {
           | ((input: T, setResult: (result: string) => void) => Promise<string>)
           | {
               withPromise: (input: T, setResult: (result: string) => void) => Promise<string>;
-              withCallback: (input: T, setResult: (result: string) => void) => string;
+              withCallback: (input: T, setResult: (result: string) => void) => void;
             };
       };
   defaultInput?: string;
@@ -46,8 +46,7 @@ export const ApiWithTextInput = <T extends unknown>(props: ApiWithTextInputProps
           setResult(result);
         } else {
           if (getTestBackCompat()) {
-            const result = submit.withCallback(input, setResult);
-            setResult(result);
+            submit.withCallback(input, setResult);
           } else {
             const result = await submit.withPromise(input, setResult);
             setResult(result);

--- a/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithoutInput.tsx
@@ -10,7 +10,7 @@ export interface ApiWithoutInputProps {
     | ((setResult: (result: string) => void) => Promise<string>)
     | {
         withPromise: (setResult: (result: string) => void) => Promise<string>;
-        withCallback: (setResult: (result: string) => void) => string;
+        withCallback: (setResult: (result: string) => void) => void;
       };
 }
 
@@ -29,7 +29,7 @@ export const ApiWithoutInput = (props: ApiWithoutInputProps): React.ReactElement
             setResult(await onClick(setResult));
           } else {
             if (getTestBackCompat()) {
-              setResult(onClick.withCallback(setResult));
+              onClick.withCallback(setResult);
             } else {
               setResult(await onClick.withPromise(setResult));
             }


### PR DESCRIPTION
Update `withCallback` utils in `ApiWithTextInput` and `ApiWithoutInput`, avoid redundant of using `noHostSdkMsg` at every call.