### PR TITLE
Updating prepRelease script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,13 @@
     "clean:full": "yarn clean && yarn clean:modules",
     "clean:modules": "lerna clean -y && rimraf node_modules",
     "efb": "lerna run eslint-fix-build",
-    "publish-sdk": "yarn publish packages/teams-js",
+    "lint": "lerna run lint",
+    "release": "node tools/cli/prepNextRelease.js",
     "start-perf-app": "yarn workspace teams-perf-test-app start",
     "start-test-app": "yarn workspace teams-test-app start",
     "start-test-app-local": "yarn workspace teams-test-app start:local",
-    "test": "lerna run test --stream",
-    "lint": "lerna run lint"
+    "test": "lerna run test --stream"
+    
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/tools/cli/prepNextRelease.js
+++ b/tools/cli/prepNextRelease.js
@@ -110,6 +110,11 @@ const checkoutAndPushReleaseBranch = async () => {
 };
 
 (async () => {
+  const newVersion = getNewPackageVersion();
+  process.stdout.write(`Are you sure you want to create a new release for ${newVersion}? (y/n) `);
+  if (!(await boolPrompt())) {
+    console.log('Aborting!');
+  }
   try {
     await checkoutAndPullMainBranch();
     await updatePackageVersion();

--- a/tools/cli/prepNextRelease.js
+++ b/tools/cli/prepNextRelease.js
@@ -1,56 +1,122 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable */
+
+/*
+ * Run this script locally to create a new release
+ * Once this is executed, a CI/Release will be invoked.
+ * The release must be approved before the packages can be deployed.
+ * Once the release is completed, the created PR should be approved and merged back into 2.0-preview
+ */
+const { exec } = require('child_process');
 const fs = require('fs');
+const path = require('path');
 
-let packageJsonPath = '../../packages/teams-js/package.json';
-const EXIT_CODE_FATAL_ERROR = 5;
+const currentPackageVersion = require('../../packages/teams-js/package.json').version;
 
-function getPackageJson() {
-  if (fs.existsSync(packageJsonPath)) {
-    return JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+const getNewPackageVersion = () => {
+  const stringPattern = '2.0.0-beta.';
+  const betaVersionNumber = parseInt(currentPackageVersion.substring(stringPattern.length)) + 1;
+  const newPackageVersion = `${stringPattern}${betaVersionNumber}`;
+  return newPackageVersion;
+};
+
+const execShellCommand = async cmd => {
+  return new Promise((resolve, reject) => {
+    exec(cmd, { maxBuffer: 1024 * 500 }, (error, stdout, stderr) => {
+      if (error) {
+        reject(error);
+      } else if (stderr) {
+        reject(stderr);
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+};
+
+const boolPrompt = () => {
+  process.stdin.resume();
+  return new Promise(resolve => {
+    process.stdin.on('error', err => {
+      reject(err);
+    });
+    process.stdin.on('data', data => {
+      const result = data
+        .toString()
+        .toLowerCase()
+        .trimEnd();
+      if (result === 'y' || result === 'yes') {
+        resolve(true);
+        process.stdin.pause();
+      } else {
+        resolve(false);
+        process.stdin.pause();
+      }
+    });
+  });
+};
+
+const checkoutAndPullMainBranch = async () => {
+  const diff = await execShellCommand('git diff');
+  const diffStaged = await execShellCommand('git diff --staged');
+  if (diff || diffStaged) {
+    throw 'You have uncommitted changes. Please commit your changes before proceeding.\nAborting!';
   }
-  console.log('FATAL ERROR: package.json path could not be found in the file system.');
-  process.exitCode = EXIT_CODE_FATAL_ERROR;
-  return;
-}
-
-function savePackageJson(packageJson) {
-  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
-}
-
-function getFileVersion(packageJson) {
-  if (!packageJson.version) {
-    console.log('FATAL ERROR: a version was not found in the package.json.');
-    process.exitCode = EXIT_CODE_FATAL_ERROR;
-    return;
-  } else {
-    return packageJson.version;
+  const gitBranch = await execShellCommand('git branch');
+  const branches = gitBranch.split('\n');
+  const currentBranch = branches.find(branch => branch.startsWith('*'));
+  console.log(currentBranch);
+  if (currentBranch !== '2.0-preview') {
+    process.stdout.write('You are not on 2.0-preview branch. Do you want to checkout? (y/n) ');
+    if (!(await boolPrompt())) {
+      throw 'User aborted!';
+    }
+    await execShellCommand('git checkout 2.0-preview');
   }
-}
+  await execShellCommand('git pull');
+};
 
-let packageJson = getPackageJson();
+const updatePackageVersion = async () => {
+  const relativePathToTeamsjsPackageJson = '../../packages/teams-js/package.json';
+  const newVersion = getNewPackageVersion();
+  console.log(`Updating package.json to ${newVersion}`);
+  const absolutePathToTeamsjsPackageJson = path.resolve(__dirname, relativePathToTeamsjsPackageJson);
+  if (!fs.existsSync(absolutePathToTeamsjsPackageJson)) {
+    throw `ERROR: ${absolutePathToTeamsjsPackageJson} was not found.`;
+  }
+  const packageJson = fs.readFileSync(absolutePathToTeamsjsPackageJson, 'utf8');
+  const newPackageJson = packageJson.replace(`"version": "${currentPackageVersion}"`, `"version": "${newVersion}"`);
+  fs.writeFileSync(absolutePathToTeamsjsPackageJson, newPackageJson);
+};
 
-// SHA of the commit the package was generated from
-let hash = process.env['BUILD_SOURCEVERSION'];
+const buildAndUpdateIntegrityHash = async () => {
+  console.log('Updating integrity hash');
+  await execShellCommand('cd packages/teams-js & yarn build & node prepNewReadme.js');
+};
 
-// pre-release version part, either from the hash or random if has not available
-let suffixLength = 10;
-let versionSuffix = 'dev.' + hash.substr(0, suffixLength);
+const checkoutAndPushReleaseBranch = async () => {
+  console.log('Please validate all uncommitted changes: \n');
+  const diff = await execShellCommand('git diff -U0');
+  console.log(diff);
+  process.stdout.write('Proceed? (y/n) ');
+  if (!(await boolPrompt())) {
+    throw 'User aborted!';
+  }
+  const newVersion = getNewPackageVersion();
+  const branchName = `release/${newVersion}`;
+  await execShellCommand(`git checkout -b ${branchName}`);
+  await execShellCommand('git add -A');
+  await execShellCommand(`git commit -m "Releasing ${newVersion}"`);
+  await execShellCommand(`git push --set-upstream origin ${branchName}`);
+};
 
-console.log('version suffix: ' + versionSuffix);
-
-// get package version from package.json
-let version = getFileVersion(packageJson);
-
-console.log('package.json version: ' + version);
-
-// append the suffix to form a new version
-let nextVersion = version + '-' + versionSuffix;
-console.log('@next version: ' + nextVersion);
-
-// update package.json with the new version
-packageJson.version = nextVersion;
-
-// Sets result in Azure devops pipeline output variable 'NextVersion'
-console.log(`##vso[task.setvariable variable=NextVersion;isOutput=true]${nextVersion}`);
-
-savePackageJson(packageJson);
+(async () => {
+  try {
+    await checkoutAndPullMainBranch();
+    await updatePackageVersion();
+    await buildAndUpdateIntegrityHash();
+    await checkoutAndPushReleaseBranch();
+    // TODO: Add code to create the PR automatically using github api
+  } catch (e) {
+    console.log(e);
+  }
+})();

--- a/tools/cli/prepNextRelease.js
+++ b/tools/cli/prepNextRelease.js
@@ -64,8 +64,7 @@ const checkoutAndPullMainBranch = async () => {
   const gitBranch = await execShellCommand('git branch');
   const branches = gitBranch.split('\n');
   const currentBranch = branches.find(branch => branch.startsWith('*'));
-  console.log(currentBranch);
-  if (currentBranch !== '2.0-preview') {
+  if (currentBranch !== '* 2.0-preview') {
     process.stdout.write('You are not on 2.0-preview branch. Do you want to checkout? (y/n) ');
     if (!(await boolPrompt())) {
       throw 'User aborted!';

--- a/tools/cli/prepNextRelease.js
+++ b/tools/cli/prepNextRelease.js
@@ -113,7 +113,8 @@ const checkoutAndPushReleaseBranch = async () => {
   const newVersion = getNewPackageVersion();
   process.stdout.write(`Are you sure you want to create a new release for ${newVersion}? (y/n) `);
   if (!(await boolPrompt())) {
-    console.log('Aborting!');
+    console.log('User aborted!');
+    return;
   }
   try {
     await checkoutAndPullMainBranch();


### PR DESCRIPTION
With this script, we can just run `yarn release` from the root of the repo, and that will automatically do all the following steps: 
1. Checkout 2.0-preview and pull it from origin
2. Update the package.json version by incrementing the beta value
3. Build teams-js and copy the new integrity hash back into the readme
4. checkout a release/{newVersion}, commit the changes, and push that branch.

Once a branch with release* gets pushed, the CI pipeline will trigger and build artifacts. If the CI pipeline passes, the production release pipeline triggers and publishes the respective artifacts to npm/cdn. The prod release pipeline will require approval if we want to sanity check the artifacts before we allow the publishing.

#793 Note: This is related to this PR too. That PR will also update the readme for sdf releases to have the sdf endpoint and integrity hash. One Prod releases, it will also run, but it shouldn't end up making any changes. 