### PR TITLE
Made getAuthToken's param optional

### DIFF
--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -148,11 +148,11 @@ export namespace authentication {
    * Requests an Azure AD token to be issued on behalf of the app. The token is acquired from the cache
    * if it is not expired. Otherwise a request is sent to Azure AD to obtain a new token.
    *
-   * @param authTokenRequest - A set of values that configure the token request.
+   * @param authTokenRequest - An optional set of values that configure the token request.
    *
    * @returns Promise that will be fulfilled with the token if successful.
    */
-  export function getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise<string>;
+  export function getAuthToken(authTokenRequest?: AuthTokenRequestParameters): Promise<string>;
   /**
    * @deprecated
    * As of 2.0.0-beta.1, please use {@link authentication.getAuthToken authentication.getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise\<string\>} instead.
@@ -160,11 +160,11 @@ export namespace authentication {
    * Requests an Azure AD token to be issued on behalf of the app. The token is acquired from the cache
    * if it is not expired. Otherwise a request is sent to Azure AD to obtain a new token.
    *
-   * @param authTokenRequest - A set of values that configure the token request.
+   * @param authTokenRequest - An optional set of values that configure the token request.
    * It contains callbacks to call in case of success/failure
    */
-  export function getAuthToken(authTokenRequest: AuthTokenRequest): void;
-  export function getAuthToken(authTokenRequest: AuthTokenRequest): Promise<string> {
+  export function getAuthToken(authTokenRequest?: AuthTokenRequest): void;
+  export function getAuthToken(authTokenRequest?: AuthTokenRequest): Promise<string> {
     ensureInitialized();
     return getAuthTokenHelper(authTokenRequest)
       .then((value: string) => {
@@ -183,13 +183,13 @@ export namespace authentication {
       });
   }
 
-  function getAuthTokenHelper(authTokenRequest: AuthTokenRequest): Promise<string> {
+  function getAuthTokenHelper(authTokenRequest?: AuthTokenRequest): Promise<string> {
     return new Promise<[boolean, string]>(resolve => {
       resolve(
         sendMessageToParentAsync('authentication.getAuthToken', [
-          authTokenRequest.resources,
-          authTokenRequest.claims,
-          authTokenRequest.silent,
+          authTokenRequest?.resources,
+          authTokenRequest?.claims,
+          authTokenRequest?.silent,
         ]),
       );
     }).then(([success, result]: [boolean, string]) => {

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -752,6 +752,22 @@ describe('authentication', () => {
     return expect(promise).resolves.toEqual('token');
   });
 
+  it('should successfully return getAuthToken in case of success when using no authTokenRequest', async () => {
+    await utils.initializeWithContext('content');
+
+    const promise = authentication.getAuthToken();
+
+    const message = utils.findMessageByFunc('authentication.getAuthToken');
+    expect(message).not.toBeNull();
+    expect(message.args.length).toBe(3);
+    expect(message.args[0]).toEqual(undefined);
+    expect(message.args[1]).toEqual(undefined);
+    expect(message.args[2]).toEqual(undefined);
+
+    utils.respondToMessage(message, true, 'token');
+    return expect(promise).resolves.toEqual('token');
+  });
+
   it('should successfully return error from getAuthToken in case of failure', async () => {
     await utils.initializeWithContext('content');
 
@@ -765,6 +781,22 @@ describe('authentication', () => {
     expect(message).not.toBeNull();
     expect(message.args.length).toBe(3);
     expect(message.args[0]).toEqual(['https://someresource/']);
+    expect(message.args[1]).toEqual(undefined);
+    expect(message.args[2]).toEqual(undefined);
+
+    utils.respondToMessage(message, false, 'error');
+    return expect(promise).rejects.toThrowError('error');
+  });
+
+  it('should successfully return error from getAuthToken in case of failure when using no authTokenRequest', async () => {
+    await utils.initializeWithContext('content');
+
+    const promise = authentication.getAuthToken();
+
+    const message = utils.findMessageByFunc('authentication.getAuthToken');
+    expect(message).not.toBeNull();
+    expect(message.args.length).toBe(3);
+    expect(message.args[0]).toEqual(undefined);
     expect(message.args[1]).toEqual(undefined);
     expect(message.args[2]).toEqual(undefined);
 


### PR DESCRIPTION
getAuthToken took in a parameter that was an array that contained only optional values. Made the array an optional parameter as well and added two new unit tests to verify that passing in no array still works as expected.

This is a fix for bug #5377609