### PR TITLE
Add FrameContext to public\index.ts exports

### DIFF
--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -5,6 +5,7 @@ export {
   Context,
   DeepLinkParameters,
   ErrorCode,
+  FrameContext,
   LoadContext,
   SdkError,
   TabInformation,


### PR DESCRIPTION
Erin checked with Yuri and it sounds like not exporting this was an oversight in the main branch.