### PR TITLE
Add isTouchEnabled to Context

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -434,6 +434,12 @@ export interface Context {
    * Teamsite ID, aka sharepoint site id.
    */
   teamSiteId?: string;
+
+  /**
+   * Indication whether the screen is touchable or not.
+   * The implementation is available on mobile(iOS/Android) for now.
+   */
+  isTouchEnabled?: boolean;
 }
 
 export interface DeepLinkParameters {


### PR DESCRIPTION
Add isTouchEnabled to Context in order to expose the capability on whether the screen is touchable or not.
Currently the implementation of isTouchEnabled is available on mobile(iOS/Android).
For other platforms like Windows/Mac/Web, the implementation will be filled as needed in the future.