### PR TITLE
Test App: Print error response in the output of liveStreamState Handler

### DIFF
--- a/apps/teams-test-app/src/components/MeetingAPIs.tsx
+++ b/apps/teams-test-app/src/components/MeetingAPIs.tsx
@@ -97,7 +97,11 @@ const RegisterLiveStreamChangedHandler = (): React.ReactElement =>
     title: 'Register LiveStream Changed Handler',
     onClick: async setResult => {
       const handler = (liveStreamState: meeting.LiveStreamState): void => {
-        setResult('Live StreamState changed to ' + liveStreamState.isStreaming);
+        let res = `Live StreamState changed to ${liveStreamState.isStreaming}`;
+        if (liveStreamState.error) {
+          res += ` with error ${JSON.stringify(liveStreamState.error)}`;
+        }
+        setResult(res);
       };
       meeting.registerLiveStreamChangedHandler(handler);
 


### PR DESCRIPTION
> liveStreamState interface of meeting has error response struct which is used to notify incase of error. This PR contains changes in test app to print error response in output for testing