### PR TITLE
Intentional unit test failure

### DIFF
--- a/packages/teams-js/test/private/files.spec.ts
+++ b/packages/teams-js/test/private/files.spec.ts
@@ -28,7 +28,7 @@ describe('files', () => {
 
   describe('getCloudStorageFolders', () => {
     it('should not allow calls before initialization', () => {
-      expect(files.getCloudStorageFolders('channelId')).rejects.toThrowError(
+      return expect(files.getCloudStorageFolders('channelId')).rejects.toThrowError(
         'The library has not yet been initialized THIS SHOULD FAIL',
       );
     });

--- a/packages/teams-js/test/private/files.spec.ts
+++ b/packages/teams-js/test/private/files.spec.ts
@@ -29,7 +29,7 @@ describe('files', () => {
   describe('getCloudStorageFolders', () => {
     it('should not allow calls before initialization', () => {
       expect(files.getCloudStorageFolders('channelId')).rejects.toThrowError(
-        'The library has not yet been initialized',
+        'The library has not yet been initialized THIS SHOULD FAIL',
       );
     });
 


### PR DESCRIPTION
Want to see if this causes the cloud build to notice the failed test. When I run the test locally it prints errors to the console but jest reports that 763/763 tests passed

This should NOT be merged.