### PR TITLE
Fixing stderr on checkout issue

### DIFF
--- a/tools/cli/prepNextRelease.js
+++ b/tools/cli/prepNextRelease.js
@@ -69,9 +69,9 @@ const checkoutAndPullMainBranch = async () => {
     if (!(await boolPrompt())) {
       throw 'User aborted!';
     }
-    await execShellCommand('git checkout 2.0-preview');
+    await execShellCommand('git checkout 2.0-preview --quiet');
   }
-  await execShellCommand('git pull');
+  await execShellCommand('git pull --quiet');
 };
 
 const updatePackageVersion = async () => {
@@ -102,7 +102,7 @@ const checkoutAndPushReleaseBranch = async () => {
   }
   const newVersion = getNewPackageVersion();
   const branchName = `release/${newVersion}`;
-  await execShellCommand(`git checkout -b ${branchName}`);
+  await execShellCommand(`git checkout -b ${branchName} --quiet`);
   await execShellCommand('git add -A');
   await execShellCommand(`git commit -m "Releasing ${newVersion}"`);
   await execShellCommand(`git push --set-upstream origin ${branchName}`);
@@ -122,6 +122,7 @@ const checkoutAndPushReleaseBranch = async () => {
     await checkoutAndPushReleaseBranch();
     // TODO: Add code to create the PR automatically using github api
   } catch (e) {
+    console.log('Something went wrong!');
     console.log(e);
   }
 })();


### PR DESCRIPTION
This is a weird behavior from git which I missed because I had originally thought was because the file was not actually in 2.0-preview, and the script loses it once the checkout happens.

Turns out, git commands like `git checkout 2.0-preview` write out to the console something like: 
-- Switched to branch '2.0-preview'
-- Your branch is up to date with 'origin/2.0-preview'.

For some reason, the 1st message is output to `stderr`, and the second is output to `stdout`. This seems to be a historical thing.
Because it goes to stderr, the script aborts there (which is good behavior). 

Same thing happens with `git pull` on a remote tracked branch. The new origin branches shown is logged through stderr instead of stdout. 

Adding the `--quiet` flags fixes the issue. If something does indeed error (ie checking out with uncommitted changes), the quiet flag is overridden and it would then correctly log to stderr with an actual error, which is good.