### PR TITLE
Fixed a bug with getAuthenticationTokenForANonymousUser callback

### DIFF
--- a/apps/teams-test-app/src/components/MeetingAPIs.tsx
+++ b/apps/teams-test-app/src/components/MeetingAPIs.tsx
@@ -83,8 +83,10 @@ const GetAuthenticationTokenForAnonymousUser = (): React.ReactElement =>
         const callback = (error: SdkError | null, authenticationTokenOfAnonymousUser: string | null): void => {
           if (error) {
             setResult(JSON.stringify(error));
+          } else if (authenticationTokenOfAnonymousUser) {
+            setResult(authenticationTokenOfAnonymousUser);
           } else {
-            setResult(JSON.stringify(authenticationTokenOfAnonymousUser));
+            setResult('getAuthTokenForAnonymousUser was called but nothing was returned');
           }
         };
         meeting.getAuthenticationTokenForAnonymousUser(callback);


### PR DESCRIPTION
Previously we JSON stringified a string value, this was unnecessary and led to failures in tests