### PR TITLE
Combine our yaml files

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -291,13 +291,14 @@ jobs:
         inputs:
           Arguments: 'build'
           ProjectDirectory: 'microsoft-teams-library-js'
-          - task: CmdLine@2
-            displayName: 'Configure host machine'
-            inputs:
-              script: |
-                sudo chmod -R 755 ./ 
-                sudo yarn setup
-              workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: CmdLine@2
+        displayName: 'Configure host machine'
+        inputs:
+          script: |
+            sudo chmod -R 755 ./ 
+            sudo yarn setup
+          workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,11 +14,6 @@ trigger:
     include:
       - 'v*'
 
-steps:
-  - checkout: self
-  - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-    persistCredentials: true
-
 jobs:
   - job: Security
     displayName: 'Security Tasks'
@@ -257,6 +252,10 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
+      - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+        persistCredentials: true
+
       - task: NodeTool@0
         inputs:
           versionSpec: '14.x'
@@ -304,6 +303,8 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
+      - checkout: self
+
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'
         condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,6 +149,7 @@ jobs:
         inputs:
           Arguments: 'bundleAnalyze:collect'
         displayName: 'Run bundle analysis and collect'
+
       # Bundle analysis comparison : should trigger only by PR against 2.0-preview
       # Adding comment for a commit that should queue the pipeline with a PR trigger
       - bash: 'node --max-old-space-size=4096 tools/cli/compareBundleAnalysis.js --commitId=$(System.PullRequest.SourceCommitId) --orgUrl=$(System.CollectionUri) --projectName=$(System.TeamProject) --buildId=$(System.DefinitionId) --bundleArtifactName=$(bundleArtifactName) --baseBranchName=$(System.PullRequest.TargetBranch)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -249,7 +249,7 @@ jobs:
           ArtifactName: 'NPMFeed'
         displayName: 'Publish NPM feed to Build Artifacts'
 
-  - job: E2e Test
+  - job: E2e_Test
     displayName: 'E2e Testing'
     dependsOn: Build
     condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -297,16 +297,23 @@ jobs:
             sudo yarn setup
           workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
+      - bash: 'node tools/cli/runAppsWithE2ETests.js'
+        displayName: 'Run E2E integration tests'
+        condition: succeeded()
+        workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '**/e2e-tests-report*.xml'
+        condition: succeededOrFailed()
+
   - job: E2e_Test
     displayName: 'E2e test'
     dependsOn: E2e_Test_Setup
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-      - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-        persistCredentials: true
-
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'
         condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -324,12 +324,12 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       - task: CmdLine@2
-      displayName: 'Configure host machine'
-      inputs:
-        script: |
-          sudo chmod -R 755 ./ 
-          sudo yarn setup
-        workingDirectory: '$(AppHostingSdkProjectDirectory)'
+        displayName: 'Configure host machine'
+        inputs:
+          script: |
+            sudo chmod -R 755 ./ 
+            sudo yarn setup
+          workingDirectory: '$(AppHostingSdkProjectDirectory)'
       - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
         displayName: 'Run E2E Perf tests'
         condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
   - job: Build
     displayName: 'Build, Test, and Publish Artifacts'
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'ubuntu-latest'
     steps:
       - task: YarnInstaller@3
         displayName: 'Yarn 1.x'
@@ -109,30 +109,30 @@ jobs:
         inputs:
           Arguments: 'install'
 
-      # - script: 'node prepNextDevRelease.js'
-      #   displayName: 'node prepNextDevRelease.js'
-      #   workingDirectory: '$(System.DefaultWorkingDirectory)\packages\teams-js'
-      #   condition: and(
-      #     eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'),
-      #     in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-      #     ne(variables['Build.Reason'], 'PullRequest'),
-      #     ne(variables['Build.Reason'], 'Manual')
-      #     )
+      - script: 'node prepNextDevRelease.js'
+        displayName: 'node prepNextDevRelease.js'
+        workingDirectory: '$(System.DefaultWorkingDirectory)\packages\teams-js'
+        condition: and(
+          eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'),
+          in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
+          ne(variables['Build.Reason'], 'PullRequest'),
+          ne(variables['Build.Reason'], 'Manual')
+          )
 
-      # - task: Yarn@3
-      #   inputs:
-      #     Arguments: 'build'
-      #   displayName: 'yarn build'
+      - task: Yarn@3
+        inputs:
+          Arguments: 'build'
+        displayName: 'yarn build'
 
-      # - script: 'node prepNewReadme.js'
-      #   workingDirectory: '$(System.DefaultWorkingDirectory)\packages\teams-js'
-      #   condition: and(
-      #     startsWith(variables['Build.SourceBranch'], 'refs/tags/v'),
-      #     in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-      #     ne(variables['Build.Reason'], 'PullRequest'),
-      #     ne(variables['Build.Reason'], 'Manual')
-      #     )
-      #   displayName: 'node prepNewReadme.js'
+      - script: 'node prepNewReadme.js'
+        workingDirectory: '$(System.DefaultWorkingDirectory)\packages\teams-js'
+        condition: and(
+          startsWith(variables['Build.SourceBranch'], 'refs/tags/v'),
+          in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
+          ne(variables['Build.Reason'], 'PullRequest'),
+          ne(variables['Build.Reason'], 'Manual')
+          )
+        displayName: 'node prepNewReadme.js'
 
       - task: Yarn@3
         inputs:
@@ -145,96 +145,96 @@ jobs:
           testResultsFiles: '**/unit-tests-report*.xml'
         condition: succeededOrFailed()
 
-      # - task: Yarn@2
-      #   inputs:
-      #     Arguments: 'bundleAnalyze:collect'
-      #   displayName: 'Run bundle analysis and collect'
-      # # Bundle analysis comparison : should trigger only by PR against 2.0-preview
-      # # Adding comment for a commit that should queue the pipeline with a PR trigger
-      # - bash: 'node --max-old-space-size=4096 tools/cli/compareBundleAnalysis.js --commitId=$(System.PullRequest.SourceCommitId) --orgUrl=$(System.CollectionUri) --projectName=$(System.TeamProject) --buildId=$(System.DefinitionId) --bundleArtifactName=$(bundleArtifactName) --baseBranchName=$(System.PullRequest.TargetBranch)'
-      #   env:
-      #     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      #   condition: and(
-      #     in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-      #     eq(variables['Build.Reason'], 'PullRequest'),
-      #     eq(variables['System.PullRequest.TargetBranch'], '2.0-preview'))
-      #   name: bundleAnalysisTask
-      #   displayName: 'Analyze bundles against 2.0-preview and output result'
-      # - task: GitHubComment@0
-      #   condition: and(
-      #     in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-      #     eq(variables['Build.Reason'], 'PullRequest'),
-      #     eq(variables['System.PullRequest.TargetBranch'], '2.0-preview'))
-      #   inputs:
-      #     gitHubConnection: '$(RepoGitHubConnection)'
-      #     repositoryName: '$(Build.Repository.Name)'
-      #     id: '$(System.PullRequest.PullRequestNumber)'
-      #     comment: '$(bundleAnalysisTask.bundleAnalysisComment)'
-      #   displayName: 'Post bundle analysis result as PR comment on GitHub'
-      # - task: PublishBuildArtifacts@1
-      #   condition: and(
-      #     in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-      #     ne(variables['Build.Reason'], 'PullRequest'))
-      #   inputs:
-      #     PathtoPublish: './common/temp/bundleAnalysis'
-      #     ArtifactName: '$(bundleArtifactName)'
-      #   displayName: 'Publish bundle analysis'
-      # - powershell: |
-      #     $npmVer=$(node -p "require('./packages/teams-js/package.json').version")
-      #     Write-Host "##vso[task.setvariable variable=version;isOutput=true]$npmVer"
-      #   name: package
-      #   displayName: 'Set package.version Variable'
-      # - task: CopyFiles@2
-      #   inputs:
-      #     sourceFolder: 'apps/teams-test-app/build'
-      #     contents: '**'
-      #     targetFolder: '$(Build.ArtifactStagingDirectory)\teams-test-app'
-      #   displayName: 'Copy Test app to artifacts staging directory'
-      # - task: ArchiveFiles@2
-      #   inputs:
-      #     rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\teams-test-app'
-      #     includeRootFolder: false
-      #     archiveType: 'zip'
-      #     archiveFile: '$(Build.ArtifactStagingDirectory)\teams-test-app\$(Build.BuildId).zip'
-      #     replaceExistingArchive: true
-      #   displayName: 'Zip Test app artifacts'
-      # - task: PublishBuildArtifacts@1
-      #   inputs:
-      #     PathtoPublish: '$(Build.ArtifactStagingDirectory)\teams-test-app\$(Build.BuildId).zip'
-      #     ArtifactName: 'teams-test-app'
-      #   displayName: 'Publish Test app artifacts'
-      # - task: CopyFiles@2
-      #   inputs:
-      #     sourceFolder: 'packages\teams-js\dist'
-      #     contents: '**\?(*.js|*.ts|*.map)'
-      #     targetFolder: '$(Build.ArtifactStagingDirectory)\CDNFeed\$(package.version)\js'
-      #   displayName: 'Copy TeamsJS Content for CDN'
-      # - task: CopyFiles@2
-      #   inputs:
-      #     Contents: |
-      #       packages\teams-js\package.json
-      #       packages\teams-js\README.md
-      #       LICENSE
-      #     TargetFolder: '$(Build.ArtifactStagingDirectory)\NPMFeed'
-      #     flattenFolders: true
-      #   displayName: 'Copy TeamsJS Content for NPM'
-      # - task: CopyFiles@2
-      #   inputs:
-      #     Contents: |
-      #       packages\teams-js\dist\**\?(*.js|*.ts|*.map)
-      #     TargetFolder: '$(Build.ArtifactStagingDirectory)\NPMFeed\dist'
-      #     flattenFolders: true
-      #   displayName: 'Copy JS Content for NPM'
-      # - task: PublishBuildArtifacts@1
-      #   inputs:
-      #     PathtoPublish: '$(Build.ArtifactStagingDirectory)\CDNFeed'
-      #     ArtifactName: 'CDNFeed'
-      #   displayName: 'Publish CDN feed to build Artifacts'
-      # - task: PublishBuildArtifacts@1
-      #   inputs:
-      #     PathtoPublish: '$(Build.ArtifactStagingDirectory)\NPMFeed'
-      #     ArtifactName: 'NPMFeed'
-      #   displayName: 'Publish NPM feed to Build Artifacts'
+      - task: Yarn@2
+        inputs:
+          Arguments: 'bundleAnalyze:collect'
+        displayName: 'Run bundle analysis and collect'
+      # Bundle analysis comparison : should trigger only by PR against 2.0-preview
+      # Adding comment for a commit that should queue the pipeline with a PR trigger
+      - bash: 'node --max-old-space-size=4096 tools/cli/compareBundleAnalysis.js --commitId=$(System.PullRequest.SourceCommitId) --orgUrl=$(System.CollectionUri) --projectName=$(System.TeamProject) --buildId=$(System.DefinitionId) --bundleArtifactName=$(bundleArtifactName) --baseBranchName=$(System.PullRequest.TargetBranch)'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        condition: and(
+          in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
+          eq(variables['Build.Reason'], 'PullRequest'),
+          eq(variables['System.PullRequest.TargetBranch'], '2.0-preview'))
+        name: bundleAnalysisTask
+        displayName: 'Analyze bundles against 2.0-preview and output result'
+      - task: GitHubComment@0
+        condition: and(
+          in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
+          eq(variables['Build.Reason'], 'PullRequest'),
+          eq(variables['System.PullRequest.TargetBranch'], '2.0-preview'))
+        inputs:
+          gitHubConnection: '$(RepoGitHubConnection)'
+          repositoryName: '$(Build.Repository.Name)'
+          id: '$(System.PullRequest.PullRequestNumber)'
+          comment: '$(bundleAnalysisTask.bundleAnalysisComment)'
+        displayName: 'Post bundle analysis result as PR comment on GitHub'
+      - task: PublishBuildArtifacts@1
+        condition: and(
+          in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
+          ne(variables['Build.Reason'], 'PullRequest'))
+        inputs:
+          PathtoPublish: './common/temp/bundleAnalysis'
+          ArtifactName: '$(bundleArtifactName)'
+        displayName: 'Publish bundle analysis'
+      - powershell: |
+          $npmVer=$(node -p "require('./packages/teams-js/package.json').version")
+          Write-Host "##vso[task.setvariable variable=version;isOutput=true]$npmVer"
+        name: package
+        displayName: 'Set package.version Variable'
+      - task: CopyFiles@2
+        inputs:
+          sourceFolder: 'apps/teams-test-app/build'
+          contents: '**'
+          targetFolder: '$(Build.ArtifactStagingDirectory)\teams-test-app'
+        displayName: 'Copy Test app to artifacts staging directory'
+      - task: ArchiveFiles@2
+        inputs:
+          rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\teams-test-app'
+          includeRootFolder: false
+          archiveType: 'zip'
+          archiveFile: '$(Build.ArtifactStagingDirectory)\teams-test-app\$(Build.BuildId).zip'
+          replaceExistingArchive: true
+        displayName: 'Zip Test app artifacts'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)\teams-test-app\$(Build.BuildId).zip'
+          ArtifactName: 'teams-test-app'
+        displayName: 'Publish Test app artifacts'
+      - task: CopyFiles@2
+        inputs:
+          sourceFolder: 'packages\teams-js\dist'
+          contents: '**\?(*.js|*.ts|*.map)'
+          targetFolder: '$(Build.ArtifactStagingDirectory)\CDNFeed\$(package.version)\js'
+        displayName: 'Copy TeamsJS Content for CDN'
+      - task: CopyFiles@2
+        inputs:
+          Contents: |
+            packages\teams-js\package.json
+            packages\teams-js\README.md
+            LICENSE
+          TargetFolder: '$(Build.ArtifactStagingDirectory)\NPMFeed'
+          flattenFolders: true
+        displayName: 'Copy TeamsJS Content for NPM'
+      - task: CopyFiles@2
+        inputs:
+          Contents: |
+            packages\teams-js\dist\**\?(*.js|*.ts|*.map)
+          TargetFolder: '$(Build.ArtifactStagingDirectory)\NPMFeed\dist'
+          flattenFolders: true
+        displayName: 'Copy JS Content for NPM'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)\CDNFeed'
+          ArtifactName: 'CDNFeed'
+        displayName: 'Publish CDN feed to build Artifacts'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)\NPMFeed'
+          ArtifactName: 'NPMFeed'
+        displayName: 'Publish NPM feed to Build Artifacts'
 
   - job: E2e_Test
     displayName: 'E2e Testing'
@@ -246,18 +246,6 @@ jobs:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
         persistCredentials: true
-
-      - task: Yarn@2
-        displayName: 'Run yarn on app hosting sdk'
-        inputs:
-          Arguments:
-          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: Yarn@2
-        displayName: 'Build app hosting sdk'
-        inputs:
-          Arguments: 'build'
-          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
 
       - task: NodeTool@0
         inputs:
@@ -280,17 +268,17 @@ jobs:
           Arguments: 'build'
           ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
 
-      - task: Yarn@2
-        displayName: 'Run yarn on client sdk'
-        inputs:
-          Arguments:
-          ProjectDirectory: 'microsoft-teams-library-js'
+      # - task: Yarn@2
+      #   displayName: 'Run yarn on client sdk'
+      #   inputs:
+      #     Arguments:
+      #     ProjectDirectory: 'microsoft-teams-library-js'
 
-      - task: Yarn@2
-        displayName: 'Build client sdk'
-        inputs:
-          Arguments: 'build'
-          ProjectDirectory: 'microsoft-teams-library-js'
+      # - task: Yarn@2
+      #   displayName: 'Build client sdk'
+      #   inputs:
+      #     Arguments: 'build'
+      #     ProjectDirectory: 'microsoft-teams-library-js'
 
       - task: CmdLine@2
         displayName: 'Configure host machine'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
 resources:
   repositories:
     - repository: appHostSdkRepo
-      type: AzureRepos
+      type: Git
       source: $(AppHostingSdkGitPath)
 
 trigger:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -297,23 +297,15 @@ jobs:
             sudo yarn setup
           workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
-      - bash: 'node tools/cli/runAppsWithE2ETests.js'
-        displayName: 'Run E2E integration tests'
-        condition: succeeded()
-        workingDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '**/e2e-tests-report*.xml'
-        condition: succeededOrFailed()
-
   - job: E2e_Test
     displayName: 'E2e test'
     dependsOn: E2e_Test_Setup
     pool:
       vmImage: 'ubuntu-latest'
     steps:
+      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+        persistCredentials: true
+
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'
         condition: succeeded()
@@ -331,6 +323,13 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
+      - task: CmdLine@2
+      displayName: 'Configure host machine'
+      inputs:
+        script: |
+          sudo chmod -R 755 ./ 
+          sudo yarn setup
+        workingDirectory: '$(AppHostingSdkProjectDirectory)'
       - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
         displayName: 'Run E2E Perf tests'
         condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,23 @@ jobs:
           GdnBreakGdnToolESLintSeverity: Warning
           GdnBreakPolicy: M365
 
+      - task: ComponentGovernanceComponentDetection@0
+        condition: and(
+          eq(variables['Build.Reason'], 'PullRequest'),
+          eq(variables['System.PullRequest.TargetBranch'], '2.0-preview'))
+        inputs:
+          scanType: 'LogOnly'
+          verbosity: 'Verbose'
+          alertWarningLevel: 'High'
+          failOnAlert: true
+        displayName: 'Component Governance (Pull Request)'
+
+      - task: ComponentGovernanceComponentDetection@0
+        condition: and(
+          or(eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'), startsWith(variables['Build.SourceBranch'], 'refs/tags/v')),
+          ne(variables['Build.Reason'], 'PullRequest'))
+        displayName: 'Component Governance (2.0-preview, release)'
+
   - job: Build
     displayName: 'Build, Test, and Publish Artifacts'
     pool:
@@ -232,19 +249,48 @@ jobs:
           ArtifactName: 'NPMFeed'
         displayName: 'Publish NPM feed to Build Artifacts'
 
-      - task: ComponentGovernanceComponentDetection@0
-        condition: and(
-          eq(variables['Build.Reason'], 'PullRequest'),
-          eq(variables['System.PullRequest.TargetBranch'], '2.0-preview'))
+  - job: E2e Test
+    displayName: 'E2e Testing'
+    dependsOn: Build
+    condition: succeeded()
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+      - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+        persistCredentials: true
+      - task: Yarn@2
+        displayName: 'Run yarn on app hosting sdk'
         inputs:
-          scanType: 'LogOnly'
-          verbosity: 'Verbose'
-          alertWarningLevel: 'High'
-          failOnAlert: true
-        displayName: 'Component Governance (Pull Request)'
+          Arguments:
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
 
-      - task: ComponentGovernanceComponentDetection@0
-        condition: and(
-          or(eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'), startsWith(variables['Build.SourceBranch'], 'refs/tags/v')),
-          ne(variables['Build.Reason'], 'PullRequest'))
-        displayName: 'Component Governance (2.0-preview, release)'
+      - task: Yarn@2
+        displayName: 'Build app hosting sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: CmdLine@2
+        displayName: 'Configure host machine'
+        inputs:
+          script: |
+            sudo chmod -R 755 ./ 
+            sudo yarn setup
+          workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - bash: 'node tools/cli/runAppsWithE2ETests.js'
+        displayName: 'Run E2E integration tests'
+        condition: succeeded()
+        workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
+        displayName: 'Run E2E Perf tests'
+        condition: succeeded()
+        workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '**/e2e-tests-report*.xml'
+        condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -247,8 +247,8 @@ jobs:
           ArtifactName: 'NPMFeed'
         displayName: 'Publish NPM feed to Build Artifacts'
 
-  - job: E2e_Test
-    displayName: 'E2e Testing'
+  - job: E2e_Test_Setup
+    displayName: 'E2e Testing Setup'
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -297,13 +297,11 @@ jobs:
             sudo yarn setup
           workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
+  - job: E2e_Test
+    displayName: 'E2e test'
+    dependsOn: E2e_Test_Setup
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'
-        condition: succeeded()
-        workingDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
-        displayName: 'Run E2E Perf tests'
         condition: succeeded()
         workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
@@ -313,6 +311,17 @@ jobs:
           testResultsFiles: '**/e2e-tests-report*.xml'
         condition: succeededOrFailed()
 
+  - job: E2e_Performance_Test
+    displayName: 'E2e performance test'
+    dependsOn: E2e_Test_Setup
+      - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
+        displayName: 'Run E2E Perf tests'
+        condition: succeeded()
+        workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+  - job: E2e_Test_Local_Script_Tag
+    displayName: 'E2e test with local script tag'
+    dependsOn: E2e_Test_Setup
       - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
         displayName: 'Run E2E integration tests with local script tag'
         condition: succeeded()
@@ -321,5 +330,5 @@ jobs:
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: 'JUnit'
-          testResultsFiles: '**/e2e-tests-report-local-script-tag*.xml'
+          testResultsFiles: '**/e2e-tests-report*.xml'
         condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -254,7 +254,7 @@ jobs:
     dependsOn: Build
     condition: succeeded()
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'ubuntu-latest'
     steps:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -411,6 +411,14 @@ jobs:
           Arguments: 'build'
           ProjectDirectory: 'microsoft-teams-library-js'
 
+      - task: CmdLine@2
+        displayName: 'Configure host machine'
+        inputs:
+          script: |
+            sudo chmod -R 755 ./ 
+            sudo yarn setup
+          workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
       - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
         displayName: 'Run E2E integration tests with local script tag'
         condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ resources:
   repositories:
     - repository: appHostSdkRepo
       type: git
-      name: ${{AppHostingSdkProjectDirectory}}
+      name: ${AppHostingSdkProjectDirectory}
 
 trigger:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -254,8 +254,8 @@ jobs:
     steps:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-        persistCredentials: true
-
+      persistCredentials: false
+      
       - task: NodeTool@0
         inputs:
           versionSpec: '14.x'
@@ -315,8 +315,8 @@ jobs:
     steps:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-        persistCredentials: true
-
+      persistCredentials: false
+      
       - task: NodeTool@0
         inputs:
           versionSpec: '14.x'
@@ -376,7 +376,7 @@ jobs:
     steps:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-        persistCredentials: true
+        persistCredentials: false
 
       - task: NodeTool@0
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -254,8 +254,8 @@ jobs:
     steps:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-      persistCredentials: false
-      
+        persistCredentials: false
+
       - task: NodeTool@0
         inputs:
           versionSpec: '14.x'
@@ -315,8 +315,8 @@ jobs:
     steps:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-      persistCredentials: false
-      
+        persistCredentials: false
+
       - task: NodeTool@0
         inputs:
           versionSpec: '14.x'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,11 +5,11 @@
 variables:
   - group: InfoSec-SecurityResults
 
-resources:
-  repositories:
-    - repository: appHostSdkRepo
-      type: git
-      name: '$(AppHostingSdkProjectDirectory)'
+# resources:
+#   repositories:
+#     - repository: appHostSdkRepo
+#       type: git
+#       name: '$(AppHostingSdkProjectDirectory)'
 
 trigger:
   branches:
@@ -309,98 +309,100 @@ jobs:
           testResultsFormat: 'JUnit'
           testResultsFiles: '**/e2e-tests-report*.xml'
         condition: succeededOrFailed()
-  # - job: E2e_Performance_Test
-  #   displayName: 'E2e performance test'
-  #   pool:
-  #     vmImage: 'ubuntu-latest'
-  #   steps:
-  #     - checkout: self
-  #     - checkout: git://$(AppHostingSdkGitPath)@$refs/heads/main
-  #       persistCredentials: false
-  #     - task: NodeTool@0
-  #       inputs:
-  #         versionSpec: '14.x'
-  #       displayName: 'Install Node.js'
-  #     - task: YarnInstaller@3
-  #       inputs:
-  #         versionSpec: '1.x'
-  #     - task: Yarn@2
-  #       displayName: 'Run yarn on app hosting sdk'
-  #       inputs:
-  #         Arguments:
-  #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-  #     - task: Yarn@2
-  #       displayName: 'Build app hosting sdk'
-  #       inputs:
-  #         Arguments: 'build'
-  #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-  #     - task: Yarn@2
-  #       displayName: 'Run yarn on client sdk'
-  #       inputs:
-  #         Arguments:
-  #         ProjectDirectory: 'microsoft-teams-library-js'
-  #     - task: Yarn@2
-  #       displayName: 'Build client sdk'
-  #       inputs:
-  #         Arguments: 'build'
-  #         ProjectDirectory: 'microsoft-teams-library-js'
-  #     - task: CmdLine@2
-  #       displayName: 'Configure host machine'
-  #       inputs:
-  #         script: |
-  #           sudo chmod -R 755 ./
-  #           sudo yarn setup
-  #         workingDirectory: '$(AppHostingSdkProjectDirectory)'
-  #     - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
-  #       displayName: 'Run E2E Perf tests'
-  #       condition: succeeded()
-  #       workingDirectory: '$(AppHostingSdkProjectDirectory)'
-  #     - task: PublishTestResults@2
-  #       inputs:
-  #         testResultsFormat: 'JUnit'
-  #         testResultsFiles: '**/e2e-tests-report*.xml'
-  #       condition: succeededOrFailed()
-  # - job: E2e_Test_Local_Script_Tag
-  #   displayName: 'E2e test with local script tag'
-  #   pool:
-  #     vmImage: 'ubuntu-latest'
-  #   steps:
-  #     - checkout: self
-  #     - checkout: git://$(AppHostingSdkGitPath)@refs/heads/main
-  #       persistCredentials: false
-  #     - task: NodeTool@0
-  #       inputs:
-  #         versionSpec: '14.x'
-  #       displayName: 'Install Node.js'
-  #     - task: YarnInstaller@3
-  #       inputs:
-  #         versionSpec: '1.x'
-  #     - task: Yarn@2
-  #       displayName: 'Run yarn on app hosting sdk'
-  #       inputs:
-  #         Arguments:
-  #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-  #     - task: Yarn@2
-  #       displayName: 'Build app hosting sdk'
-  #       inputs:
-  #         Arguments: 'build'
-  #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-  #     - task: Yarn@2
-  #       displayName: 'Run yarn on client sdk'
-  #       inputs:
-  #         Arguments:
-  #         ProjectDirectory: 'microsoft-teams-library-js'
-  #     - task: Yarn@2
-  #       displayName: 'Build client sdk'
-  #       inputs:
-  #         Arguments: 'build'
-  #         ProjectDirectory: 'microsoft-teams-library-js'
-  #     - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
-  #       displayName: 'Run E2E integration tests with local script tag'
-  #       condition: succeeded()
-  #       workingDirectory: '$(AppHostingSdkProjectDirectory)'
-  #     - task: PublishTestResults@2
-  #       inputs:
-  #         testResultsFormat: 'JUnit'
-  #         testResultsFiles: '**/e2e-tests-report*.xml'
-  #       condition: succeededOrFailed()
+      # - job: E2e_Performance_Test
+      #   displayName: 'E2e performance test'
+      #   pool:
+      #     vmImage: 'ubuntu-latest'
+      #   steps:
+      #     - checkout: self
+      #     - checkout: git://$(AppHostingSdkGitPath)@$refs/heads/main
+      #       persistCredentials: false
+      #     - task: NodeTool@0
+      #       inputs:
+      #         versionSpec: '14.x'
+      #       displayName: 'Install Node.js'
+      #     - task: YarnInstaller@3
+      #       inputs:
+      #         versionSpec: '1.x'
+      #     - task: Yarn@2
+      #       displayName: 'Run yarn on app hosting sdk'
+      #       inputs:
+      #         Arguments:
+      #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+      #     - task: Yarn@2
+      #       displayName: 'Build app hosting sdk'
+      #       inputs:
+      #         Arguments: 'build'
+      #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+      #     - task: Yarn@2
+      #       displayName: 'Run yarn on client sdk'
+      #       inputs:
+      #         Arguments:
+      #         ProjectDirectory: 'microsoft-teams-library-js'
+      #     - task: Yarn@2
+      #       displayName: 'Build client sdk'
+      #       inputs:
+      #         Arguments: 'build'
+      #         ProjectDirectory: 'microsoft-teams-library-js'
+      #     - task: CmdLine@2
+      #       displayName: 'Configure host machine'
+      #       inputs:
+      #         script: |
+      #           sudo chmod -R 755 ./
+      #           sudo yarn setup
+      #         workingDirectory: '$(AppHostingSdkProjectDirectory)'
+      - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
+        displayName: 'Run E2E Perf tests'
+        condition: succeeded()
+        workingDirectory: '$(AppHostingSdkProjectDirectory)'
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '**/e2e-tests-report*.xml'
+        condition: succeededOrFailed()
+      # - job: E2e_Test_Local_Script_Tag
+      #   displayName: 'E2e test with local script tag'
+      #   pool:
+      #     vmImage: 'ubuntu-latest'
+      #   steps:
+      #     - checkout: self
+      #     - checkout: git://$(AppHostingSdkGitPath)@refs/heads/main
+      #       persistCredentials: false
+      #     - task: NodeTool@0
+      #       inputs:
+      #         versionSpec: '14.x'
+      #       displayName: 'Install Node.js'
+      #     - task: YarnInstaller@3
+      #       inputs:
+      #         versionSpec: '1.x'
+      #     - task: Yarn@2
+      #       displayName: 'Run yarn on app hosting sdk'
+      #       inputs:
+      #         Arguments:
+      #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+      #     - task: Yarn@2
+      #       displayName: 'Build app hosting sdk'
+      #       inputs:
+      #         Arguments: 'build'
+      #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+      #     - task: Yarn@2
+      #       displayName: 'Run yarn on client sdk'
+      #       inputs:
+      #         Arguments:
+      #         ProjectDirectory: 'microsoft-teams-library-js'
+      #     - task: Yarn@2
+      #       displayName: 'Build client sdk'
+      #       inputs:
+      #         Arguments: 'build'
+      #         ProjectDirectory: 'microsoft-teams-library-js'
+
+      - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
+        displayName: 'Run E2E integration tests with local script tag'
+        condition: succeeded()
+        workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '**/e2e-tests-report*.xml'
+        condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -253,7 +253,7 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+      - checkout: git://$(AppHostingSdkGitPath)@refs/heads/main
         persistCredentials: false
 
       - task: NodeTool@0
@@ -314,7 +314,7 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+      - checkout: git://$(AppHostingSdkGitPath)@$refs/heads/main
         persistCredentials: false
 
       - task: NodeTool@0
@@ -375,7 +375,7 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+      - checkout: git://$(AppHostingSdkGitPath)@refs/heads/main
         persistCredentials: false
 
       - task: NodeTool@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -258,6 +258,10 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
+      - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+        persistCredentials: true
+
       - task: NodeTool@0
         inputs:
           versionSpec: '14.x'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -434,7 +434,7 @@ jobs:
     displayName: 'E2e test TeamsJS V1'
     pool:
       vmImage: 'ubuntu-latest'
-    
+
     steps:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath4)@$(AppHostingSdkGitRef)
@@ -474,10 +474,10 @@ jobs:
           ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
       - task: Yarn@2
-      displayName: 'Build Teams Test App V1'
-      inputs:
-        Arguments: 'build-test-app-V1'
-        ProjectDirectory: '$(ClientSdkProjectDirectory)'
+        displayName: 'Build Teams Test App V1'
+        inputs:
+          Arguments: 'build-test-app-V1'
+          ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
       - task: CmdLine@2
         displayName: 'Configure host machine'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -412,6 +412,12 @@ jobs:
           Arguments: 'build'
           ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
+      - task: Yarn@2
+        displayName: 'Build Test App Local'
+        inputs:
+          Arguments: 'build-test-app-local'
+          ProjectDirectory: '$(ClientSdkProjectDirectory)'
+
       - task: CmdLine@2
         displayName: 'Configure host machine'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -249,8 +249,6 @@ jobs:
 
   - job: E2e_Test
     displayName: 'E2e Testing'
-    dependsOn: Build
-    condition: succeeded()
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -313,4 +311,15 @@ jobs:
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: '**/e2e-tests-report*.xml'
+        condition: succeededOrFailed()
+
+      - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
+        displayName: 'Run E2E integration tests with local script tag'
+        condition: succeeded()
+        workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '**/e2e-tests-report-local-script-tag*.xml'
         condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -300,11 +300,9 @@ jobs:
   - job: E2e_Test
     displayName: 'E2e test'
     dependsOn: E2e_Test_Setup
+    pool:
+      vmImage: 'ubuntu-latest'
     steps:
-      - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-        persistCredentials: true
-
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'
         condition: succeeded()
@@ -319,11 +317,9 @@ jobs:
   - job: E2e_Performance_Test
     displayName: 'E2e performance test'
     dependsOn: E2e_Test_Setup
+    pool:
+      vmImage: 'ubuntu-latest'
     steps:
-      - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-        persistCredentials: true
-
       - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
         displayName: 'Run E2E Perf tests'
         condition: succeeded()
@@ -332,11 +328,9 @@ jobs:
   - job: E2e_Test_Local_Script_Tag
     displayName: 'E2e test with local script tag'
     dependsOn: E2e_Test_Setup
+    pool:
+      vmImage: 'ubuntu-latest'
     steps:
-      - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-        persistCredentials: true
-
       - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
         displayName: 'Run E2E integration tests with local script tag'
         condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,7 @@ resources:
   repositories:
     - repository: appHostSdkRepo
       type: git
-      name: $(AppHostingSdkProjectDirectory)
-      endpoint: $(RepoGitHubConnection)
+      name: '$(AppHostingSdkProjectDirectory)'
 
 trigger:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -304,6 +304,7 @@ jobs:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
         persistCredentials: true
+
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'
         condition: succeeded()
@@ -322,6 +323,7 @@ jobs:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
         persistCredentials: true
+
       - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
         displayName: 'Run E2E Perf tests'
         condition: succeeded()
@@ -334,6 +336,7 @@ jobs:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
         persistCredentials: true
+
       - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
         displayName: 'Run E2E integration tests with local script tag'
         condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -281,13 +281,13 @@ jobs:
         displayName: 'Run yarn on client sdk'
         inputs:
           Arguments:
-          ProjectDirectory: 'microsoft-teams-library-js'
+          ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
       - task: Yarn@2
         displayName: 'Build client sdk'
         inputs:
           Arguments: 'build'
-          ProjectDirectory: 'microsoft-teams-library-js'
+          ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
       - task: CmdLine@2
         displayName: 'Configure host machine'
@@ -342,13 +342,13 @@ jobs:
         displayName: 'Run yarn on client sdk'
         inputs:
           Arguments:
-          ProjectDirectory: 'microsoft-teams-library-js'
+          ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
       - task: Yarn@2
         displayName: 'Build client sdk'
         inputs:
           Arguments: 'build'
-          ProjectDirectory: 'microsoft-teams-library-js'
+          ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
       - task: CmdLine@2
         displayName: 'Configure host machine'
@@ -403,13 +403,13 @@ jobs:
         displayName: 'Run yarn on client sdk'
         inputs:
           Arguments:
-          ProjectDirectory: 'microsoft-teams-library-js'
+          ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
       - task: Yarn@2
         displayName: 'Build client sdk'
         inputs:
           Arguments: 'build'
-          ProjectDirectory: 'microsoft-teams-library-js'
+          ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
       - task: CmdLine@2
         displayName: 'Configure host machine'
@@ -419,8 +419,76 @@ jobs:
             sudo yarn setup
           workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
-      - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
+      - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4003 --reportFileName=e2e-tests-report-local-script-tag --envType=--envType=localScriptTag'
         displayName: 'Run E2E integration tests with local script tag'
+        condition: succeeded()
+        workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '**/e2e-tests-report*.xml'
+        condition: succeededOrFailed()
+
+  - job: E2e_Test_TeamsV1
+    displayName: 'E2e test TeamsJS V1'
+    pool:
+      vmImage: 'ubuntu-latest'
+    
+    steps:
+      - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath4)@$(AppHostingSdkGitRef)
+        persistCredentials: true
+
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '14.x'
+        displayName: 'Install Node.js'
+
+      - task: YarnInstaller@3
+        inputs:
+          versionSpec: '1.x'
+
+      - task: Yarn@2
+        displayName: 'Run yarn on app hosting sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: Yarn@2
+        displayName: 'Build app hosting sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: Yarn@2
+        displayName: 'Run yarn on client sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: '$(ClientSdkProjectDirectory)'
+
+      - task: Yarn@2
+        displayName: 'Build client sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: '$(ClientSdkProjectDirectory)'
+
+      - task: Yarn@2
+      displayName: 'Build Teams Test App V1'
+      inputs:
+        Arguments: 'build-test-app-V1'
+        ProjectDirectory: '$(ClientSdkProjectDirectory)'
+
+      - task: CmdLine@2
+        displayName: 'Configure host machine'
+        inputs:
+          script: |
+            sudo chmod -R 755 ./ 
+            sudo yarn setup
+          workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4004 --reportFileName=e2e-tests-report-V1 --envType=--envType=teamsV1'
+        displayName: 'Run E2E integration tests on Teams Test App V1'
         condition: succeeded()
         workingDirectory: '$(AppHostingSdkProjectDirectory)'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -247,8 +247,8 @@ jobs:
           ArtifactName: 'NPMFeed'
         displayName: 'Publish NPM feed to Build Artifacts'
 
-  - job: E2e_Test_Setup
-    displayName: 'E2e Testing Setup'
+  - job: E2e_Test
+    displayName: 'E2e test'
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -289,14 +289,6 @@ jobs:
           Arguments: 'build'
           ProjectDirectory: 'microsoft-teams-library-js'
 
-  - job: E2e_Test
-    displayName: 'E2e test'
-    dependsOn: E2e_Test_Setup
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-
       - task: CmdLine@2
         displayName: 'Configure host machine'
         inputs:
@@ -318,10 +310,46 @@ jobs:
 
   - job: E2e_Performance_Test
     displayName: 'E2e performance test'
-    dependsOn: E2e_Test_Setup
     pool:
       vmImage: 'ubuntu-latest'
     steps:
+      - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+        persistCredentials: true
+
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '14.x'
+        displayName: 'Install Node.js'
+
+      - task: YarnInstaller@3
+        inputs:
+          versionSpec: '1.x'
+
+      - task: Yarn@2
+        displayName: 'Run yarn on app hosting sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: Yarn@2
+        displayName: 'Build app hosting sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: Yarn@2
+        displayName: 'Run yarn on client sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: 'microsoft-teams-library-js'
+
+      - task: Yarn@2
+        displayName: 'Build client sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: 'microsoft-teams-library-js'
+
       - task: CmdLine@2
         displayName: 'Configure host machine'
         inputs:
@@ -329,17 +357,60 @@ jobs:
             sudo chmod -R 755 ./ 
             sudo yarn setup
           workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
       - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
         displayName: 'Run E2E Perf tests'
         condition: succeeded()
         workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '**/e2e-tests-report*.xml'
+        condition: succeededOrFailed()
+
   - job: E2e_Test_Local_Script_Tag
     displayName: 'E2e test with local script tag'
-    dependsOn: E2e_Test_Setup
     pool:
       vmImage: 'ubuntu-latest'
     steps:
+      - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+        persistCredentials: true
+
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '14.x'
+        displayName: 'Install Node.js'
+
+      - task: YarnInstaller@3
+        inputs:
+          versionSpec: '1.x'
+
+      - task: Yarn@2
+        displayName: 'Run yarn on app hosting sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: Yarn@2
+        displayName: 'Build app hosting sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: Yarn@2
+        displayName: 'Run yarn on client sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: 'microsoft-teams-library-js'
+
+      - task: Yarn@2
+        displayName: 'Build client sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: 'microsoft-teams-library-js'
+
       - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
         displayName: 'Run E2E integration tests with local script tag'
         condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ resources:
   repositories:
     - repository: appHostSdkRepo
       type: git
-      name: $(AppHostingSdkProjectDirectory)
+      name: ${{AppHostingSdkProjectDirectory}}
 
 trigger:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -300,6 +300,10 @@ jobs:
   - job: E2e_Test
     displayName: 'E2e test'
     dependsOn: E2e_Test_Setup
+    - checkout: self
+    - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+      persistCredentials: true
+
     steps:
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'
@@ -315,6 +319,10 @@ jobs:
   - job: E2e_Performance_Test
     displayName: 'E2e performance test'
     dependsOn: E2e_Test_Setup
+    - checkout: self
+    - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+      persistCredentials: true
+
     steps:
       - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
         displayName: 'Run E2E Perf tests'
@@ -324,6 +332,10 @@ jobs:
   - job: E2e_Test_Local_Script_Tag
     displayName: 'E2e test with local script tag'
     dependsOn: E2e_Test_Setup
+    - checkout: self
+    - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+      persistCredentials: true
+
     steps:
       - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
         displayName: 'Run E2E integration tests with local script tag'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -300,6 +300,7 @@ jobs:
   - job: E2e_Test
     displayName: 'E2e test'
     dependsOn: E2e_Test_Setup
+    steps:
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'
         condition: succeeded()
@@ -314,6 +315,7 @@ jobs:
   - job: E2e_Performance_Test
     displayName: 'E2e performance test'
     dependsOn: E2e_Test_Setup
+    steps:
       - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
         displayName: 'Run E2E Perf tests'
         condition: succeeded()
@@ -322,6 +324,7 @@ jobs:
   - job: E2e_Test_Local_Script_Tag
     displayName: 'E2e test with local script tag'
     dependsOn: E2e_Test_Setup
+    steps:
       - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
         displayName: 'Run E2E integration tests with local script tag'
         condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,12 @@
 variables:
   - group: InfoSec-SecurityResults
 
+resources:
+  repositories:
+    - repository: appHostSdkRepo
+      type: AzureRepos
+      source: $(AppHostingSdkGitPath)
+
 trigger:
   branches:
     include:
@@ -252,10 +258,6 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-      - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@$refs/heads/main
-        persistCredentials: false
-
       - task: NodeTool@0
         inputs:
           versionSpec: '14.x'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -289,6 +289,14 @@ jobs:
           Arguments: 'build'
           ProjectDirectory: 'microsoft-teams-library-js'
 
+  - job: E2e_Test
+    displayName: 'E2e test'
+    dependsOn: E2e_Test_Setup
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+
       - task: CmdLine@2
         displayName: 'Configure host machine'
         inputs:
@@ -296,15 +304,6 @@ jobs:
             sudo chmod -R 755 ./ 
             sudo yarn setup
           workingDirectory: '$(AppHostingSdkProjectDirectory)'
-
-  - job: E2e_Test
-    displayName: 'E2e test'
-    dependsOn: E2e_Test_Setup
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
 
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -303,9 +303,6 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-        persistCredentials: true
-
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'
         condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -253,8 +253,8 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@refs/heads/main
-        persistCredentials: false
+      - script: mkdir appHostSdk && cd appHostSdk && git clone $(AppHostingSdkGitCloneAddr) --branch main
+        workingDirectory: $(Agent.BuildDirectory)
 
       - task: NodeTool@0
         inputs:
@@ -307,117 +307,98 @@ jobs:
           testResultsFormat: 'JUnit'
           testResultsFiles: '**/e2e-tests-report*.xml'
         condition: succeededOrFailed()
-
-  - job: E2e_Performance_Test
-    displayName: 'E2e performance test'
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@$refs/heads/main
-        persistCredentials: false
-
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '14.x'
-        displayName: 'Install Node.js'
-
-      - task: YarnInstaller@3
-        inputs:
-          versionSpec: '1.x'
-
-      - task: Yarn@2
-        displayName: 'Run yarn on app hosting sdk'
-        inputs:
-          Arguments:
-          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: Yarn@2
-        displayName: 'Build app hosting sdk'
-        inputs:
-          Arguments: 'build'
-          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: Yarn@2
-        displayName: 'Run yarn on client sdk'
-        inputs:
-          Arguments:
-          ProjectDirectory: 'microsoft-teams-library-js'
-
-      - task: Yarn@2
-        displayName: 'Build client sdk'
-        inputs:
-          Arguments: 'build'
-          ProjectDirectory: 'microsoft-teams-library-js'
-
-      - task: CmdLine@2
-        displayName: 'Configure host machine'
-        inputs:
-          script: |
-            sudo chmod -R 755 ./ 
-            sudo yarn setup
-          workingDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
-        displayName: 'Run E2E Perf tests'
-        condition: succeeded()
-        workingDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '**/e2e-tests-report*.xml'
-        condition: succeededOrFailed()
-
-  - job: E2e_Test_Local_Script_Tag
-    displayName: 'E2e test with local script tag'
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@refs/heads/main
-        persistCredentials: false
-
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '14.x'
-        displayName: 'Install Node.js'
-
-      - task: YarnInstaller@3
-        inputs:
-          versionSpec: '1.x'
-
-      - task: Yarn@2
-        displayName: 'Run yarn on app hosting sdk'
-        inputs:
-          Arguments:
-          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: Yarn@2
-        displayName: 'Build app hosting sdk'
-        inputs:
-          Arguments: 'build'
-          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: Yarn@2
-        displayName: 'Run yarn on client sdk'
-        inputs:
-          Arguments:
-          ProjectDirectory: 'microsoft-teams-library-js'
-
-      - task: Yarn@2
-        displayName: 'Build client sdk'
-        inputs:
-          Arguments: 'build'
-          ProjectDirectory: 'microsoft-teams-library-js'
-
-      - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
-        displayName: 'Run E2E integration tests with local script tag'
-        condition: succeeded()
-        workingDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '**/e2e-tests-report*.xml'
-        condition: succeededOrFailed()
+  # - job: E2e_Performance_Test
+  #   displayName: 'E2e performance test'
+  #   pool:
+  #     vmImage: 'ubuntu-latest'
+  #   steps:
+  #     - checkout: self
+  #     - checkout: git://$(AppHostingSdkGitPath)@$refs/heads/main
+  #       persistCredentials: false
+  #     - task: NodeTool@0
+  #       inputs:
+  #         versionSpec: '14.x'
+  #       displayName: 'Install Node.js'
+  #     - task: YarnInstaller@3
+  #       inputs:
+  #         versionSpec: '1.x'
+  #     - task: Yarn@2
+  #       displayName: 'Run yarn on app hosting sdk'
+  #       inputs:
+  #         Arguments:
+  #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+  #     - task: Yarn@2
+  #       displayName: 'Build app hosting sdk'
+  #       inputs:
+  #         Arguments: 'build'
+  #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+  #     - task: Yarn@2
+  #       displayName: 'Run yarn on client sdk'
+  #       inputs:
+  #         Arguments:
+  #         ProjectDirectory: 'microsoft-teams-library-js'
+  #     - task: Yarn@2
+  #       displayName: 'Build client sdk'
+  #       inputs:
+  #         Arguments: 'build'
+  #         ProjectDirectory: 'microsoft-teams-library-js'
+  #     - task: CmdLine@2
+  #       displayName: 'Configure host machine'
+  #       inputs:
+  #         script: |
+  #           sudo chmod -R 755 ./
+  #           sudo yarn setup
+  #         workingDirectory: '$(AppHostingSdkProjectDirectory)'
+  #     - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
+  #       displayName: 'Run E2E Perf tests'
+  #       condition: succeeded()
+  #       workingDirectory: '$(AppHostingSdkProjectDirectory)'
+  #     - task: PublishTestResults@2
+  #       inputs:
+  #         testResultsFormat: 'JUnit'
+  #         testResultsFiles: '**/e2e-tests-report*.xml'
+  #       condition: succeededOrFailed()
+  # - job: E2e_Test_Local_Script_Tag
+  #   displayName: 'E2e test with local script tag'
+  #   pool:
+  #     vmImage: 'ubuntu-latest'
+  #   steps:
+  #     - checkout: self
+  #     - checkout: git://$(AppHostingSdkGitPath)@refs/heads/main
+  #       persistCredentials: false
+  #     - task: NodeTool@0
+  #       inputs:
+  #         versionSpec: '14.x'
+  #       displayName: 'Install Node.js'
+  #     - task: YarnInstaller@3
+  #       inputs:
+  #         versionSpec: '1.x'
+  #     - task: Yarn@2
+  #       displayName: 'Run yarn on app hosting sdk'
+  #       inputs:
+  #         Arguments:
+  #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+  #     - task: Yarn@2
+  #       displayName: 'Build app hosting sdk'
+  #       inputs:
+  #         Arguments: 'build'
+  #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+  #     - task: Yarn@2
+  #       displayName: 'Run yarn on client sdk'
+  #       inputs:
+  #         Arguments:
+  #         ProjectDirectory: 'microsoft-teams-library-js'
+  #     - task: Yarn@2
+  #       displayName: 'Build client sdk'
+  #       inputs:
+  #         Arguments: 'build'
+  #         ProjectDirectory: 'microsoft-teams-library-js'
+  #     - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
+  #       displayName: 'Run E2E integration tests with local script tag'
+  #       condition: succeeded()
+  #       workingDirectory: '$(AppHostingSdkProjectDirectory)'
+  #     - task: PublishTestResults@2
+  #       inputs:
+  #         testResultsFormat: 'JUnit'
+  #         testResultsFiles: '**/e2e-tests-report*.xml'
+  #       condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,7 @@ resources:
   repositories:
     - repository: appHostSdkRepo
       type: git
-      name: $(AppHostingSdkProjectDirectory)
-      source: $(AppHostingSdkGitPath)
+      name: $(AppHostingSdkGitPath)
 
 trigger:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,8 @@ variables:
 resources:
   repositories:
     - repository: appHostSdkRepo
-      type: Git
+      type: git
+      name: $(AppHostingSdkProjectDirectory)
       source: $(AppHostingSdkGitPath)
 
 trigger:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,8 @@ resources:
   repositories:
     - repository: appHostSdkRepo
       type: git
-      name: ${AppHostingSdkProjectDirectory}
+      name: $(AppHostingSdkProjectDirectory)
+      endpoint: $(RepoGitHubConnection)
 
 trigger:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -300,11 +300,10 @@ jobs:
   - job: E2e_Test
     displayName: 'E2e test'
     dependsOn: E2e_Test_Setup
-    - checkout: self
-    - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-      persistCredentials: true
-
     steps:
+      - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+        persistCredentials: true
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'
         condition: succeeded()
@@ -319,11 +318,10 @@ jobs:
   - job: E2e_Performance_Test
     displayName: 'E2e performance test'
     dependsOn: E2e_Test_Setup
-    - checkout: self
-    - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-      persistCredentials: true
-
     steps:
+      - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+        persistCredentials: true
       - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
         displayName: 'Run E2E Perf tests'
         condition: succeeded()
@@ -332,11 +330,10 @@ jobs:
   - job: E2e_Test_Local_Script_Tag
     displayName: 'E2e test with local script tag'
     dependsOn: E2e_Test_Setup
-    - checkout: self
-    - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-      persistCredentials: true
-
     steps:
+      - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+        persistCredentials: true
       - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
         displayName: 'Run E2E integration tests with local script tag'
         condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,11 @@ trigger:
     include:
       - 'v*'
 
+steps:
+  - checkout: self
+  - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+    persistCredentials: true
+
 jobs:
   - job: Security
     displayName: 'Security Tasks'
@@ -252,10 +257,6 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-      - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
-        persistCredentials: true
-
       - task: NodeTool@0
         inputs:
           versionSpec: '14.x'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ resources:
   repositories:
     - repository: appHostSdkRepo
       type: git
-      name: $(AppHostingSdkGitPath)
+      name: $(AppHostingSdkProjectDirectory)
 
 trigger:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
   - job: Build
     displayName: 'Build, Test, and Publish Artifacts'
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: 'windows-latest'
     steps:
       - task: YarnInstaller@3
         displayName: 'Yarn 1.x'
@@ -160,6 +160,7 @@ jobs:
           eq(variables['System.PullRequest.TargetBranch'], '2.0-preview'))
         name: bundleAnalysisTask
         displayName: 'Analyze bundles against 2.0-preview and output result'
+
       - task: GitHubComment@0
         condition: and(
           in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
@@ -171,6 +172,7 @@ jobs:
           id: '$(System.PullRequest.PullRequestNumber)'
           comment: '$(bundleAnalysisTask.bundleAnalysisComment)'
         displayName: 'Post bundle analysis result as PR comment on GitHub'
+
       - task: PublishBuildArtifacts@1
         condition: and(
           in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
@@ -179,17 +181,20 @@ jobs:
           PathtoPublish: './common/temp/bundleAnalysis'
           ArtifactName: '$(bundleArtifactName)'
         displayName: 'Publish bundle analysis'
+
       - powershell: |
           $npmVer=$(node -p "require('./packages/teams-js/package.json').version")
           Write-Host "##vso[task.setvariable variable=version;isOutput=true]$npmVer"
         name: package
         displayName: 'Set package.version Variable'
+
       - task: CopyFiles@2
         inputs:
           sourceFolder: 'apps/teams-test-app/build'
           contents: '**'
           targetFolder: '$(Build.ArtifactStagingDirectory)\teams-test-app'
         displayName: 'Copy Test app to artifacts staging directory'
+
       - task: ArchiveFiles@2
         inputs:
           rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\teams-test-app'
@@ -198,17 +203,20 @@ jobs:
           archiveFile: '$(Build.ArtifactStagingDirectory)\teams-test-app\$(Build.BuildId).zip'
           replaceExistingArchive: true
         displayName: 'Zip Test app artifacts'
+
       - task: PublishBuildArtifacts@1
         inputs:
           PathtoPublish: '$(Build.ArtifactStagingDirectory)\teams-test-app\$(Build.BuildId).zip'
           ArtifactName: 'teams-test-app'
         displayName: 'Publish Test app artifacts'
+
       - task: CopyFiles@2
         inputs:
           sourceFolder: 'packages\teams-js\dist'
           contents: '**\?(*.js|*.ts|*.map)'
           targetFolder: '$(Build.ArtifactStagingDirectory)\CDNFeed\$(package.version)\js'
         displayName: 'Copy TeamsJS Content for CDN'
+
       - task: CopyFiles@2
         inputs:
           Contents: |
@@ -218,6 +226,7 @@ jobs:
           TargetFolder: '$(Build.ArtifactStagingDirectory)\NPMFeed'
           flattenFolders: true
         displayName: 'Copy TeamsJS Content for NPM'
+
       - task: CopyFiles@2
         inputs:
           Contents: |
@@ -225,11 +234,13 @@ jobs:
           TargetFolder: '$(Build.ArtifactStagingDirectory)\NPMFeed\dist'
           flattenFolders: true
         displayName: 'Copy JS Content for NPM'
+
       - task: PublishBuildArtifacts@1
         inputs:
           PathtoPublish: '$(Build.ArtifactStagingDirectory)\CDNFeed'
           ArtifactName: 'CDNFeed'
         displayName: 'Publish CDN feed to build Artifacts'
+
       - task: PublishBuildArtifacts@1
         inputs:
           PathtoPublish: '$(Build.ArtifactStagingDirectory)\NPMFeed'
@@ -268,17 +279,17 @@ jobs:
           Arguments: 'build'
           ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
 
-      # - task: Yarn@2
-      #   displayName: 'Run yarn on client sdk'
-      #   inputs:
-      #     Arguments:
-      #     ProjectDirectory: 'microsoft-teams-library-js'
+      - task: Yarn@2
+        displayName: 'Run yarn on client sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: 'microsoft-teams-library-js'
 
-      # - task: Yarn@2
-      #   displayName: 'Build client sdk'
-      #   inputs:
-      #     Arguments: 'build'
-      #     ProjectDirectory: 'microsoft-teams-library-js'
+      - task: Yarn@2
+        displayName: 'Build client sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: 'microsoft-teams-library-js'
 
       - task: CmdLine@2
         displayName: 'Configure host machine'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -430,71 +430,59 @@ jobs:
           testResultsFormat: 'JUnit'
           testResultsFiles: '**/e2e-tests-report*.xml'
         condition: succeededOrFailed()
-
-  - job: E2e_Test_TeamsV1
-    displayName: 'E2e test TeamsJS V1'
-    pool:
-      vmImage: 'ubuntu-latest'
-
-    steps:
-      - checkout: self
-      - checkout: git://$(AppHostingSdkGitPath4)@$(AppHostingSdkGitRef)
-        persistCredentials: true
-
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '14.x'
-        displayName: 'Install Node.js'
-
-      - task: YarnInstaller@3
-        inputs:
-          versionSpec: '1.x'
-
-      - task: Yarn@2
-        displayName: 'Run yarn on app hosting sdk'
-        inputs:
-          Arguments:
-          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: Yarn@2
-        displayName: 'Build app hosting sdk'
-        inputs:
-          Arguments: 'build'
-          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: Yarn@2
-        displayName: 'Run yarn on client sdk'
-        inputs:
-          Arguments:
-          ProjectDirectory: '$(ClientSdkProjectDirectory)'
-
-      - task: Yarn@2
-        displayName: 'Build client sdk'
-        inputs:
-          Arguments: 'build'
-          ProjectDirectory: '$(ClientSdkProjectDirectory)'
-
-      - task: Yarn@2
-        displayName: 'Build Teams Test App V1'
-        inputs:
-          Arguments: 'build-test-app-V1'
-          ProjectDirectory: '$(ClientSdkProjectDirectory)'
-
-      - task: CmdLine@2
-        displayName: 'Configure host machine'
-        inputs:
-          script: |
-            sudo chmod -R 755 ./ 
-            sudo yarn setup
-          workingDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - bash: 'node tools/cli/runAppsWithE2ETests.js --reportFileName=e2e-tests-report-V1 --envType=--envType=teamsV1'
-        displayName: 'Run E2E integration tests on Teams Test App V1'
-        condition: succeeded()
-        workingDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '**/e2e-tests-report*.xml'
-        condition: succeededOrFailed()
+  # - job: E2e_Test_TeamsV1
+  #   displayName: 'E2e test TeamsJS V1'
+  #   pool:
+  #     vmImage: 'ubuntu-latest'
+  #   steps:
+  #     - checkout: self
+  #     - checkout: git://$(AppHostingSdkGitPath4)@$(AppHostingSdkGitRef)
+  #       persistCredentials: true
+  #     - task: NodeTool@0
+  #       inputs:
+  #         versionSpec: '14.x'
+  #       displayName: 'Install Node.js'
+  #     - task: YarnInstaller@3
+  #       inputs:
+  #         versionSpec: '1.x'
+  #     - task: Yarn@2
+  #       displayName: 'Run yarn on app hosting sdk'
+  #       inputs:
+  #         Arguments:
+  #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+  #     - task: Yarn@2
+  #       displayName: 'Build app hosting sdk'
+  #       inputs:
+  #         Arguments: 'build'
+  #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+  #     - task: Yarn@2
+  #       displayName: 'Run yarn on client sdk'
+  #       inputs:
+  #         Arguments:
+  #         ProjectDirectory: '$(ClientSdkProjectDirectory)'
+  #     - task: Yarn@2
+  #       displayName: 'Build client sdk'
+  #       inputs:
+  #         Arguments: 'build'
+  #         ProjectDirectory: '$(ClientSdkProjectDirectory)'
+  #     - task: Yarn@2
+  #       displayName: 'Build Teams Test App V1'
+  #       inputs:
+  #         Arguments: 'build-test-app-V1'
+  #         ProjectDirectory: '$(ClientSdkProjectDirectory)'
+  #     - task: CmdLine@2
+  #       displayName: 'Configure host machine'
+  #       inputs:
+  #         script: |
+  #           sudo chmod -R 755 ./
+  #           sudo yarn setup
+  #         workingDirectory: '$(AppHostingSdkProjectDirectory)'
+  #     - bash: 'node tools/cli/runAppsWithE2ETests.js --reportFileName=e2e-tests-report-V1 --envType=--envType=teamsV1'
+  #       displayName: 'Run E2E integration tests on Teams Test App V1'
+  #       condition: succeeded()
+  #       workingDirectory: '$(AppHostingSdkProjectDirectory)'
+  #     - task: PublishTestResults@2
+  #       inputs:
+  #         testResultsFormat: 'JUnit'
+  #         testResultsFiles: '**/e2e-tests-report*.xml'
+  #       condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -419,7 +419,7 @@ jobs:
             sudo yarn setup
           workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
-      - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4003 --reportFileName=e2e-tests-report-local-script-tag --envType=--envType=localScriptTag'
+      - bash: 'node tools/cli/runAppsWithE2ETests.js --reportFileName=e2e-tests-report-local-script-tag --envType=--envType=localScriptTag'
         displayName: 'Run E2E integration tests with local script tag'
         condition: succeeded()
         workingDirectory: '$(AppHostingSdkProjectDirectory)'
@@ -487,7 +487,7 @@ jobs:
             sudo yarn setup
           workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
-      - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4004 --reportFileName=e2e-tests-report-V1 --envType=--envType=teamsV1'
+      - bash: 'node tools/cli/runAppsWithE2ETests.js --reportFileName=e2e-tests-report-V1 --envType=--envType=teamsV1'
         displayName: 'Run E2E integration tests on Teams Test App V1'
         condition: succeeded()
         workingDirectory: '$(AppHostingSdkProjectDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,30 +109,30 @@ jobs:
         inputs:
           Arguments: 'install'
 
-      - script: 'node prepNextDevRelease.js'
-        displayName: 'node prepNextDevRelease.js'
-        workingDirectory: '$(System.DefaultWorkingDirectory)\packages\teams-js'
-        condition: and(
-          eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'),
-          in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-          ne(variables['Build.Reason'], 'PullRequest'),
-          ne(variables['Build.Reason'], 'Manual')
-          )
+      # - script: 'node prepNextDevRelease.js'
+      #   displayName: 'node prepNextDevRelease.js'
+      #   workingDirectory: '$(System.DefaultWorkingDirectory)\packages\teams-js'
+      #   condition: and(
+      #     eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'),
+      #     in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
+      #     ne(variables['Build.Reason'], 'PullRequest'),
+      #     ne(variables['Build.Reason'], 'Manual')
+      #     )
 
-      - task: Yarn@3
-        inputs:
-          Arguments: 'build'
-        displayName: 'yarn build'
+      # - task: Yarn@3
+      #   inputs:
+      #     Arguments: 'build'
+      #   displayName: 'yarn build'
 
-      - script: 'node prepNewReadme.js'
-        workingDirectory: '$(System.DefaultWorkingDirectory)\packages\teams-js'
-        condition: and(
-          startsWith(variables['Build.SourceBranch'], 'refs/tags/v'),
-          in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-          ne(variables['Build.Reason'], 'PullRequest'),
-          ne(variables['Build.Reason'], 'Manual')
-          )
-        displayName: 'node prepNewReadme.js'
+      # - script: 'node prepNewReadme.js'
+      #   workingDirectory: '$(System.DefaultWorkingDirectory)\packages\teams-js'
+      #   condition: and(
+      #     startsWith(variables['Build.SourceBranch'], 'refs/tags/v'),
+      #     in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
+      #     ne(variables['Build.Reason'], 'PullRequest'),
+      #     ne(variables['Build.Reason'], 'Manual')
+      #     )
+      #   displayName: 'node prepNewReadme.js'
 
       - task: Yarn@3
         inputs:
@@ -145,109 +145,96 @@ jobs:
           testResultsFiles: '**/unit-tests-report*.xml'
         condition: succeededOrFailed()
 
-      - task: Yarn@2
-        inputs:
-          Arguments: 'bundleAnalyze:collect'
-        displayName: 'Run bundle analysis and collect'
-
-      # Bundle analysis comparison : should trigger only by PR against 2.0-preview
-      # Adding comment for a commit that should queue the pipeline with a PR trigger
-
-      - bash: 'node --max-old-space-size=4096 tools/cli/compareBundleAnalysis.js --commitId=$(System.PullRequest.SourceCommitId) --orgUrl=$(System.CollectionUri) --projectName=$(System.TeamProject) --buildId=$(System.DefinitionId) --bundleArtifactName=$(bundleArtifactName) --baseBranchName=$(System.PullRequest.TargetBranch)'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        condition: and(
-          in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-          eq(variables['Build.Reason'], 'PullRequest'),
-          eq(variables['System.PullRequest.TargetBranch'], '2.0-preview'))
-        name: bundleAnalysisTask
-        displayName: 'Analyze bundles against 2.0-preview and output result'
-
-      - task: GitHubComment@0
-        condition: and(
-          in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-          eq(variables['Build.Reason'], 'PullRequest'),
-          eq(variables['System.PullRequest.TargetBranch'], '2.0-preview'))
-        inputs:
-          gitHubConnection: '$(RepoGitHubConnection)'
-          repositoryName: '$(Build.Repository.Name)'
-          id: '$(System.PullRequest.PullRequestNumber)'
-          comment: '$(bundleAnalysisTask.bundleAnalysisComment)'
-        displayName: 'Post bundle analysis result as PR comment on GitHub'
-
-      - task: PublishBuildArtifacts@1
-        condition: and(
-          in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-          ne(variables['Build.Reason'], 'PullRequest'))
-        inputs:
-          PathtoPublish: './common/temp/bundleAnalysis'
-          ArtifactName: '$(bundleArtifactName)'
-        displayName: 'Publish bundle analysis'
-
-      - powershell: |
-          $npmVer=$(node -p "require('./packages/teams-js/package.json').version") 
-          Write-Host "##vso[task.setvariable variable=version;isOutput=true]$npmVer"
-        name: package
-        displayName: 'Set package.version Variable'
-
-      - task: CopyFiles@2
-        inputs:
-          sourceFolder: 'apps/teams-test-app/build'
-          contents: '**'
-          targetFolder: '$(Build.ArtifactStagingDirectory)\teams-test-app'
-        displayName: 'Copy Test app to artifacts staging directory'
-
-      - task: ArchiveFiles@2
-        inputs:
-          rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\teams-test-app'
-          includeRootFolder: false
-          archiveType: 'zip'
-          archiveFile: '$(Build.ArtifactStagingDirectory)\teams-test-app\$(Build.BuildId).zip'
-          replaceExistingArchive: true
-        displayName: 'Zip Test app artifacts'
-
-      - task: PublishBuildArtifacts@1
-        inputs:
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)\teams-test-app\$(Build.BuildId).zip'
-          ArtifactName: 'teams-test-app'
-        displayName: 'Publish Test app artifacts'
-
-      - task: CopyFiles@2
-        inputs:
-          sourceFolder: 'packages\teams-js\dist'
-          contents: '**\?(*.js|*.ts|*.map)'
-          targetFolder: '$(Build.ArtifactStagingDirectory)\CDNFeed\$(package.version)\js'
-        displayName: 'Copy TeamsJS Content for CDN'
-
-      - task: CopyFiles@2
-        inputs:
-          Contents: |
-            packages\teams-js\package.json
-            packages\teams-js\README.md
-            LICENSE
-          TargetFolder: '$(Build.ArtifactStagingDirectory)\NPMFeed'
-          flattenFolders: true
-        displayName: 'Copy TeamsJS Content for NPM'
-
-      - task: CopyFiles@2
-        inputs:
-          Contents: |
-            packages\teams-js\dist\**\?(*.js|*.ts|*.map)
-          TargetFolder: '$(Build.ArtifactStagingDirectory)\NPMFeed\dist'
-          flattenFolders: true
-        displayName: 'Copy JS Content for NPM'
-
-      - task: PublishBuildArtifacts@1
-        inputs:
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)\CDNFeed'
-          ArtifactName: 'CDNFeed'
-        displayName: 'Publish CDN feed to build Artifacts'
-
-      - task: PublishBuildArtifacts@1
-        inputs:
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)\NPMFeed'
-          ArtifactName: 'NPMFeed'
-        displayName: 'Publish NPM feed to Build Artifacts'
+      # - task: Yarn@2
+      #   inputs:
+      #     Arguments: 'bundleAnalyze:collect'
+      #   displayName: 'Run bundle analysis and collect'
+      # # Bundle analysis comparison : should trigger only by PR against 2.0-preview
+      # # Adding comment for a commit that should queue the pipeline with a PR trigger
+      # - bash: 'node --max-old-space-size=4096 tools/cli/compareBundleAnalysis.js --commitId=$(System.PullRequest.SourceCommitId) --orgUrl=$(System.CollectionUri) --projectName=$(System.TeamProject) --buildId=$(System.DefinitionId) --bundleArtifactName=$(bundleArtifactName) --baseBranchName=$(System.PullRequest.TargetBranch)'
+      #   env:
+      #     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      #   condition: and(
+      #     in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
+      #     eq(variables['Build.Reason'], 'PullRequest'),
+      #     eq(variables['System.PullRequest.TargetBranch'], '2.0-preview'))
+      #   name: bundleAnalysisTask
+      #   displayName: 'Analyze bundles against 2.0-preview and output result'
+      # - task: GitHubComment@0
+      #   condition: and(
+      #     in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
+      #     eq(variables['Build.Reason'], 'PullRequest'),
+      #     eq(variables['System.PullRequest.TargetBranch'], '2.0-preview'))
+      #   inputs:
+      #     gitHubConnection: '$(RepoGitHubConnection)'
+      #     repositoryName: '$(Build.Repository.Name)'
+      #     id: '$(System.PullRequest.PullRequestNumber)'
+      #     comment: '$(bundleAnalysisTask.bundleAnalysisComment)'
+      #   displayName: 'Post bundle analysis result as PR comment on GitHub'
+      # - task: PublishBuildArtifacts@1
+      #   condition: and(
+      #     in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
+      #     ne(variables['Build.Reason'], 'PullRequest'))
+      #   inputs:
+      #     PathtoPublish: './common/temp/bundleAnalysis'
+      #     ArtifactName: '$(bundleArtifactName)'
+      #   displayName: 'Publish bundle analysis'
+      # - powershell: |
+      #     $npmVer=$(node -p "require('./packages/teams-js/package.json').version")
+      #     Write-Host "##vso[task.setvariable variable=version;isOutput=true]$npmVer"
+      #   name: package
+      #   displayName: 'Set package.version Variable'
+      # - task: CopyFiles@2
+      #   inputs:
+      #     sourceFolder: 'apps/teams-test-app/build'
+      #     contents: '**'
+      #     targetFolder: '$(Build.ArtifactStagingDirectory)\teams-test-app'
+      #   displayName: 'Copy Test app to artifacts staging directory'
+      # - task: ArchiveFiles@2
+      #   inputs:
+      #     rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\teams-test-app'
+      #     includeRootFolder: false
+      #     archiveType: 'zip'
+      #     archiveFile: '$(Build.ArtifactStagingDirectory)\teams-test-app\$(Build.BuildId).zip'
+      #     replaceExistingArchive: true
+      #   displayName: 'Zip Test app artifacts'
+      # - task: PublishBuildArtifacts@1
+      #   inputs:
+      #     PathtoPublish: '$(Build.ArtifactStagingDirectory)\teams-test-app\$(Build.BuildId).zip'
+      #     ArtifactName: 'teams-test-app'
+      #   displayName: 'Publish Test app artifacts'
+      # - task: CopyFiles@2
+      #   inputs:
+      #     sourceFolder: 'packages\teams-js\dist'
+      #     contents: '**\?(*.js|*.ts|*.map)'
+      #     targetFolder: '$(Build.ArtifactStagingDirectory)\CDNFeed\$(package.version)\js'
+      #   displayName: 'Copy TeamsJS Content for CDN'
+      # - task: CopyFiles@2
+      #   inputs:
+      #     Contents: |
+      #       packages\teams-js\package.json
+      #       packages\teams-js\README.md
+      #       LICENSE
+      #     TargetFolder: '$(Build.ArtifactStagingDirectory)\NPMFeed'
+      #     flattenFolders: true
+      #   displayName: 'Copy TeamsJS Content for NPM'
+      # - task: CopyFiles@2
+      #   inputs:
+      #     Contents: |
+      #       packages\teams-js\dist\**\?(*.js|*.ts|*.map)
+      #     TargetFolder: '$(Build.ArtifactStagingDirectory)\NPMFeed\dist'
+      #     flattenFolders: true
+      #   displayName: 'Copy JS Content for NPM'
+      # - task: PublishBuildArtifacts@1
+      #   inputs:
+      #     PathtoPublish: '$(Build.ArtifactStagingDirectory)\CDNFeed'
+      #     ArtifactName: 'CDNFeed'
+      #   displayName: 'Publish CDN feed to build Artifacts'
+      # - task: PublishBuildArtifacts@1
+      #   inputs:
+      #     PathtoPublish: '$(Build.ArtifactStagingDirectory)\NPMFeed'
+      #     ArtifactName: 'NPMFeed'
+      #   displayName: 'Publish NPM feed to Build Artifacts'
 
   - job: E2e_Test
     displayName: 'E2e Testing'
@@ -259,6 +246,7 @@ jobs:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
         persistCredentials: true
+
       - task: Yarn@2
         displayName: 'Run yarn on app hosting sdk'
         inputs:
@@ -271,13 +259,45 @@ jobs:
           Arguments: 'build'
           ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
 
-      - task: CmdLine@2
-        displayName: 'Configure host machine'
+      - task: NodeTool@0
         inputs:
-          script: |
-            sudo chmod -R 755 ./ 
-            sudo yarn setup
-          workingDirectory: '$(AppHostingSdkProjectDirectory)'
+          versionSpec: '14.x'
+        displayName: 'Install Node.js'
+
+      - task: YarnInstaller@3
+        inputs:
+          versionSpec: '1.x'
+
+      - task: Yarn@2
+        displayName: 'Run yarn on app hosting sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: Yarn@2
+        displayName: 'Build app hosting sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: Yarn@2
+        displayName: 'Run yarn on client sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: 'microsoft-teams-library-js'
+
+      - task: Yarn@2
+        displayName: 'Build client sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: 'microsoft-teams-library-js'
+          - task: CmdLine@2
+            displayName: 'Configure host machine'
+            inputs:
+              script: |
+                sudo chmod -R 755 ./ 
+                sudo yarn setup
+              workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -253,8 +253,8 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       - checkout: self
-      - script: mkdir appHostSdk && cd appHostSdk && git clone $(AppHostingSdkGitCloneAddr) --branch main
-        workingDirectory: $(Agent.BuildDirectory)
+      - checkout: git://$(AppHostingSdkGitPath)@$refs/heads/main
+        persistCredentials: false
 
       - task: NodeTool@0
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -304,6 +304,7 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
 
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,12 +5,6 @@
 variables:
   - group: InfoSec-SecurityResults
 
-# resources:
-#   repositories:
-#     - repository: appHostSdkRepo
-#       type: git
-#       name: '$(AppHostingSdkProjectDirectory)'
-
 trigger:
   branches:
     include:
@@ -321,34 +315,41 @@ jobs:
     steps:
       - checkout: self
       - checkout: git://$(AppHostingSdkGitPath2)
-        persistCredentials: false
+        persistCredentials: true
+
       - task: NodeTool@0
         inputs:
           versionSpec: '14.x'
         displayName: 'Install Node.js'
+
       - task: YarnInstaller@3
         inputs:
           versionSpec: '1.x'
+
       - task: Yarn@2
         displayName: 'Run yarn on app hosting sdk'
         inputs:
           Arguments:
           ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
       - task: Yarn@2
         displayName: 'Build app hosting sdk'
         inputs:
           Arguments: 'build'
           ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
       - task: Yarn@2
         displayName: 'Run yarn on client sdk'
         inputs:
           Arguments:
           ProjectDirectory: 'microsoft-teams-library-js'
+
       - task: Yarn@2
         displayName: 'Build client sdk'
         inputs:
           Arguments: 'build'
           ProjectDirectory: 'microsoft-teams-library-js'
+
       - task: CmdLine@2
         displayName: 'Configure host machine'
         inputs:
@@ -356,50 +357,59 @@ jobs:
             sudo chmod -R 755 ./
             sudo yarn setup
           workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
       - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
         displayName: 'Run E2E Perf tests'
         condition: succeeded()
         workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: 'JUnit'
           testResultsFiles: '**/e2e-tests-report*.xml'
         condition: succeededOrFailed()
-      # - job: E2e_Test_Local_Script_Tag
-      #   displayName: 'E2e test with local script tag'
-      #   pool:
-      #     vmImage: 'ubuntu-latest'
-      #   steps:
-      #     - checkout: self
-      #     - checkout: git://$(AppHostingSdkGitPath)@refs/heads/main
-      #       persistCredentials: false
-      #     - task: NodeTool@0
-      #       inputs:
-      #         versionSpec: '14.x'
-      #       displayName: 'Install Node.js'
-      #     - task: YarnInstaller@3
-      #       inputs:
-      #         versionSpec: '1.x'
-      #     - task: Yarn@2
-      #       displayName: 'Run yarn on app hosting sdk'
-      #       inputs:
-      #         Arguments:
-      #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-      #     - task: Yarn@2
-      #       displayName: 'Build app hosting sdk'
-      #       inputs:
-      #         Arguments: 'build'
-      #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-      #     - task: Yarn@2
-      #       displayName: 'Run yarn on client sdk'
-      #       inputs:
-      #         Arguments:
-      #         ProjectDirectory: 'microsoft-teams-library-js'
-      #     - task: Yarn@2
-      #       displayName: 'Build client sdk'
-      #       inputs:
-      #         Arguments: 'build'
-      #         ProjectDirectory: 'microsoft-teams-library-js'
+
+  - job: E2e_Test_Local_Script_Tag
+    displayName: 'E2e test with local script tag'
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath3)
+        persistCredentials: false
+
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '14.x'
+        displayName: 'Install Node.js'
+
+      - task: YarnInstaller@3
+        inputs:
+          versionSpec: '1.x'
+
+      - task: Yarn@2
+        displayName: 'Run yarn on app hosting sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: Yarn@2
+        displayName: 'Build app hosting sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+
+      - task: Yarn@2
+        displayName: 'Run yarn on client sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: 'microsoft-teams-library-js'
+
+      - task: Yarn@2
+        displayName: 'Build client sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: 'microsoft-teams-library-js'
 
       - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=localScriptTag'
         displayName: 'Run E2E integration tests with local script tag'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -313,48 +313,49 @@ jobs:
           testResultsFormat: 'JUnit'
           testResultsFiles: '**/e2e-tests-report*.xml'
         condition: succeededOrFailed()
-      # - job: E2e_Performance_Test
-      #   displayName: 'E2e performance test'
-      #   pool:
-      #     vmImage: 'ubuntu-latest'
-      #   steps:
-      #     - checkout: self
-      #     - checkout: git://$(AppHostingSdkGitPath)@$refs/heads/main
-      #       persistCredentials: false
-      #     - task: NodeTool@0
-      #       inputs:
-      #         versionSpec: '14.x'
-      #       displayName: 'Install Node.js'
-      #     - task: YarnInstaller@3
-      #       inputs:
-      #         versionSpec: '1.x'
-      #     - task: Yarn@2
-      #       displayName: 'Run yarn on app hosting sdk'
-      #       inputs:
-      #         Arguments:
-      #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-      #     - task: Yarn@2
-      #       displayName: 'Build app hosting sdk'
-      #       inputs:
-      #         Arguments: 'build'
-      #         ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
-      #     - task: Yarn@2
-      #       displayName: 'Run yarn on client sdk'
-      #       inputs:
-      #         Arguments:
-      #         ProjectDirectory: 'microsoft-teams-library-js'
-      #     - task: Yarn@2
-      #       displayName: 'Build client sdk'
-      #       inputs:
-      #         Arguments: 'build'
-      #         ProjectDirectory: 'microsoft-teams-library-js'
-      #     - task: CmdLine@2
-      #       displayName: 'Configure host machine'
-      #       inputs:
-      #         script: |
-      #           sudo chmod -R 755 ./
-      #           sudo yarn setup
-      #         workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+  - job: E2e_Performance_Test
+    displayName: 'E2e performance test'
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath2)
+        persistCredentials: false
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '14.x'
+        displayName: 'Install Node.js'
+      - task: YarnInstaller@3
+        inputs:
+          versionSpec: '1.x'
+      - task: Yarn@2
+        displayName: 'Run yarn on app hosting sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+      - task: Yarn@2
+        displayName: 'Build app hosting sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+      - task: Yarn@2
+        displayName: 'Run yarn on client sdk'
+        inputs:
+          Arguments:
+          ProjectDirectory: 'microsoft-teams-library-js'
+      - task: Yarn@2
+        displayName: 'Build client sdk'
+        inputs:
+          Arguments: 'build'
+          ProjectDirectory: 'microsoft-teams-library-js'
+      - task: CmdLine@2
+        displayName: 'Configure host machine'
+        inputs:
+          script: |
+            sudo chmod -R 755 ./
+            sudo yarn setup
+          workingDirectory: '$(AppHostingSdkProjectDirectory)'
       - bash: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
         displayName: 'Run E2E Perf tests'
         condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -303,6 +303,10 @@ jobs:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
+      - checkout: self
+      - checkout: git://$(AppHostingSdkGitPath)@$(AppHostingSdkGitRef)
+        persistCredentials: true
+
       - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'
         condition: succeeded()


### PR DESCRIPTION
First step in taking our numerous yaml files and combining them into one. This PR will allow for us to not only avoid depending on several pipeline runs but also keep the jobs parallelized and efficient.

A few notable/potentially confusing points explained:
 - Newly introduced pipeline variables `$(AppHostingSdkGitPath2)`, `$(AppHostingSdkGitPath3)`, etc. (Example: Line 317)
   - These `$(AppHostingSdkGitPath#)` variables actually contain the same value as the original `$(AppHostingSdkGitPath)` variable. This is the best getaround I've found to YAML's issue which doesn't allow for checking out the same repository defined by the same variable more than once in the same file. 
 - If we're combining the yaml files, why aren't the old ones being deleted?
   - Before this PR is merged, all of this test content still needs to be run on all other PRs to 2.0-preview, so those GitHub checks have to stay. And since those GitHub checks have to stay, this PR won't pass the checks unless those files are present. After this PR is merged, I will turn off the GitHub checks that utilize those files and then submit a PR to delete the outdated files. This multi-step process will allow us to have no 'gap' where the test content isn't being covered.
 - Lots of tasks that are "duplicated" in the e2e test jobs
   - I tried to have them depend on a job that would `yarn install` and `build` the teamsJs library and the appHostSdk library to avoid the duplication, but all these things have to be done specifically by the job/agent running each test. 
 - Tons of commits
   - Please ignore them, I had to test a ton with our pipeline. Also, they'll be squashed :)

Update 1: 
 - Commented out the v1 test steps. Will uncomment after PR when hub sdk is ready and include it in new PR