### PR TITLE
Adding prerelease yml to master

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,17 @@
+# This needs to be added in the master branch to show the workflow fir all branches on GitHub
+# Running this on master will not do anything
+name: Initiate Release Workflow
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        required: true
+        default: '2.0.0-beta.x'
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hello
+        run: echo Hello

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,4 +1,4 @@
-# This needs to be added in the master branch to show the workflow fir all branches on GitHub
+# This needs to be added in the master branch to show the workflow for all branches on GitHub
 # Running this on master will not do anything
 name: Initiate Release Workflow
 on:


### PR DESCRIPTION
This will add the manually triggerable workflow to master. The workflow on master will not really do anything now. 
However for the same workflow in 2.0-preview to become available for invoking, we need to add this file to master.

For context, we are creating these workflows in 2.0-preview to facilitate the release process, and automate all manual steps that would need to be done by developers when a new version is to be released. More details in #865 