### PR TITLE
Publicize release-ready programmatic app sharing APIs

### DIFF
--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -254,8 +254,6 @@ export namespace meeting {
   }
 
   /**
-   * @private
-   * Hide from docs
    * Allows an app to share contents in the meeting
    * @param callback Callback contains 2 parameters, error and result.
    * error can either contain an error of type SdkError, incase of an error, or null when share is successful
@@ -274,8 +272,6 @@ export namespace meeting {
   }
 
   /**
-   * @private
-   * Hide from docs
    * Provides information related app's in-meeting sharing capabilities
    * @param callback Callback contains 2 parameters, error and result.
    * error can either contain an error of type SdkError (error indication), or null (non-error indication)
@@ -314,8 +310,6 @@ export namespace meeting {
   }
 
   /**
-   * @private
-   * Hide from docs
    * Provides information related to current stage sharing state for app
    * @param callback Callback contains 2 parameters, error and result.
    * error can either contain an error of type SdkError (error indication), or null (non-error indication)


### PR DESCRIPTION
This PR makes release-ready programmatic app sharing APIs. Affects:

- `shareAppContentToStage`
- `getAppContentStageSharingCapabilities`
- `getAppContentStageSharingState`

Note: stopSharingAppContentToStage will be kept `private`