### PR TITLE
Jekoch/throwing errors

### DIFF
--- a/packages/teams-js/src/internal/internalAPIs.ts
+++ b/packages/teams-js/src/internal/internalAPIs.ts
@@ -37,7 +37,7 @@ export function ensureInitialized(...expectedFrameContexts: string[]): void {
  *
  * @internal
  */
-export function isAPISupportedByPlatform(requiredVersion: string = defaultSDKVersionForCompatCheck): boolean {
+export function isCurrentSDKVersionAtLeast(requiredVersion: string = defaultSDKVersionForCompatCheck): boolean {
   const value = compareSDKVersions(GlobalVars.clientSupportedSDKVersion, requiredVersion);
   if (isNaN(value)) {
     return false;

--- a/packages/teams-js/src/internal/internalAPIs.ts
+++ b/packages/teams-js/src/internal/internalAPIs.ts
@@ -58,20 +58,21 @@ export function isHostClientMobile(): boolean {
 /**
  * @hidden
  * Helper function which indicates if current API is supported on mobile or not.
- * @returns SdkError if host client is not android/ios or if the requiredVersion is not
+ * @throws SdkError if host client is not android/ios or if the requiredVersion is not
  *          supported by platform or not. Null is returned in case of success.
  *
  * @internal
  */
-export function isApiSupportedOnMobile(requiredVersion: string = defaultSDKVersionForCompatCheck): SdkError {
+export function throwExceptionIfMobileApiIsNotSupported(
+  requiredVersion: string = defaultSDKVersionForCompatCheck,
+): void {
   if (!isHostClientMobile()) {
     const notSupportedError: SdkError = { errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM };
-    return notSupportedError;
-  } else if (!isAPISupportedByPlatform(requiredVersion)) {
+    throw notSupportedError;
+  } else if (!isCurrentSDKVersionAtLeast(requiredVersion)) {
     const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
-    return oldPlatformError;
+    throw oldPlatformError;
   }
-  return null;
 }
 
 /**

--- a/packages/teams-js/src/internal/mediaUtil.ts
+++ b/packages/teams-js/src/internal/mediaUtil.ts
@@ -1,4 +1,3 @@
-import { SdkError } from '../public/interfaces';
 import { media } from '../public/media';
 import { people } from '../public/people';
 import {
@@ -67,11 +66,11 @@ export function decodeAttachment(attachment: media.MediaChunk, mimeType: string)
  */
 export function throwExceptionIfMediaCallIsNotSupportedOnMobile(mediaInputs: media.MediaInputs): void {
   if (isMediaCallForVideoAndImageInputs(mediaInputs)) {
-    return throwExceptionIfMobileApiIsNotSupported(videoAndImageMediaAPISupportVersion);
+    throwExceptionIfMobileApiIsNotSupported(videoAndImageMediaAPISupportVersion);
   } else if (isMediaCallForNonFullScreenVideoMode(mediaInputs)) {
-    return throwExceptionIfMobileApiIsNotSupported(nonFullScreenVideoModeAPISupportVersion);
+    throwExceptionIfMobileApiIsNotSupported(nonFullScreenVideoModeAPISupportVersion);
   } else if (isMediaCallForImageOutputFormats(mediaInputs)) {
-    return throwExceptionIfMobileApiIsNotSupported(imageOutputFormatsAPISupportVersion);
+    throwExceptionIfMobileApiIsNotSupported(imageOutputFormatsAPISupportVersion);
   }
 }
 

--- a/packages/teams-js/src/internal/mediaUtil.ts
+++ b/packages/teams-js/src/internal/mediaUtil.ts
@@ -6,7 +6,7 @@ import {
   nonFullScreenVideoModeAPISupportVersion,
   videoAndImageMediaAPISupportVersion,
 } from './constants';
-import { isApiSupportedOnMobile } from './internalAPIs';
+import { throwExceptionIfMobileApiIsNotSupported } from './internalAPIs';
 
 /**
  * @hidden
@@ -61,19 +61,18 @@ export function decodeAttachment(attachment: media.MediaChunk, mimeType: string)
 
 /**
  * @hidden
- * Function returns null if the media call is supported on current mobile version, else SdkError.
- *
+ * Function throws an SdkError if the media call is not supported on current mobile version, else undefined.
+ * @throws an SdkError if the media call is not supported
  * @internal
  */
-export function isMediaCallSupportedOnMobile(mediaInputs: media.MediaInputs): SdkError {
+export function throwExceptionIfMediaCallIsNotSupportedOnMobile(mediaInputs: media.MediaInputs): void {
   if (isMediaCallForVideoAndImageInputs(mediaInputs)) {
-    return isApiSupportedOnMobile(videoAndImageMediaAPISupportVersion);
+    return throwExceptionIfMobileApiIsNotSupported(videoAndImageMediaAPISupportVersion);
   } else if (isMediaCallForNonFullScreenVideoMode(mediaInputs)) {
-    return isApiSupportedOnMobile(nonFullScreenVideoModeAPISupportVersion);
+    return throwExceptionIfMobileApiIsNotSupported(nonFullScreenVideoModeAPISupportVersion);
   } else if (isMediaCallForImageOutputFormats(mediaInputs)) {
-    return isApiSupportedOnMobile(imageOutputFormatsAPISupportVersion);
+    return throwExceptionIfMobileApiIsNotSupported(imageOutputFormatsAPISupportVersion);
   }
-  return null;
 }
 
 /**

--- a/packages/teams-js/src/private/legacy.ts
+++ b/packages/teams-js/src/private/legacy.ts
@@ -1,7 +1,7 @@
 import { sendAndUnwrap } from '../internal/communication';
 import { getUserJoinedTeamsSupportedAndroidClientVersion } from '../internal/constants';
 import { GlobalVars } from '../internal/globalVars';
-import { ensureInitialized, isAPISupportedByPlatform } from '../internal/internalAPIs';
+import { ensureInitialized, isCurrentSDKVersionAtLeast } from '../internal/internalAPIs';
 import { HostClientType } from '../public/constants';
 import { ErrorCode, SdkError } from '../public/interfaces';
 import { runtime } from '../public/runtime';
@@ -32,7 +32,7 @@ export namespace legacy {
             GlobalVars.hostClientType === HostClientType.teamsRoomsAndroid ||
             GlobalVars.hostClientType === HostClientType.teamsPhones ||
             GlobalVars.hostClientType === HostClientType.teamsDisplays) &&
-          !isAPISupportedByPlatform(getUserJoinedTeamsSupportedAndroidClientVersion)
+          !isCurrentSDKVersionAtLeast(getUserJoinedTeamsSupportedAndroidClientVersion)
         ) {
           const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
           throw new Error(JSON.stringify(oldPlatformError));

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -1,6 +1,6 @@
 import { sendAndHandleSdkError as sendAndHandleError } from '../internal/communication';
 import { locationAPIsRequiredVersion } from '../internal/constants';
-import { ensureInitialized, isAPISupportedByPlatform } from '../internal/internalAPIs';
+import { ensureInitialized, isCurrentSDKVersionAtLeast } from '../internal/internalAPIs';
 import {
   callCallbackWithErrorOrBooleanFromPromiseAndReturnPromise,
   callCallbackWithErrorOrResultFromPromiseAndReturnPromise,
@@ -71,7 +71,7 @@ export namespace location {
 
   function getLocationHelper(props: LocationProps): Promise<Location> {
     return new Promise<Location>(resolve => {
-      if (!isAPISupportedByPlatform(locationAPIsRequiredVersion)) {
+      if (!isCurrentSDKVersionAtLeast(locationAPIsRequiredVersion)) {
         throw { errorCode: ErrorCode.OLD_PLATFORM };
       }
       if (!props) {
@@ -106,7 +106,7 @@ export namespace location {
 
   export function showLocationHelper(location: Location): Promise<void> {
     return new Promise<void>(resolve => {
-      if (!isAPISupportedByPlatform(locationAPIsRequiredVersion)) {
+      if (!isCurrentSDKVersionAtLeast(locationAPIsRequiredVersion)) {
         throw { errorCode: ErrorCode.OLD_PLATFORM };
       }
       if (!location) {

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -412,34 +412,69 @@ export namespace media {
      * @hidden
      * Hide from docs
      * --------
+     *
+     * Function to notify the host client to programatically control the experience
+     * @param mediaEvent indicates what the event that needs to be signaled to the host client
+     * @returns A promise resolved promise
+     */
+    protected notifyEventToHost(mediaEvent: MediaControllerEvent): Promise<void>;
+    /**
+     * @hidden
+     * Hide from docs
+     * --------
+     *
+     * @deprecated
+     * As of 2.0.0-beta.3, please use {@link media.MediaController.notifyEventToHost media.MediaController.notifyEventToHost(mediaEvent: MediaControllerEvent): Promise\<void\>} instead.
+     *
      * Function to notify the host client to programatically control the experience
      * @param mediaEvent indicates what the event that needs to be signaled to the host client
      * Optional; @param callback is used to send app if host client has successfully handled the notification event or not
      */
-    protected notifyEventToHost(mediaEvent: MediaControllerEvent, callback?: (err?: SdkError) => void): void {
+    protected notifyEventToHost(mediaEvent: MediaControllerEvent, callback?: (err?: SdkError) => void): void;
+    protected notifyEventToHost(mediaEvent: MediaControllerEvent, callback?: (err?: SdkError) => void): Promise<void> {
       ensureInitialized(FrameContexts.content, FrameContexts.task);
-      const err = throwExceptionIfMobileApiIsNotSupported(nonFullScreenVideoModeAPISupportVersion);
-      if (err) {
-        if (callback) {
-          callback(err);
-        }
-        return;
-      }
 
-      const params: MediaControllerParam = { mediaType: this.getMediaType(), mediaControllerEvent: mediaEvent };
-      sendMessageToParent('media.controller', [params], (err?: SdkError) => {
-        if (callback) {
-          callback(err);
-        }
-      });
+      return Promise.resolve()
+        .then(() => {
+          return throwExceptionIfMobileApiIsNotSupported(nonFullScreenVideoModeAPISupportVersion);
+        })
+        .then(() => {
+          const params: MediaControllerParam = { mediaType: this.getMediaType(), mediaControllerEvent: mediaEvent };
+
+          sendMessageToParent('media.controller', [params], (err?: SdkError) => {
+            if (callback) {
+              callback(err);
+            } else if (err) {
+              throw err;
+            }
+          });
+        })
+        .catch(err => {
+          if (callback) {
+            callback(err);
+          }
+          throw err;
+        });
     }
 
     /**
      * Function to programatically stop the ongoing media event
+     *
+     * @returns A resolved promise
+     * */
+    public stop(): Promise<void>;
+    /**
+     *
+     * Function to programatically stop the ongoing media event
+     *
+     * @deprecated
+     * As of 2.0.0-beta.3, please use {@link media.MediaController.stop media.MediaController.stop(): Promise\<void\>} instead.
+     *
      * Optional; @param callback is used to send app if host client has successfully stopped the event or not
      */
-    public stop(callback?: (err?: SdkError) => void): void {
-      this.notifyEventToHost(MediaControllerEvent.StopRecording, callback);
+    public stop(callback?: (err?: SdkError) => void): void;
+    public stop(callback?: (err?: SdkError) => void): Promise<void> {
+      return Promise.resolve(this.notifyEventToHost(MediaControllerEvent.StopRecording, callback));
     }
   }
 

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -436,7 +436,7 @@ export namespace media {
 
       return Promise.resolve()
         .then(() => {
-          return throwExceptionIfMobileApiIsNotSupported(nonFullScreenVideoModeAPISupportVersion);
+          throwExceptionIfMobileApiIsNotSupported(nonFullScreenVideoModeAPISupportVersion);
         })
         .then(() => {
           const params: MediaControllerParam = { mediaType: this.getMediaType(), mediaControllerEvent: mediaEvent };

--- a/packages/teams-js/src/public/people.ts
+++ b/packages/teams-js/src/public/people.ts
@@ -1,6 +1,6 @@
 import { sendAndHandleSdkError as sendAndHandleError } from '../internal/communication';
 import { peoplePickerRequiredVersion } from '../internal/constants';
-import { ensureInitialized, isAPISupportedByPlatform } from '../internal/internalAPIs';
+import { ensureInitialized, isCurrentSDKVersionAtLeast } from '../internal/internalAPIs';
 import { validatePeoplePickerInput } from '../internal/mediaUtil';
 import { callCallbackWithErrorOrResultFromPromiseAndReturnPromise } from '../internal/utils';
 import { FrameContexts } from './constants';
@@ -67,7 +67,7 @@ export namespace people {
 
   function selectPeopleHelper(peoplePickerInputs?: PeoplePickerInputs): Promise<PeoplePickerResult[]> {
     return new Promise<PeoplePickerResult[]>(resolve => {
-      if (!isAPISupportedByPlatform(peoplePickerRequiredVersion)) {
+      if (!isCurrentSDKVersionAtLeast(peoplePickerRequiredVersion)) {
         throw { errorCode: ErrorCode.OLD_PLATFORM };
       }
 

--- a/packages/teams-js/test/public/appInstallDialog.spec.ts
+++ b/packages/teams-js/test/public/appInstallDialog.spec.ts
@@ -20,15 +20,19 @@ describe('appInstallDialog', () => {
     }
   });
 
-  it('should not allow openAppInstallDialog before initialization', () => {
-    expect(appInstallDialog.openAppInstallDialog(mockOpenAppInstallDialogParams)).rejects.toThrowError(
-      'The library has not yet been initialized',
-    );
+  it('should not allow openAppInstallDialog before initialization', async () => {
+    expect.assertions(1);
+    await appInstallDialog
+      .openAppInstallDialog(mockOpenAppInstallDialogParams)
+      .catch(e => expect(e).toMatchObject(new Error('The library has not yet been initialized')));
   });
 
-  it('Should not allow openAppInstallDialog if not supported', () => {
+  it('Should not allow openAppInstallDialog if not supported', async () => {
+    expect.assertions(1);
     utils.initializeWithContext(FrameContexts.content);
-    expect(appInstallDialog.openAppInstallDialog(mockOpenAppInstallDialogParams)).rejects.toEqual('Not supported');
+    await appInstallDialog
+      .openAppInstallDialog(mockOpenAppInstallDialogParams)
+      .catch(e => expect(e).toMatch('Not supported'));
   });
 
   it('openAppInstallDialog should be called if supported', async () => {

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -756,7 +756,7 @@ describe('media', () => {
         };
 
         await new media.VideoController().stop((e: SdkError) => {
-          expect(e).toMatchObject(err);
+          expect(e).toEqual(err);
         });
 
         const message = mobilePlatformMock.findMessageByFunc('media.controller');
@@ -787,7 +787,7 @@ describe('media', () => {
             return e;
           });
         } catch (err) {
-          expect(err).toMatchObject({ errorCode: ErrorCode.OLD_PLATFORM });
+          expect(err).toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
         }
 
         expect(sendMessageToParentSpy).not.toHaveBeenCalled();
@@ -802,7 +802,7 @@ describe('media', () => {
         const sendMessageToParentSpy = jest.spyOn(communication, 'sendMessageToParent');
 
         await new media.VideoController().stop().catch(err => {
-          return expect(err).toMatchObject({ errorCode: ErrorCode.OLD_PLATFORM });
+          return expect(err).toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
         });
         expect(sendMessageToParentSpy).not.toHaveBeenCalled();
       });
@@ -850,7 +850,7 @@ describe('media', () => {
             } as DOMMessageEvent);
           })
           .catch(error => {
-            return expect(error).toMatchObject(err);
+            return expect(error).toEqual(err);
           });
         expect(sendMessageToParentSpy).toHaveBeenCalled();
       });

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { getMediaCallbackSupportVersion, mediaAPISupportVersion } from '../../src/internal/constants';
+import { captureImageMobileSupportVersion, getMediaCallbackSupportVersion } from '../../src/internal/constants';
 import { callHandler } from '../../src/internal/handlers';
 import { DOMMessageEvent, MessageRequest } from '../../src/internal/interfaces';
 import { app } from '../../src/public/app';
@@ -284,7 +284,6 @@ describe('media', () => {
           });
         });
       });
-
       it('should not allow selectMedia calls with invalid mediaInputs', done => {
         mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
@@ -299,11 +298,9 @@ describe('media', () => {
           });
         });
       });
-
       it('selectMedia call in default version of platform support fails', done => {
         mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-          let mediaError: SdkError;
           const mediaInputs: media.MediaInputs = {
             mediaType: media.MediaType.Image,
             maxMediaCount: 10,
@@ -315,7 +312,6 @@ describe('media', () => {
           });
         });
       });
-
       it('selectMedia call for mediaType = 3 in mediaAPISupportVersion of platform support fails', done => {
         mobilePlatformMock.initializeWithContext(FrameContexts.task, HostClientType.android).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
@@ -330,7 +326,6 @@ describe('media', () => {
           });
         });
       });
-
       it('selectMedia call in task frameContext works', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.task);
         mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
@@ -343,7 +338,6 @@ describe('media', () => {
         expect(message).not.toBeNull();
         expect(message.args.length).toBe(1);
       });
-
       it('selectMedia call in content frameContext works', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.content);
         mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
@@ -356,7 +350,6 @@ describe('media', () => {
         expect(message).not.toBeNull();
         expect(message.args.length).toBe(1);
       });
-
       it('selectMedia calls with successful result for mediaType = 1', done => {
         mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
@@ -377,11 +370,9 @@ describe('media', () => {
             expect(mediaAttachment.getMedia).toBeDefined();
             done();
           });
-
           const message = mobilePlatformMock.findMessageByFunc('selectMedia');
           expect(message).not.toBeNull();
           expect(message.args.length).toBe(1);
-
           const callbackId = message.id;
           const filesArray = [
             {
@@ -400,7 +391,6 @@ describe('media', () => {
           } as DOMMessageEvent);
         });
       });
-
       it('selectMedia calls with successful result for mediaType = 3', done => {
         mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.ios).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(videoAndImageMediaAPISupportVersion);
@@ -421,11 +411,9 @@ describe('media', () => {
             expect(mediaAttachment.getMedia).toBeDefined();
             done();
           });
-
           const message = mobilePlatformMock.findMessageByFunc('selectMedia');
           expect(message).not.toBeNull();
           expect(message.args.length).toBe(1);
-
           const callbackId = message.id;
           const filesArray = [
             {
@@ -465,11 +453,9 @@ describe('media', () => {
             expect(mediaAttachment.getMedia).toBeDefined();
             done();
           });
-
           const message = mobilePlatformMock.findMessageByFunc('selectMedia');
           expect(message).not.toBeNull();
           expect(message.args.length).toBe(1);
-
           const callbackId = message.id;
           const filesArray = [
             {
@@ -488,50 +474,345 @@ describe('media', () => {
           } as DOMMessageEvent);
         });
       });
-
       it('selectMedia call for mediaType = 1 and imageOutputFormats in mediaAPISupportVersion of platform support fails', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.task, HostClientType.android);
-        await mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        let mediaError: SdkError;
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
         const mediaInputs: media.MediaInputs = {
           mediaType: media.MediaType.Image,
           imageProps: { imageOutputFormats: [media.ImageOutputFormats.PDF] },
           maxMediaCount: 6,
         };
-        try {
-          await media.selectMedia(mediaInputs, (error: SdkError, attachments: media.Media[]) => {
-            mediaError = error;
-          });
-        } catch (err) {
-          expect(err).not.toBeNull();
-          expect(err.errorCode).toBe(ErrorCode.OLD_PLATFORM);
-        }
-      });
-
-      it('videoController notifyEventToHost should fail in default version of platform', () => {
-        return mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-          let error;
-          new media.VideoController().stop((e: SdkError) => {
-            error = e;
-          });
+        media.selectMedia(mediaInputs, (error: SdkError, attachments: media.Media[]) => {
           expect(error).not.toBeNull();
           expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
         });
       });
+      it('videoController notifyEventToHost should fail in default version of platform', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
+        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+        let mediaError: SdkError;
+        new media.VideoController().stop(e => {
+          mediaError = e;
+          expect(mediaError).toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+        });
+      });
+      it('videoController notifyEventToHost is handled successfully', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
+        mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+        let mediaError: SdkError;
+        new media.VideoController().stop(err => (mediaError = err));
+        const message = mobilePlatformMock.findMessageByFunc('media.controller');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+        const callbackId = message.id;
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [undefined],
+          },
+        } as DOMMessageEvent);
+        expect(mediaError).toBeFalsy();
+      });
+    });
+    it('selectMedia calls with error', () => {
+      return mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaInputs: media.MediaInputs = {
+          mediaType: media.MediaType.Image,
+          maxMediaCount: 10,
+        };
+        media.selectMedia(mediaInputs, (mediaError: SdkError, mediaAttachments: media.Media[]) => {
+          expect(mediaAttachments).toBeFalsy();
+          expect(mediaError.errorCode).toBe(ErrorCode.SIZE_EXCEEDED);
+        });
+        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+        const callbackId = message.id;
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [{ errorCode: ErrorCode.SIZE_EXCEEDED }],
+          },
+        } as DOMMessageEvent);
+      });
+    });
+  });
+  describe('v2', () => {
+    it('should not allow selectMedia calls with null mediaInputs', async () => {
+      await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+      return expect(media.selectMedia(null)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+    });
 
-      it('videoController notifyEventToHost is handled successfully', () => {
-        return mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
-          let mediaError: SdkError;
-          new media.VideoController().stop((e: SdkError) => {
+    it('should not allow selectMedia calls with invalid mediaInputs', async () => {
+      await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+      const mediaInputs: media.MediaInputs = {
+        mediaType: media.MediaType.Image,
+        maxMediaCount: 11,
+      };
+      return expect(media.selectMedia(mediaInputs)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+    });
+
+    it('selectMedia call in default version of platform support fails', async () => {
+      await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+      const mediaInputs: media.MediaInputs = {
+        mediaType: media.MediaType.Image,
+        maxMediaCount: 10,
+      };
+      return expect(media.selectMedia(mediaInputs)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+    });
+
+    it('selectMedia call for mediaType = 3 in mediaAPISupportVersion of platform support fails', async () => {
+      await mobilePlatformMock.initializeWithContext(FrameContexts.task, HostClientType.android);
+      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+      const mediaInputs: media.MediaInputs = {
+        mediaType: media.MediaType.VideoAndImage,
+        maxMediaCount: 10,
+      };
+      return expect(media.selectMedia(mediaInputs)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+    });
+
+    it('selectMedia call in task frameContext works', async () => {
+      await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+      const mediaInputs: media.MediaInputs = {
+        mediaType: media.MediaType.Image,
+        maxMediaCount: 10,
+      };
+      media.selectMedia(mediaInputs);
+      const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+      expect(message).not.toBeNull();
+      expect(message.args.length).toBe(1);
+    });
+
+    it('selectMedia call in content frameContext works', async () => {
+      await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+      const mediaInputs: media.MediaInputs = {
+        mediaType: media.MediaType.Image,
+        maxMediaCount: 10,
+      };
+      media.selectMedia(mediaInputs);
+      const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+      expect(message).not.toBeNull();
+      expect(message.args.length).toBe(1);
+    });
+
+    it('selectMedia calls with successful result for mediaType = 1', async () => {
+      await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+      const mediaInputs: media.MediaInputs = {
+        mediaType: media.MediaType.Image,
+        maxMediaCount: 10,
+      };
+      const promise = media.selectMedia(mediaInputs);
+
+      const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+      expect(message).not.toBeNull();
+      expect(message.args.length).toBe(1);
+
+      const callbackId = message.id;
+      const filesArray = [
+        {
+          content: 'base64encodedImage',
+          preview: null,
+          format: media.FileFormat.ID,
+          mimeType: 'image/jpeg',
+          size: 300,
+        } as media.Media,
+      ];
+      mobilePlatformMock.respondToMessage({
+        data: {
+          id: callbackId,
+          args: [undefined, filesArray],
+        },
+      } as DOMMessageEvent);
+
+      const mediaAttachments = await promise;
+      expect(mediaAttachments.length).toBe(1);
+      const mediaAttachment = mediaAttachments[0];
+      expect(mediaAttachment).not.toBeNull();
+      expect(mediaAttachment.format).toBe(media.FileFormat.ID);
+      expect(mediaAttachment.mimeType).toBe('image/jpeg');
+      expect(mediaAttachment.content).not.toBeNull();
+      expect(mediaAttachment.size).not.toBeNull();
+      expect(typeof mediaAttachment.size === 'number').toBeTruthy();
+      expect(mediaAttachment.getMedia).toBeDefined();
+    });
+
+    it('selectMedia calls with successful result for mediaType = 3', async () => {
+      await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.ios);
+      mobilePlatformMock.setClientSupportedSDKVersion(videoAndImageMediaAPISupportVersion);
+      const mediaInputs: media.MediaInputs = {
+        mediaType: media.MediaType.VideoAndImage,
+        maxMediaCount: 10,
+      };
+      const promise = media.selectMedia(mediaInputs);
+
+      const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+      expect(message).not.toBeNull();
+      expect(message.args.length).toBe(1);
+
+      const callbackId = message.id;
+      const filesArray = [
+        {
+          content: 'base64encodedImage',
+          preview: null,
+          format: media.FileFormat.ID,
+          mimeType: 'video/mp4',
+          size: 300,
+        } as media.Media,
+      ];
+      mobilePlatformMock.respondToMessage({
+        data: {
+          id: callbackId,
+          args: [undefined, filesArray],
+        },
+      } as DOMMessageEvent);
+
+      const mediaAttachments = await promise;
+      expect(mediaAttachments.length).toBe(1);
+      const mediaAttachment = mediaAttachments[0];
+      expect(mediaAttachment).not.toBeNull();
+      expect(mediaAttachment.format).toBe(media.FileFormat.ID);
+      expect(mediaAttachment.mimeType).toBe('video/mp4');
+      expect(mediaAttachment.content).not.toBeNull();
+      expect(mediaAttachment.size).not.toBeNull();
+      expect(typeof mediaAttachment.size === 'number').toBeTruthy();
+      expect(mediaAttachment.getMedia).toBeDefined();
+      await expect(promise).resolves;
+    });
+
+    it('selectMedia calls with error', async () => {
+      expect.assertions(6); // initializeWithContext has 3 assertions + 3 local assertions
+      await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+      const mediaInputs: media.MediaInputs = {
+        mediaType: media.MediaType.Image,
+        maxMediaCount: 10,
+      };
+      const promise = media.selectMedia(mediaInputs);
+
+      const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+      expect(message).not.toBeNull();
+      expect(message.args.length).toBe(1);
+
+      const callbackId = message.id;
+      mobilePlatformMock.respondToMessage({
+        data: {
+          id: callbackId,
+          args: [{ errorCode: ErrorCode.SIZE_EXCEEDED }],
+        },
+      } as DOMMessageEvent);
+
+      await expect(promise).rejects.toMatchObject({ errorCode: ErrorCode.SIZE_EXCEEDED });
+    });
+  });
+  describe('videoController', () => {
+    describe('v1', () => {
+      it('videoController notifyEventToHost is not handled successfully', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
+        mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+        let mediaError: SdkError;
+        new media.VideoController().stop((e: SdkError) => (mediaError = e));
+        const message = mobilePlatformMock.findMessageByFunc('media.controller');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+        const callbackId = message.id;
+        const err = {
+          errorCode: ErrorCode.INTERNAL_ERROR,
+        };
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [err],
+          },
+        } as DOMMessageEvent);
+        expect(mediaError).toEqual(err);
+      });
+      it('should invoke correct video callback for MediaControllerEvent when registered', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.ios);
+        mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+        let mediaError: SdkError;
+        const mockCallback = jest.fn();
+        const videoControllerCallback: media.VideoControllerCallback = {
+          onRecordingStarted() {
+            mockCallback();
+          },
+        };
+        const videoProps: media.VideoProps = {
+          videoController: new media.VideoController(videoControllerCallback),
+        };
+        const mediaInputs: media.MediaInputs = {
+          mediaType: media.MediaType.Video,
+          maxMediaCount: 10,
+          videoProps: videoProps,
+        };
+        media
+          .selectMedia(mediaInputs, (e: SdkError, attachments: media.Media[]) => {
             mediaError = e;
+          })
+          .then(() => {
+            const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1);
+            const callbackId = message.id;
+            mobilePlatformMock.respondToMessage({
+              data: {
+                id: callbackId,
+                args: [undefined, undefined, 1],
+              },
+            } as DOMMessageEvent);
+            expect(mediaError).toBeFalsy();
+            expect(mockCallback).toHaveBeenCalled();
           });
+      });
+      it('should not invoke video callback for MediaControllerEvent when not registered', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.ios);
+        mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+        let mediaError: SdkError;
+        const mediaInputs: media.MediaInputs = {
+          mediaType: media.MediaType.Video,
+          maxMediaCount: 10,
+          videoProps: {},
+        };
+        media.selectMedia(mediaInputs, (e: SdkError, attachments: media.Media[]) => {
+          mediaError = e;
+        });
+        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+        const callbackId = message.id;
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [undefined, undefined, 2],
+          },
+        } as DOMMessageEvent);
+        expect(mediaError).toBeFalsy();
+        expect(jest.fn()).not.toHaveBeenCalled();
+      });
+      describe('v2', () => {
+        it('videoController notifyEventToHost should fail in default version of platform', async () => {
+          expect.assertions(4); // initializeWithContext has 3 assertions + 1 local assertion
+          await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
+          mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
 
+          return new media.VideoController().stop().catch(err => {
+            expect(err).toMatchObject({ errorCode: ErrorCode.OLD_PLATFORM });
+          });
+        });
+        it('videoController notifyEventToHost is handled successfully', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
+          mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+
+          const stopPromise = new media.VideoController().stop();
           const message = mobilePlatformMock.findMessageByFunc('media.controller');
           expect(message).not.toBeNull();
           expect(message.args.length).toBe(1);
-
           const callbackId = message.id;
           mobilePlatformMock.respondToMessage({
             data: {
@@ -539,26 +820,19 @@ describe('media', () => {
               args: [undefined],
             },
           } as DOMMessageEvent);
-
-          expect(mediaError).toBeFalsy();
+          expect(stopPromise).resolves;
         });
-      });
 
-      it('videoController notifyEventToHost is not handled successfully', () => {
-        return mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android).then(() => {
+        it('videoController notifyEventToHost is not handled successfully but stop', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
           mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
-          let mediaError: SdkError;
-          new media.VideoController().stop((e: SdkError) => {
-            mediaError = e;
-          });
 
-          const err: SdkError = {
-            errorCode: ErrorCode.INTERNAL_ERROR,
-          };
+          const err = { errorCode: ErrorCode.INTERNAL_ERROR };
+          const stopPromise = new media.VideoController().stop();
+
           const message = mobilePlatformMock.findMessageByFunc('media.controller');
           expect(message).not.toBeNull();
           expect(message.args.length).toBe(1);
-
           const callbackId = message.id;
           mobilePlatformMock.respondToMessage({
             data: {
@@ -567,705 +841,524 @@ describe('media', () => {
             },
           } as DOMMessageEvent);
 
-          expect(mediaError).toBe(err);
-        });
-      });
-
-      it('should invoke correct video callback for MediaControllerEvent when registered', () => {
-        return mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.ios).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
-          let mediaError: SdkError;
-          const mockCallback = jest.fn();
-          const videoControllerCallback: media.VideoControllerCallback = {
-            onRecordingStarted() {
-              mockCallback();
-            },
-          };
-          const videoProps: media.VideoProps = {
-            videoController: new media.VideoController(videoControllerCallback),
-          };
-          const mediaInputs: media.MediaInputs = {
-            mediaType: media.MediaType.Video,
-            maxMediaCount: 10,
-            videoProps: videoProps,
-          };
-
-          media
-            .selectMedia(mediaInputs, (e: SdkError, attachments: media.Media[]) => {
-              mediaError = e;
-            })
-            .then(() => {
-              const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-              expect(message).not.toBeNull();
-              expect(message.args.length).toBe(1);
-
-              const callbackId = message.id;
-              mobilePlatformMock.respondToMessage({
-                data: {
-                  id: callbackId,
-                  args: [undefined, undefined, 1],
-                },
-              } as DOMMessageEvent);
-
-              expect(mediaError).toBeFalsy();
-              expect(mockCallback).toHaveBeenCalled();
-            });
-        });
-      });
-
-      it('should not invoke video callback for MediaControllerEvent when not registered', () => {
-        return mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.ios).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
-          let mediaError: SdkError;
-          const mediaInputs: media.MediaInputs = {
-            mediaType: media.MediaType.Video,
-            maxMediaCount: 10,
-            videoProps: {},
-          };
-
-          media.selectMedia(mediaInputs, (e: SdkError, attachments: media.Media[]) => {
-            mediaError = e;
+          await stopPromise.catch(err => {
+            expect(err).toMatchObject(err);
           });
-
-          const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(1);
-
-          const callbackId = message.id;
-          mobilePlatformMock.respondToMessage({
-            data: {
-              id: callbackId,
-              args: [undefined, undefined, 2],
-            },
-          } as DOMMessageEvent);
-
-          expect(mediaError).toBeFalsy();
-          expect(jest.fn()).not.toHaveBeenCalled();
-        });
-      });
-
-      it('selectMedia calls with error', () => {
-        return mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-          const mediaInputs: media.MediaInputs = {
-            mediaType: media.MediaType.Image,
-            maxMediaCount: 10,
-          };
-          media.selectMedia(mediaInputs, (mediaError: SdkError, mediaAttachments: media.Media[]) => {
-            expect(mediaAttachments).toBeFalsy();
-            expect(mediaError.errorCode).toBe(ErrorCode.SIZE_EXCEEDED);
-          });
-
-          const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(1);
-
-          const callbackId = message.id;
-          mobilePlatformMock.respondToMessage({
-            data: {
-              id: callbackId,
-              args: [{ errorCode: ErrorCode.SIZE_EXCEEDED }],
-            },
-          } as DOMMessageEvent);
         });
       });
     });
-    describe('v2', () => {
-      it('should not allow selectMedia calls with null mediaInputs', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        return expect(media.selectMedia(null)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
-      });
-
-      it('should not allow selectMedia calls with invalid mediaInputs', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaInputs: media.MediaInputs = {
-          mediaType: media.MediaType.Image,
-          maxMediaCount: 11,
-        };
-        return expect(media.selectMedia(mediaInputs)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
-      });
-
-      it('selectMedia call in default version of platform support fails', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-        const mediaInputs: media.MediaInputs = {
-          mediaType: media.MediaType.Image,
-          maxMediaCount: 10,
-        };
-        return expect(media.selectMedia(mediaInputs)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
-      });
-
-      it('selectMedia call for mediaType = 3 in mediaAPISupportVersion of platform support fails', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task, HostClientType.android);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaInputs: media.MediaInputs = {
-          mediaType: media.MediaType.VideoAndImage,
-          maxMediaCount: 10,
-        };
-        return expect(media.selectMedia(mediaInputs)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
-      });
-
-      it('selectMedia call in task frameContext works', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaInputs: media.MediaInputs = {
-          mediaType: media.MediaType.Image,
-          maxMediaCount: 10,
-        };
-        media.selectMedia(mediaInputs);
-        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-      });
-
-      it('selectMedia call in content frameContext works', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaInputs: media.MediaInputs = {
-          mediaType: media.MediaType.Image,
-          maxMediaCount: 10,
-        };
-        media.selectMedia(mediaInputs);
-        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-      });
-
-      it('selectMedia calls with successful result for mediaType = 1', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaInputs: media.MediaInputs = {
-          mediaType: media.MediaType.Image,
-          maxMediaCount: 10,
-        };
-        const promise = media.selectMedia(mediaInputs);
-
-        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-
-        const callbackId = message.id;
-        const filesArray = [
-          {
-            content: 'base64encodedImage',
-            preview: null,
-            format: media.FileFormat.ID,
-            mimeType: 'image/jpeg',
-            size: 300,
-          } as media.Media,
-        ];
-        mobilePlatformMock.respondToMessage({
-          data: {
-            id: callbackId,
-            args: [undefined, filesArray],
-          },
-        } as DOMMessageEvent);
-
-        const mediaAttachments = await promise;
-        expect(mediaAttachments.length).toBe(1);
-        const mediaAttachment = mediaAttachments[0];
-        expect(mediaAttachment).not.toBeNull();
-        expect(mediaAttachment.format).toBe(media.FileFormat.ID);
-        expect(mediaAttachment.mimeType).toBe('image/jpeg');
-        expect(mediaAttachment.content).not.toBeNull();
-        expect(mediaAttachment.size).not.toBeNull();
-        expect(typeof mediaAttachment.size === 'number').toBeTruthy();
-        expect(mediaAttachment.getMedia).toBeDefined();
-      });
-
-      it('selectMedia calls with successful result for mediaType = 3', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.ios);
-        mobilePlatformMock.setClientSupportedSDKVersion(videoAndImageMediaAPISupportVersion);
-        const mediaInputs: media.MediaInputs = {
-          mediaType: media.MediaType.VideoAndImage,
-          maxMediaCount: 10,
-        };
-        const promise = media.selectMedia(mediaInputs);
-
-        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-
-        const callbackId = message.id;
-        const filesArray = [
-          {
-            content: 'base64encodedImage',
-            preview: null,
-            format: media.FileFormat.ID,
-            mimeType: 'video/mp4',
-            size: 300,
-          } as media.Media,
-        ];
-        mobilePlatformMock.respondToMessage({
-          data: {
-            id: callbackId,
-            args: [undefined, filesArray],
-          },
-        } as DOMMessageEvent);
-
-        const mediaAttachments = await promise;
-        expect(mediaAttachments.length).toBe(1);
-        const mediaAttachment = mediaAttachments[0];
-        expect(mediaAttachment).not.toBeNull();
-        expect(mediaAttachment.format).toBe(media.FileFormat.ID);
-        expect(mediaAttachment.mimeType).toBe('video/mp4');
-        expect(mediaAttachment.content).not.toBeNull();
-        expect(mediaAttachment.size).not.toBeNull();
-        expect(typeof mediaAttachment.size === 'number').toBeTruthy();
-        expect(mediaAttachment.getMedia).toBeDefined();
-      });
-
-      it('selectMedia calls with error', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaInputs: media.MediaInputs = {
-          mediaType: media.MediaType.Image,
-          maxMediaCount: 10,
-        };
-        const promise = media.selectMedia(mediaInputs);
-
-        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-
-        const callbackId = message.id;
-        mobilePlatformMock.respondToMessage({
-          data: {
-            id: callbackId,
-            args: [{ errorCode: ErrorCode.SIZE_EXCEEDED }],
-          },
-        } as DOMMessageEvent);
-
-        return expect(promise).rejects.toEqual({ errorCode: ErrorCode.SIZE_EXCEEDED });
-      });
-    });
-  });
-
-  describe('getMedia', () => {
-    describe('v1', () => {
-      it('should not allow getMedia calls with invalid media mimetype', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-          const mediaOutput: media.Media = new media.Media();
-          mediaOutput.content = '1234567';
-          mediaOutput.mimeType = null;
-          mediaOutput.format = media.FileFormat.ID;
-          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-            expect(error).not.toBeNull();
-            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
-            done();
-          });
-        });
-      });
-
-      it('should not allow getMedia calls with invalid media content', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-          const mediaOutput: media.Media = new media.Media();
-          mediaOutput.content = null;
-          mediaOutput.mimeType = 'image/jpeg';
-          mediaOutput.format = media.FileFormat.ID;
-          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-            expect(error).not.toBeNull();
-            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
-            done();
-          });
-        });
-      });
-
-      it('should not allow getMedia calls with invalid media file format', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-          const mediaOutput: media.Media = new media.Media();
-          mediaOutput.content = '1234567';
-          mediaOutput.mimeType = 'image/jpeg';
-          mediaOutput.format = media.FileFormat.Base64;
-          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-            expect(error).not.toBeNull();
-            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
-            done();
-          });
-        });
-      });
-
-      it('getMedia call in default version of platform support fails', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-          const mediaOutput: media.Media = new media.Media();
-          mediaOutput.content = '1234567';
-          mediaOutput.mimeType = 'image/jpeg';
-          mediaOutput.format = media.FileFormat.ID;
-          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-            expect(error).not.toBeNull();
-            expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
-            done();
-          });
-        });
-      });
-
-      it('getMedia call in task frameContext works', async () => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-          const mediaOutput: media.Media = new media.Media();
-          mediaOutput.content = '1234567';
-          mediaOutput.mimeType = 'image/jpeg';
-          mediaOutput.format = media.FileFormat.ID;
-          mediaOutput.getMedia(emptyCallback);
-          const message = mobilePlatformMock.findMessageByFunc('getMedia');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(2);
-        });
-      });
-
-      async function getStringContainedInBlob(blob: Blob): Promise<string> {
-        let resolverMethod: (value: string | PromiseLike<string>) => void;
-        let rejectionMethod: (reason?: any) => void;
-        const blobReadingPromise: Promise<string> = new Promise<string>((resolve, reject) => {
-          resolverMethod = resolve;
-          rejectionMethod = reject;
-        });
-
-        const blobReader = new FileReader();
-        blobReader.onloadend = (): void => {
-          resolverMethod(String.fromCharCode(...new Uint8Array(blobReader.result as ArrayBuffer)));
-        };
-        blobReader.onerror = (): void => {
-          rejectionMethod(blobReader.error);
-        };
-
-        blobReader.readAsArrayBuffer(blob);
-
-        return blobReadingPromise;
-      }
-
-      it('getMedia calls with successful result via the handler', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-          //mediaAPISupport version(1.8.0) is less than the MediaCallbackSupportVersion(2.0.0)
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-          const mediaOutput: media.Media = new media.Media();
-          mediaOutput.content = '1234567';
-          mediaOutput.mimeType = 'image/jpeg';
-          mediaOutput.format = media.FileFormat.ID;
-          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-            getStringContainedInBlob(blob).then(res => {
-              expect(res).toEqual(stringMediaData);
+    describe('getMedia', () => {
+      describe('v1', () => {
+        it('should not allow getMedia calls with invalid media mimetype', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+            const mediaOutput: media.Media = new media.Media();
+            mediaOutput.content = '1234567';
+            mediaOutput.mimeType = null;
+            mediaOutput.format = media.FileFormat.ID;
+            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+              expect(error).not.toBeNull();
+              expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
               done();
             });
           });
-
-          const message = mobilePlatformMock.findMessageByFunc('getMedia');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(2);
-
-          const stringMediaData = 'the media data';
-          const firstMediaResult: media.MediaResult = {
-            error: undefined,
-            mediaChunk: {
-              chunk: btoa(stringMediaData),
-              chunkSequence: 1,
-            },
-          };
-          const secondMediaResult: media.MediaResult = {
-            error: undefined,
-            mediaChunk: {
-              chunk: undefined,
-              chunkSequence: 0,
-            },
-          };
-
-          const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
-          const getMediaHandlerName = handlerRegistrationMessage.args[0];
-
-          const mediaResults = Array.of(firstMediaResult, secondMediaResult);
-
-          for (let i = 0; i < mediaResults.length; ++i) {
-            callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
-          }
         });
-      });
 
-      it('getMedia calls with successful result via the callback', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-          // here we give the same version as the supported version
-          mobilePlatformMock.setClientSupportedSDKVersion(getMediaCallbackSupportVersion);
-          const mediaOutput: media.Media = new media.Media();
-          mediaOutput.content = '1234567';
-          mediaOutput.mimeType = 'image/jpeg';
-          mediaOutput.format = media.FileFormat.ID;
-          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-            getStringContainedInBlob(blob).then(res => {
-              expect(res).toEqual(stringMediaData);
+        it('should not allow getMedia calls with invalid media content', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+            const mediaOutput: media.Media = new media.Media();
+            mediaOutput.content = null;
+            mediaOutput.mimeType = 'image/jpeg';
+            mediaOutput.format = media.FileFormat.ID;
+            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+              expect(error).not.toBeNull();
+              expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
               done();
             });
           });
+        });
 
-          const message = mobilePlatformMock.findMessageByFunc('getMedia');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(1); // args will be of length 1 for the supported version
+        it('should not allow getMedia calls with invalid media file format', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+            const mediaOutput: media.Media = new media.Media();
+            mediaOutput.content = '1234567';
+            mediaOutput.mimeType = 'image/jpeg';
+            mediaOutput.format = media.FileFormat.Base64;
+            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+              expect(error).not.toBeNull();
+              expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+              done();
+            });
+          });
+        });
 
-          const stringMediaData = 'the media data';
-          const firstMediaResult: media.MediaResult = {
-            error: undefined,
-            mediaChunk: {
-              chunk: btoa(stringMediaData),
-              chunkSequence: 1,
-            },
+        it('getMedia call in default version of platform support fails', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+            const mediaOutput: media.Media = new media.Media();
+            mediaOutput.content = '1234567';
+            mediaOutput.mimeType = 'image/jpeg';
+            mediaOutput.format = media.FileFormat.ID;
+            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+              expect(error).not.toBeNull();
+              expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
+              done();
+            });
+          });
+        });
+
+        it('getMedia call in task frameContext works', async () => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+            const mediaOutput: media.Media = new media.Media();
+            mediaOutput.content = '1234567';
+            mediaOutput.mimeType = 'image/jpeg';
+            mediaOutput.format = media.FileFormat.ID;
+            mediaOutput.getMedia(emptyCallback);
+            const message = mobilePlatformMock.findMessageByFunc('getMedia');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(2);
+          });
+        });
+
+        async function getStringContainedInBlob(blob: Blob): Promise<string> {
+          let resolverMethod: (value: string | PromiseLike<string>) => void;
+          let rejectionMethod: (reason?: any) => void;
+          const blobReadingPromise: Promise<string> = new Promise<string>((resolve, reject) => {
+            resolverMethod = resolve;
+            rejectionMethod = reject;
+          });
+
+          const blobReader = new FileReader();
+          blobReader.onloadend = (): void => {
+            resolverMethod(String.fromCharCode(...new Uint8Array(blobReader.result as ArrayBuffer)));
           };
-          const secondMediaResult: media.MediaResult = {
-            error: undefined,
-            mediaChunk: {
-              chunk: undefined,
-              chunkSequence: 0,
-            },
+          blobReader.onerror = (): void => {
+            rejectionMethod(blobReader.error);
           };
 
-          const mediaResults = Array.of(firstMediaResult, secondMediaResult);
+          blobReader.readAsArrayBuffer(blob);
 
-          for (let i = 0; i < mediaResults.length; ++i) {
-            mobilePlatformMock.respondToMessage({
-              data: {
-                id: message.id,
-                args: [mediaResults[i]],
-                isPartialResponse: i < mediaResults.length - 1,
+          return blobReadingPromise;
+        }
+
+        it('getMedia calls with successful result via the handler', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+            //mediaAPISupport version(1.8.0) is less than the MediaCallbackSupportVersion(2.0.0)
+            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+            const mediaOutput: media.Media = new media.Media();
+            mediaOutput.content = '1234567';
+            mediaOutput.mimeType = 'image/jpeg';
+            mediaOutput.format = media.FileFormat.ID;
+            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+              getStringContainedInBlob(blob).then(res => {
+                expect(res).toEqual(stringMediaData);
+                done();
+              });
+            });
+
+            const message = mobilePlatformMock.findMessageByFunc('getMedia');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(2);
+
+            const stringMediaData = 'the media data';
+            const firstMediaResult: media.MediaResult = {
+              error: undefined,
+              mediaChunk: {
+                chunk: btoa(stringMediaData),
+                chunkSequence: 1,
               },
-            } as DOMMessageEvent);
-          }
-        });
-      });
+            };
+            const secondMediaResult: media.MediaResult = {
+              error: undefined,
+              mediaChunk: {
+                chunk: undefined,
+                chunkSequence: 0,
+              },
+            };
 
-      it('getMedia calls with error with MediaCallback', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(getMediaCallbackSupportVersion);
-          const mediaOutput: media.Media = new media.Media();
-          mediaOutput.content = '12345678';
-          mediaOutput.mimeType = 'image/jpeg';
-          mediaOutput.format = media.FileFormat.ID;
-          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-            expect(error.errorCode).toBe(500);
-            expect(error.message).toEqual('data received is null');
-            expect(blob).toBeFalsy();
-            done();
+            const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
+            const getMediaHandlerName = handlerRegistrationMessage.args[0];
+
+            const mediaResults = Array.of(firstMediaResult, secondMediaResult);
+
+            for (let i = 0; i < mediaResults.length; ++i) {
+              callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
+            }
           });
-
-          const message = mobilePlatformMock.findMessageByFunc('getMedia');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(1);
-
-          const callbackId = message.id;
-          mobilePlatformMock.respondToMessage({
-            data: {
-              id: callbackId,
-              args: [undefined, undefined],
-            },
-          } as DOMMessageEvent);
-        });
-      });
-
-      it('getMedia calls with error with Handler', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-
-          const mediaOutput: media.Media = new media.Media();
-          mediaOutput.content = '1234567';
-          mediaOutput.mimeType = 'image/jpeg';
-          mediaOutput.format = media.FileFormat.ID;
-          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-            expect(blob).toBeFalsy();
-            expect(error.errorCode).toBe(500);
-            done();
-          });
-
-          const message = mobilePlatformMock.findMessageByFunc('getMedia');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(2);
-
-          const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
-          const getMediaHandlerName = handlerRegistrationMessage.args[0];
-          callHandler(getMediaHandlerName, [JSON.stringify(undefined)]);
-        });
-      });
-    });
-    describe('v2', () => {
-      it('should not allow getMedia calls with invalid media mimetype', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaOutput: media.Media = new media.Media();
-        mediaOutput.content = '1234567';
-        mediaOutput.mimeType = null;
-        mediaOutput.format = media.FileFormat.ID;
-        return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
-      });
-
-      it('should not allow getMedia calls with invalid media content', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaOutput: media.Media = new media.Media();
-        mediaOutput.content = null;
-        mediaOutput.mimeType = 'image/jpeg';
-        mediaOutput.format = media.FileFormat.ID;
-        return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
-      });
-
-      it('should not allow getMedia calls with invalid media file format', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaOutput: media.Media = new media.Media();
-        mediaOutput.content = '1234567';
-        mediaOutput.mimeType = 'image/jpeg';
-        mediaOutput.format = media.FileFormat.Base64;
-        return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
-      });
-
-      it('getMedia call in default version of platform support fails', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-        const mediaOutput: media.Media = new media.Media();
-        mediaOutput.content = '1234567';
-        mediaOutput.mimeType = 'image/jpeg';
-        mediaOutput.format = media.FileFormat.ID;
-        return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
-      });
-
-      it('getMedia call in task frameContext works', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaOutput: media.Media = new media.Media();
-        mediaOutput.content = '1234567';
-        mediaOutput.mimeType = 'image/jpeg';
-        mediaOutput.format = media.FileFormat.ID;
-        mediaOutput.getMedia();
-        const message = mobilePlatformMock.findMessageByFunc('getMedia');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(2);
-      });
-
-      async function getStringContainedInBlob(blob: Blob): Promise<string> {
-        let resolverMethod: (value: string | PromiseLike<string>) => void;
-        let rejectionMethod: (reason?: any) => void;
-        const blobReadingPromise: Promise<string> = new Promise<string>((resolve, reject) => {
-          resolverMethod = resolve;
-          rejectionMethod = reject;
         });
 
-        const blobReader = new FileReader();
-        blobReader.onloadend = (): void => {
-          resolverMethod(String.fromCharCode(...new Uint8Array(blobReader.result as ArrayBuffer)));
-        };
-        blobReader.onerror = (): void => {
-          rejectionMethod(blobReader.error);
-        };
+        it('getMedia calls with successful result via the callback', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+            // here we give the same version as the supported version
+            mobilePlatformMock.setClientSupportedSDKVersion(getMediaCallbackSupportVersion);
+            const mediaOutput: media.Media = new media.Media();
+            mediaOutput.content = '1234567';
+            mediaOutput.mimeType = 'image/jpeg';
+            mediaOutput.format = media.FileFormat.ID;
+            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+              getStringContainedInBlob(blob).then(res => {
+                expect(res).toEqual(stringMediaData);
+                done();
+              });
+            });
 
-        blobReader.readAsArrayBuffer(blob);
+            const message = mobilePlatformMock.findMessageByFunc('getMedia');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1); // args will be of length 1 for the supported version
 
-        return blobReadingPromise;
-      }
+            const stringMediaData = 'the media data';
+            const firstMediaResult: media.MediaResult = {
+              error: undefined,
+              mediaChunk: {
+                chunk: btoa(stringMediaData),
+                chunkSequence: 1,
+              },
+            };
+            const secondMediaResult: media.MediaResult = {
+              error: undefined,
+              mediaChunk: {
+                chunk: undefined,
+                chunkSequence: 0,
+              },
+            };
 
-      async function validateGetMediaMessageAndResults(
-        supportedSDKVersion: string,
-        expectedNumberOfParametersInGetMediaMessage: number,
-        respondToMessages: (message: MessageRequest, mediaResults: media.MediaResult[]) => void,
-      ): Promise<void> {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        mobilePlatformMock.setClientSupportedSDKVersion(supportedSDKVersion);
-
-        const stringMediaData = 'the media data';
-        const firstMediaResult: media.MediaResult = {
-          error: undefined,
-          mediaChunk: {
-            chunk: btoa(stringMediaData),
-            chunkSequence: 1,
-          },
-        };
-        const secondMediaResult: media.MediaResult = {
-          error: undefined,
-          mediaChunk: {
-            chunk: undefined,
-            chunkSequence: 0,
-          },
-        };
-
-        const mediaOutput: media.Media = new media.Media();
-        mediaOutput.content = '1234567';
-        mediaOutput.mimeType = 'image/jpeg';
-        mediaOutput.format = media.FileFormat.ID;
-        const getMediaPromise: Promise<Blob> = mediaOutput.getMedia();
-
-        const message = mobilePlatformMock.findMessageByFunc('getMedia');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(expectedNumberOfParametersInGetMediaMessage);
-
-        respondToMessages(message, [firstMediaResult, secondMediaResult]);
-
-        const blobContents: string = await getStringContainedInBlob(await getMediaPromise);
-        expect(blobContents).toEqual(stringMediaData);
-      }
-
-      it('getMedia using callback method returns successful result with expected data', async () => {
-        validateGetMediaMessageAndResults(
-          getMediaCallbackSupportVersion,
-          1,
-          (message: MessageRequest, mediaResults: media.MediaResult[]) => {
-            const callbackId = message.id;
+            const mediaResults = Array.of(firstMediaResult, secondMediaResult);
 
             for (let i = 0; i < mediaResults.length; ++i) {
               mobilePlatformMock.respondToMessage({
                 data: {
-                  id: callbackId,
+                  id: message.id,
                   args: [mediaResults[i]],
                   isPartialResponse: i < mediaResults.length - 1,
                 },
               } as DOMMessageEvent);
             }
-          },
-        );
-      });
+          });
+        });
 
-      it('getMedia using register handler method returns successful result with expected data', async () => {
-        validateGetMediaMessageAndResults(
-          mediaAPISupportVersion,
-          2,
-          (_message: MessageRequest, mediaResults: media.MediaResult[]) => {
+        it('getMedia calls with error with MediaCallback', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(getMediaCallbackSupportVersion);
+            const mediaOutput: media.Media = new media.Media();
+            mediaOutput.content = '12345678';
+            mediaOutput.mimeType = 'image/jpeg';
+            mediaOutput.format = media.FileFormat.ID;
+            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+              expect(error.errorCode).toBe(500);
+              expect(error.message).toEqual('data received is null');
+              expect(blob).toBeFalsy();
+              done();
+            });
+
+            const message = mobilePlatformMock.findMessageByFunc('getMedia');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1);
+
+            const callbackId = message.id;
+            mobilePlatformMock.respondToMessage({
+              data: {
+                id: callbackId,
+                args: [undefined, undefined],
+              },
+            } as DOMMessageEvent);
+          });
+        });
+
+        it('getMedia calls with error with Handler', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+
+            const mediaOutput: media.Media = new media.Media();
+            mediaOutput.content = '1234567';
+            mediaOutput.mimeType = 'image/jpeg';
+            mediaOutput.format = media.FileFormat.ID;
+            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+              expect(blob).toBeFalsy();
+              expect(error.errorCode).toBe(500);
+              done();
+            });
+
+            const message = mobilePlatformMock.findMessageByFunc('getMedia');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(2);
+
             const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
             const getMediaHandlerName = handlerRegistrationMessage.args[0];
+            callHandler(getMediaHandlerName, [JSON.stringify(undefined)]);
+          });
+        });
+      });
+      describe('v2', () => {
+        it('should not allow getMedia calls with invalid media mimetype', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = null;
+          mediaOutput.format = media.FileFormat.ID;
+          return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+        });
 
-            for (let i = 0; i < mediaResults.length; ++i) {
-              callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
-            }
-          },
-        );
+        it('should not allow getMedia calls with invalid media content', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = null;
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+        });
+
+        it('should not allow getMedia calls with invalid media file format', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.Base64;
+          return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+        });
+
+        it('getMedia call in default version of platform support fails', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+          mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+        });
+
+        it('getMedia call in task frameContext works', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          mediaOutput.getMedia();
+          const message = mobilePlatformMock.findMessageByFunc('getMedia');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(2);
+        });
+
+        async function getStringContainedInBlob(blob: Blob): Promise<string> {
+          let resolverMethod: (value: string | PromiseLike<string>) => void;
+          let rejectionMethod: (reason?: any) => void;
+          const blobReadingPromise: Promise<string> = new Promise<string>((resolve, reject) => {
+            resolverMethod = resolve;
+            rejectionMethod = reject;
+          });
+
+          const blobReader = new FileReader();
+          blobReader.onloadend = (): void => {
+            resolverMethod(String.fromCharCode(...new Uint8Array(blobReader.result as ArrayBuffer)));
+          };
+          blobReader.onerror = (): void => {
+            rejectionMethod(blobReader.error);
+          };
+
+          blobReader.readAsArrayBuffer(blob);
+
+          return blobReadingPromise;
+        }
+
+        async function validateGetMediaMessageAndResults(
+          supportedSDKVersion: string,
+          expectedNumberOfParametersInGetMediaMessage: number,
+          respondToMessages: (message: MessageRequest, mediaResults: media.MediaResult[]) => void,
+        ): Promise<void> {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+          mobilePlatformMock.setClientSupportedSDKVersion(supportedSDKVersion);
+
+          const stringMediaData = 'the media data';
+          const firstMediaResult: media.MediaResult = {
+            error: undefined,
+            mediaChunk: {
+              chunk: btoa(stringMediaData),
+              chunkSequence: 1,
+            },
+          };
+          const secondMediaResult: media.MediaResult = {
+            error: undefined,
+            mediaChunk: {
+              chunk: undefined,
+              chunkSequence: 0,
+            },
+          };
+
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          const getMediaPromise: Promise<Blob> = mediaOutput.getMedia();
+
+          const message = mobilePlatformMock.findMessageByFunc('getMedia');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(expectedNumberOfParametersInGetMediaMessage);
+
+          respondToMessages(message, [firstMediaResult, secondMediaResult]);
+
+          const blobContents: string = await getStringContainedInBlob(await getMediaPromise);
+          expect(blobContents).toEqual(stringMediaData);
+        }
+
+        it('getMedia using callback method returns successful result with expected data', async () => {
+          validateGetMediaMessageAndResults(
+            getMediaCallbackSupportVersion,
+            1,
+            (message: MessageRequest, mediaResults: media.MediaResult[]) => {
+              const callbackId = message.id;
+
+              for (let i = 0; i < mediaResults.length; ++i) {
+                mobilePlatformMock.respondToMessage({
+                  data: {
+                    id: callbackId,
+                    args: [mediaResults[i]],
+                    isPartialResponse: i < mediaResults.length - 1,
+                  },
+                } as DOMMessageEvent);
+              }
+            },
+          );
+        });
+
+        it('getMedia using register handler method returns successful result with expected data', async () => {
+          validateGetMediaMessageAndResults(
+            mediaAPISupportVersion,
+            2,
+            (_message: MessageRequest, mediaResults: media.MediaResult[]) => {
+              const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
+              const getMediaHandlerName = handlerRegistrationMessage.args[0];
+
+              for (let i = 0; i < mediaResults.length; ++i) {
+                callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
+              }
+            },
+          );
+        });
       });
     });
-  });
 
-  describe('viewImages', () => {
-    describe('v1', () => {
-      it('should not allow viewImages calls with null imageuris', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-          media.viewImages(null, (error: SdkError) => {
-            expect(error).not.toBeNull();
-            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
-            done();
+    describe('viewImages', () => {
+      describe('v1', () => {
+        it('should not allow viewImages calls with null imageuris', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+            media.viewImages(null, (error: SdkError) => {
+              expect(error).not.toBeNull();
+              expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+              done();
+            });
           });
         });
-      });
 
-      it('should not allow viewImages calls with invalid imageuris', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+        it('should not allow viewImages calls with invalid imageuris', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+            const uris: media.ImageUri[] = [];
+            media.viewImages(uris, (error: SdkError) => {
+              expect(error).not.toBeNull();
+              expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+              done();
+            });
+          });
+        });
+
+        it('viewImages call in default version of platform support fails', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+            const uris: media.ImageUri[] = [];
+            const uri: media.ImageUri = {
+              value: 'https://www.w3schools.com/images/picture.jpg',
+              type: media.ImageUriType.URL,
+            };
+            uris.push(uri);
+            media.viewImages(uris, (error: SdkError) => {
+              expect(error).not.toBeNull();
+              expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
+              done();
+            });
+          });
+        });
+
+        it('viewImages call in task frameContext works', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
           mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
           const uris: media.ImageUri[] = [];
-          media.viewImages(uris, (error: SdkError) => {
-            expect(error).not.toBeNull();
-            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
-            done();
+          const uri: media.ImageUri = {
+            value: 'https://www.w3schools.com/images/picture.jpg',
+            type: media.ImageUriType.URL,
+          };
+          uris.push(uri);
+          media.viewImages(uris, emptyCallback);
+          const message = mobilePlatformMock.findMessageByFunc('viewImages');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
+        });
+
+        it('viewImages call in content frameContext works', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const uris: media.ImageUri[] = [];
+          const uri: media.ImageUri = {
+            value: 'https://www.w3schools.com/images/picture.jpg',
+            type: media.ImageUriType.URL,
+          };
+          uris.push(uri);
+          media.viewImages(uris, emptyCallback);
+          const message = mobilePlatformMock.findMessageByFunc('viewImages');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
+        });
+
+        it('viewImages calls with error', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+            const uris: media.ImageUri[] = [];
+            const uri: media.ImageUri = {
+              value: '1234567',
+              type: media.ImageUriType.ID,
+            };
+            uris.push(uri);
+            media.viewImages(uris, (error: SdkError) => {
+              expect(error.errorCode).toBe(ErrorCode.FILE_NOT_FOUND);
+              done();
+            });
+
+            const message = mobilePlatformMock.findMessageByFunc('viewImages');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1);
+
+            const callbackId = message.id;
+            mobilePlatformMock.respondToMessage({
+              data: {
+                id: callbackId,
+                args: [{ errorCode: ErrorCode.FILE_NOT_FOUND }],
+              },
+            } as DOMMessageEvent);
           });
         });
       });
+      describe('v2', () => {
+        it('should not allow viewImages calls with null imageuris', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          return expect(media.viewImages(null)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+        });
 
-      it('viewImages call in default version of platform support fails', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+        it('should not allow viewImages calls with invalid imageuris', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const uris: media.ImageUri[] = [];
+          return expect(media.viewImages(uris)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+        });
+
+        it('viewImages call in default version of platform support fails', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
           mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
           const uris: media.ImageUri[] = [];
           const uri: media.ImageUri = {
@@ -1273,46 +1366,41 @@ describe('media', () => {
             type: media.ImageUriType.URL,
           };
           uris.push(uri);
-          media.viewImages(uris, (error: SdkError) => {
-            expect(error).not.toBeNull();
-            expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
-            done();
-          });
+          return expect(media.viewImages(uris)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
         });
-      });
 
-      it('viewImages call in task frameContext works', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const uris: media.ImageUri[] = [];
-        const uri: media.ImageUri = {
-          value: 'https://www.w3schools.com/images/picture.jpg',
-          type: media.ImageUriType.URL,
-        };
-        uris.push(uri);
-        media.viewImages(uris, emptyCallback);
-        const message = mobilePlatformMock.findMessageByFunc('viewImages');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-      });
+        it('viewImages call in task frameContext works', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const uris: media.ImageUri[] = [];
+          const uri: media.ImageUri = {
+            value: 'https://www.w3schools.com/images/picture.jpg',
+            type: media.ImageUriType.URL,
+          };
+          uris.push(uri);
+          media.viewImages(uris);
+          const message = mobilePlatformMock.findMessageByFunc('viewImages');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
+        });
 
-      it('viewImages call in content frameContext works', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const uris: media.ImageUri[] = [];
-        const uri: media.ImageUri = {
-          value: 'https://www.w3schools.com/images/picture.jpg',
-          type: media.ImageUriType.URL,
-        };
-        uris.push(uri);
-        media.viewImages(uris, emptyCallback);
-        const message = mobilePlatformMock.findMessageByFunc('viewImages');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-      });
+        it('viewImages call in content frameContext works', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const uris: media.ImageUri[] = [];
+          const uri: media.ImageUri = {
+            value: 'https://www.w3schools.com/images/picture.jpg',
+            type: media.ImageUriType.URL,
+          };
+          uris.push(uri);
+          media.viewImages(uris);
+          const message = mobilePlatformMock.findMessageByFunc('viewImages');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
+        });
 
-      it('viewImages calls with error', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+        it('viewImages calls with error', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
           mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
           const uris: media.ImageUri[] = [];
           const uri: media.ImageUri = {
@@ -1320,10 +1408,7 @@ describe('media', () => {
             type: media.ImageUriType.ID,
           };
           uris.push(uri);
-          media.viewImages(uris, (error: SdkError) => {
-            expect(error.errorCode).toBe(ErrorCode.FILE_NOT_FOUND);
-            done();
-          });
+          const promise = media.viewImages(uris);
 
           const message = mobilePlatformMock.findMessageByFunc('viewImages');
           expect(message).not.toBeNull();
@@ -1336,143 +1421,195 @@ describe('media', () => {
               args: [{ errorCode: ErrorCode.FILE_NOT_FOUND }],
             },
           } as DOMMessageEvent);
+          return expect(promise).rejects.toEqual({ errorCode: ErrorCode.FILE_NOT_FOUND });
         });
       });
     });
-    describe('v2', () => {
-      it('should not allow viewImages calls with null imageuris', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        return expect(media.viewImages(null)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
-      });
 
-      it('should not allow viewImages calls with invalid imageuris', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const uris: media.ImageUri[] = [];
-        return expect(media.viewImages(uris)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
-      });
+    describe('scanBarCode', () => {
+      describe('_v1', () => {
+        it('scanBarCode call in default version of platform support fails', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+            media.scanBarCode((e: SdkError, d: string) => {
+              expect(e).not.toBeNull();
+              expect(e.errorCode).toBe(ErrorCode.OLD_PLATFORM);
+              done();
+            });
+          });
+        });
 
-      it('viewImages call in default version of platform support fails', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-        const uris: media.ImageUri[] = [];
-        const uri: media.ImageUri = {
-          value: 'https://www.w3schools.com/images/picture.jpg',
-          type: media.ImageUriType.URL,
-        };
-        uris.push(uri);
-        return expect(media.viewImages(uris)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
-      });
+        it('should not allow scanBarCode calls for authentication frame context', () => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.authentication).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+            expect(() => media.scanBarCode(emptyCallback, null)).toThrowError(
+              'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
+            );
+          });
+        });
 
-      it('viewImages call in task frameContext works', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const uris: media.ImageUri[] = [];
-        const uri: media.ImageUri = {
-          value: 'https://www.w3schools.com/images/picture.jpg',
-          type: media.ImageUriType.URL,
-        };
-        uris.push(uri);
-        media.viewImages(uris);
-        const message = mobilePlatformMock.findMessageByFunc('viewImages');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-      });
+        it('scanBarCode call in task frameContext works', () => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+            media.scanBarCode(emptyCallback, null);
+            const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1);
+          });
+        });
 
-      it('viewImages call in content frameContext works', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const uris: media.ImageUri[] = [];
-        const uri: media.ImageUri = {
-          value: 'https://www.w3schools.com/images/picture.jpg',
-          type: media.ImageUriType.URL,
-        };
-        uris.push(uri);
-        media.viewImages(uris);
-        const message = mobilePlatformMock.findMessageByFunc('viewImages');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-      });
+        it('scanBarCode call in content frameContext works', () => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+            media.scanBarCode(emptyCallback, null);
+            const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1);
+          });
+        });
 
-      it('viewImages calls with error', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const uris: media.ImageUri[] = [];
-        const uri: media.ImageUri = {
-          value: '1234567',
-          type: media.ImageUriType.ID,
-        };
-        uris.push(uri);
-        const promise = media.viewImages(uris);
+        it('scanBarCode calls with successful result', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
 
-        const message = mobilePlatformMock.findMessageByFunc('viewImages');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
+            media.scanBarCode((err: SdkError, decodedText: string) => {
+              expect(err).toBeFalsy();
+              expect(decodedText).toBe('decodedText');
+              done();
+            });
 
-        const callbackId = message.id;
-        mobilePlatformMock.respondToMessage({
-          data: {
-            id: callbackId,
-            args: [{ errorCode: ErrorCode.FILE_NOT_FOUND }],
-          },
-        } as DOMMessageEvent);
-        return expect(promise).rejects.toEqual({ errorCode: ErrorCode.FILE_NOT_FOUND });
-      });
-    });
-  });
+            const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1);
 
-  describe('scanBarCode', () => {
-    describe('_v1', () => {
-      it('scanBarCode call in default version of platform support fails', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-          mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-          media.scanBarCode((e: SdkError, d: string) => {
-            expect(e).not.toBeNull();
-            expect(e.errorCode).toBe(ErrorCode.OLD_PLATFORM);
-            done();
+            const callbackId = message.id;
+            const response = 'decodedText';
+            mobilePlatformMock.respondToMessage({
+              data: {
+                id: callbackId,
+                args: [undefined, response],
+              },
+            } as DOMMessageEvent);
+          });
+        });
+
+        it('scanBarCode with optional barcode config calls with successful result', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+            const barCodeConfig: media.BarCodeConfig = {
+              timeOutIntervalInSec: 40,
+            };
+            media.scanBarCode((mediaError: SdkError, decodedText: string) => {
+              expect(mediaError).toBeFalsy();
+              expect(decodedText).not.toBeNull;
+              expect(decodedText).toBe('decodedText');
+              done();
+            }, barCodeConfig);
+
+            const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1);
+
+            const callbackId = message.id;
+            const response = 'decodedText';
+            mobilePlatformMock.respondToMessage({
+              data: {
+                id: callbackId,
+                args: [undefined, response],
+              },
+            } as DOMMessageEvent);
+          });
+        });
+
+        it('scanBarCode calls with error', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+            media.scanBarCode((err: SdkError, decodedText: string) => {
+              expect(decodedText).toBeFalsy();
+              expect(err.errorCode).toBe(ErrorCode.OPERATION_TIMED_OUT);
+              done();
+            });
+
+            const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1);
+
+            const callbackId = message.id;
+            mobilePlatformMock.respondToMessage({
+              data: {
+                id: callbackId,
+                args: [{ errorCode: ErrorCode.OPERATION_TIMED_OUT }],
+              },
+            } as DOMMessageEvent);
+          });
+        });
+
+        it('should not allow scanBarCode calls with invalid timeOutIntervalInSec', done => {
+          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+            const barCodeConfig: any = {
+              timeOutIntervalInSec: 0,
+            };
+            media.scanBarCode((mediaError: SdkError, d: string) => {
+              expect(mediaError).not.toBeNull();
+              expect(mediaError.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+              done();
+            }, barCodeConfig);
+          });
+        });
+
+        it('should not allow scanBarCode calls in desktop', done => {
+          desktopPlatformMock.initializeWithContext(FrameContexts.content, HostClientType.desktop).then(() => {
+            media.scanBarCode((error: SdkError, d: string) => {
+              expect(error).not.toBeNull();
+              expect(error.errorCode).toBe(ErrorCode.NOT_SUPPORTED_ON_PLATFORM);
+              done();
+            });
           });
         });
       });
 
-      it('should not allow scanBarCode calls for authentication frame context', () => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.authentication).then(() => {
+      describe('_v2', () => {
+        it('should not allow scanBarCode calls before initialization', () => {
+          return expect(() => media.scanBarCode()).toThrowError('The library has not yet been initialized');
+        });
+
+        it('scanBarCode call in default version of platform support fails', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+          mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+          return expect(media.scanBarCode()).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+        });
+
+        it('should not allow scanBarCode calls for authentication frame context', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-          expect(() => media.scanBarCode(emptyCallback, null)).toThrowError(
+          return expect(() => media.scanBarCode()).toThrowError(
             'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
           );
         });
-      });
 
-      it('scanBarCode call in task frameContext works', () => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+        it('scanBarCode call in task frameContext works', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-          media.scanBarCode(emptyCallback, null);
+          media.scanBarCode(null);
           const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
           expect(message).not.toBeNull();
           expect(message.args.length).toBe(1);
         });
-      });
 
-      it('scanBarCode call in content frameContext works', () => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+        it('scanBarCode call in content frameContext works', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-          media.scanBarCode(emptyCallback, null);
+          media.scanBarCode(null);
           const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
           expect(message).not.toBeNull();
           expect(message.args.length).toBe(1);
         });
-      });
 
-      it('scanBarCode calls with successful result', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+        it('scanBarCode calls with successful result', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-
-          media.scanBarCode((err: SdkError, decodedText: string) => {
-            expect(err).toBeFalsy();
-            expect(decodedText).toBe('decodedText');
-            done();
-          });
+          const promise = media.scanBarCode();
 
           const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
           expect(message).not.toBeNull();
@@ -1486,21 +1623,17 @@ describe('media', () => {
               args: [undefined, response],
             },
           } as DOMMessageEvent);
-        });
-      });
 
-      it('scanBarCode with optional barcode config calls with successful result', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          return expect(promise).resolves.toBe('decodedText');
+        });
+
+        it('scanBarCode with optional barcode config calls with successful result', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
           const barCodeConfig: media.BarCodeConfig = {
             timeOutIntervalInSec: 40,
           };
-          media.scanBarCode((mediaError: SdkError, decodedText: string) => {
-            expect(mediaError).toBeFalsy();
-            expect(decodedText).not.toBeNull;
-            expect(decodedText).toBe('decodedText');
-            done();
-          }, barCodeConfig);
+          const promise = media.scanBarCode(barCodeConfig);
 
           const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
           expect(message).not.toBeNull();
@@ -1514,17 +1647,14 @@ describe('media', () => {
               args: [undefined, response],
             },
           } as DOMMessageEvent);
-        });
-      });
 
-      it('scanBarCode calls with error', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          return expect(promise).resolves.toBe('decodedText');
+        });
+
+        it('scanBarCode calls with error', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-          media.scanBarCode((err: SdkError, decodedText: string) => {
-            expect(decodedText).toBeFalsy();
-            expect(err.errorCode).toBe(ErrorCode.OPERATION_TIMED_OUT);
-            done();
-          });
+          const promise = media.scanBarCode();
 
           const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
           expect(message).not.toBeNull();
@@ -1537,155 +1667,30 @@ describe('media', () => {
               args: [{ errorCode: ErrorCode.OPERATION_TIMED_OUT }],
             },
           } as DOMMessageEvent);
-        });
-      });
 
-      it('should not allow scanBarCode calls with invalid timeOutIntervalInSec', done => {
-        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          return expect(promise).rejects.toEqual({ errorCode: ErrorCode.OPERATION_TIMED_OUT });
+        });
+
+        it('should not allow scanBarCode calls with invalid timeOutIntervalInSec', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-          const barCodeConfig: any = {
+          const barCodeConfig = {
             timeOutIntervalInSec: 0,
           };
-          media.scanBarCode((mediaError: SdkError, d: string) => {
-            expect(mediaError).not.toBeNull();
-            expect(mediaError.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
-            done();
-          }, barCodeConfig);
+          return expect(media.scanBarCode(barCodeConfig)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
         });
-      });
 
-      it('should not allow scanBarCode calls in desktop', done => {
-        desktopPlatformMock.initializeWithContext(FrameContexts.content, HostClientType.desktop).then(() => {
-          media.scanBarCode((error: SdkError, d: string) => {
-            expect(error).not.toBeNull();
-            expect(error.errorCode).toBe(ErrorCode.NOT_SUPPORTED_ON_PLATFORM);
-            done();
-          });
+        it('should allow scanBarCode calls when timeOutIntervalInSec is not passed in config params', async () => {
+          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+          mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+          const barCodeConfig: media.BarCodeConfig = {};
+          return expect(media.scanBarCode(barCodeConfig)).resolves;
         });
-      });
-    });
 
-    describe('_v2', () => {
-      it('should not allow scanBarCode calls before initialization', () => {
-        return expect(() => media.scanBarCode()).toThrowError('The library has not yet been initialized');
-      });
-
-      it('scanBarCode call in default version of platform support fails', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-        return expect(media.scanBarCode()).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
-      });
-
-      it('should not allow scanBarCode calls for authentication frame context', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
-        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-        return expect(() => media.scanBarCode()).toThrowError(
-          'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
-        );
-      });
-
-      it('scanBarCode call in task frameContext works', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-        media.scanBarCode(null);
-        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-      });
-
-      it('scanBarCode call in content frameContext works', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-        media.scanBarCode(null);
-        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-      });
-
-      it('scanBarCode calls with successful result', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-        const promise = media.scanBarCode();
-
-        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-
-        const callbackId = message.id;
-        const response = 'decodedText';
-        mobilePlatformMock.respondToMessage({
-          data: {
-            id: callbackId,
-            args: [undefined, response],
-          },
-        } as DOMMessageEvent);
-
-        return expect(promise).resolves.toBe('decodedText');
-      });
-
-      it('scanBarCode with optional barcode config calls with successful result', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-        const barCodeConfig: media.BarCodeConfig = {
-          timeOutIntervalInSec: 40,
-        };
-        const promise = media.scanBarCode(barCodeConfig);
-
-        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-
-        const callbackId = message.id;
-        const response = 'decodedText';
-        mobilePlatformMock.respondToMessage({
-          data: {
-            id: callbackId,
-            args: [undefined, response],
-          },
-        } as DOMMessageEvent);
-
-        return expect(promise).resolves.toBe('decodedText');
-      });
-
-      it('scanBarCode calls with error', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-        const promise = media.scanBarCode();
-
-        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-
-        const callbackId = message.id;
-        mobilePlatformMock.respondToMessage({
-          data: {
-            id: callbackId,
-            args: [{ errorCode: ErrorCode.OPERATION_TIMED_OUT }],
-          },
-        } as DOMMessageEvent);
-
-        return expect(promise).rejects.toEqual({ errorCode: ErrorCode.OPERATION_TIMED_OUT });
-      });
-
-      it('should not allow scanBarCode calls with invalid timeOutIntervalInSec', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-        const barCodeConfig = {
-          timeOutIntervalInSec: 0,
-        };
-        return expect(media.scanBarCode(barCodeConfig)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
-      });
-
-      it('should allow scanBarCode calls when timeOutIntervalInSec is not passed in config params', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-        const barCodeConfig: media.BarCodeConfig = {};
-        return expect(media.scanBarCode(barCodeConfig)).resolves;
-      });
-
-      it('should not allow scanBarCode calls in desktop', async () => {
-        await desktopPlatformMock.initializeWithContext(FrameContexts.content, HostClientType.desktop);
-        return expect(media.scanBarCode()).rejects.toEqual({ errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM });
+        it('should not allow scanBarCode calls in desktop', async () => {
+          await desktopPlatformMock.initializeWithContext(FrameContexts.content, HostClientType.desktop);
+          return expect(media.scanBarCode()).rejects.toEqual({ errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM });
+        });
       });
     });
   });

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -474,7 +474,7 @@ describe('media', () => {
           } as DOMMessageEvent);
         });
       });
-      it('selectMedia call for mediaType = 1 and imageOutputFormats in mediaAPISupportVersion of platform support fails', async () => {
+      it('selectMedia call for mediaType = 1 and imageOutputFormats in mediaAPISupportVersion of platform support fails', async done => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.task, HostClientType.android);
         mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
         const mediaInputs: media.MediaInputs = {
@@ -485,15 +485,17 @@ describe('media', () => {
         media.selectMedia(mediaInputs, (error: SdkError, attachments: media.Media[]) => {
           expect(error).not.toBeNull();
           expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
+          done();
         });
       });
-      it('videoController notifyEventToHost should fail in default version of platform', async () => {
+      it('videoController notifyEventToHost should fail in default version of platform', async done => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
         mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
         let mediaError: SdkError;
         new media.VideoController().stop(e => {
           mediaError = e;
           expect(mediaError).toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+          done();
         });
       });
       it('videoController notifyEventToHost is handled successfully', async () => {

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -713,7 +713,7 @@ describe('media', () => {
           },
         } as DOMMessageEvent);
 
-        await expect(promise).rejects.toMatchObject({ errorCode: ErrorCode.SIZE_EXCEEDED });
+        await expect(promise).rejects.toEqual({ errorCode: ErrorCode.SIZE_EXCEEDED });
       });
     });
   });

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -744,7 +744,7 @@ describe('media', () => {
         expect(sendMessageToParentSpy).toHaveBeenCalled();
       });
 
-      it('videoController notifyEventToHost is not handled successfully', async () => {
+      it('videoController stop function returns SdkError to callback when parent rejects message"', async () => {
         expect.assertions(7);
 
         await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
@@ -955,48 +955,50 @@ describe('media', () => {
         return blobReadingPromise;
       }
 
-      it('getMedia calls with successful result via the handler', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        //mediaAPISupport version(1.8.0) is less than the MediaCallbackSupportVersion(2.0.0)
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaOutput: media.Media = new media.Media();
-        mediaOutput.content = '1234567';
-        mediaOutput.mimeType = 'image/jpeg';
-        mediaOutput.format = media.FileFormat.ID;
-        mediaOutput.getMedia((error: SdkError, blob: Blob) =>
-          getStringContainedInBlob(blob).then(res => {
-            return expect(res).toEqual(stringMediaData);
-          }),
-        );
+      it('getMedia calls with successful result via the handler', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          //mediaAPISupport version(1.8.0) is less than the MediaCallbackSupportVersion(2.0.0)
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          mediaOutput.getMedia((error: SdkError, blob: Blob) =>
+            getStringContainedInBlob(blob).then(res => {
+              return expect(res).toEqual(stringMediaData);
+            }),
+          );
 
-        const message = mobilePlatformMock.findMessageByFunc('getMedia');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(2);
+          const message = mobilePlatformMock.findMessageByFunc('getMedia');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(2);
 
-        const stringMediaData = 'the media data';
-        const firstMediaResult: media.MediaResult = {
-          error: undefined,
-          mediaChunk: {
-            chunk: btoa(stringMediaData),
-            chunkSequence: 1,
-          },
-        };
-        const secondMediaResult: media.MediaResult = {
-          error: undefined,
-          mediaChunk: {
-            chunk: undefined,
-            chunkSequence: 0,
-          },
-        };
+          const stringMediaData = 'the media data';
+          const firstMediaResult: media.MediaResult = {
+            error: undefined,
+            mediaChunk: {
+              chunk: btoa(stringMediaData),
+              chunkSequence: 1,
+            },
+          };
+          const secondMediaResult: media.MediaResult = {
+            error: undefined,
+            mediaChunk: {
+              chunk: undefined,
+              chunkSequence: 0,
+            },
+          };
 
-        const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
-        const getMediaHandlerName = handlerRegistrationMessage.args[0];
+          const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
+          const getMediaHandlerName = handlerRegistrationMessage.args[0];
 
-        const mediaResults = Array.of(firstMediaResult, secondMediaResult);
+          const mediaResults = Array.of(firstMediaResult, secondMediaResult);
 
-        for (let i = 0; i < mediaResults.length; ++i) {
-          callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
-        }
+          for (let i = 0; i < mediaResults.length; ++i) {
+            callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
+          }
+          done();
+        });
       });
 
       it('getMedia calls with successful result via the callback', done => {
@@ -1800,48 +1802,50 @@ describe('media', () => {
         return blobReadingPromise;
       }
 
-      it('getMedia calls with successful result via the handler', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-        //mediaAPISupport version(1.8.0) is less than the MediaCallbackSupportVersion(2.0.0)
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaOutput: media.Media = new media.Media();
-        mediaOutput.content = '1234567';
-        mediaOutput.mimeType = 'image/jpeg';
-        mediaOutput.format = media.FileFormat.ID;
-        mediaOutput.getMedia((error: SdkError, blob: Blob) =>
-          getStringContainedInBlob(blob).then(res => {
-            return expect(res).toEqual(stringMediaData);
-          }),
-        );
+      it('getMedia calls with successful result via the handler', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          //mediaAPISupport version(1.8.0) is less than the MediaCallbackSupportVersion(2.0.0)
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          mediaOutput.getMedia((error: SdkError, blob: Blob) =>
+            getStringContainedInBlob(blob).then(res => {
+              return expect(res).toEqual(stringMediaData);
+            }),
+          );
+          done();
 
-        const message = mobilePlatformMock.findMessageByFunc('getMedia');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(2);
+          const message = mobilePlatformMock.findMessageByFunc('getMedia');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(2);
 
-        const stringMediaData = 'the media data';
-        const firstMediaResult: media.MediaResult = {
-          error: undefined,
-          mediaChunk: {
-            chunk: btoa(stringMediaData),
-            chunkSequence: 1,
-          },
-        };
-        const secondMediaResult: media.MediaResult = {
-          error: undefined,
-          mediaChunk: {
-            chunk: undefined,
-            chunkSequence: 0,
-          },
-        };
+          const stringMediaData = 'the media data';
+          const firstMediaResult: media.MediaResult = {
+            error: undefined,
+            mediaChunk: {
+              chunk: btoa(stringMediaData),
+              chunkSequence: 1,
+            },
+          };
+          const secondMediaResult: media.MediaResult = {
+            error: undefined,
+            mediaChunk: {
+              chunk: undefined,
+              chunkSequence: 0,
+            },
+          };
 
-        const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
-        const getMediaHandlerName = handlerRegistrationMessage.args[0];
+          const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
+          const getMediaHandlerName = handlerRegistrationMessage.args[0];
 
-        const mediaResults = Array.of(firstMediaResult, secondMediaResult);
+          const mediaResults = Array.of(firstMediaResult, secondMediaResult);
 
-        for (let i = 0; i < mediaResults.length; ++i) {
-          callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
-        }
+          for (let i = 0; i < mediaResults.length; ++i) {
+            callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
+          }
+        });
       });
 
       it('getMedia calls with successful result via the callback', done => {

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -490,7 +490,7 @@ describe('media', () => {
         try {
           await media.selectMedia(mediaInputs, emptyCallback);
         } catch (error) {
-          expect(error).toMatchObject({ errorCode: ErrorCode.OLD_PLATFORM });
+          expect(error).toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
         }
       });
 
@@ -688,7 +688,6 @@ describe('media', () => {
         expect(mediaAttachment.size).not.toBeNull();
         expect(typeof mediaAttachment.size === 'number').toBeTruthy();
         expect(mediaAttachment.getMedia).toBeDefined();
-        await expect(promise).resolves;
       });
 
       it('selectMedia calls with error', async () => {

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/no-empty-function */
+import { notDeepStrictEqual } from 'assert';
 import * as communication from '../../src/internal/communication';
 import { captureImageMobileSupportVersion, getMediaCallbackSupportVersion } from '../../src/internal/constants';
 import { callHandler } from '../../src/internal/handlers';
@@ -41,6 +42,7 @@ describe('media', () => {
     if (app._uninitialize) {
       app._uninitialize();
     }
+    jest.clearAllMocks();
   });
 
   describe('captureImage', () => {
@@ -475,7 +477,8 @@ describe('media', () => {
           } as DOMMessageEvent);
         });
       });
-      it('selectMedia call for mediaType = 1 and imageOutputFormats in mediaAPISupportVersion of platform support fails', async done => {
+      it('selectMedia call for mediaType = 1 and imageOutputFormats in mediaAPISupportVersion of platform support fails', async () => {
+        expect.assertions(4); // initializeWithContext has 3 assertions + 1 in this test = 4
         await mobilePlatformMock.initializeWithContext(FrameContexts.task, HostClientType.android);
         mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
         const mediaInputs: media.MediaInputs = {
@@ -483,295 +486,35 @@ describe('media', () => {
           imageProps: { imageOutputFormats: [media.ImageOutputFormats.PDF] },
           maxMediaCount: 6,
         };
-        media.selectMedia(mediaInputs, (error: SdkError, attachments: media.Media[]) => {
-          expect(error).not.toBeNull();
-          expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
-          done();
-        });
+        try {
+          await media.selectMedia(mediaInputs, emptyCallback);
+        } catch (error) {
+          expect(error).toMatchObject({ errorCode: ErrorCode.OLD_PLATFORM });
+        }
       });
-      it('videoController notifyEventToHost should fail in default version of platform', async done => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
-        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-        let mediaError: SdkError;
-        new media.VideoController().stop(e => {
-          mediaError = e;
-          expect(mediaError).toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
-          done();
-        });
-      });
-      it('videoController notifyEventToHost is handled successfully', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
-        mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
-        let mediaError: SdkError;
-        new media.VideoController().stop(err => (mediaError = err));
-        const message = mobilePlatformMock.findMessageByFunc('media.controller');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-        const callbackId = message.id;
-        mobilePlatformMock.respondToMessage({
-          data: {
-            id: callbackId,
-            args: [undefined],
-          },
-        } as DOMMessageEvent);
-        expect(mediaError).toBeFalsy();
-      });
-    });
-    it('selectMedia calls with error', () => {
-      return mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-        const mediaInputs: media.MediaInputs = {
-          mediaType: media.MediaType.Image,
-          maxMediaCount: 10,
-        };
-        media.selectMedia(mediaInputs, (mediaError: SdkError, mediaAttachments: media.Media[]) => {
-          expect(mediaAttachments).toBeFalsy();
-          expect(mediaError.errorCode).toBe(ErrorCode.SIZE_EXCEEDED);
-        });
-        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-        const callbackId = message.id;
-        mobilePlatformMock.respondToMessage({
-          data: {
-            id: callbackId,
-            args: [{ errorCode: ErrorCode.SIZE_EXCEEDED }],
-          },
-        } as DOMMessageEvent);
-      });
-    });
-  });
-  describe('v2', () => {
-    it('should not allow selectMedia calls with null mediaInputs', async () => {
-      await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-      return expect(media.selectMedia(null)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
-    });
 
-    it('should not allow selectMedia calls with invalid mediaInputs', async () => {
-      await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-      const mediaInputs: media.MediaInputs = {
-        mediaType: media.MediaType.Image,
-        maxMediaCount: 11,
-      };
-      return expect(media.selectMedia(mediaInputs)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
-    });
-
-    it('selectMedia call in default version of platform support fails', async () => {
-      await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-      mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-      const mediaInputs: media.MediaInputs = {
-        mediaType: media.MediaType.Image,
-        maxMediaCount: 10,
-      };
-      return expect(media.selectMedia(mediaInputs)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
-    });
-
-    it('selectMedia call for mediaType = 3 in mediaAPISupportVersion of platform support fails', async () => {
-      await mobilePlatformMock.initializeWithContext(FrameContexts.task, HostClientType.android);
-      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-      const mediaInputs: media.MediaInputs = {
-        mediaType: media.MediaType.VideoAndImage,
-        maxMediaCount: 10,
-      };
-      return expect(media.selectMedia(mediaInputs)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
-    });
-
-    it('selectMedia call in task frameContext works', async () => {
-      await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-      const mediaInputs: media.MediaInputs = {
-        mediaType: media.MediaType.Image,
-        maxMediaCount: 10,
-      };
-      media.selectMedia(mediaInputs);
-      const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
-    });
-
-    it('selectMedia call in content frameContext works', async () => {
-      await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-      const mediaInputs: media.MediaInputs = {
-        mediaType: media.MediaType.Image,
-        maxMediaCount: 10,
-      };
-      media.selectMedia(mediaInputs);
-      const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
-    });
-
-    it('selectMedia calls with successful result for mediaType = 1', async () => {
-      await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-      const mediaInputs: media.MediaInputs = {
-        mediaType: media.MediaType.Image,
-        maxMediaCount: 10,
-      };
-      const promise = media.selectMedia(mediaInputs);
-
-      const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
-
-      const callbackId = message.id;
-      const filesArray = [
-        {
-          content: 'base64encodedImage',
-          preview: null,
-          format: media.FileFormat.ID,
-          mimeType: 'image/jpeg',
-          size: 300,
-        } as media.Media,
-      ];
-      mobilePlatformMock.respondToMessage({
-        data: {
-          id: callbackId,
-          args: [undefined, filesArray],
-        },
-      } as DOMMessageEvent);
-
-      const mediaAttachments = await promise;
-      expect(mediaAttachments.length).toBe(1);
-      const mediaAttachment = mediaAttachments[0];
-      expect(mediaAttachment).not.toBeNull();
-      expect(mediaAttachment.format).toBe(media.FileFormat.ID);
-      expect(mediaAttachment.mimeType).toBe('image/jpeg');
-      expect(mediaAttachment.content).not.toBeNull();
-      expect(mediaAttachment.size).not.toBeNull();
-      expect(typeof mediaAttachment.size === 'number').toBeTruthy();
-      expect(mediaAttachment.getMedia).toBeDefined();
-    });
-
-    it('selectMedia calls with successful result for mediaType = 3', async () => {
-      await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.ios);
-      mobilePlatformMock.setClientSupportedSDKVersion(videoAndImageMediaAPISupportVersion);
-      const mediaInputs: media.MediaInputs = {
-        mediaType: media.MediaType.VideoAndImage,
-        maxMediaCount: 10,
-      };
-      const promise = media.selectMedia(mediaInputs);
-
-      const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
-
-      const callbackId = message.id;
-      const filesArray = [
-        {
-          content: 'base64encodedImage',
-          preview: null,
-          format: media.FileFormat.ID,
-          mimeType: 'video/mp4',
-          size: 300,
-        } as media.Media,
-      ];
-      mobilePlatformMock.respondToMessage({
-        data: {
-          id: callbackId,
-          args: [undefined, filesArray],
-        },
-      } as DOMMessageEvent);
-
-      const mediaAttachments = await promise;
-      expect(mediaAttachments.length).toBe(1);
-      const mediaAttachment = mediaAttachments[0];
-      expect(mediaAttachment).not.toBeNull();
-      expect(mediaAttachment.format).toBe(media.FileFormat.ID);
-      expect(mediaAttachment.mimeType).toBe('video/mp4');
-      expect(mediaAttachment.content).not.toBeNull();
-      expect(mediaAttachment.size).not.toBeNull();
-      expect(typeof mediaAttachment.size === 'number').toBeTruthy();
-      expect(mediaAttachment.getMedia).toBeDefined();
-      await expect(promise).resolves;
-    });
-
-    it('selectMedia calls with error', async () => {
-      expect.assertions(6); // initializeWithContext has 3 assertions + 3 local assertions
-      await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-      mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-      const mediaInputs: media.MediaInputs = {
-        mediaType: media.MediaType.Image,
-        maxMediaCount: 10,
-      };
-      const promise = media.selectMedia(mediaInputs);
-
-      const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
-
-      const callbackId = message.id;
-      mobilePlatformMock.respondToMessage({
-        data: {
-          id: callbackId,
-          args: [{ errorCode: ErrorCode.SIZE_EXCEEDED }],
-        },
-      } as DOMMessageEvent);
-
-      await expect(promise).rejects.toMatchObject({ errorCode: ErrorCode.SIZE_EXCEEDED });
-    });
-  });
-  describe('videoController', () => {
-    describe('v1', () => {
-      it('videoController notifyEventToHost is not handled successfully', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
-        mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
-        let mediaError: SdkError;
-        new media.VideoController().stop((e: SdkError) => (mediaError = e));
-        const message = mobilePlatformMock.findMessageByFunc('media.controller');
-        expect(message).not.toBeNull();
-        expect(message.args.length).toBe(1);
-        const callbackId = message.id;
-        const err = {
-          errorCode: ErrorCode.INTERNAL_ERROR,
-        };
-        mobilePlatformMock.respondToMessage({
-          data: {
-            id: callbackId,
-            args: [err],
-          },
-        } as DOMMessageEvent);
-        expect(mediaError).toEqual(err);
-      });
-      it('should invoke correct video callback for MediaControllerEvent when registered', async () => {
-        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.ios);
-        mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
-        let mediaError: SdkError;
-        const mockCallback = jest.fn();
-        const videoControllerCallback: media.VideoControllerCallback = {
-          onRecordingStarted() {
-            mockCallback();
-          },
-        };
-        const videoProps: media.VideoProps = {
-          videoController: new media.VideoController(videoControllerCallback),
-        };
-        const mediaInputs: media.MediaInputs = {
-          mediaType: media.MediaType.Video,
-          maxMediaCount: 10,
-          videoProps: videoProps,
-        };
-        media
-          .selectMedia(mediaInputs, (e: SdkError, attachments: media.Media[]) => {
-            mediaError = e;
-          })
-          .then(() => {
-            const message = mobilePlatformMock.findMessageByFunc('selectMedia');
-            expect(message).not.toBeNull();
-            expect(message.args.length).toBe(1);
-            const callbackId = message.id;
-            mobilePlatformMock.respondToMessage({
-              data: {
-                id: callbackId,
-                args: [undefined, undefined, 1],
-              },
-            } as DOMMessageEvent);
-            expect(mediaError).toBeFalsy();
-            expect(mockCallback).toHaveBeenCalled();
+      it('selectMedia calls with error', () => {
+        return mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const mediaInputs: media.MediaInputs = {
+            mediaType: media.MediaType.Image,
+            maxMediaCount: 10,
+          };
+          media.selectMedia(mediaInputs, (mediaError: SdkError, mediaAttachments: media.Media[]) => {
+            expect(mediaAttachments).toBeFalsy();
+            expect(mediaError.errorCode).toBe(ErrorCode.SIZE_EXCEEDED);
           });
+          const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
+          const callbackId = message.id;
+          mobilePlatformMock.respondToMessage({
+            data: {
+              id: callbackId,
+              args: [{ errorCode: ErrorCode.SIZE_EXCEEDED }],
+            },
+          } as DOMMessageEvent);
+        });
       });
       it('should not invoke video callback for MediaControllerEvent when not registered', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.ios);
@@ -798,384 +541,480 @@ describe('media', () => {
         expect(mediaError).toBeFalsy();
         expect(jest.fn()).not.toHaveBeenCalled();
       });
-      describe('v2', () => {
-        it('videoController notifyEventToHost should fail in default version of platform', async () => {
-          expect.assertions(4); // initializeWithContext has 3 assertions + 1 local assertion
-          await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
-          mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+    });
+    describe('v2', () => {
+      it('should not allow selectMedia calls with null mediaInputs', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        return expect(media.selectMedia(null)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
 
-          return new media.VideoController().stop().catch(err => {
-            expect(err).toMatchObject({ errorCode: ErrorCode.OLD_PLATFORM });
-          });
-        });
-        it('videoController notifyEventToHost is handled successfully', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
-          mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+      it('should not allow selectMedia calls with invalid mediaInputs', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaInputs: media.MediaInputs = {
+          mediaType: media.MediaType.Image,
+          maxMediaCount: 11,
+        };
+        return expect(media.selectMedia(mediaInputs)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
 
-          const stopPromise = new media.VideoController().stop();
-          const message = mobilePlatformMock.findMessageByFunc('media.controller');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(1);
-          const callbackId = message.id;
-          mobilePlatformMock.respondToMessage({
-            data: {
-              id: callbackId,
-              args: [undefined],
-            },
-          } as DOMMessageEvent);
-          expect(stopPromise).resolves;
-        });
+      it('selectMedia call in default version of platform support fails', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+        const mediaInputs: media.MediaInputs = {
+          mediaType: media.MediaType.Image,
+          maxMediaCount: 10,
+        };
+        return expect(media.selectMedia(mediaInputs)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+      });
 
-        it('videoController notifyEventToHost is not handled successfully and sendMessageToParent does not run', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
-          mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+      it('selectMedia call for mediaType = 3 in mediaAPISupportVersion of platform support fails', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task, HostClientType.android);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaInputs: media.MediaInputs = {
+          mediaType: media.MediaType.VideoAndImage,
+          maxMediaCount: 10,
+        };
+        return expect(media.selectMedia(mediaInputs)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+      });
 
-          const err = { errorCode: ErrorCode.INTERNAL_ERROR };
-          const stopPromise = new media.VideoController().stop();
-          const sendMessageToParentSpy = jest.spyOn(communication, 'sendMessageToParent');
-          const message = mobilePlatformMock.findMessageByFunc('media.controller');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(1);
-          const callbackId = message.id;
-          mobilePlatformMock.respondToMessage({
-            data: {
-              id: callbackId,
-              args: [err],
-            },
-          } as DOMMessageEvent);
-          expect(sendMessageToParentSpy).not.toBeCalled();
-          await stopPromise.catch(err => {
-            expect(err).toMatchObject(err);
-          });
-        });
+      it('selectMedia call in task frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaInputs: media.MediaInputs = {
+          mediaType: media.MediaType.Image,
+          maxMediaCount: 10,
+        };
+        media.selectMedia(mediaInputs);
+        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
+
+      it('selectMedia call in content frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaInputs: media.MediaInputs = {
+          mediaType: media.MediaType.Image,
+          maxMediaCount: 10,
+        };
+        media.selectMedia(mediaInputs);
+        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
+
+      it('selectMedia calls with successful result for mediaType = 1', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaInputs: media.MediaInputs = {
+          mediaType: media.MediaType.Image,
+          maxMediaCount: 10,
+        };
+        const promise = media.selectMedia(mediaInputs);
+
+        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+
+        const callbackId = message.id;
+        const filesArray = [
+          {
+            content: 'base64encodedImage',
+            preview: null,
+            format: media.FileFormat.ID,
+            mimeType: 'image/jpeg',
+            size: 300,
+          } as media.Media,
+        ];
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [undefined, filesArray],
+          },
+        } as DOMMessageEvent);
+
+        const mediaAttachments = await promise;
+        expect(mediaAttachments.length).toBe(1);
+        const mediaAttachment = mediaAttachments[0];
+        expect(mediaAttachment).not.toBeNull();
+        expect(mediaAttachment.format).toBe(media.FileFormat.ID);
+        expect(mediaAttachment.mimeType).toBe('image/jpeg');
+        expect(mediaAttachment.content).not.toBeNull();
+        expect(mediaAttachment.size).not.toBeNull();
+        expect(typeof mediaAttachment.size === 'number').toBeTruthy();
+        expect(mediaAttachment.getMedia).toBeDefined();
+      });
+
+      it('selectMedia calls with successful result for mediaType = 3', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.ios);
+        mobilePlatformMock.setClientSupportedSDKVersion(videoAndImageMediaAPISupportVersion);
+        const mediaInputs: media.MediaInputs = {
+          mediaType: media.MediaType.VideoAndImage,
+          maxMediaCount: 10,
+        };
+        const promise = media.selectMedia(mediaInputs);
+
+        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+
+        const callbackId = message.id;
+        const filesArray = [
+          {
+            content: 'base64encodedImage',
+            preview: null,
+            format: media.FileFormat.ID,
+            mimeType: 'video/mp4',
+            size: 300,
+          } as media.Media,
+        ];
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [undefined, filesArray],
+          },
+        } as DOMMessageEvent);
+
+        const mediaAttachments = await promise;
+        expect(mediaAttachments.length).toBe(1);
+        const mediaAttachment = mediaAttachments[0];
+        expect(mediaAttachment).not.toBeNull();
+        expect(mediaAttachment.format).toBe(media.FileFormat.ID);
+        expect(mediaAttachment.mimeType).toBe('video/mp4');
+        expect(mediaAttachment.content).not.toBeNull();
+        expect(mediaAttachment.size).not.toBeNull();
+        expect(typeof mediaAttachment.size === 'number').toBeTruthy();
+        expect(mediaAttachment.getMedia).toBeDefined();
+        await expect(promise).resolves;
+      });
+
+      it('selectMedia calls with error', async () => {
+        expect.assertions(6); // initializeWithContext has 3 assertions + 3 local assertions
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaInputs: media.MediaInputs = {
+          mediaType: media.MediaType.Image,
+          maxMediaCount: 10,
+        };
+        const promise = media.selectMedia(mediaInputs);
+
+        const message = mobilePlatformMock.findMessageByFunc('selectMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+
+        const callbackId = message.id;
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [{ errorCode: ErrorCode.SIZE_EXCEEDED }],
+          },
+        } as DOMMessageEvent);
+
+        await expect(promise).rejects.toMatchObject({ errorCode: ErrorCode.SIZE_EXCEEDED });
       });
     });
-    describe('getMedia', () => {
-      describe('v1', () => {
-        it('should not allow getMedia calls with invalid media mimetype', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-            const mediaOutput: media.Media = new media.Media();
-            mediaOutput.content = '1234567';
-            mediaOutput.mimeType = null;
-            mediaOutput.format = media.FileFormat.ID;
-            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-              expect(error).not.toBeNull();
-              expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
-              done();
-            });
-          });
+  });
+
+  describe('videoController', () => {
+    describe('v1', () => {
+      it('videoController notifyEventToHost is handled successfully', async () => {
+        expect.assertions(7); // initializeWithContext has 3 assertions + 4 in this test = 7
+
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task, HostClientType.android);
+        mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+        const sendMessageToParentSpy = jest.spyOn(communication, 'sendMessageToParent');
+
+        await expect(new media.VideoController().stop(emptyCallback)).resolves.not.toThrow();
+
+        const message = mobilePlatformMock.findMessageByFunc('media.controller');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+        const callbackId = message.id;
+
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [undefined],
+          },
+        } as DOMMessageEvent);
+
+        expect(sendMessageToParentSpy).toHaveBeenCalled();
+      });
+
+      it('videoController notifyEventToHost is not handled successfully', async () => {
+        expect.assertions(7);
+
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
+        mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+
+        const sendMessageToParentSpy = jest.spyOn(communication, 'sendMessageToParent');
+        const err = {
+          errorCode: ErrorCode.INTERNAL_ERROR,
+        };
+
+        await new media.VideoController().stop((e: SdkError) => {
+          expect(e).toMatchObject(err);
         });
 
-        it('should not allow getMedia calls with invalid media content', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-            const mediaOutput: media.Media = new media.Media();
-            mediaOutput.content = null;
-            mediaOutput.mimeType = 'image/jpeg';
-            mediaOutput.format = media.FileFormat.ID;
-            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-              expect(error).not.toBeNull();
-              expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
-              done();
-            });
+        const message = mobilePlatformMock.findMessageByFunc('media.controller');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+        const callbackId = message.id;
+
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [err],
+          },
+        } as DOMMessageEvent);
+
+        expect(sendMessageToParentSpy).toHaveBeenCalled();
+      });
+
+      it('videoController notifyEventToHost should fail in default version of platform and should exit early', async () => {
+        expect.assertions(5);
+
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
+        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+
+        const sendMessageToParentSpy = jest.spyOn(communication, 'sendMessageToParent');
+
+        try {
+          await new media.VideoController().stop(e => {
+            return e;
           });
-        });
-
-        it('should not allow getMedia calls with invalid media file format', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-            const mediaOutput: media.Media = new media.Media();
-            mediaOutput.content = '1234567';
-            mediaOutput.mimeType = 'image/jpeg';
-            mediaOutput.format = media.FileFormat.Base64;
-            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-              expect(error).not.toBeNull();
-              expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
-              done();
-            });
-          });
-        });
-
-        it('getMedia call in default version of platform support fails', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-            const mediaOutput: media.Media = new media.Media();
-            mediaOutput.content = '1234567';
-            mediaOutput.mimeType = 'image/jpeg';
-            mediaOutput.format = media.FileFormat.ID;
-            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-              expect(error).not.toBeNull();
-              expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
-              done();
-            });
-          });
-        });
-
-        it('getMedia call in task frameContext works', async () => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-            const mediaOutput: media.Media = new media.Media();
-            mediaOutput.content = '1234567';
-            mediaOutput.mimeType = 'image/jpeg';
-            mediaOutput.format = media.FileFormat.ID;
-            mediaOutput.getMedia(emptyCallback);
-            const message = mobilePlatformMock.findMessageByFunc('getMedia');
-            expect(message).not.toBeNull();
-            expect(message.args.length).toBe(2);
-          });
-        });
-
-        async function getStringContainedInBlob(blob: Blob): Promise<string> {
-          let resolverMethod: (value: string | PromiseLike<string>) => void;
-          let rejectionMethod: (reason?: any) => void;
-          const blobReadingPromise: Promise<string> = new Promise<string>((resolve, reject) => {
-            resolverMethod = resolve;
-            rejectionMethod = reject;
-          });
-
-          const blobReader = new FileReader();
-          blobReader.onloadend = (): void => {
-            resolverMethod(String.fromCharCode(...new Uint8Array(blobReader.result as ArrayBuffer)));
-          };
-          blobReader.onerror = (): void => {
-            rejectionMethod(blobReader.error);
-          };
-
-          blobReader.readAsArrayBuffer(blob);
-
-          return blobReadingPromise;
+        } catch (err) {
+          expect(err).toMatchObject({ errorCode: ErrorCode.OLD_PLATFORM });
         }
 
-        it('getMedia calls with successful result via the handler', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-            //mediaAPISupport version(1.8.0) is less than the MediaCallbackSupportVersion(2.0.0)
-            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-            const mediaOutput: media.Media = new media.Media();
-            mediaOutput.content = '1234567';
-            mediaOutput.mimeType = 'image/jpeg';
-            mediaOutput.format = media.FileFormat.ID;
-            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-              getStringContainedInBlob(blob).then(res => {
-                expect(res).toEqual(stringMediaData);
-                done();
-              });
-            });
+        expect(sendMessageToParentSpy).not.toHaveBeenCalled();
+      });
+    });
 
-            const message = mobilePlatformMock.findMessageByFunc('getMedia');
-            expect(message).not.toBeNull();
-            expect(message.args.length).toBe(2);
+    describe('v2', () => {
+      it('videoController notifyEventToHost should fail in default version of platform and exit early', async () => {
+        expect.assertions(5); // initializeWithContext has 3 assertions + 2 local assertion
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
+        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+        const sendMessageToParentSpy = jest.spyOn(communication, 'sendMessageToParent');
 
-            const stringMediaData = 'the media data';
-            const firstMediaResult: media.MediaResult = {
-              error: undefined,
-              mediaChunk: {
-                chunk: btoa(stringMediaData),
-                chunkSequence: 1,
-              },
-            };
-            const secondMediaResult: media.MediaResult = {
-              error: undefined,
-              mediaChunk: {
-                chunk: undefined,
-                chunkSequence: 0,
-              },
-            };
-
-            const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
-            const getMediaHandlerName = handlerRegistrationMessage.args[0];
-
-            const mediaResults = Array.of(firstMediaResult, secondMediaResult);
-
-            for (let i = 0; i < mediaResults.length; ++i) {
-              callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
-            }
-          });
+        await new media.VideoController().stop().catch(err => {
+          return expect(err).toMatchObject({ errorCode: ErrorCode.OLD_PLATFORM });
         });
+        expect(sendMessageToParentSpy).not.toHaveBeenCalled();
+      });
 
-        it('getMedia calls with successful result via the callback', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-            // here we give the same version as the supported version
-            mobilePlatformMock.setClientSupportedSDKVersion(getMediaCallbackSupportVersion);
-            const mediaOutput: media.Media = new media.Media();
-            mediaOutput.content = '1234567';
-            mediaOutput.mimeType = 'image/jpeg';
-            mediaOutput.format = media.FileFormat.ID;
-            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-              getStringContainedInBlob(blob).then(res => {
-                expect(res).toEqual(stringMediaData);
-                done();
-              });
-            });
+      it('videoController notifyEventToHost is handled successfully', async () => {
+        expect.assertions(6); // initializeWithContext has 3 assertions + 3 local assertion
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
+        mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
 
-            const message = mobilePlatformMock.findMessageByFunc('getMedia');
-            expect(message).not.toBeNull();
-            expect(message.args.length).toBe(1); // args will be of length 1 for the supported version
+        await expect(new media.VideoController().stop()).resolves.not.toThrow();
+        const message = mobilePlatformMock.findMessageByFunc('media.controller');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+        const callbackId = message.id;
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [undefined],
+          },
+        } as DOMMessageEvent);
+      });
 
-            const stringMediaData = 'the media data';
-            const firstMediaResult: media.MediaResult = {
-              error: undefined,
-              mediaChunk: {
-                chunk: btoa(stringMediaData),
-                chunkSequence: 1,
-              },
-            };
-            const secondMediaResult: media.MediaResult = {
-              error: undefined,
-              mediaChunk: {
-                chunk: undefined,
-                chunkSequence: 0,
-              },
-            };
+      it('videoController notifyEventToHost is not handled successfully and returns error', async () => {
+        expect.assertions(7);
 
-            const mediaResults = Array.of(firstMediaResult, secondMediaResult);
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
+        mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
 
-            for (let i = 0; i < mediaResults.length; ++i) {
-              mobilePlatformMock.respondToMessage({
-                data: {
-                  id: message.id,
-                  args: [mediaResults[i]],
-                  isPartialResponse: i < mediaResults.length - 1,
-                },
-              } as DOMMessageEvent);
-            }
-          });
-        });
+        const err = { errorCode: ErrorCode.INTERNAL_ERROR };
 
-        it('getMedia calls with error with MediaCallback', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(getMediaCallbackSupportVersion);
-            const mediaOutput: media.Media = new media.Media();
-            mediaOutput.content = '12345678';
-            mediaOutput.mimeType = 'image/jpeg';
-            mediaOutput.format = media.FileFormat.ID;
-            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-              expect(error.errorCode).toBe(500);
-              expect(error.message).toEqual('data received is null');
-              expect(blob).toBeFalsy();
-              done();
-            });
+        const sendMessageToParentSpy = jest.spyOn(communication, 'sendMessageToParent');
 
-            const message = mobilePlatformMock.findMessageByFunc('getMedia');
+        await new media.VideoController()
+          .stop()
+          .then(() => {
+            const message = mobilePlatformMock.findMessageByFunc('media.controller');
             expect(message).not.toBeNull();
             expect(message.args.length).toBe(1);
-
             const callbackId = message.id;
-            mobilePlatformMock.respondToMessage({
+            return mobilePlatformMock.respondToMessage({
               data: {
                 id: callbackId,
-                args: [undefined, undefined],
+                args: [err],
               },
             } as DOMMessageEvent);
+          })
+          .catch(error => {
+            return expect(error).toMatchObject(err);
           });
-        });
-
-        it('getMedia calls with error with Handler', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-
-            const mediaOutput: media.Media = new media.Media();
-            mediaOutput.content = '1234567';
-            mediaOutput.mimeType = 'image/jpeg';
-            mediaOutput.format = media.FileFormat.ID;
-            mediaOutput.getMedia((error: SdkError, blob: Blob) => {
-              expect(blob).toBeFalsy();
-              expect(error.errorCode).toBe(500);
-              done();
-            });
-
-            const message = mobilePlatformMock.findMessageByFunc('getMedia');
-            expect(message).not.toBeNull();
-            expect(message.args.length).toBe(2);
-
-            const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
-            const getMediaHandlerName = handlerRegistrationMessage.args[0];
-            callHandler(getMediaHandlerName, [JSON.stringify(undefined)]);
-          });
-        });
+        expect(sendMessageToParentSpy).toHaveBeenCalled();
       });
-      describe('v2', () => {
-        it('should not allow getMedia calls with invalid media mimetype', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+    });
+  });
+
+  describe('getMedia', () => {
+    describe('v1', () => {
+      it('should not allow getMedia calls with invalid media mimetype', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
           const mediaOutput: media.Media = new media.Media();
           mediaOutput.content = '1234567';
           mediaOutput.mimeType = null;
           mediaOutput.format = media.FileFormat.ID;
-          return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+            done();
+          });
         });
+      });
 
-        it('should not allow getMedia calls with invalid media content', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      it('should not allow getMedia calls with invalid media content', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
           const mediaOutput: media.Media = new media.Media();
           mediaOutput.content = null;
           mediaOutput.mimeType = 'image/jpeg';
           mediaOutput.format = media.FileFormat.ID;
-          return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+            done();
+          });
         });
+      });
 
-        it('should not allow getMedia calls with invalid media file format', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      it('should not allow getMedia calls with invalid media file format', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
           const mediaOutput: media.Media = new media.Media();
           mediaOutput.content = '1234567';
           mediaOutput.mimeType = 'image/jpeg';
           mediaOutput.format = media.FileFormat.Base64;
-          return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+            done();
+          });
         });
+      });
 
-        it('getMedia call in default version of platform support fails', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      it('getMedia call in default version of platform support fails', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
           const mediaOutput: media.Media = new media.Media();
           mediaOutput.content = '1234567';
           mediaOutput.mimeType = 'image/jpeg';
           mediaOutput.format = media.FileFormat.ID;
-          return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
+            done();
+          });
         });
+      });
 
-        it('getMedia call in task frameContext works', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      it('getMedia call in task frameContext works', async () => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
           const mediaOutput: media.Media = new media.Media();
           mediaOutput.content = '1234567';
           mediaOutput.mimeType = 'image/jpeg';
           mediaOutput.format = media.FileFormat.ID;
-          mediaOutput.getMedia();
+          mediaOutput.getMedia(emptyCallback);
           const message = mobilePlatformMock.findMessageByFunc('getMedia');
           expect(message).not.toBeNull();
           expect(message.args.length).toBe(2);
         });
+      });
 
-        async function getStringContainedInBlob(blob: Blob): Promise<string> {
-          let resolverMethod: (value: string | PromiseLike<string>) => void;
-          let rejectionMethod: (reason?: any) => void;
-          const blobReadingPromise: Promise<string> = new Promise<string>((resolve, reject) => {
-            resolverMethod = resolve;
-            rejectionMethod = reject;
+      async function getStringContainedInBlob(blob: Blob): Promise<string> {
+        let resolverMethod: (value: string | PromiseLike<string>) => void;
+        let rejectionMethod: (reason?: any) => void;
+        const blobReadingPromise: Promise<string> = new Promise<string>((resolve, reject) => {
+          resolverMethod = resolve;
+          rejectionMethod = reject;
+        });
+
+        const blobReader = new FileReader();
+        blobReader.onloadend = (): void => {
+          resolverMethod(String.fromCharCode(...new Uint8Array(blobReader.result as ArrayBuffer)));
+        };
+        blobReader.onerror = (): void => {
+          rejectionMethod(blobReader.error);
+        };
+
+        blobReader.readAsArrayBuffer(blob);
+
+        return blobReadingPromise;
+      }
+
+      it('getMedia calls with successful result via the handler', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        //mediaAPISupport version(1.8.0) is less than the MediaCallbackSupportVersion(2.0.0)
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = '1234567';
+        mediaOutput.mimeType = 'image/jpeg';
+        mediaOutput.format = media.FileFormat.ID;
+        mediaOutput.getMedia((error: SdkError, blob: Blob) =>
+          getStringContainedInBlob(blob).then(res => {
+            return expect(res).toEqual(stringMediaData);
+          }),
+        );
+
+        const message = mobilePlatformMock.findMessageByFunc('getMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(2);
+
+        const stringMediaData = 'the media data';
+        const firstMediaResult: media.MediaResult = {
+          error: undefined,
+          mediaChunk: {
+            chunk: btoa(stringMediaData),
+            chunkSequence: 1,
+          },
+        };
+        const secondMediaResult: media.MediaResult = {
+          error: undefined,
+          mediaChunk: {
+            chunk: undefined,
+            chunkSequence: 0,
+          },
+        };
+
+        const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
+        const getMediaHandlerName = handlerRegistrationMessage.args[0];
+
+        const mediaResults = Array.of(firstMediaResult, secondMediaResult);
+
+        for (let i = 0; i < mediaResults.length; ++i) {
+          callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
+        }
+      });
+
+      it('getMedia calls with successful result via the callback', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          // here we give the same version as the supported version
+          mobilePlatformMock.setClientSupportedSDKVersion(getMediaCallbackSupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            getStringContainedInBlob(blob).then(res => {
+              expect(res).toEqual(stringMediaData);
+              done();
+            });
           });
 
-          const blobReader = new FileReader();
-          blobReader.onloadend = (): void => {
-            resolverMethod(String.fromCharCode(...new Uint8Array(blobReader.result as ArrayBuffer)));
-          };
-          blobReader.onerror = (): void => {
-            rejectionMethod(blobReader.error);
-          };
-
-          blobReader.readAsArrayBuffer(blob);
-
-          return blobReadingPromise;
-        }
-
-        async function validateGetMediaMessageAndResults(
-          supportedSDKVersion: string,
-          expectedNumberOfParametersInGetMediaMessage: number,
-          respondToMessages: (message: MessageRequest, mediaResults: media.MediaResult[]) => void,
-        ): Promise<void> {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-          mobilePlatformMock.setClientSupportedSDKVersion(supportedSDKVersion);
+          const message = mobilePlatformMock.findMessageByFunc('getMedia');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1); // args will be of length 1 for the supported version
 
           const stringMediaData = 'the media data';
           const firstMediaResult: media.MediaResult = {
@@ -1193,175 +1032,251 @@ describe('media', () => {
             },
           };
 
+          const mediaResults = Array.of(firstMediaResult, secondMediaResult);
+
+          for (let i = 0; i < mediaResults.length; ++i) {
+            mobilePlatformMock.respondToMessage({
+              data: {
+                id: message.id,
+                args: [mediaResults[i]],
+                isPartialResponse: i < mediaResults.length - 1,
+              },
+            } as DOMMessageEvent);
+          }
+        });
+      });
+
+      it('getMedia calls with error with MediaCallback', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(getMediaCallbackSupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '12345678';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            expect(error.errorCode).toBe(500);
+            expect(error.message).toEqual('data received is null');
+            expect(blob).toBeFalsy();
+            done();
+          });
+
+          const message = mobilePlatformMock.findMessageByFunc('getMedia');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
+
+          const callbackId = message.id;
+          mobilePlatformMock.respondToMessage({
+            data: {
+              id: callbackId,
+              args: [undefined, undefined],
+            },
+          } as DOMMessageEvent);
+        });
+      });
+
+      it('getMedia calls with error with Handler', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+
           const mediaOutput: media.Media = new media.Media();
           mediaOutput.content = '1234567';
           mediaOutput.mimeType = 'image/jpeg';
           mediaOutput.format = media.FileFormat.ID;
-          const getMediaPromise: Promise<Blob> = mediaOutput.getMedia();
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            expect(blob).toBeFalsy();
+            expect(error.errorCode).toBe(500);
+            done();
+          });
 
           const message = mobilePlatformMock.findMessageByFunc('getMedia');
           expect(message).not.toBeNull();
-          expect(message.args.length).toBe(expectedNumberOfParametersInGetMediaMessage);
+          expect(message.args.length).toBe(2);
 
-          respondToMessages(message, [firstMediaResult, secondMediaResult]);
-
-          const blobContents: string = await getStringContainedInBlob(await getMediaPromise);
-          expect(blobContents).toEqual(stringMediaData);
-        }
-
-        it('getMedia using callback method returns successful result with expected data', async () => {
-          validateGetMediaMessageAndResults(
-            getMediaCallbackSupportVersion,
-            1,
-            (message: MessageRequest, mediaResults: media.MediaResult[]) => {
-              const callbackId = message.id;
-
-              for (let i = 0; i < mediaResults.length; ++i) {
-                mobilePlatformMock.respondToMessage({
-                  data: {
-                    id: callbackId,
-                    args: [mediaResults[i]],
-                    isPartialResponse: i < mediaResults.length - 1,
-                  },
-                } as DOMMessageEvent);
-              }
-            },
-          );
-        });
-
-        it('getMedia using register handler method returns successful result with expected data', async () => {
-          validateGetMediaMessageAndResults(
-            mediaAPISupportVersion,
-            2,
-            (_message: MessageRequest, mediaResults: media.MediaResult[]) => {
-              const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
-              const getMediaHandlerName = handlerRegistrationMessage.args[0];
-
-              for (let i = 0; i < mediaResults.length; ++i) {
-                callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
-              }
-            },
-          );
+          const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
+          const getMediaHandlerName = handlerRegistrationMessage.args[0];
+          callHandler(getMediaHandlerName, [JSON.stringify(undefined)]);
         });
       });
     });
+    describe('v2', () => {
+      it('should not allow getMedia calls with invalid media mimetype', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = '1234567';
+        mediaOutput.mimeType = null;
+        mediaOutput.format = media.FileFormat.ID;
+        return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
 
-    describe('viewImages', () => {
-      describe('v1', () => {
-        it('should not allow viewImages calls with null imageuris', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-            media.viewImages(null, (error: SdkError) => {
-              expect(error).not.toBeNull();
-              expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
-              done();
-            });
-          });
+      it('should not allow getMedia calls with invalid media content', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = null;
+        mediaOutput.mimeType = 'image/jpeg';
+        mediaOutput.format = media.FileFormat.ID;
+        return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
+
+      it('should not allow getMedia calls with invalid media file format', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = '1234567';
+        mediaOutput.mimeType = 'image/jpeg';
+        mediaOutput.format = media.FileFormat.Base64;
+        return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
+
+      it('getMedia call in default version of platform support fails', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = '1234567';
+        mediaOutput.mimeType = 'image/jpeg';
+        mediaOutput.format = media.FileFormat.ID;
+        return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+      });
+
+      it('getMedia call in task frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = '1234567';
+        mediaOutput.mimeType = 'image/jpeg';
+        mediaOutput.format = media.FileFormat.ID;
+        mediaOutput.getMedia();
+        const message = mobilePlatformMock.findMessageByFunc('getMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(2);
+      });
+
+      async function getStringContainedInBlob(blob: Blob): Promise<string> {
+        let resolverMethod: (value: string | PromiseLike<string>) => void;
+        let rejectionMethod: (reason?: any) => void;
+        const blobReadingPromise: Promise<string> = new Promise<string>((resolve, reject) => {
+          resolverMethod = resolve;
+          rejectionMethod = reject;
         });
 
-        it('should not allow viewImages calls with invalid imageuris', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-            const uris: media.ImageUri[] = [];
-            media.viewImages(uris, (error: SdkError) => {
-              expect(error).not.toBeNull();
-              expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
-              done();
-            });
-          });
-        });
+        const blobReader = new FileReader();
+        blobReader.onloadend = (): void => {
+          resolverMethod(String.fromCharCode(...new Uint8Array(blobReader.result as ArrayBuffer)));
+        };
+        blobReader.onerror = (): void => {
+          rejectionMethod(blobReader.error);
+        };
 
-        it('viewImages call in default version of platform support fails', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-            const uris: media.ImageUri[] = [];
-            const uri: media.ImageUri = {
-              value: 'https://www.w3schools.com/images/picture.jpg',
-              type: media.ImageUriType.URL,
-            };
-            uris.push(uri);
-            media.viewImages(uris, (error: SdkError) => {
-              expect(error).not.toBeNull();
-              expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
-              done();
-            });
-          });
-        });
+        blobReader.readAsArrayBuffer(blob);
 
-        it('viewImages call in task frameContext works', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-          const uris: media.ImageUri[] = [];
-          const uri: media.ImageUri = {
-            value: 'https://www.w3schools.com/images/picture.jpg',
-            type: media.ImageUriType.URL,
-          };
-          uris.push(uri);
-          media.viewImages(uris, emptyCallback);
-          const message = mobilePlatformMock.findMessageByFunc('viewImages');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(1);
-        });
+        return blobReadingPromise;
+      }
 
-        it('viewImages call in content frameContext works', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-          const uris: media.ImageUri[] = [];
-          const uri: media.ImageUri = {
-            value: 'https://www.w3schools.com/images/picture.jpg',
-            type: media.ImageUriType.URL,
-          };
-          uris.push(uri);
-          media.viewImages(uris, emptyCallback);
-          const message = mobilePlatformMock.findMessageByFunc('viewImages');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(1);
-        });
+      async function validateGetMediaMessageAndResults(
+        supportedSDKVersion: string,
+        expectedNumberOfParametersInGetMediaMessage: number,
+        respondToMessages: (message: MessageRequest, mediaResults: media.MediaResult[]) => void,
+      ): Promise<void> {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(supportedSDKVersion);
 
-        it('viewImages calls with error', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-            const uris: media.ImageUri[] = [];
-            const uri: media.ImageUri = {
-              value: '1234567',
-              type: media.ImageUriType.ID,
-            };
-            uris.push(uri);
-            media.viewImages(uris, (error: SdkError) => {
-              expect(error.errorCode).toBe(ErrorCode.FILE_NOT_FOUND);
-              done();
-            });
+        const stringMediaData = 'the media data';
+        const firstMediaResult: media.MediaResult = {
+          error: undefined,
+          mediaChunk: {
+            chunk: btoa(stringMediaData),
+            chunkSequence: 1,
+          },
+        };
+        const secondMediaResult: media.MediaResult = {
+          error: undefined,
+          mediaChunk: {
+            chunk: undefined,
+            chunkSequence: 0,
+          },
+        };
 
-            const message = mobilePlatformMock.findMessageByFunc('viewImages');
-            expect(message).not.toBeNull();
-            expect(message.args.length).toBe(1);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = '1234567';
+        mediaOutput.mimeType = 'image/jpeg';
+        mediaOutput.format = media.FileFormat.ID;
+        const getMediaPromise: Promise<Blob> = mediaOutput.getMedia();
 
+        const message = mobilePlatformMock.findMessageByFunc('getMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(expectedNumberOfParametersInGetMediaMessage);
+
+        respondToMessages(message, [firstMediaResult, secondMediaResult]);
+
+        const blobContents: string = await getStringContainedInBlob(await getMediaPromise);
+        expect(blobContents).toEqual(stringMediaData);
+      }
+
+      it('getMedia using callback method returns successful result with expected data', async () => {
+        validateGetMediaMessageAndResults(
+          getMediaCallbackSupportVersion,
+          1,
+          (message: MessageRequest, mediaResults: media.MediaResult[]) => {
             const callbackId = message.id;
-            mobilePlatformMock.respondToMessage({
-              data: {
-                id: callbackId,
-                args: [{ errorCode: ErrorCode.FILE_NOT_FOUND }],
-              },
-            } as DOMMessageEvent);
+
+            for (let i = 0; i < mediaResults.length; ++i) {
+              mobilePlatformMock.respondToMessage({
+                data: {
+                  id: callbackId,
+                  args: [mediaResults[i]],
+                  isPartialResponse: i < mediaResults.length - 1,
+                },
+              } as DOMMessageEvent);
+            }
+          },
+        );
+      });
+
+      it('getMedia using register handler method returns successful result with expected data', async () => {
+        validateGetMediaMessageAndResults(
+          mediaAPISupportVersion,
+          2,
+          (_message: MessageRequest, mediaResults: media.MediaResult[]) => {
+            const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
+            const getMediaHandlerName = handlerRegistrationMessage.args[0];
+
+            for (let i = 0; i < mediaResults.length; ++i) {
+              callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
+            }
+          },
+        );
+      });
+    });
+  });
+
+  describe('viewImages', () => {
+    describe('v1', () => {
+      it('should not allow viewImages calls with null imageuris', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          media.viewImages(null, (error: SdkError) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+            done();
           });
         });
       });
-      describe('v2', () => {
-        it('should not allow viewImages calls with null imageuris', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-          return expect(media.viewImages(null)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
-        });
 
-        it('should not allow viewImages calls with invalid imageuris', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      it('should not allow viewImages calls with invalid imageuris', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
           const uris: media.ImageUri[] = [];
-          return expect(media.viewImages(uris)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+          media.viewImages(uris, (error: SdkError) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+            done();
+          });
         });
+      });
 
-        it('viewImages call in default version of platform support fails', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      it('viewImages call in default version of platform support fails', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
           const uris: media.ImageUri[] = [];
           const uri: media.ImageUri = {
@@ -1369,41 +1284,46 @@ describe('media', () => {
             type: media.ImageUriType.URL,
           };
           uris.push(uri);
-          return expect(media.viewImages(uris)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+          media.viewImages(uris, (error: SdkError) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
+            done();
+          });
         });
+      });
 
-        it('viewImages call in task frameContext works', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-          const uris: media.ImageUri[] = [];
-          const uri: media.ImageUri = {
-            value: 'https://www.w3schools.com/images/picture.jpg',
-            type: media.ImageUriType.URL,
-          };
-          uris.push(uri);
-          media.viewImages(uris);
-          const message = mobilePlatformMock.findMessageByFunc('viewImages');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(1);
-        });
+      it('viewImages call in task frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const uris: media.ImageUri[] = [];
+        const uri: media.ImageUri = {
+          value: 'https://www.w3schools.com/images/picture.jpg',
+          type: media.ImageUriType.URL,
+        };
+        uris.push(uri);
+        media.viewImages(uris, emptyCallback);
+        const message = mobilePlatformMock.findMessageByFunc('viewImages');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
 
-        it('viewImages call in content frameContext works', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
-          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
-          const uris: media.ImageUri[] = [];
-          const uri: media.ImageUri = {
-            value: 'https://www.w3schools.com/images/picture.jpg',
-            type: media.ImageUriType.URL,
-          };
-          uris.push(uri);
-          media.viewImages(uris);
-          const message = mobilePlatformMock.findMessageByFunc('viewImages');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(1);
-        });
+      it('viewImages call in content frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const uris: media.ImageUri[] = [];
+        const uri: media.ImageUri = {
+          value: 'https://www.w3schools.com/images/picture.jpg',
+          type: media.ImageUriType.URL,
+        };
+        uris.push(uri);
+        media.viewImages(uris, emptyCallback);
+        const message = mobilePlatformMock.findMessageByFunc('viewImages');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
 
-        it('viewImages calls with error', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+      it('viewImages calls with error', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
           const uris: media.ImageUri[] = [];
           const uri: media.ImageUri = {
@@ -1411,7 +1331,10 @@ describe('media', () => {
             type: media.ImageUriType.ID,
           };
           uris.push(uri);
-          const promise = media.viewImages(uris);
+          media.viewImages(uris, (error: SdkError) => {
+            expect(error.errorCode).toBe(ErrorCode.FILE_NOT_FOUND);
+            done();
+          });
 
           const message = mobilePlatformMock.findMessageByFunc('viewImages');
           expect(message).not.toBeNull();
@@ -1424,195 +1347,143 @@ describe('media', () => {
               args: [{ errorCode: ErrorCode.FILE_NOT_FOUND }],
             },
           } as DOMMessageEvent);
-          return expect(promise).rejects.toEqual({ errorCode: ErrorCode.FILE_NOT_FOUND });
         });
       });
     });
+    describe('v2', () => {
+      it('should not allow viewImages calls with null imageuris', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        return expect(media.viewImages(null)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
 
-    describe('scanBarCode', () => {
-      describe('_v1', () => {
-        it('scanBarCode call in default version of platform support fails', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-            media.scanBarCode((e: SdkError, d: string) => {
-              expect(e).not.toBeNull();
-              expect(e.errorCode).toBe(ErrorCode.OLD_PLATFORM);
-              done();
-            });
-          });
-        });
+      it('should not allow viewImages calls with invalid imageuris', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const uris: media.ImageUri[] = [];
+        return expect(media.viewImages(uris)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
 
-        it('should not allow scanBarCode calls for authentication frame context', () => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.authentication).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-            expect(() => media.scanBarCode(emptyCallback, null)).toThrowError(
-              'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
-            );
-          });
-        });
+      it('viewImages call in default version of platform support fails', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+        const uris: media.ImageUri[] = [];
+        const uri: media.ImageUri = {
+          value: 'https://www.w3schools.com/images/picture.jpg',
+          type: media.ImageUriType.URL,
+        };
+        uris.push(uri);
+        return expect(media.viewImages(uris)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+      });
 
-        it('scanBarCode call in task frameContext works', () => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-            media.scanBarCode(emptyCallback, null);
-            const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
-            expect(message).not.toBeNull();
-            expect(message.args.length).toBe(1);
-          });
-        });
+      it('viewImages call in task frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const uris: media.ImageUri[] = [];
+        const uri: media.ImageUri = {
+          value: 'https://www.w3schools.com/images/picture.jpg',
+          type: media.ImageUriType.URL,
+        };
+        uris.push(uri);
+        media.viewImages(uris);
+        const message = mobilePlatformMock.findMessageByFunc('viewImages');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
 
-        it('scanBarCode call in content frameContext works', () => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-            media.scanBarCode(emptyCallback, null);
-            const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
-            expect(message).not.toBeNull();
-            expect(message.args.length).toBe(1);
-          });
-        });
+      it('viewImages call in content frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const uris: media.ImageUri[] = [];
+        const uri: media.ImageUri = {
+          value: 'https://www.w3schools.com/images/picture.jpg',
+          type: media.ImageUriType.URL,
+        };
+        uris.push(uri);
+        media.viewImages(uris);
+        const message = mobilePlatformMock.findMessageByFunc('viewImages');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
 
-        it('scanBarCode calls with successful result', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+      it('viewImages calls with error', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const uris: media.ImageUri[] = [];
+        const uri: media.ImageUri = {
+          value: '1234567',
+          type: media.ImageUriType.ID,
+        };
+        uris.push(uri);
+        const promise = media.viewImages(uris);
 
-            media.scanBarCode((err: SdkError, decodedText: string) => {
-              expect(err).toBeFalsy();
-              expect(decodedText).toBe('decodedText');
-              done();
-            });
+        const message = mobilePlatformMock.findMessageByFunc('viewImages');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
 
-            const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
-            expect(message).not.toBeNull();
-            expect(message.args.length).toBe(1);
+        const callbackId = message.id;
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [{ errorCode: ErrorCode.FILE_NOT_FOUND }],
+          },
+        } as DOMMessageEvent);
+        return expect(promise).rejects.toEqual({ errorCode: ErrorCode.FILE_NOT_FOUND });
+      });
+    });
+  });
 
-            const callbackId = message.id;
-            const response = 'decodedText';
-            mobilePlatformMock.respondToMessage({
-              data: {
-                id: callbackId,
-                args: [undefined, response],
-              },
-            } as DOMMessageEvent);
-          });
-        });
-
-        it('scanBarCode with optional barcode config calls with successful result', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-            const barCodeConfig: media.BarCodeConfig = {
-              timeOutIntervalInSec: 40,
-            };
-            media.scanBarCode((mediaError: SdkError, decodedText: string) => {
-              expect(mediaError).toBeFalsy();
-              expect(decodedText).not.toBeNull;
-              expect(decodedText).toBe('decodedText');
-              done();
-            }, barCodeConfig);
-
-            const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
-            expect(message).not.toBeNull();
-            expect(message.args.length).toBe(1);
-
-            const callbackId = message.id;
-            const response = 'decodedText';
-            mobilePlatformMock.respondToMessage({
-              data: {
-                id: callbackId,
-                args: [undefined, response],
-              },
-            } as DOMMessageEvent);
-          });
-        });
-
-        it('scanBarCode calls with error', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-            media.scanBarCode((err: SdkError, decodedText: string) => {
-              expect(decodedText).toBeFalsy();
-              expect(err.errorCode).toBe(ErrorCode.OPERATION_TIMED_OUT);
-              done();
-            });
-
-            const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
-            expect(message).not.toBeNull();
-            expect(message.args.length).toBe(1);
-
-            const callbackId = message.id;
-            mobilePlatformMock.respondToMessage({
-              data: {
-                id: callbackId,
-                args: [{ errorCode: ErrorCode.OPERATION_TIMED_OUT }],
-              },
-            } as DOMMessageEvent);
-          });
-        });
-
-        it('should not allow scanBarCode calls with invalid timeOutIntervalInSec', done => {
-          mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
-            mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-            const barCodeConfig: any = {
-              timeOutIntervalInSec: 0,
-            };
-            media.scanBarCode((mediaError: SdkError, d: string) => {
-              expect(mediaError).not.toBeNull();
-              expect(mediaError.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
-              done();
-            }, barCodeConfig);
-          });
-        });
-
-        it('should not allow scanBarCode calls in desktop', done => {
-          desktopPlatformMock.initializeWithContext(FrameContexts.content, HostClientType.desktop).then(() => {
-            media.scanBarCode((error: SdkError, d: string) => {
-              expect(error).not.toBeNull();
-              expect(error.errorCode).toBe(ErrorCode.NOT_SUPPORTED_ON_PLATFORM);
-              done();
-            });
+  describe('scanBarCode', () => {
+    describe('_v1', () => {
+      it('scanBarCode call in default version of platform support fails', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+          media.scanBarCode((e: SdkError, d: string) => {
+            expect(e).not.toBeNull();
+            expect(e.errorCode).toBe(ErrorCode.OLD_PLATFORM);
+            done();
           });
         });
       });
 
-      describe('_v2', () => {
-        it('should not allow scanBarCode calls before initialization', () => {
-          return expect(() => media.scanBarCode()).toThrowError('The library has not yet been initialized');
-        });
-
-        it('scanBarCode call in default version of platform support fails', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
-          mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-          return expect(media.scanBarCode()).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
-        });
-
-        it('should not allow scanBarCode calls for authentication frame context', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
+      it('should not allow scanBarCode calls for authentication frame context', () => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.authentication).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-          return expect(() => media.scanBarCode()).toThrowError(
+          expect(() => media.scanBarCode(emptyCallback, null)).toThrowError(
             'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
           );
         });
+      });
 
-        it('scanBarCode call in task frameContext works', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      it('scanBarCode call in task frameContext works', () => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-          media.scanBarCode(null);
+          media.scanBarCode(emptyCallback, null);
           const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
           expect(message).not.toBeNull();
           expect(message.args.length).toBe(1);
         });
+      });
 
-        it('scanBarCode call in content frameContext works', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+      it('scanBarCode call in content frameContext works', () => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-          media.scanBarCode(null);
+          media.scanBarCode(emptyCallback, null);
           const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
           expect(message).not.toBeNull();
           expect(message.args.length).toBe(1);
         });
+      });
 
-        it('scanBarCode calls with successful result', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+      it('scanBarCode calls with successful result', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-          const promise = media.scanBarCode();
+
+          media.scanBarCode((err: SdkError, decodedText: string) => {
+            expect(err).toBeFalsy();
+            expect(decodedText).toBe('decodedText');
+            done();
+          });
 
           const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
           expect(message).not.toBeNull();
@@ -1626,17 +1497,21 @@ describe('media', () => {
               args: [undefined, response],
             },
           } as DOMMessageEvent);
-
-          return expect(promise).resolves.toBe('decodedText');
         });
+      });
 
-        it('scanBarCode with optional barcode config calls with successful result', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+      it('scanBarCode with optional barcode config calls with successful result', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
           const barCodeConfig: media.BarCodeConfig = {
             timeOutIntervalInSec: 40,
           };
-          const promise = media.scanBarCode(barCodeConfig);
+          media.scanBarCode((mediaError: SdkError, decodedText: string) => {
+            expect(mediaError).toBeFalsy();
+            expect(decodedText).not.toBeNull;
+            expect(decodedText).toBe('decodedText');
+            done();
+          }, barCodeConfig);
 
           const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
           expect(message).not.toBeNull();
@@ -1650,14 +1525,17 @@ describe('media', () => {
               args: [undefined, response],
             },
           } as DOMMessageEvent);
-
-          return expect(promise).resolves.toBe('decodedText');
         });
+      });
 
-        it('scanBarCode calls with error', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+      it('scanBarCode calls with error', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-          const promise = media.scanBarCode();
+          media.scanBarCode((err: SdkError, decodedText: string) => {
+            expect(decodedText).toBeFalsy();
+            expect(err.errorCode).toBe(ErrorCode.OPERATION_TIMED_OUT);
+            done();
+          });
 
           const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
           expect(message).not.toBeNull();
@@ -1670,30 +1548,1000 @@ describe('media', () => {
               args: [{ errorCode: ErrorCode.OPERATION_TIMED_OUT }],
             },
           } as DOMMessageEvent);
-
-          return expect(promise).rejects.toEqual({ errorCode: ErrorCode.OPERATION_TIMED_OUT });
         });
+      });
 
-        it('should not allow scanBarCode calls with invalid timeOutIntervalInSec', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+      it('should not allow scanBarCode calls with invalid timeOutIntervalInSec', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-          const barCodeConfig = {
+          const barCodeConfig: any = {
             timeOutIntervalInSec: 0,
           };
-          return expect(media.scanBarCode(barCodeConfig)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+          media.scanBarCode((mediaError: SdkError, d: string) => {
+            expect(mediaError).not.toBeNull();
+            expect(mediaError.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+            done();
+          }, barCodeConfig);
+        });
+      });
+
+      it('should not allow scanBarCode calls in desktop', done => {
+        desktopPlatformMock.initializeWithContext(FrameContexts.content, HostClientType.desktop).then(() => {
+          media.scanBarCode((error: SdkError, d: string) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.NOT_SUPPORTED_ON_PLATFORM);
+            done();
+          });
+        });
+      });
+    });
+
+    describe('_v2', () => {
+      it('should not allow scanBarCode calls before initialization', () => {
+        return expect(() => media.scanBarCode()).toThrowError('The library has not yet been initialized');
+      });
+
+      it('scanBarCode call in default version of platform support fails', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+        return expect(media.scanBarCode()).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+      });
+
+      it('should not allow scanBarCode calls for authentication frame context', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        return expect(() => media.scanBarCode()).toThrowError(
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
+        );
+      });
+
+      it('scanBarCode call in task frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        media.scanBarCode(null);
+        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
+
+      it('scanBarCode call in content frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        media.scanBarCode(null);
+        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
+
+      it('scanBarCode calls with successful result', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        const promise = media.scanBarCode();
+
+        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+
+        const callbackId = message.id;
+        const response = 'decodedText';
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [undefined, response],
+          },
+        } as DOMMessageEvent);
+
+        return expect(promise).resolves.toBe('decodedText');
+      });
+
+      it('scanBarCode with optional barcode config calls with successful result', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        const barCodeConfig: media.BarCodeConfig = {
+          timeOutIntervalInSec: 40,
+        };
+        const promise = media.scanBarCode(barCodeConfig);
+
+        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+
+        const callbackId = message.id;
+        const response = 'decodedText';
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [undefined, response],
+          },
+        } as DOMMessageEvent);
+
+        return expect(promise).resolves.toBe('decodedText');
+      });
+
+      it('scanBarCode calls with error', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        const promise = media.scanBarCode();
+
+        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+
+        const callbackId = message.id;
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [{ errorCode: ErrorCode.OPERATION_TIMED_OUT }],
+          },
+        } as DOMMessageEvent);
+
+        return expect(promise).rejects.toEqual({ errorCode: ErrorCode.OPERATION_TIMED_OUT });
+      });
+
+      it('should not allow scanBarCode calls with invalid timeOutIntervalInSec', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        const barCodeConfig = {
+          timeOutIntervalInSec: 0,
+        };
+        return expect(media.scanBarCode(barCodeConfig)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
+
+      it('should allow scanBarCode calls when timeOutIntervalInSec is not passed in config params', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        const barCodeConfig: media.BarCodeConfig = {};
+        return expect(media.scanBarCode(barCodeConfig)).resolves;
+      });
+
+      it('should not allow scanBarCode calls in desktop', async () => {
+        await desktopPlatformMock.initializeWithContext(FrameContexts.content, HostClientType.desktop);
+        return expect(media.scanBarCode()).rejects.toEqual({ errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM });
+      });
+    });
+  });
+
+  describe('getMedia', () => {
+    describe('v1', () => {
+      it('should not allow getMedia calls with invalid media mimetype', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = null;
+          mediaOutput.format = media.FileFormat.ID;
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+            done();
+          });
+        });
+      });
+
+      it('should not allow getMedia calls with invalid media content', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = null;
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+            done();
+          });
+        });
+      });
+
+      it('should not allow getMedia calls with invalid media file format', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.Base64;
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+            done();
+          });
+        });
+      });
+
+      it('getMedia call in default version of platform support fails', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
+            done();
+          });
+        });
+      });
+
+      it('getMedia call in task frameContext works', async () => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          mediaOutput.getMedia(emptyCallback);
+          const message = mobilePlatformMock.findMessageByFunc('getMedia');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(2);
+        });
+      });
+
+      async function getStringContainedInBlob(blob: Blob): Promise<string> {
+        let resolverMethod: (value: string | PromiseLike<string>) => void;
+        let rejectionMethod: (reason?: any) => void;
+        const blobReadingPromise: Promise<string> = new Promise<string>((resolve, reject) => {
+          resolverMethod = resolve;
+          rejectionMethod = reject;
         });
 
-        it('should allow scanBarCode calls when timeOutIntervalInSec is not passed in config params', async () => {
-          await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        const blobReader = new FileReader();
+        blobReader.onloadend = (): void => {
+          resolverMethod(String.fromCharCode(...new Uint8Array(blobReader.result as ArrayBuffer)));
+        };
+        blobReader.onerror = (): void => {
+          rejectionMethod(blobReader.error);
+        };
+
+        blobReader.readAsArrayBuffer(blob);
+
+        return blobReadingPromise;
+      }
+
+      it('getMedia calls with successful result via the handler', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        //mediaAPISupport version(1.8.0) is less than the MediaCallbackSupportVersion(2.0.0)
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = '1234567';
+        mediaOutput.mimeType = 'image/jpeg';
+        mediaOutput.format = media.FileFormat.ID;
+        mediaOutput.getMedia((error: SdkError, blob: Blob) =>
+          getStringContainedInBlob(blob).then(res => {
+            return expect(res).toEqual(stringMediaData);
+          }),
+        );
+
+        const message = mobilePlatformMock.findMessageByFunc('getMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(2);
+
+        const stringMediaData = 'the media data';
+        const firstMediaResult: media.MediaResult = {
+          error: undefined,
+          mediaChunk: {
+            chunk: btoa(stringMediaData),
+            chunkSequence: 1,
+          },
+        };
+        const secondMediaResult: media.MediaResult = {
+          error: undefined,
+          mediaChunk: {
+            chunk: undefined,
+            chunkSequence: 0,
+          },
+        };
+
+        const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
+        const getMediaHandlerName = handlerRegistrationMessage.args[0];
+
+        const mediaResults = Array.of(firstMediaResult, secondMediaResult);
+
+        for (let i = 0; i < mediaResults.length; ++i) {
+          callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
+        }
+      });
+
+      it('getMedia calls with successful result via the callback', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          // here we give the same version as the supported version
+          mobilePlatformMock.setClientSupportedSDKVersion(getMediaCallbackSupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            getStringContainedInBlob(blob).then(res => {
+              expect(res).toEqual(stringMediaData);
+              done();
+            });
+          });
+
+          const message = mobilePlatformMock.findMessageByFunc('getMedia');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1); // args will be of length 1 for the supported version
+
+          const stringMediaData = 'the media data';
+          const firstMediaResult: media.MediaResult = {
+            error: undefined,
+            mediaChunk: {
+              chunk: btoa(stringMediaData),
+              chunkSequence: 1,
+            },
+          };
+          const secondMediaResult: media.MediaResult = {
+            error: undefined,
+            mediaChunk: {
+              chunk: undefined,
+              chunkSequence: 0,
+            },
+          };
+
+          const mediaResults = Array.of(firstMediaResult, secondMediaResult);
+
+          for (let i = 0; i < mediaResults.length; ++i) {
+            mobilePlatformMock.respondToMessage({
+              data: {
+                id: message.id,
+                args: [mediaResults[i]],
+                isPartialResponse: i < mediaResults.length - 1,
+              },
+            } as DOMMessageEvent);
+          }
+        });
+      });
+
+      it('getMedia calls with error with MediaCallback', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(getMediaCallbackSupportVersion);
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '12345678';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            expect(error.errorCode).toBe(500);
+            expect(error.message).toEqual('data received is null');
+            expect(blob).toBeFalsy();
+            done();
+          });
+
+          const message = mobilePlatformMock.findMessageByFunc('getMedia');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
+
+          const callbackId = message.id;
+          mobilePlatformMock.respondToMessage({
+            data: {
+              id: callbackId,
+              args: [undefined, undefined],
+            },
+          } as DOMMessageEvent);
+        });
+      });
+
+      it('getMedia calls with error with Handler', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+
+          const mediaOutput: media.Media = new media.Media();
+          mediaOutput.content = '1234567';
+          mediaOutput.mimeType = 'image/jpeg';
+          mediaOutput.format = media.FileFormat.ID;
+          mediaOutput.getMedia((error: SdkError, blob: Blob) => {
+            expect(blob).toBeFalsy();
+            expect(error.errorCode).toBe(500);
+            done();
+          });
+
+          const message = mobilePlatformMock.findMessageByFunc('getMedia');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(2);
+
+          const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
+          const getMediaHandlerName = handlerRegistrationMessage.args[0];
+          callHandler(getMediaHandlerName, [JSON.stringify(undefined)]);
+        });
+      });
+    });
+    describe('v2', () => {
+      it('should not allow getMedia calls with invalid media mimetype', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = '1234567';
+        mediaOutput.mimeType = null;
+        mediaOutput.format = media.FileFormat.ID;
+        return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
+
+      it('should not allow getMedia calls with invalid media content', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = null;
+        mediaOutput.mimeType = 'image/jpeg';
+        mediaOutput.format = media.FileFormat.ID;
+        return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
+
+      it('should not allow getMedia calls with invalid media file format', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = '1234567';
+        mediaOutput.mimeType = 'image/jpeg';
+        mediaOutput.format = media.FileFormat.Base64;
+        return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
+
+      it('getMedia call in default version of platform support fails', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = '1234567';
+        mediaOutput.mimeType = 'image/jpeg';
+        mediaOutput.format = media.FileFormat.ID;
+        return expect(mediaOutput.getMedia()).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+      });
+
+      it('getMedia call in task frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = '1234567';
+        mediaOutput.mimeType = 'image/jpeg';
+        mediaOutput.format = media.FileFormat.ID;
+        mediaOutput.getMedia();
+        const message = mobilePlatformMock.findMessageByFunc('getMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(2);
+      });
+
+      async function getStringContainedInBlob(blob: Blob): Promise<string> {
+        let resolverMethod: (value: string | PromiseLike<string>) => void;
+        let rejectionMethod: (reason?: any) => void;
+        const blobReadingPromise: Promise<string> = new Promise<string>((resolve, reject) => {
+          resolverMethod = resolve;
+          rejectionMethod = reject;
+        });
+
+        const blobReader = new FileReader();
+        blobReader.onloadend = (): void => {
+          resolverMethod(String.fromCharCode(...new Uint8Array(blobReader.result as ArrayBuffer)));
+        };
+        blobReader.onerror = (): void => {
+          rejectionMethod(blobReader.error);
+        };
+
+        blobReader.readAsArrayBuffer(blob);
+
+        return blobReadingPromise;
+      }
+
+      async function validateGetMediaMessageAndResults(
+        supportedSDKVersion: string,
+        expectedNumberOfParametersInGetMediaMessage: number,
+        respondToMessages: (message: MessageRequest, mediaResults: media.MediaResult[]) => void,
+      ): Promise<void> {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(supportedSDKVersion);
+
+        const stringMediaData = 'the media data';
+        const firstMediaResult: media.MediaResult = {
+          error: undefined,
+          mediaChunk: {
+            chunk: btoa(stringMediaData),
+            chunkSequence: 1,
+          },
+        };
+        const secondMediaResult: media.MediaResult = {
+          error: undefined,
+          mediaChunk: {
+            chunk: undefined,
+            chunkSequence: 0,
+          },
+        };
+
+        const mediaOutput: media.Media = new media.Media();
+        mediaOutput.content = '1234567';
+        mediaOutput.mimeType = 'image/jpeg';
+        mediaOutput.format = media.FileFormat.ID;
+        const getMediaPromise: Promise<Blob> = mediaOutput.getMedia();
+
+        const message = mobilePlatformMock.findMessageByFunc('getMedia');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(expectedNumberOfParametersInGetMediaMessage);
+
+        respondToMessages(message, [firstMediaResult, secondMediaResult]);
+
+        const blobContents: string = await getStringContainedInBlob(await getMediaPromise);
+        expect(blobContents).toEqual(stringMediaData);
+      }
+
+      it('getMedia using callback method returns successful result with expected data', async () => {
+        validateGetMediaMessageAndResults(
+          getMediaCallbackSupportVersion,
+          1,
+          (message: MessageRequest, mediaResults: media.MediaResult[]) => {
+            const callbackId = message.id;
+
+            for (let i = 0; i < mediaResults.length; ++i) {
+              mobilePlatformMock.respondToMessage({
+                data: {
+                  id: callbackId,
+                  args: [mediaResults[i]],
+                  isPartialResponse: i < mediaResults.length - 1,
+                },
+              } as DOMMessageEvent);
+            }
+          },
+        );
+      });
+
+      it('getMedia using register handler method returns successful result with expected data', async () => {
+        validateGetMediaMessageAndResults(
+          mediaAPISupportVersion,
+          2,
+          (_message: MessageRequest, mediaResults: media.MediaResult[]) => {
+            const handlerRegistrationMessage = mobilePlatformMock.findMessageByFunc('registerHandler');
+            const getMediaHandlerName = handlerRegistrationMessage.args[0];
+
+            for (let i = 0; i < mediaResults.length; ++i) {
+              callHandler(getMediaHandlerName, [JSON.stringify(mediaResults[i])]);
+            }
+          },
+        );
+      });
+    });
+  });
+
+  describe('viewImages', () => {
+    describe('v1', () => {
+      it('should not allow viewImages calls with null imageuris', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          media.viewImages(null, (error: SdkError) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+            done();
+          });
+        });
+      });
+
+      it('should not allow viewImages calls with invalid imageuris', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const uris: media.ImageUri[] = [];
+          media.viewImages(uris, (error: SdkError) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+            done();
+          });
+        });
+      });
+
+      it('viewImages call in default version of platform support fails', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+          const uris: media.ImageUri[] = [];
+          const uri: media.ImageUri = {
+            value: 'https://www.w3schools.com/images/picture.jpg',
+            type: media.ImageUriType.URL,
+          };
+          uris.push(uri);
+          media.viewImages(uris, (error: SdkError) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
+            done();
+          });
+        });
+      });
+
+      it('viewImages call in task frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const uris: media.ImageUri[] = [];
+        const uri: media.ImageUri = {
+          value: 'https://www.w3schools.com/images/picture.jpg',
+          type: media.ImageUriType.URL,
+        };
+        uris.push(uri);
+        media.viewImages(uris, emptyCallback);
+        const message = mobilePlatformMock.findMessageByFunc('viewImages');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
+
+      it('viewImages call in content frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const uris: media.ImageUri[] = [];
+        const uri: media.ImageUri = {
+          value: 'https://www.w3schools.com/images/picture.jpg',
+          type: media.ImageUriType.URL,
+        };
+        uris.push(uri);
+        media.viewImages(uris, emptyCallback);
+        const message = mobilePlatformMock.findMessageByFunc('viewImages');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
+
+      it('viewImages calls with error', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+          const uris: media.ImageUri[] = [];
+          const uri: media.ImageUri = {
+            value: '1234567',
+            type: media.ImageUriType.ID,
+          };
+          uris.push(uri);
+          media.viewImages(uris, (error: SdkError) => {
+            expect(error.errorCode).toBe(ErrorCode.FILE_NOT_FOUND);
+            done();
+          });
+
+          const message = mobilePlatformMock.findMessageByFunc('viewImages');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
+
+          const callbackId = message.id;
+          mobilePlatformMock.respondToMessage({
+            data: {
+              id: callbackId,
+              args: [{ errorCode: ErrorCode.FILE_NOT_FOUND }],
+            },
+          } as DOMMessageEvent);
+        });
+      });
+    });
+    describe('v2', () => {
+      it('should not allow viewImages calls with null imageuris', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        return expect(media.viewImages(null)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
+
+      it('should not allow viewImages calls with invalid imageuris', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const uris: media.ImageUri[] = [];
+        return expect(media.viewImages(uris)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
+
+      it('viewImages call in default version of platform support fails', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+        const uris: media.ImageUri[] = [];
+        const uri: media.ImageUri = {
+          value: 'https://www.w3schools.com/images/picture.jpg',
+          type: media.ImageUriType.URL,
+        };
+        uris.push(uri);
+        return expect(media.viewImages(uris)).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+      });
+
+      it('viewImages call in task frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const uris: media.ImageUri[] = [];
+        const uri: media.ImageUri = {
+          value: 'https://www.w3schools.com/images/picture.jpg',
+          type: media.ImageUriType.URL,
+        };
+        uris.push(uri);
+        media.viewImages(uris);
+        const message = mobilePlatformMock.findMessageByFunc('viewImages');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
+
+      it('viewImages call in content frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const uris: media.ImageUri[] = [];
+        const uri: media.ImageUri = {
+          value: 'https://www.w3schools.com/images/picture.jpg',
+          type: media.ImageUriType.URL,
+        };
+        uris.push(uri);
+        media.viewImages(uris);
+        const message = mobilePlatformMock.findMessageByFunc('viewImages');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
+
+      it('viewImages calls with error', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
+        const uris: media.ImageUri[] = [];
+        const uri: media.ImageUri = {
+          value: '1234567',
+          type: media.ImageUriType.ID,
+        };
+        uris.push(uri);
+        const promise = media.viewImages(uris);
+
+        const message = mobilePlatformMock.findMessageByFunc('viewImages');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+
+        const callbackId = message.id;
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [{ errorCode: ErrorCode.FILE_NOT_FOUND }],
+          },
+        } as DOMMessageEvent);
+        return expect(promise).rejects.toEqual({ errorCode: ErrorCode.FILE_NOT_FOUND });
+      });
+    });
+  });
+
+  describe('scanBarCode', () => {
+    describe('_v1', () => {
+      it('scanBarCode call in default version of platform support fails', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+          media.scanBarCode((e: SdkError, d: string) => {
+            expect(e).not.toBeNull();
+            expect(e.errorCode).toBe(ErrorCode.OLD_PLATFORM);
+            done();
+          });
+        });
+      });
+
+      it('should not allow scanBarCode calls for authentication frame context', () => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.authentication).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
-          const barCodeConfig: media.BarCodeConfig = {};
-          return expect(media.scanBarCode(barCodeConfig)).resolves;
+          expect(() => media.scanBarCode(emptyCallback, null)).toThrowError(
+            'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
+          );
         });
+      });
 
-        it('should not allow scanBarCode calls in desktop', async () => {
-          await desktopPlatformMock.initializeWithContext(FrameContexts.content, HostClientType.desktop);
-          return expect(media.scanBarCode()).rejects.toEqual({ errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM });
+      it('scanBarCode call in task frameContext works', () => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+          media.scanBarCode(emptyCallback, null);
+          const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
         });
+      });
+
+      it('scanBarCode call in content frameContext works', () => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+          media.scanBarCode(emptyCallback, null);
+          const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
+        });
+      });
+
+      it('scanBarCode calls with successful result', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+
+          media.scanBarCode((err: SdkError, decodedText: string) => {
+            expect(err).toBeFalsy();
+            expect(decodedText).toBe('decodedText');
+            done();
+          });
+
+          const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
+
+          const callbackId = message.id;
+          const response = 'decodedText';
+          mobilePlatformMock.respondToMessage({
+            data: {
+              id: callbackId,
+              args: [undefined, response],
+            },
+          } as DOMMessageEvent);
+        });
+      });
+
+      it('scanBarCode with optional barcode config calls with successful result', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+          const barCodeConfig: media.BarCodeConfig = {
+            timeOutIntervalInSec: 40,
+          };
+          media.scanBarCode((mediaError: SdkError, decodedText: string) => {
+            expect(mediaError).toBeFalsy();
+            expect(decodedText).not.toBeNull;
+            expect(decodedText).toBe('decodedText');
+            done();
+          }, barCodeConfig);
+
+          const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
+
+          const callbackId = message.id;
+          const response = 'decodedText';
+          mobilePlatformMock.respondToMessage({
+            data: {
+              id: callbackId,
+              args: [undefined, response],
+            },
+          } as DOMMessageEvent);
+        });
+      });
+
+      it('scanBarCode calls with error', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.content).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+          media.scanBarCode((err: SdkError, decodedText: string) => {
+            expect(decodedText).toBeFalsy();
+            expect(err.errorCode).toBe(ErrorCode.OPERATION_TIMED_OUT);
+            done();
+          });
+
+          const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+          expect(message).not.toBeNull();
+          expect(message.args.length).toBe(1);
+
+          const callbackId = message.id;
+          mobilePlatformMock.respondToMessage({
+            data: {
+              id: callbackId,
+              args: [{ errorCode: ErrorCode.OPERATION_TIMED_OUT }],
+            },
+          } as DOMMessageEvent);
+        });
+      });
+
+      it('should not allow scanBarCode calls with invalid timeOutIntervalInSec', done => {
+        mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
+          mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+          const barCodeConfig: any = {
+            timeOutIntervalInSec: 0,
+          };
+          media.scanBarCode((mediaError: SdkError, d: string) => {
+            expect(mediaError).not.toBeNull();
+            expect(mediaError.errorCode).toBe(ErrorCode.INVALID_ARGUMENTS);
+            done();
+          }, barCodeConfig);
+        });
+      });
+
+      it('should not allow scanBarCode calls in desktop', done => {
+        desktopPlatformMock.initializeWithContext(FrameContexts.content, HostClientType.desktop).then(() => {
+          media.scanBarCode((error: SdkError, d: string) => {
+            expect(error).not.toBeNull();
+            expect(error.errorCode).toBe(ErrorCode.NOT_SUPPORTED_ON_PLATFORM);
+            done();
+          });
+        });
+      });
+    });
+
+    describe('_v2', () => {
+      it('should not allow scanBarCode calls before initialization', () => {
+        return expect(() => media.scanBarCode()).toThrowError('The library has not yet been initialized');
+      });
+
+      it('scanBarCode call in default version of platform support fails', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+        return expect(media.scanBarCode()).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+      });
+
+      it('should not allow scanBarCode calls for authentication frame context', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.authentication);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        return expect(() => media.scanBarCode()).toThrowError(
+          'This call is only allowed in following contexts: ["content","task"]. Current context: "authentication".',
+        );
+      });
+
+      it('scanBarCode call in task frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        media.scanBarCode(null);
+        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
+
+      it('scanBarCode call in content frameContext works', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        media.scanBarCode(null);
+        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
+
+      it('scanBarCode calls with successful result', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        const promise = media.scanBarCode();
+
+        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+
+        const callbackId = message.id;
+        const response = 'decodedText';
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [undefined, response],
+          },
+        } as DOMMessageEvent);
+
+        return expect(promise).resolves.toBe('decodedText');
+      });
+
+      it('scanBarCode with optional barcode config calls with successful result', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        const barCodeConfig: media.BarCodeConfig = {
+          timeOutIntervalInSec: 40,
+        };
+        const promise = media.scanBarCode(barCodeConfig);
+
+        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+
+        const callbackId = message.id;
+        const response = 'decodedText';
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [undefined, response],
+          },
+        } as DOMMessageEvent);
+
+        return expect(promise).resolves.toBe('decodedText');
+      });
+
+      it('scanBarCode calls with error', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        const promise = media.scanBarCode();
+
+        const message = mobilePlatformMock.findMessageByFunc('media.scanBarCode');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+
+        const callbackId = message.id;
+        mobilePlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [{ errorCode: ErrorCode.OPERATION_TIMED_OUT }],
+          },
+        } as DOMMessageEvent);
+
+        return expect(promise).rejects.toEqual({ errorCode: ErrorCode.OPERATION_TIMED_OUT });
+      });
+
+      it('should not allow scanBarCode calls with invalid timeOutIntervalInSec', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        const barCodeConfig = {
+          timeOutIntervalInSec: 0,
+        };
+        return expect(media.scanBarCode(barCodeConfig)).rejects.toEqual({ errorCode: ErrorCode.INVALID_ARGUMENTS });
+      });
+
+      it('should allow scanBarCode calls when timeOutIntervalInSec is not passed in config params', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.task);
+        mobilePlatformMock.setClientSupportedSDKVersion(scanBarCodeAPISupportVersion);
+        const barCodeConfig: media.BarCodeConfig = {};
+        return expect(media.scanBarCode(barCodeConfig)).resolves;
+      });
+
+      it('should not allow scanBarCode calls in desktop', async () => {
+        await desktopPlatformMock.initializeWithContext(FrameContexts.content, HostClientType.desktop);
+        return expect(media.scanBarCode()).rejects.toEqual({ errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM });
       });
     });
   });

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -526,9 +526,10 @@ describe('media', () => {
           maxMediaCount: 10,
           videoProps: {},
         };
-        media.selectMedia(mediaInputs, (e: SdkError, attachments: media.Media[]) => {
+        const callbackSpy = jest.fn((e: SdkError, attachments: media.Media[]) => {
           mediaError = e;
         });
+        media.selectMedia(mediaInputs, callbackSpy);
         const message = mobilePlatformMock.findMessageByFunc('selectMedia');
         expect(message).not.toBeNull();
         expect(message.args.length).toBe(1);
@@ -540,7 +541,7 @@ describe('media', () => {
           },
         } as DOMMessageEvent);
         expect(mediaError).toBeFalsy();
-        expect(jest.fn()).not.toHaveBeenCalled();
+        expect(callbackSpy).not.toHaveBeenCalled();
       });
     });
     describe('v2', () => {

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/no-empty-function */
+import * as communication from '../../src/internal/communication';
 import { captureImageMobileSupportVersion, getMediaCallbackSupportVersion } from '../../src/internal/constants';
 import { callHandler } from '../../src/internal/handlers';
 import { DOMMessageEvent, MessageRequest } from '../../src/internal/interfaces';
@@ -825,13 +826,13 @@ describe('media', () => {
           expect(stopPromise).resolves;
         });
 
-        it('videoController notifyEventToHost is not handled successfully but stop', async () => {
+        it('videoController notifyEventToHost is not handled successfully and sendMessageToParent does not run', async () => {
           await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
           mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
 
           const err = { errorCode: ErrorCode.INTERNAL_ERROR };
           const stopPromise = new media.VideoController().stop();
-
+          const sendMessageToParentSpy = jest.spyOn(communication, 'sendMessageToParent');
           const message = mobilePlatformMock.findMessageByFunc('media.controller');
           expect(message).not.toBeNull();
           expect(message.args.length).toBe(1);
@@ -842,7 +843,7 @@ describe('media', () => {
               args: [err],
             },
           } as DOMMessageEvent);
-
+          expect(sendMessageToParentSpy).not.toBeCalled();
           await stopPromise.catch(err => {
             expect(err).toMatchObject(err);
           });

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { notDeepStrictEqual } from 'assert';
+
 import * as communication from '../../src/internal/communication';
 import { captureImageMobileSupportVersion, getMediaCallbackSupportVersion } from '../../src/internal/constants';
 import { callHandler } from '../../src/internal/handlers';

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -919,7 +919,7 @@ describe('media', () => {
         });
       });
 
-      it('getMedia call in task frameContext works', async () => {
+      it('getMedia call in task frameContext works', done => {
         mobilePlatformMock.initializeWithContext(FrameContexts.task).then(() => {
           mobilePlatformMock.setClientSupportedSDKVersion(mediaAPISupportVersion);
           const mediaOutput: media.Media = new media.Media();
@@ -930,6 +930,7 @@ describe('media', () => {
           const message = mobilePlatformMock.findMessageByFunc('getMedia');
           expect(message).not.toBeNull();
           expect(message.args.length).toBe(2);
+          done();
         });
       });
 


### PR DESCRIPTION
* deprecated notifyEventToHost in media.ts
* deprecated stop in media.ts
* renamed utility functions to better describe their new behavior
* modified utility functions to throw sdk errors rather than return objects containing error codes