### PR TITLE
Added ipadOS to HostClientType

### DIFF
--- a/src/public/constants.ts
+++ b/src/public/constants.ts
@@ -3,6 +3,7 @@ export enum HostClientType {
   web = 'web',
   android = 'android',
   ios = 'ios',
+  ipados = 'ipados',
   /**
    * @deprecated Use teamsRoomsWindows instead.
    */


### PR DESCRIPTION
Feature: https://domoreexp.visualstudio.com/MSTeams/_workitems/edit/1774162
iPad Experience 
As a part of above feature we are sending the hostClientType via getContext as "ipados" if the client device is iPad.
Hence adding the same constant on the enum HostClientType.