### PR TITLE
Making Menu APIs Public

### DIFF
--- a/src/private/index.ts
+++ b/src/private/index.ts
@@ -1,5 +1,4 @@
 export { bot } from './bot';
-export { menus } from './menus';
 export { logs } from './logs';
 export {
   ChatMembersInformation,

--- a/src/private/privateAPIs.ts
+++ b/src/private/privateAPIs.ts
@@ -10,14 +10,14 @@ import {
 } from './interfaces';
 import { getGenericOnCompleteHandler } from '../internal/utils';
 import { Communication, sendMessageToParent, sendMessageEventToChild } from '../internal/communication';
-import { menus } from './menus';
+
 import { registerHandler } from '../internal/handlers';
 import { GlobalVars } from '../internal/globalVars';
 import { ErrorCode, SdkError } from '../public/interfaces';
 import { getUserJoinedTeamsSupportedAndroidClientVersion } from '../internal/constants';
 
 export function initializePrivateApis(): void {
-  menus.initialize();
+  //Keeping this API for any future usage, wherein privateAPIs need to be initialized
 }
 
 /**

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -41,6 +41,7 @@ export { returnFocus, navigateBack, navigateCrossDomain, navigateToTab } from '.
 export { settings } from './settings';
 export { tasks } from './tasks';
 export { ChildAppWindow, IAppWindow, ParentAppWindow } from './appWindow';
+export { menus } from './menus';
 export { media } from './media';
 export { location } from './location';
 export { meeting } from './meeting';

--- a/src/public/menus.ts
+++ b/src/public/menus.ts
@@ -5,8 +5,6 @@ import { registerHandler } from '../internal/handlers';
  * Namespace to interact with the menu-specific part of the SDK.
  * This object is used to show View Configuration, Action Menu and Navigation Bar Menu.
  *
- * @private
- * Hide from docs until feature is complete
  */
 export namespace menus {
   /**

--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -21,6 +21,7 @@ import {
 } from '../internal/communication';
 import { authentication } from './authentication';
 import { initializePrivateApis } from '../private/privateAPIs';
+import { menus } from './menus';
 import * as Handlers from '../internal/handlers'; // Conflict with some names
 
 // ::::::::::::::::::::::: MicrosoftTeams SDK public API ::::::::::::::::::::
@@ -58,6 +59,7 @@ export function initialize(callback?: () => void, validMessageOrigins?: string[]
 
     authentication.initialize();
     settings.initialize();
+    menus.initialize();
     initializePrivateApis();
   }
 


### PR DESCRIPTION
Making the following API's public 
- setUpViews
- setNavBarMenu
- showActionMenu
This is an ask from the Product as they want to increase usage of the API by 3rd Party App Developers

Verified tests are passing locally by running `yarn test`

Queries
- Is there anything we need to consider from Desktop as the ask is from Mobile Side