### PR TITLE
Hooking up beachball to release scripts

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -10,6 +10,9 @@ const postbump = (packagePath, packageName, packageVersion) => {
   });
 };
 
+// Overriding the default entry renderer so that it just shows the comment without the author.
+const customRenderEntry = ChangelogEntry => `- ${ChangelogEntry.comment}`;
+
 module.exports = {
   branch: 'origin/2.0-preview',
   bumpDeps: false,
@@ -20,4 +23,9 @@ module.exports = {
   publish: false,
   push: false,
   scope: ['packages/teams-js'],
+  changelog: {
+    customRenderers: {
+      renderEntry: customRenderEntry,
+    },
+  },
 };

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -11,7 +11,7 @@ const postbump = (packagePath, packageName, packageVersion) => {
 };
 
 // Overriding the default entry renderer so that it just shows the comment without the author.
-const customRenderEntry = ChangelogEntry => `- ${ChangelogEntry.comment}`;
+const customRenderEntry = ChangelogEntry => new Promise(res => res(`- ${ChangelogEntry.comment}`));
 
 module.exports = {
   branch: 'origin/2.0-preview',

--- a/change/@microsoft-teams-js-e47e48ff-feb5-4cf2-989a-a7e830948544.json
+++ b/change/@microsoft-teams-js-e47e48ff-feb5-4cf2-989a-a7e830948544.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "`null` runtimeConfig is no longer allowed during initialization. This will now throw a \"Received runtime config is invalid\" error.",
+  "packageName": "@microsoft/teams-js",
+  "email": "ramourt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-eb072478-2fb7-4472-8af2-5c8fbfa6e30d.json
+++ b/change/@microsoft-teams-js-eb072478-2fb7-4472-8af2-5c8fbfa6e30d.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "`core.shareDeepLink` has moved to `pages.shareDeepLink`",
+  "packageName": "@microsoft/teams-js",
+  "email": "ramourt@microsoft.com",
+  "dependentChangeType": "major"
+}

--- a/change/@microsoft-teams-js-f11bf3ab-5159-4a30-8cfe-6a1ef412b684.json
+++ b/change/@microsoft-teams-js-f11bf3ab-5159-4a30-8cfe-6a1ef412b684.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "`core.executeDeepLink` has renamed and moved to `app.openLink`",
+  "packageName": "@microsoft/teams-js",
+  "email": "ramourt@microsoft.com",
+  "dependentChangeType": "major"
+}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,18 +1,3 @@
-## 2.0.0-beta.3
-
-### Breaking Changes
-
-#### Core APIs have been moved and renamed
-
-APIs previously under the `core` namespace, `executeDeepLink` and `shareDeepLink`, have moved.
-
-- `core.executeDeepLink` has renamed and moved to `app.openLink`
-- `core.shareDeepLink` has moved to `pages.shareDeepLink`
-
-### Bug fixes
-
-`null` runtimeConfig is no longer allowed during initialization. This will now throw a "Received runtime config is invalid" error.
-
 ## 2.0.0-beta.2
 
 ### Bug Fixes

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,330 +1,245 @@
 ## 2.0.0-beta.2
 
-### Bug Fixes
+### Patches
 
-Update TSDoc @deprecated comments to include links to replaced APIs.
+- Update TSDoc @deprecated comments to include links to replaced APIs.
 
-Update webpack-dev-server types to match webpack 5 versions and stop generating module wrappers in MicrosoftTeams.d.ts.
+- Update webpack-dev-server types to match webpack 5 versions and stop generating module wrappers in MicrosoftTeams.d.ts.
 
-Fix warnings produced during documentation generation, including exporting additional existing interfaces.
+- Fix warnings produced during documentation generation, including exporting additional existing interfaces.
 
-Update repository URLs to reference `2.0-preview` branch.
+- Update repository URLs to reference `2.0-preview` branch.
 
 ## 2.0.0-beta.1
 
-### Bug Fixes
+### Patches
 
-Update integrity hash to valid value in README file.
+- Update integrity hash to valid value in README file.
 
 ## 2.0.0-beta.0
 
-### Breaking changes
+### Major changes
 
-#### The Teams JavaScript client SDK repo is now a monorepo
+- The Teams JavaScript client SDK repo is now a monorepo
+- We utilized [Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/) to turn our repo into a monorepo. <br> The files specific to the Teams client SDK have been moved to an inner directory with the name `teams-js`
+- A new TeamsJS Test App for validating the Teams client SDK has been added in the <root>/apps/teams-test-app location.
 
-We utilized [Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/) to turn our repo into a monorepo. The files specific to the Teams client SDK have been moved to an inner directory
-with the name `teams-js`. A new TeamsJS Test App for validating the Teams client SDK has been added in the <root>/apps/teams-test-app location.
+- Several API functions have been moved and renamed. <br>
+  Organized top-level library functions under a core namespace. For example, `shareDeepLink` has been moved under `core` namespace. <br> Using `import * as ... from ...` will now fail. Importing now follows the following convention: <br>
 
-#### Several API functions have been moved and renamed
+  ```ts
+  import { core } from '@microsoft/teams-js';
+  ```
 
-Organized top-level library functions under a core namespace. For example, `shareDeepLink` has been moved under `core` namespace.
-Using `import * as ... from ...` will now fail. Importing now follows the following convention:
+  For more detailed API organization, please refer to the **Capabilities organization introduced** section below.
 
-```typescript
-import { core } from '@microsoft/teams-js';
-```
+- Support for `hostName` added to Context interface <br>
+  The name of the host the app is running in is now part of the application context in the `hostName` property.
 
-For more detailed API organization, please refer to the **Capabilities organization introduced** section below.
+- Several meeting APIs changes <br>
+  `meeting.requestStartLiveStreaming` and `meeting.requestStopLiveStreaming` no longer take in the parameter liveStreamState.
 
-#### Support for `hostName` added to Context interface
+- Context interface changes <br>
+  The Context interface has been updated to group similar properties for better scalability in a multi-host environment.
 
-The name of the host the app is running in is now part of the application context in the `hostName` property.
+- FrameContext changes <br>
+  FrameContext's `user.tenant.sku` has been renamed to `user.tenant.teamsSku` to reflect that it is used by Teams for a different purpose than from the Graph API's user.tenant.sku's.
+  The `FrameContext` interface has been renamed `FrameInfo`.
 
-#### Several meeting APIs changes
-
-meeting.requestStartLiveStreaming and meeting.requestStopLiveStreaming no longer take in the parameter liveStreamState.
-
-#### Context interface changes
-
-The Context interface has been updated to group similar properties for better scalability in a multi-host environment.
-
-#### FrameContext changes
-
-FrameContext's user.tenant.sku has been renamed to user.tenant.teamsSku to reflect that it is used by Teams for a different purpose than from the Graph API's user.tenant.sku's.
-The `FrameContext` interface has been renamed `FrameInfo`.
-
-#### appEntity.selectAppEntity now takes in an additional parameter and the callback has reversed parameters with one one of them becoming optional.
-
-```
-selectAppEntity(
+- appEntity.selectAppEntity now takes in an additional parameter and the callback has reversed parameters with one one of them becoming optional.
+  ```
+  selectAppEntity(
     threadId: string,
     categories: string[],
     callback: (appEntity: AppEntity, sdkError?: SdkError) => void,
   ): void
-```
-
-is now:
-
-```
-selectAppEntity(
+  ```
+  is now:
+  ```
+  selectAppEntity(
     threadId: string,
     categories: string[],
     subEntityId: string,
     callback: (sdkError?: SdkError, appEntity?: AppEntity) => void,
   ): void
-```
-
-#### threadId parameter removed from callback passed into teams.refreshSiteUrl()
-
-```
-refreshSiteUrl(threadId: string, callback: (threadId: string, error: SdkError) => void): void
-```
-
-is now:
-
-```
-refreshSiteUrl(threadId: string, callback: (error: SdkError) => void): void
-```
-
-#### Capabilities organization introduced
-
-##### Added App capability
-
-The following APIs have been moved from `publicAPIs` to new `app` namespace:
-
-- `initialize`
-- `getContext`
-- `registerOnThemeChangeHandler`
-
-The following APIs have been moved from `appInitialization` to `app` namespace:
-
-- `notifyAppLoaded`
-- `notifySuccess`
-- `notifyFailure`
-- `notifyExpectedFailure`
-
-The following APIs have been added to `app` namespace:
-
-- `isInitialized`
-- `getFrameContext`
-
-##### Added Core capability
-
-The following APIs have been moved from `publicAPIs` to new `core` namespace:
-
-- `shareDeepLink`
-- `executeDeepLink`
-
-##### Several APIs reorganized under new Pages capability
-
-The following APIs have been moved to the new `pages` namespace:
-
-- `registerFullScreenHandler`
-- `initializeWithFrameContext`
-- `navigateCrossDomain`
-- `returnFocus`
-- `setFrameContext` has been renamed `pages.setCurrentFrame`
-
-The following APIs have been been renamed and moved from `publicAPIs` to a new Pages.AppButton sub-capability in the new `pages.appButton` namespace:
-
-- `registerAppButtonClickHandler` has renamed and moved to `pages.appButton.onClick`
-- `registerAppButtonHoverEnterHandler` has renamed and moved to `pages.appButton.onHoverEnter`
-- `regsiterAppButtonHoverLeaveHandler` has renamed and moved to `pages.appButton.onHoverLeave`
-
-The following APIs have been moved to a new Pages.BackStack sub-capability in the new `pages.backStack` namespace:
-
-- `registerBackButtonHandler`
-- `navigateBack`
-
-The following APIs have been renamed and moved into the Pages.Config sub-capability in the `pages.config` namespace (formerly the `settings` namespace):
-
-- `registerEnterSettingsHandler` has renamed and moved to `pages.config.registerChangeConfigHandler`
-- `getSettings` has been renamed `pages.config.getConfig`
-- `setSettings` has been renamed `pages.config.setConfig`
-
-The following APIs have been been moved from `privateAPIs` to a new Pages.FullTrust sub-capability in the new `pages.fullTrust` namespace:
-
-- `enterFullscreen`
-- `exitFullscreen`
-
-The following APIs have been been moved to a new Pages.Tabs sub-capability in the new `pages.tabs` namespace:
-
-- `getTabInstances`
-- `getMruTabInstances`
-- `navigateToTab`
-
-##### Added Dialog capability, renamed `tasks` namespace to `dialog`, and renamed APIs
-
-The following APIs have been renamed:
-
-- `startTask` has been renamed `dialog.open`
-- `submitTasks` has been renamed `dialog.submit`
-- `updateTask` has been renamed `dialog.resize`
-- `TaskInfo` interface has been renamed `DialogInfo`
-- `TaskModuleDimension` enum has been renamed `DialogDimension`
-
-##### Added TeamsCore capability
-
-The following APIs have been moved from `publicAPIs` to new `teamsCore` namespace:
-
-- `enablePrintCapability`
-- `print`
-- `registerOnLoadHandler`
-- `registerBeforeUnloadHandler`
-- `registerFocusEnterHandler`
-
-##### Added AppInstallDialog capability
-
-- `openAppInstallDialog` is added to new `appInstallDialog` namespace
-
-##### Added Calendar capability
-
-The following APIs have been added to new `calendar` namespace:
-
-- `openCalendarItem` is added
-- `composeMeeting` is added
-
-##### Added Call capability
-
-- `startCall` is added to new `call` namespace
-
-##### Added Mail capability
-
-The following APIs have been added to the new `mail` namespace:
-
-- `openMailItem` is added
-- `composeMail` is added
-
-##### Added Chat capability and renamed `conversations` namespace to `chat`
-
-- `openConversation` and `closeConversation` have been moved to `chat` namespace
-- `getChatMembers` has been moved to `chat` namespace
-
-##### Added Files capability
-
-- `openFilePreview` has moved from `privateAPIs` to `files` namespace
-
-##### Added Legacy capability
-
-The following APIs have been moved from `privateAPIs` to a new `legacy.fullTrust` namespace:
-
-- `getUserJoinedTeams`
-- `getConfigSetting`
-
-##### Added Notifications capability
-
-- `showNotification` has moved from `privateAPIs` to `notifications` namespace
-
-##### Added the following new capabilites from existing namespaces
-
-- Location
-- Media
-- Meeting
-- Monetization
-- People
-- Sharing
-- Video
-- Bot
-- Logs
-- MeetingRoom
-- Menus
-- RemoteCamera
-
-##### Added Runtime capability
-
-- `applyRuntimeConfig` is added
-
-#### Promises introduced
-
-The following APIs that took in a callback function as a parameter now instead return a Promise.
-
-app APIs:
-
-- app.initialize
-- app.getContext
-
-authentication APIs：
-
-- authentication.authenticate
-- authentication.getAuthToken
-- authentication.getUser
-
-calendar APIs:
-
-- calendar.openCalendarItem
-- calendar.composeMeeting
-
-chat APIs:
-
-- chat.getChatMembers
-- chat.openConversation
-
-files APIs:
-
-- files.addCloudStorageFolder
-- files.deleteCloudStorageFolder
-- files.getCloudStorageFolderContents
-- files.getCloudStorageFolders
-
-legacy APIs:
-
-- legacy.fulltrust.getConfigSetting
-- legacy.fulltrust.getUserJoinedTeams
-
-location APIs:
-
-- location.getLocation
-- location.showLocation
-
-mail APIs:
-
-- mail.openMailItem
-- mail.composeMail
-
-media APIs:
-
-- media.captureImage
-- media.selectMedia
-- media.viewImages
-- media.scanBarCode
-
-meeting APIs:
-
-- meeting.getAppContentStageSharingState
-- meeting.getAppContentStageSharingCapabilities
-- meeting.getAuthenticationTokenForAnonymousUser
-- meeting.getIncomingClientAudioState
-- meeting.getLiveStreamState
-- meeting.getMeetingDetails
-- meeting.requestStartLiveStreaming
-- meeting.requestStopLiveStreaming
-- meeting.shareAppContentToStage
-- meeting.stopSharingAppContentToStage
-- meeting.toggleIncomingClientAudio
-
-meetingRoom APIs:
-
-- meetingRoom.getPairedMeetingRoomInfo
-- meetingRoom.sendCommandToPairedMeetingRoom
-
-pages APIs：
-
-- pages.navigateCrossDomain
-- pages.tabs.navigateToTab
-- pages.tabs.getTabInstances
-- pages.tabs.getMruTabInstances
-- pages.config.getConfig
-- pages.config.setConfig
-- pages.backStack.navigateBack
-
-people APIs:
-
-- people.selectPeople
-
-others:
-
-- ChildAppWindow.postMessage
-- ParentAppWindow.postMessage
-- core.executeDeepLink
-- appInstallDialog.openAppInstallDialog
-- call.startCall
+  ```
+- threadId parameter removed from callback passed into teams.refreshSiteUrl()
+
+  ```
+  refreshSiteUrl(threadId: string, callback: (threadId: string, error: SdkError) => void): void
+  ```
+
+  is now:
+
+  ```
+  refreshSiteUrl(threadId: string, callback: (error: SdkError) => void): void
+  ```
+
+- Capabilities organization introduced
+
+  - Added App capability
+    - The following APIs have been moved from `publicAPIs` to new `app` namespace:
+      - `initialize`
+      - `getContext`
+      - `registerOnThemeChangeHandler`
+    - The following APIs have been moved from `appInitialization` to `app` namespace:
+      - `notifyAppLoaded`
+      - `notifySuccess`
+      - `notifyFailure`
+      - `notifyExpectedFailure`
+    - The following APIs have been added to `app` namespace:
+      - `isInitialized`
+      - `getFrameContext`
+  - Added Core capability
+    - The following APIs have been moved from `publicAPIs` to new `core` namespace:
+      - `shareDeepLink`
+      - `executeDeepLink`
+  - Several APIs reorganized under new Pages capability:
+
+    - The following APIs have been moved to the new `pages` namespace:
+      - `registerFullScreenHandler`
+      - `initializeWithFrameContext`
+      - `navigateCrossDomain`
+      - `returnFocus`
+      - `setFrameContext` has been renamed `pages.setCurrentFrame`
+    - The following APIs have been been renamed and moved from `publicAPIs` to a new Pages.AppButton sub-capability in the new `pages.appButton` namespace:
+      - `registerAppButtonClickHandler` has renamed and moved to `pages.appButton.onClick`
+      - `registerAppButtonHoverEnterHandler` has renamed and moved to `pages.appButton.onHoverEnter`
+      - `regsiterAppButtonHoverLeaveHandler` has renamed and moved to `pages.appButton.onHoverLeave`
+    - The following APIs have been moved to a new Pages.BackStack sub-capability in the new `pages.backStack` namespace:
+      - `registerBackButtonHandler`
+      - `navigateBack`
+    - The following APIs have been renamed and moved into the Pages.Config sub-capability in the `pages.config` namespace (formerly the `settings` namespace):
+      - `registerEnterSettingsHandler` has renamed and moved to `pages.config.registerChangeConfigHandler`
+      - `getSettings` has been renamed `pages.config.getConfig`
+      - `setSettings` has been renamed `pages.config.setConfig`
+    - The following APIs have been been moved from `privateAPIs` to a new Pages.FullTrust sub-capability in the new `pages.fullTrust` namespace:
+      - `enterFullscreen`
+      - `exitFullscreen`
+    - The following APIs have been been moved to a new Pages.Tabs sub-capability in the new `pages.tabs` namespace:
+      - `getTabInstances`
+      - `getMruTabInstances`
+      - `navigateToTab`
+
+  - Added Dialog capability, renamed `tasks` namespace to `dialog`, and renamed APIs
+
+    - The following APIs have been renamed:
+      - `startTask` has been renamed `dialog.open`
+      - `submitTasks` has been renamed `dialog.submit`
+      - `updateTask` has been renamed `dialog.resize`
+      - `TaskInfo` interface has been renamed `DialogInfo`
+      - `TaskModuleDimension` enum has been renamed `DialogDimension`
+
+  - Added TeamsCore capability
+
+    - The following APIs have been moved from `publicAPIs` to new `teamsCore` namespace:
+      - `enablePrintCapability`
+      - `print`
+      - `registerOnLoadHandler`
+      - `registerBeforeUnloadHandler`
+      - `registerFocusEnterHandler`
+
+  - Added AppInstallDialog capability
+    - `openAppInstallDialog` is added to new `appInstallDialog` namespace
+  - Added Calendar capability
+    - The following APIs have been added to new `calendar` namespace:
+      - `openCalendarItem` is added
+      - `composeMeeting` is added
+  - Added Call capability
+    - `startCall` is added to new `call` namespace
+  - Added Mail capability
+    - The following APIs have been added to the new `mail` namespace:
+      - `openMailItem` is added
+      - `composeMail` is added
+  - Added Chat capability and renamed `conversations` namespace to `chat`
+    - `openConversation` and `closeConversation` have been moved to `chat` namespace
+    - `getChatMembers` has been moved to `chat` namespace
+  - Added Files capability
+    - `openFilePreview` has moved from `privateAPIs` to `files` namespace
+  - Added Legacy capability
+    - The following APIs have been moved from `privateAPIs` to a new `legacy.fullTrust` namespace:
+      - `getUserJoinedTeams`
+      - `getConfigSetting`
+  - Added Notifications capability
+    - `showNotification` has moved from `privateAPIs` to `notifications` namespace
+  - Added the following new capabilites from existing namespaces
+    - Location
+    - Media
+    - Meeting
+    - Monetization
+    - People
+    - Sharing
+    - Video
+    - Bot
+    - Logs
+    - MeetingRoom
+    - Menus
+    - RemoteCamera
+  - Added Runtime capability
+    - `applyRuntimeConfig` is added
+
+- Promises introduced
+  - The following APIs that took in a callback function as a parameter now instead return a Promise.
+    - app APIs:
+      - app.initialize
+      - app.getContext
+    - authentication APIs：
+      - authentication.authenticate
+      - authentication.getAuthToken
+      - authentication.getUser
+    - calendar APIs:
+      - calendar.openCalendarItem
+      - calendar.composeMeeting
+    - chat APIs:
+      - chat.getChatMembers
+      - chat.openConversation
+    - files APIs:
+      - files.addCloudStorageFolder
+      - files.deleteCloudStorageFolder
+      - files.getCloudStorageFolderContents
+      - files.getCloudStorageFolders
+    - legacy APIs:
+      - legacy.fulltrust.getConfigSetting
+      - legacy.fulltrust.getUserJoinedTeams
+    - location APIs:
+      - location.getLocation
+      - location.showLocation
+    - mail APIs:
+      - mail.openMailItem
+      - mail.composeMail
+    - media APIs:
+      - media.captureImage
+      - media.selectMedia
+      - media.viewImages
+      - media.scanBarCode
+    - meeting APIs:
+      - meeting.getAppContentStageSharingState
+      - meeting.getAppContentStageSharingCapabilities
+      - meeting.getAuthenticationTokenForAnonymousUser
+      - meeting.getIncomingClientAudioState
+      - meeting.getLiveStreamState
+      - meeting.getMeetingDetails
+      - meeting.requestStartLiveStreaming
+      - meeting.requestStopLiveStreaming
+      - meeting.shareAppContentToStage
+      - meeting.stopSharingAppContentToStage
+      - meeting.toggleIncomingClientAudio
+    - meetingRoom APIs:
+      - meetingRoom.getPairedMeetingRoomInfo
+      - meetingRoom.sendCommandToPairedMeetingRoom
+    - pages APIs：
+      - pages.navigateCrossDomain
+      - pages.tabs.navigateToTab
+      - pages.tabs.getTabInstances
+      - pages.tabs.getMruTabInstances
+      - pages.config.getConfig
+      - pages.config.setConfig
+      - pages.backStack.navigateBack
+    - people APIs:
+      - people.selectPeople
+    - others:
+      - ChildAppWindow.postMessage
+      - ParentAppWindow.postMessage
+      - core.executeDeepLink
+      - appInstallDialog.openAppInstallDialog
+      - call.startCall

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -21,8 +21,9 @@
 ### Major changes
 
 - The Teams JavaScript client SDK repo is now a monorepo
-- We utilized [Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/) to turn our repo into a monorepo. <br> The files specific to the Teams client SDK have been moved to an inner directory with the name `teams-js`
-- A new TeamsJS Test App for validating the Teams client SDK has been added in the <root>/apps/teams-test-app location.
+
+  - We utilized [Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/) to turn our repo into a monorepo. <br> The files specific to the Teams client SDK have been moved to an inner directory with the name `teams-js`
+  - A new TeamsJS Test App for validating the Teams client SDK has been added in the <root>/apps/teams-test-app location.
 
 - Several API functions have been moved and renamed. <br>
   Organized top-level library functions under a core namespace. For example, `shareDeepLink` has been moved under `core` namespace. <br> Using `import * as ... from ...` will now fail. Importing now follows the following convention: <br>

--- a/tools/cli/preRelease.js
+++ b/tools/cli/preRelease.js
@@ -70,12 +70,8 @@ const updateChangeLog = async version => {
   }
   await execShellCommand('yarn beachball bump');
   const changeLog = fs.readFileSync(absolutePathToChangelog, 'utf8');
-  if (!version) {
-    return changeLog;
-  } else {
-    const newChangeLog = changeLog.replace(/(## 2.0.0)/, `## ${version}"`);
-    fs.writeFileSync(absolutePathToChangelog, newChangeLog);
-  }
+  const newChangeLog = changeLog.replace(/(## 2.0.0)/, `## ${version}"`);
+  fs.writeFileSync(absolutePathToChangelog, newChangeLog);
 };
 
 (async () => {

--- a/tools/cli/preRelease.js
+++ b/tools/cli/preRelease.js
@@ -62,6 +62,22 @@ const updateVersionAndIntegrity = async (absolutePath, version, integrityHash) =
   fs.writeFileSync(absolutePath, result);
 };
 
+const updateChangeLog = async version => {
+  const relativePathToChangelog = '../../packages/teams-js/CHANGELOG.md';
+  const absolutePathToChangelog = path.resolve(__dirname, relativePathToChangelog);
+  if (!fs.existsSync(absolutePathToChangelog)) {
+    throw `ERROR: ${absolutePathToChangelog} was not found.`;
+  }
+  await execShellCommand('yarn beachball bump');
+  const changeLog = fs.readFileSync(absolutePathToChangelog, 'utf8');
+  if (!version) {
+    return changeLog;
+  } else {
+    const newChangeLog = changeLog.replace(/(## 2.0.0)/, `## ${version}"`);
+    fs.writeFileSync(absolutePathToChangelog, newChangeLog);
+  }
+};
+
 (async () => {
   const args = process.argv.slice(2);
   const version = args[0];
@@ -79,6 +95,8 @@ const updateVersionAndIntegrity = async (absolutePath, version, integrityHash) =
     const absolutePathTestAppPackageJson = path.resolve(__dirname, relativePathToTestAppPackageJson);
     const absolutePathToTeamsJsReadme = path.resolve(__dirname, relativePathToTeamsJsReadme);
     const absolutePathToTestAppHtml = path.resolve(__dirname, relativePathToTestAppHtml);
+
+    await updateChangeLog(version);
 
     updatePackageJson(absolutePathTeamsJsPackageJson, version);
     updatePackageJson(absolutePathTestAppPackageJson, version);

--- a/tools/cli/preRelease.js
+++ b/tools/cli/preRelease.js
@@ -70,7 +70,7 @@ const updateChangeLog = async version => {
   }
   await execShellCommand('yarn beachball bump');
   const changeLog = fs.readFileSync(absolutePathToChangelog, 'utf8');
-  const newChangeLog = changeLog.replace(/(## 2.0.0)/, `## ${version}"`);
+  const newChangeLog = changeLog.replace(/(## 2.0.0)/, `## ${version}`);
   fs.writeFileSync(absolutePathToChangelog, newChangeLog);
 };
 

--- a/tools/cli/readChangelog.js
+++ b/tools/cli/readChangelog.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const readChangeLog = version => {
-  const relativePathToChangelog = '../../teams-js/packages/CHANGELOG.md';
+  const relativePathToChangelog = '../../packages/teams-js/CHANGELOG.md';
   const absolutePathToChangelog = path.resolve(__dirname, relativePathToChangelog);
   if (!fs.existsSync(absolutePathToChangelog)) {
     throw `ERROR: ${absolutePathToChangelog} was not found.`;
@@ -14,7 +14,7 @@ const readChangeLog = version => {
     return fullChangelog;
   } else {
     const result = fullChangelog.split(/(## 2.0.0-beta..*\d)/);
-    const index = result.findIndex(substr => substr.startsWith(`# ${version}`));
+    const index = result.findIndex(substr => substr.startsWith(`## ${version}`));
     if (index !== -1) {
       const log = result[index + 1];
       return log;

--- a/tools/cli/readChangelog.js
+++ b/tools/cli/readChangelog.js
@@ -13,7 +13,7 @@ const readChangeLog = version => {
   if (!version) {
     return fullChangelog;
   } else {
-    const result = fullChangelog.split(/(# 2.0.0-beta..*\d)/);
+    const result = fullChangelog.split(/(## 2.0.0-beta..*\d)/);
     const index = result.findIndex(substr => substr.startsWith(`# ${version}`));
     if (index !== -1) {
       const log = result[index + 1];


### PR DESCRIPTION
Changelog modifications: 
- Removed the 2.0.0-beta.3 part into changefiles. We can rely on beachball bump to add them on the next release.
- Updated older parts to match the formatting beachball creates

Added beachball bump to release script and made respective changes to update the version value accordingly

Added a beachball config to not render the author into the changelog. _These will still show up in the temporary changefile artifacts however, and get deleted once the bump happens_

