### PR TITLE
Updating release triggers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: [2.0-preview]
   pull_request:
-    branches: [2.0-preview, release/2.0.0-beta.*]
+    branches: [2.0-preview]
 
 jobs:
   build:

--- a/.github/workflows/postrelease.yml
+++ b/.github/workflows/postrelease.yml
@@ -45,11 +45,3 @@ jobs:
           name: 'v${{steps.extract_version.outputs.version}}'
           prerelease: true
           body: '${{steps.extract_changelog.outputs.changelog}}'
-
-      - name: Create Pull Request
-        uses: repo-sync/pull-request@v2
-        with:
-          pr_title: Merge ${{steps.extract_branch.outputs.branch}} into 2.0-preview
-          source_branch: ${{steps.extract_branch.outputs.branch}}
-          destination_branch: 2.0-preview
-          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -5,7 +5,7 @@ on:
       version:
         description: 'Version'
         required: true
-        default: '2.0.0-beta.x'
+        default: ''
 
 jobs:
   Release:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,9 @@ trigger:
   branches:
     include:
       - '2.0-preview'
-      - 'release/2.0.0-beta.*'
+  tags:
+    include:
+      - 'v2.0.0-beta.*'
 
 jobs:
   - job: Security

--- a/tools/yaml-templates/security.yml
+++ b/tools/yaml-templates/security.yml
@@ -35,7 +35,7 @@ steps:
       IsShipped: false
       DropsToRetain: 'CodeAnalysisLogs'
     condition: and(
-      or(eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/2.0.0-beta.')),
+      or(eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'), startsWith(variables['Build.SourceBranch'], 'refs/tags/v2.0.0-beta.')),
       ne(variables['Build.Reason'], 'PullRequest')
       )
     displayName: 'Artifact Retention(Arrow)'
@@ -63,6 +63,6 @@ steps:
 
   - task: ComponentGovernanceComponentDetection@0
     condition: and(
-      or(eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/2.0.0-beta.')),
+      or(eq(variables['Build.SourceBranch'], 'refs/heads/2.0-preview'), startsWith(variables['Build.SourceBranch'], 'refs/tags/v2.0.0-beta.')),
       ne(variables['Build.Reason'], 'PullRequest'))
     displayName: 'Component Governance (2.0-preview, release)'


### PR DESCRIPTION
Change summary: 
- Changed Azure Pipeline CI trigger to run on v2.0.0-beta tags, and updated respective asset retention conditions.
- Removed the trigger in the GitHub Azure pipeline for release branch since we don't use that as a status check
- Removed the automated PR create to merge the release branch back into 2.0-preview. Release manager will just create the PR manually to bypass Github workflow recursive trigger issue.
- Removed the default version from 2.0.0-beta.x to reduce the chance of a typo. Release manager would have to type it all in.