### PR TITLE
change the constructor function to make the onRecordingStarted callba…

### DIFF
--- a/change/@microsoft-teams-js-828b759f-2466-4a17-9110-350aee8e7a35.json
+++ b/change/@microsoft-teams-js-828b759f-2466-4a17-9110-350aee8e7a35.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "change the constructor function to make the onRecordingStarted callback mandatory, make onRecordingStopped an optional property that can be pssed to the constructor, add appropriate tests",
+  "packageName": "@microsoft/teams-js",
+  "email": "jekoch@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -508,7 +508,7 @@ export namespace media {
    * --------
    * Events which are used to communicate between the app and the host client during the media recording flow
    */
-  enum MediaControllerEvent {
+  export enum MediaControllerEvent {
     StartRecording = 1,
     StopRecording = 2,
   }

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -495,6 +495,7 @@ export namespace media {
         case MediaControllerEvent.StartRecording:
           this.controllerCallback.onRecordingStarted();
           break;
+        // TODO - Should discuss whether this function should be required
         case MediaControllerEvent.StopRecording:
           this.controllerCallback.onRecordingStopped && this.controllerCallback.onRecordingStopped();
           break;

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -392,7 +392,7 @@ export namespace media {
   abstract class MediaController<T> {
     protected controllerCallback: T;
 
-    public constructor(controllerCallback?: T) {
+    public constructor(controllerCallback: T) {
       this.controllerCallback = controllerCallback;
     }
 
@@ -478,7 +478,8 @@ export namespace media {
    * Callback which will register your app to listen to lifecycle events during the video capture flow
    */
   export interface VideoControllerCallback {
-    onRecordingStarted?(): void;
+    onRecordingStarted(): void;
+    onRecordingStopped?(): void;
   }
 
   /**
@@ -490,17 +491,13 @@ export namespace media {
     }
 
     public notifyEventToApp(mediaEvent: MediaControllerEvent): void {
-      if (!this.controllerCallback) {
-        // Early return as app has not registered with the callback
-        return;
-      }
-
       switch (mediaEvent) {
         case MediaControllerEvent.StartRecording:
-          if (this.controllerCallback.onRecordingStarted) {
-            this.controllerCallback.onRecordingStarted();
-            break;
-          }
+          this.controllerCallback.onRecordingStarted();
+          break;
+        case MediaControllerEvent.StopRecording:
+          this.controllerCallback.onRecordingStopped && this.controllerCallback.onRecordingStopped();
+          break;
       }
     }
   }

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -770,10 +770,6 @@ describe('media', () => {
   });
 
   describe('videoController', () => {
-    enum MediaControllerEvent {
-      StartRecording = 1,
-      StopRecording = 2,
-    }
     describe('v1', () => {
       it('videoController notifyEventToHost is handled successfully', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.task, HostClientType.android);
@@ -887,9 +883,9 @@ describe('media', () => {
         const videoController = new media.VideoController(videoControllerCallback);
 
         const notifyEventToAppSpy = jest.spyOn(videoController, 'notifyEventToApp');
-        videoController.notifyEventToApp(MediaControllerEvent.StartRecording);
+        videoController.notifyEventToApp(media.MediaControllerEvent.StartRecording);
 
-        expect(notifyEventToAppSpy).toHaveBeenCalledWith(MediaControllerEvent.StartRecording);
+        expect(notifyEventToAppSpy).toHaveBeenCalledWith(media.MediaControllerEvent.StartRecording);
         expect(videoControllerCallback.onRecordingStarted).toHaveBeenCalled();
       });
 
@@ -905,9 +901,9 @@ describe('media', () => {
         const videoController = new media.VideoController(videoControllerCallback);
 
         const notifyEventToAppSpy = jest.spyOn(videoController, 'notifyEventToApp');
-        videoController.notifyEventToApp(MediaControllerEvent.StopRecording);
+        videoController.notifyEventToApp(media.MediaControllerEvent.StopRecording);
 
-        expect(notifyEventToAppSpy).toHaveBeenCalledWith(MediaControllerEvent.StopRecording);
+        expect(notifyEventToAppSpy).toHaveBeenCalledWith(media.MediaControllerEvent.StopRecording);
         expect(videoControllerCallback.onRecordingStopped).toHaveBeenCalled();
       });
     });

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -569,11 +569,12 @@ describe('media', () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.ios);
         mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
         let mediaError: SdkError;
+        const videoControllerCallback: media.VideoControllerCallback = { onRecordingStarted: jest.fn() };
 
         const mediaInputs: media.MediaInputs = {
           mediaType: media.MediaType.Video,
           maxMediaCount: 10,
-          videoProps: { videoController: new media.VideoController() },
+          videoProps: { videoController: new media.VideoController(videoControllerCallback) },
         };
         const callbackSpy = jest.fn((e: SdkError, attachments: media.Media[]) => {
           mediaError = e;
@@ -769,12 +770,19 @@ describe('media', () => {
   });
 
   describe('videoController', () => {
+    enum MediaControllerEvent {
+      StartRecording = 1,
+      StopRecording = 2,
+    }
     describe('v1', () => {
       it('videoController notifyEventToHost is handled successfully', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.task, HostClientType.android);
         mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+        const videoControllerCallback: media.VideoControllerCallback = {
+          onRecordingStarted: jest.fn(),
+        };
 
-        const videoController = new media.VideoController();
+        const videoController = new media.VideoController(videoControllerCallback);
         const sendAndHandleSdkErrorSpy = jest.spyOn(communication, 'sendAndHandleSdkError');
         videoController.stop(emptyCallback);
 
@@ -797,8 +805,11 @@ describe('media', () => {
       it('videoController stop function returns SdkError to callback when parent rejects message', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
         mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+        const videoControllerCallback: media.VideoControllerCallback = {
+          onRecordingStarted: jest.fn(),
+        };
 
-        const videoController = new media.VideoController();
+        const videoController = new media.VideoController(videoControllerCallback);
         const sendAndHandleSdkErrorSpy = jest.spyOn(communication, 'sendAndHandleSdkError');
         const err = {
           errorCode: ErrorCode.INTERNAL_ERROR,
@@ -826,8 +837,11 @@ describe('media', () => {
 
         await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
         mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+        const videoControllerCallback: media.VideoControllerCallback = {
+          onRecordingStarted: jest.fn(),
+        };
 
-        const videoController = new media.VideoController();
+        const videoController = new media.VideoController(videoControllerCallback);
         const sendMessageToParentSpy = jest.spyOn(communication, 'sendMessageToParent');
 
         try {
@@ -844,8 +858,11 @@ describe('media', () => {
       it('videoController notifyEventToApp should return if no callback is provided', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
         mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+        const videoControllerCallback: media.VideoControllerCallback = {
+          onRecordingStarted: jest.fn(),
+        };
 
-        const videoController = new media.VideoController();
+        const videoController = new media.VideoController(videoControllerCallback);
         const notifyEventToApp = jest.spyOn(videoController, 'notifyEventToApp');
 
         try {
@@ -859,19 +876,39 @@ describe('media', () => {
         expect(notifyEventToApp).not.toHaveBeenCalled();
       });
 
-      it('videoController notifyEventToApp should call the callback if callback is provided and mediaType is 1', async () => {
+      it('videoController notifyEventToApp should call the onRecordingStarted callback when the mediaControllerEvent is 1', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
         mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
 
-        const videoControllerCallback: media.VideoControllerCallback = { onRecordingStarted: jest.fn() };
+        const videoControllerCallback: media.VideoControllerCallback = {
+          onRecordingStarted: jest.fn(),
+        };
 
         const videoController = new media.VideoController(videoControllerCallback);
 
         const notifyEventToAppSpy = jest.spyOn(videoController, 'notifyEventToApp');
-        videoController.notifyEventToApp(1);
+        videoController.notifyEventToApp(MediaControllerEvent.StartRecording);
 
-        expect(notifyEventToAppSpy).toHaveBeenCalledWith(1);
+        expect(notifyEventToAppSpy).toHaveBeenCalledWith(MediaControllerEvent.StartRecording);
         expect(videoControllerCallback.onRecordingStarted).toHaveBeenCalled();
+      });
+
+      it('videoController notifyEventToApp should call the onRecordingStopped callback if callback is provided and mediaControllerEvent is 2', async () => {
+        await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
+        mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+
+        const videoControllerCallback: media.VideoControllerCallback = {
+          onRecordingStarted: emptyCallback,
+          onRecordingStopped: jest.fn(),
+        };
+
+        const videoController = new media.VideoController(videoControllerCallback);
+
+        const notifyEventToAppSpy = jest.spyOn(videoController, 'notifyEventToApp');
+        videoController.notifyEventToApp(MediaControllerEvent.StopRecording);
+
+        expect(notifyEventToAppSpy).toHaveBeenCalledWith(MediaControllerEvent.StopRecording);
+        expect(videoControllerCallback.onRecordingStopped).toHaveBeenCalled();
       });
     });
 
@@ -879,8 +916,11 @@ describe('media', () => {
       it('videoController notifyEventToHost is handled successfully', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
         mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+        const videoControllerCallback: media.VideoControllerCallback = {
+          onRecordingStarted: jest.fn(),
+        };
 
-        const videoController = new media.VideoController();
+        const videoController = new media.VideoController(videoControllerCallback);
         const promise = videoController.stop();
         const message = mobilePlatformMock.findMessageByFunc('media.controller');
 
@@ -901,8 +941,11 @@ describe('media', () => {
       it('videoController notifyEventToHost should fail in default version of platform and exit early', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
         mobilePlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+        const videoControllerCallback: media.VideoControllerCallback = {
+          onRecordingStarted: jest.fn(),
+        };
 
-        const videoController = new media.VideoController();
+        const videoController = new media.VideoController(videoControllerCallback);
         const sendAndHandleSdkErrorSpy = jest.spyOn(communication, 'sendAndHandleSdkError');
         const promise = videoController.stop();
 
@@ -914,8 +957,11 @@ describe('media', () => {
       it('videoController notifyEventToHost is not handled successfully and returns error', async () => {
         await mobilePlatformMock.initializeWithContext(FrameContexts.content, HostClientType.android);
         mobilePlatformMock.setClientSupportedSDKVersion(nonFullScreenVideoModeAPISupportVersion);
+        const videoControllerCallback: media.VideoControllerCallback = {
+          onRecordingStarted: jest.fn(),
+        };
 
-        const videoController = new media.VideoController();
+        const videoController = new media.VideoController(videoControllerCallback);
         const promise = videoController.stop();
         const err = { errorCode: ErrorCode.INTERNAL_ERROR };
         const sendAndHandleSdkErrorSpy = jest.spyOn(communication, 'sendAndHandleSdkError');


### PR DESCRIPTION
* made `onRecordingStarted` callback property required - without this callback, the VideoController doesn't do anything
* added optional property for `onRecordingStopped`
* updated test cases
 
work related to this [ticket](https://office.visualstudio.com/MetaOS/_workitems/edit/5717225/)