### PR TITLE
Replace instances of throwing strings to throw errors instead

### DIFF
--- a/apps/teams-test-app/src/components/CalendarAPIs.tsx
+++ b/apps/teams-test-app/src/components/CalendarAPIs.tsx
@@ -31,7 +31,7 @@ const OpenCalendarItem = (): React.ReactElement =>
       },
       validateInput: x => {
         if (!x.itemId) {
-          throw 'itemId is required';
+          throw new Error('itemId is required');
         }
       },
     },

--- a/change/@microsoft-teams-js-744961a1-af6b-4a44-b128-31e9e6f0c4e9.json
+++ b/change/@microsoft-teams-js-744961a1-af6b-4a44-b128-31e9e6f0c4e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Source code will now throw errors instead of throwing strings across the repo.",
+  "packageName": "@microsoft/teams-js",
+  "email": "aeun@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/appInstallDialog.ts
+++ b/packages/teams-js/src/public/appInstallDialog.ts
@@ -22,7 +22,7 @@ export namespace appInstallDialog {
         FrameContexts.meetingStage,
       );
       if (!isSupported()) {
-        throw 'Not supported';
+        throw new Error('Not supported');
       }
       sendMessageToParent('appInstallDialog.openAppInstallDialog', [openAPPInstallDialogParams]);
       resolve();

--- a/packages/teams-js/src/public/calendar.ts
+++ b/packages/teams-js/src/public/calendar.ts
@@ -11,7 +11,7 @@ export namespace calendar {
     return new Promise<void>(resolve => {
       ensureInitialized(FrameContexts.content);
       if (!isSupported()) {
-        throw 'Not Supported';
+        throw new Error('Not supported');
       }
 
       if (!openCalendarItemParams.itemId || !openCalendarItemParams.itemId.trim()) {
@@ -25,7 +25,7 @@ export namespace calendar {
     return new Promise<void>(resolve => {
       ensureInitialized(FrameContexts.content);
       if (!isSupported()) {
-        throw 'Not Supported';
+        throw new Error('Not supported');
       }
 
       resolve(sendAndHandleError('calendar.composeMeeting', composeMeetingParams));

--- a/packages/teams-js/src/public/call.ts
+++ b/packages/teams-js/src/public/call.ts
@@ -37,7 +37,7 @@ export namespace call {
     return new Promise(resolve => {
       ensureInitialized(FrameContexts.content);
       if (!isSupported()) {
-        throw 'Not supported';
+        throw new Error('Not supported');
       }
       return sendMessageToParent('call.startCall', [startCallParams], resolve);
     });

--- a/packages/teams-js/src/public/mail.ts
+++ b/packages/teams-js/src/public/mail.ts
@@ -11,7 +11,7 @@ export namespace mail {
     return new Promise<void>(resolve => {
       ensureInitialized(FrameContexts.content);
       if (!isSupported()) {
-        throw 'Not Supported';
+        throw new Error('Not supported');
       }
 
       if (!openMailItemParams.itemId || !openMailItemParams.itemId.trim()) {
@@ -26,7 +26,7 @@ export namespace mail {
     return new Promise<void>(resolve => {
       ensureInitialized(FrameContexts.content);
       if (!isSupported()) {
-        throw 'Not Supported';
+        throw new Error('Not supported');
       }
 
       resolve(sendAndHandleError('mail.composeMail', composeMailParams));

--- a/packages/teams-js/test/public/appInstallDialog.spec.ts
+++ b/packages/teams-js/test/public/appInstallDialog.spec.ts
@@ -28,7 +28,7 @@ describe('appInstallDialog', () => {
 
   it('Should not allow openAppInstallDialog if not supported', async () => {
     utils.initializeWithContext(FrameContexts.content);
-    await expect(appInstallDialog.openAppInstallDialog(mockOpenAppInstallDialogParams)).rejects.toEqual(
+    await expect(appInstallDialog.openAppInstallDialog(mockOpenAppInstallDialogParams)).rejects.toThrowError(
       'Not supported',
     );
   });

--- a/packages/teams-js/test/public/calendar.spec.ts
+++ b/packages/teams-js/test/public/calendar.spec.ts
@@ -69,7 +69,7 @@ describe('calendar', () => {
       await utils.initializeWithContext('content');
       utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
 
-      await calendar.openCalendarItem(openCalendarItemParams).catch(e => expect(e).toBe('Not Supported'));
+      await expect(calendar.openCalendarItem(openCalendarItemParams)).rejects.toThrowError('Not supported');
     });
 
     it('should throw if a null itemId is supplied', async () => {
@@ -203,7 +203,7 @@ describe('calendar', () => {
       await utils.initializeWithContext('content');
       utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
 
-      await calendar.composeMeeting(composeMeetingParams).catch(e => expect(e).toBe('Not Supported'));
+      await expect(calendar.composeMeeting(composeMeetingParams)).rejects.toThrowError('Not supported');
     });
 
     it('should successfully throw if the composeMeeting message sends and fails', async () => {

--- a/packages/teams-js/test/public/call.spec.ts
+++ b/packages/teams-js/test/public/call.spec.ts
@@ -28,7 +28,7 @@ describe('call', () => {
 
   it('should not allow calls if not supported', async () => {
     utils.initializeWithContext(FrameContexts.content);
-    await expect(call.startCall(mockStartCallParams)).rejects.toEqual('Not supported');
+    await expect(call.startCall(mockStartCallParams)).rejects.toThrowError('Not supported');
   });
 
   it('startCall should be called if supported', async () => {

--- a/packages/teams-js/test/public/mail.spec.ts
+++ b/packages/teams-js/test/public/mail.spec.ts
@@ -68,7 +68,7 @@ describe('mail', () => {
       await utils.initializeWithContext('content');
       utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
 
-      await mail.openMailItem(openMailItemParams).catch(e => expect(e).toBe('Not Supported'));
+      await expect(mail.openMailItem(openMailItemParams)).rejects.toThrowError('Not supported');
     });
 
     it('should throw if a null itemId is supplied', async () => {
@@ -199,7 +199,7 @@ describe('mail', () => {
       await utils.initializeWithContext('content');
       utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
 
-      await mail.composeMail(composeMailParams).catch(e => expect(e).toBe('Not Supported'));
+      await expect(mail.composeMail(composeMailParams)).rejects.toThrowError('Not supported');
     });
 
     it('should successfully throw if the composeMail message sends and fails', async () => {

--- a/tools/cli/preRelease.js
+++ b/tools/cli/preRelease.js
@@ -35,7 +35,7 @@ const buildAndGetIntegrityHash = async () => {
   const manifestJson = JSON.parse(manifestFile);
   const integrityHash = manifestJson['MicrosoftTeams.min.js']['integrity'];
   if (!integrityHash) {
-    throw 'ERROR: MicrosoftTeams.min.js integrity hash value was not parsed';
+    throw new Error('MicrosoftTeams.min.js integrity hash value was not parsed');
   }
   return integrityHash;
 };

--- a/tools/cli/readChangelog.js
+++ b/tools/cli/readChangelog.js
@@ -19,7 +19,7 @@ const readChangeLog = version => {
       const log = result[index + 1];
       return log;
     }
-    throw 'Matching version in changelog was not found';
+    throw new Error('Matching version in changelog was not found');
   }
 };
 


### PR DESCRIPTION
Solves bug number #5720429 in ADO.

While Javascript allows throwing objects that aren't Error objects, it is still good style to throw Errors to capture all of the properties that can typically be expected from what is thrown and also to have a more descriptive stack trace. 