### PR TITLE
Lakhveer/focus enter

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -16,6 +16,7 @@ import LogAPIs from './components/LogsAPIs';
 import MailAPIs from './components/MailAPIs';
 import MediaAPIs from './components/MediaAPIs';
 import MeetingAPIs from './components/MeetingAPIs';
+import MenusAPIs from './components/MenusAPIs';
 import PagesAPIs from './components/PagesAPIs';
 import PagesAppButtonAPIs from './components/PagesAppButtonAPIs';
 import PagesBackStackAPIs from './components/PagesBackStackAPIs';
@@ -35,7 +36,6 @@ import RemoteCameraAPIs from './components/RemoteCameraAPIs';
 import SharingAPIs from './components/SharingAPIs';
 import TeamsCoreAPIs from './components/TeamsCoreAPIs';
 import { getTestBackCompat } from './components/utils/getTestBackCompat';
-import MenusAPIs from './components/MenusAPIs';
 
 const urlParams = new URLSearchParams(window.location.search);
 

--- a/apps/teams-test-app/src/components/MenusAPIs.tsx
+++ b/apps/teams-test-app/src/components/MenusAPIs.tsx
@@ -1,6 +1,7 @@
 import { menus } from '@microsoft/teams-js';
 import React from 'react';
 import { ReactElement } from 'react';
+
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const CheckMenusCapability = (): React.ReactElement =>

--- a/apps/teams-test-app/src/components/PagesAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesAPIs.tsx
@@ -9,7 +9,6 @@ import {
   setFrameContext,
   settings,
   shareDeepLink,
-  teamsCore,
 } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
@@ -129,7 +128,7 @@ const RegisterFocusEnterHandler = (): React.ReactElement =>
     title: 'Register On Focus Enter Handler',
     onClick: {
       withPromise: async setResult => {
-        teamsCore.registerFocusEnterHandler(navigateForward => {
+        pages.registerFocusEnterHandler(navigateForward => {
           setResult('successfully called with navigateForward:' + navigateForward);
           return true;
         });

--- a/change/@microsoft-teams-js-8faa5bd7-f5e5-4976-9489-c3ae8fbed02f.json
+++ b/change/@microsoft-teams-js-8faa5bd7-f5e5-4976-9489-c3ae8fbed02f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "\u001a",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-8faa5bd7-f5e5-4976-9489-c3ae8fbed02f.json
+++ b/change/@microsoft-teams-js-8faa5bd7-f5e5-4976-9489-c3ae8fbed02f.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
-  "comment": "\u001a",
+  "type": "major",
+  "comment": "The API registerFocusEnterHandler has been moved from teamsCore namespace to Pages",
   "packageName": "@microsoft/teams-js",
   "email": "lakhveerkaur@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "major"
 }

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0-beta.3
+
+### Patches
+
+- The API `registerFocusEnterHandler` has been moved from teamsCore namespace to Pages
+
 ## 2.0.0-beta.2
 
 ### Patches

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Patches
 
-- The API `registerFocusEnterHandler` has been moved from teamsCore namespace to Pages
+- The API `registerFocusEnterHandler` has been moved from teamsCore namespace to `Pages`.
 
 ## 2.0.0-beta.2
 

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 2.0.0-beta.3
-
-### Patches
-
-- The API `registerFocusEnterHandler` has been moved from teamsCore namespace to `Pages`.
-
 ## 2.0.0-beta.2
 
 ### Patches

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -28,6 +28,7 @@ export namespace pages {
 
     sendMessageToParent('returnFocus', [navigateForward]);
   }
+
   /**
    * @hidden
    * Registers a handler when focus needs to be passed from teams to the place of choice on app.
@@ -40,6 +41,7 @@ export namespace pages {
     ensureInitialized();
     registerHandler('focusEnter', handler);
   }
+
   export function setCurrentFrame(frameInfo: FrameInfo): void {
     ensureInitialized(FrameContexts.content);
     sendMessageToParent('setFrameContext', [frameInfo]);

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -28,7 +28,18 @@ export namespace pages {
 
     sendMessageToParent('returnFocus', [navigateForward]);
   }
-
+  /**
+   * @hidden
+   * Registers a handler when focus needs to be passed from teams to the place of choice on app.
+   *
+   * @param handler - The handler to invoked by the app when they want the focus to be in the place of their choice.
+   *
+   * @internal
+   */
+  export function registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void {
+    ensureInitialized();
+    registerHandler('focusEnter', handler);
+  }
   export function setCurrentFrame(frameInfo: FrameInfo): void {
     ensureInitialized(FrameContexts.content);
     sendMessageToParent('setFrameContext', [frameInfo]);

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -208,7 +208,7 @@ export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void)
 
 /**
  * @deprecated
- * As of 2.0.0-beta.2, please use {@link pages.registerFocusEnterHandler pages.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void} instead.
+ * As of 2.0.0-beta.3, please use {@link pages.registerFocusEnterHandler pages.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void} instead.
  *
  * @hidden
  * Registers a handler when focus needs to be passed from teams to the place of choice on app.

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -208,7 +208,7 @@ export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void)
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link teamsCore.registerFocusEnterHandler teamsCore.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void} instead.
+ * As of 2.0.0-beta.2, please use {@link pages.registerFocusEnterHandler pages.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void} instead.
  *
  * @hidden
  * Registers a handler when focus needs to be passed from teams to the place of choice on app.
@@ -216,7 +216,7 @@ export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void)
  * @param handler - The handler to invoked by the app when they want the focus to be in the place of their choice.
  */
 export function registerFocusEnterHandler(handler: (navigateForward: boolean) => boolean): void {
-  teamsCore.registerFocusEnterHandler(handler);
+  pages.registerFocusEnterHandler(handler);
 }
 
 /**

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -64,19 +64,6 @@ export namespace teamsCore {
     Handlers.registerBeforeUnloadHandler(handler);
   }
 
-  /**
-   * @hidden
-   * Registers a handler when focus needs to be passed from teams to the place of choice on app.
-   *
-   * @param handler - The handler to invoked by the app when they want the focus to be in the place of their choice.
-   *
-   * @internal
-   */
-  export function registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void {
-    ensureInitialized();
-    Handlers.registerHandler('focusEnter', handler);
-  }
-
   export function isSupported(): boolean {
     return runtime.supports.teamsCore ? true : false;
   }

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -222,4 +222,28 @@ describe('AppSDK-TeamsAPIs', () => {
       expect(returnFocusMessage.args[0]).toBe(true);
     });
   });
+  describe('registerFocusEnterHandler', () => {
+    it('should successfully register a focus enter handler', async () => {
+      await utils.initializeWithContext('content');
+      pages.registerFocusEnterHandler((x: boolean) => {
+        return true;
+      });
+      const messageForRegister = utils.findMessageByFunc('registerHandler');
+      expect(messageForRegister).not.toBeNull();
+      expect(messageForRegister.args.length).toBe(1);
+      expect(messageForRegister.args[0]).toBe('focusEnter');
+    });
+    it('should successfully invoke focus enter handler', async () => {
+      await utils.initializeWithContext('content');
+
+      let handlerInvoked = false;
+      pages.registerFocusEnterHandler((x: boolean) => {
+        handlerInvoked = true;
+        return true;
+      });
+
+      utils.sendMessage('focusEnter');
+      expect(handlerInvoked).toBe(true);
+    });
+  });
 });

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -222,6 +222,7 @@ describe('AppSDK-TeamsAPIs', () => {
       expect(returnFocusMessage.args[0]).toBe(true);
     });
   });
+
   describe('registerFocusEnterHandler', () => {
     it('should successfully register a focus enter handler', async () => {
       await utils.initializeWithContext('content');
@@ -233,6 +234,7 @@ describe('AppSDK-TeamsAPIs', () => {
       expect(messageForRegister.args.length).toBe(1);
       expect(messageForRegister.args[0]).toBe('focusEnter');
     });
+
     it('should successfully invoke focus enter handler', async () => {
       await utils.initializeWithContext('content');
 

--- a/packages/teams-js/test/public/teamsAPIs.spec.ts
+++ b/packages/teams-js/test/public/teamsAPIs.spec.ts
@@ -355,16 +355,4 @@ describe('AppSDK-TeamsAPIs', () => {
     expect(message.args.length).toBe(1);
     expect(message.args[0]).toBe(frameContext);
   });
-
-  it('should successfully register a focus enter handler and return true', async () => {
-    await utils.initializeWithContext('content');
-
-    let handlerInvoked = false;
-    teamsCore.registerFocusEnterHandler(() => {
-      handlerInvoked = true;
-    });
-
-    utils.sendMessage('focusEnter');
-    expect(handlerInvoked).toBe(true);
-  });
 });


### PR DESCRIPTION
Moving an API `registerFocusEnterHandler` from teamsCore namespace to Pages. 