### PR TITLE
Minor fixes before beta.3 release

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 
 const postbump = (packagePath, packageName, packageVersion) => {
-  fs.rm(`${packagePath}\\CHANGELOG.json`, err => {
+  fs.rm(`${packagePath}/CHANGELOG.json`, err => {
     if (err) {
       console.log(err.message);
       return;

--- a/change/@microsoft-teams-js-828b759f-2466-4a17-9110-350aee8e7a35.json
+++ b/change/@microsoft-teams-js-828b759f-2466-4a17-9110-350aee8e7a35.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "change the constructor function to make the onRecordingStarted callback mandatory, make onRecordingStopped an optional property that can be passed to the constructor.  This is because without the onRecordingStopped, the VideoController doesn't do anything.",
+  "comment": "Change the constructor function to make the `onRecordingStarted` callback mandatory, make `onRecordingStopped` an optional property that can be passed to the constructor.  This is because without the `onRecordingStopped`, the `VideoController` doesn't do anything.",
   "packageName": "@microsoft/teams-js",
   "email": "jekoch@microsoft.com",
   "dependentChangeType": "patch"


### PR DESCRIPTION
This change includes a fix for using a cross-plat compatible path separator so that when the preRelease.js script runs on Ubuntu machines, we will detect and delete the CHANGELOG.json.

Also clean up a change comment before it's included in the CHANGELOG for beta.3.