### PR TITLE
Add missing hostClientType value in comment

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -335,7 +335,7 @@ export interface Context {
 
   /**
    * The type of the host client. Possible values are : android, ios, web, desktop, rigel(deprecated, use teamsRoomsWindows instead),
-   * teamsRoomsWindows, teamsRoomsAndroid, teamsPhones, teamsDisplays
+   * surfaceHub, teamsRoomsWindows, teamsRoomsAndroid, teamsPhones, teamsDisplays
    */
   hostClientType?: HostClientType;
 


### PR DESCRIPTION
The enum in `constants.ts` has the `surfaceHub` value, but the comment in `interfaces.ts` does not. This change fixes the comment.