### PR TITLE
Lakhveer/open

### DIFF
--- a/apps/teams-test-app/src/components/DialogAPIs.tsx
+++ b/apps/teams-test-app/src/components/DialogAPIs.tsx
@@ -14,6 +14,10 @@ const DialogAPIs = (): ReactElement => {
     });
     childWindowRef.current = childWindow;
   };
+  interface Result {
+    err: string;
+    result: string | object;
+  }
 
   const OpenDialog = (): ReactElement =>
     ApiWithTextInput<DialogInfo | TaskInfo>({
@@ -27,15 +31,19 @@ const DialogAPIs = (): ReactElement => {
         },
         submit: {
           withPromise: async (dialogInfo, setResult) => {
-            const onComplete = (err: string, result: string | object): void => {
-              setResult('Error: ' + err + '\nResult: ' + result);
+            const onComplete = (result: Result): void => {
+              setResult('Result' + JSON.stringify(result));
             };
-            openDialogHelper(dialog.open(dialogInfo, onComplete), setResult);
+            const messageForChildHandler = (message: string): void => {
+              // Message from parent
+              setResult(message);
+            };
+            dialog.open(dialogInfo, onComplete, messageForChildHandler);
             return '';
           },
           withCallback: (taskInfo, setResult) => {
             const onComplete = (err: string, result: string | object): void => {
-              setResult('Error: ' + err + '\nResult: ' + result);
+              setResult('Result' + JSON.stringify(result));
             };
             // Store the reference of child window in React
             openDialogHelper(tasks.startTask(taskInfo, onComplete), setResult);

--- a/apps/teams-test-app/src/components/DialogAPIs.tsx
+++ b/apps/teams-test-app/src/components/DialogAPIs.tsx
@@ -19,9 +19,29 @@ const DialogAPIs = (): ReactElement => {
     result: string | object;
   }
 
-  const OpenDialog = (): ReactElement =>
+  const StartTask = (): ReactElement =>
     ApiWithTextInput<DialogInfo | TaskInfo>({
       name: 'dialogOpen',
+      title: 'Start Task',
+      onClick: {
+        validateInput: input => {
+          if (input.url === undefined) {
+            throw new Error('Url undefined');
+          }
+        },
+        submit: async (taskInfo, setResult) => {
+          const onComplete = (err: string, result: string | object): void => {
+            setResult('Error: ' + err + '\nResult: ' + result);
+          };
+          openDialogHelper(tasks.startTask(taskInfo, onComplete), setResult);
+          return '';
+        },
+      },
+    });
+
+  const OpenDialog = (): ReactElement =>
+    ApiWithTextInput<DialogInfo | TaskInfo>({
+      name: 'dialogOpen_v2',
       title: 'Dialog Open',
       onClick: {
         validateInput: input => {
@@ -29,25 +49,16 @@ const DialogAPIs = (): ReactElement => {
             throw new Error('Url undefined');
           }
         },
-        submit: {
-          withPromise: async (dialogInfo, setResult) => {
-            const onComplete = (result: Result): void => {
-              setResult('Result' + JSON.stringify(result));
-            };
-            const messageForChildHandler = (message: string): void => {
-              // Message from parent
-              setResult(message);
-            };
-            dialog.open(dialogInfo, onComplete, messageForChildHandler);
-            return '';
-          },
-          withCallback: (taskInfo, setResult) => {
-            const onComplete = (err: string, result: string | object): void => {
-              setResult('Result' + JSON.stringify(result));
-            };
-            // Store the reference of child window in React
-            openDialogHelper(tasks.startTask(taskInfo, onComplete), setResult);
-          },
+        submit: async (dialogInfo, setResult) => {
+          const onComplete = (resultObj: Result): void => {
+            setResult('Error: ' + resultObj.err + '\nResult: ' + resultObj.result);
+          };
+          const messageForChildHandler = (message: string): void => {
+            // Message from parent
+            setResult(message);
+          };
+          dialog.open(dialogInfo, onComplete, messageForChildHandler);
+          return '';
         },
       },
     });
@@ -207,6 +218,7 @@ const DialogAPIs = (): ReactElement => {
     <>
       <h1>dialog</h1>
       <CheckDialogCapability />
+      <StartTask />
       <OpenDialog />
       <ResizeDialog />
       <SubmitDialogWithInput />

--- a/apps/teams-test-app/src/components/DialogAPIs.tsx
+++ b/apps/teams-test-app/src/components/DialogAPIs.tsx
@@ -1,5 +1,14 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { dialog, DialogInfo, IAppWindow, ParentAppWindow, SdkResponse, TaskInfo, tasks } from '@microsoft/teams-js';
+import {
+  dialog,
+  DialogInfo,
+  IAppWindow,
+  ParentAppWindow,
+  SdkResponse,
+  TaskInfo,
+  tasks,
+  UrlDialogInfo,
+} from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
@@ -36,7 +45,7 @@ const DialogAPIs = (): ReactElement => {
     });
 
   const OpenDialog = (): ReactElement =>
-    ApiWithTextInput<DialogInfo | TaskInfo>({
+    ApiWithTextInput<UrlDialogInfo>({
       name: 'dialogOpen_v2',
       title: 'Dialog Open',
       onClick: {
@@ -45,7 +54,7 @@ const DialogAPIs = (): ReactElement => {
             throw new Error('Url undefined');
           }
         },
-        submit: async (dialogInfo, setResult) => {
+        submit: async (urlDialogInfo, setResult) => {
           const onComplete = (resultObj: SdkResponse): void => {
             setResult('Error: ' + resultObj.err + '\nResult: ' + resultObj.result);
           };
@@ -53,7 +62,7 @@ const DialogAPIs = (): ReactElement => {
             // Message from parent
             setResult(message);
           };
-          dialog.open(dialogInfo, onComplete, messageFromChildHandler);
+          dialog.open(urlDialogInfo, onComplete, messageFromChildHandler);
           return '';
         },
       },
@@ -131,7 +140,14 @@ const DialogAPIs = (): ReactElement => {
               setResult('Message sent to child');
             }
           };
-          const sendMessageToDialogHandler = dialog.open({});
+          const dialogInfo = {
+            url: 'someUrl',
+            size: {
+              height: 5,
+              width: 5,
+            },
+          };
+          const sendMessageToDialogHandler = dialog.open(dialogInfo);
           sendMessageToDialogHandler(message, onComplete);
           return '';
         },

--- a/change/@microsoft-teams-js-9c1b77aa-a0e6-4099-9eae-9fff30c8f94e.json
+++ b/change/@microsoft-teams-js-9c1b77aa-a0e6-4099-9eae-9fff30c8f94e.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Dialog.open function takes an extra optionl parameter named messageForChildHandler and retuns a handler back instead of a ChildAppWindow. ",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-9c1b77aa-a0e6-4099-9eae-9fff30c8f94e.json
+++ b/change/@microsoft-teams-js-9c1b77aa-a0e6-4099-9eae-9fff30c8f94e.json
@@ -1,6 +1,6 @@
 {
   "type": "major",
-  "comment": "Dialog.open function takes an extra optionl parameter named messageForChildHandler and retuns a handler back instead of a ChildAppWindow. ",
+  "comment": "Dialog.open function takes an extra optionl parameter named messageFromChildHandler and returns a handler back instead of a ChildAppWindow.",
   "packageName": "@microsoft/teams-js",
   "email": "lakhveerkaur@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-9c1b77aa-a0e6-4099-9eae-9fff30c8f94e.json
+++ b/change/@microsoft-teams-js-9c1b77aa-a0e6-4099-9eae-9fff30c8f94e.json
@@ -1,6 +1,12 @@
 {
   "type": "major",
-  "comment": "Dialog.open function takes an extra optionl parameter named messageFromChildHandler and returns a handler back instead of a ChildAppWindow.",
+  "comment": [
+    "1. Dialog capability has been split into a main capability (dialog) for supporting HTML-based dialogs and a subcapability dialog.bot for bot based dialogs. For now, dialog capability does not support adaptive card based dialogs",
+    "\n  2. dialog.open has been changed to take UrlDialogInfo instead of DialogInfo to enforce only HTML based dialogs",
+    "\n  3. dialog.open takes an extra optional parameter named messageFromChildHandler which is triggered if dialog sends a message to the app",
+    "\n  4. dialog.open returns a function that can be used to send messages to the dialog instead of returning a ChildAppWindow",
+    "\n  5. dialog.bot.open has the same function signature except it takes BotUrlDialogInfo instead of UrlDialogInfo"
+  ],
   "packageName": "@microsoft/teams-js",
   "email": "lakhveerkaur@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-9c1b77aa-a0e6-4099-9eae-9fff30c8f94e.json
+++ b/change/@microsoft-teams-js-9c1b77aa-a0e6-4099-9eae-9fff30c8f94e.json
@@ -2,10 +2,11 @@
   "type": "major",
   "comment": [
     "1. Dialog capability has been split into a main capability (dialog) for supporting HTML-based dialogs and a subcapability dialog.bot for bot based dialogs. For now, dialog capability does not support adaptive card based dialogs",
-    "\n  2. dialog.open has been changed to take UrlDialogInfo instead of DialogInfo to enforce only HTML based dialogs",
-    "\n  3. dialog.open takes an extra optional parameter named messageFromChildHandler which is triggered if dialog sends a message to the app",
-    "\n  4. dialog.open returns a function that can be used to send messages to the dialog instead of returning a ChildAppWindow",
-    "\n  5. dialog.bot.open has the same function signature except it takes BotUrlDialogInfo instead of UrlDialogInfo"
+    "\n  2. dialog.open takes a UrlDialogInfo instead of DialogInfo to enforce only HTML based dialogs",
+    "\n  3. callback submitHandler takes a single object parameter containing both error and result",
+    "\n  4. dialog.open takes one more optional parameter named messageFromChildHandler which is triggered if dialog sends a message to the app",
+    "\n  5. dialog.open returns a function that can be used to send messages to the dialog instead of returning a ChildAppWindow",
+    "\n  6. dialog.bot.open has the same function signature except it takes BotUrlDialogInfo instead of UrlDialogInfo"
   ],
   "packageName": "@microsoft/teams-js",
   "email": "lakhveerkaur@microsoft.com",

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -18,33 +18,33 @@ import { runtime } from './runtime';
  *
  * @beta
  */
-export interface Result {
+export interface SdkResponse {
   err: string;
   result: string | object;
 }
 
 export namespace dialog {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  type PostMessageChannel = (message: any) => void;
-  type DialogSubmitHandler = (result: Result) => void;
+  export type PostMessageChannel = (message: any, onComplete?: (status: boolean, reason?: string) => void) => void;
+  export type DialogSubmitHandler = (result: SdkResponse) => void;
   /**
    * Allows an app to open the dialog module.
    *
    * @param dialogInfo - An object containing the parameters of the dialog module
    * @param submitHandler - Handler to call when the task module is completed
-   * @param messageForChildHandler - Handler that triggers if dialog tries to send a message to the app.
+   * @param messageFromChildHandler - Handler that triggers if dialog tries to send a message to the app.
    *
    * @returns a Handler that is triggerd to send a message to the dialog.
    */
   export function open(
     dialogInfo: DialogInfo,
     submitHandler?: DialogSubmitHandler,
-    messageForChildHandler?: PostMessageChannel,
+    messageFromChildHandler?: PostMessageChannel,
   ): PostMessageChannel {
     ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
 
-    if (messageForChildHandler) {
-      registerHandler('messageForParent', messageForChildHandler);
+    if (messageFromChildHandler) {
+      registerHandler('messageForParent', messageFromChildHandler);
     }
 
     sendMessageToParent('tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
@@ -53,7 +53,6 @@ export namespace dialog {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sendMessageToDialog = (message: any, onComplete?: (status: boolean, reason?: string) => void): void => {
-      ensureInitialized();
       sendMessageToParent('messageForChild', [message], onComplete ? onComplete : getGenericOnCompleteHandler());
     };
     return sendMessageToDialog;

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -29,11 +29,11 @@ export namespace dialog {
   /**
    * Allows an app to open the dialog module.
    *
-   * @param urlDialogInfo - An object containing the parameters of the dialog module
-   * @param submitHandler - Handler to call when the task module is completed
-   * @param messageFromChildHandler - Handler that triggers if dialog tries to send a message to the app.
+   * @param urlDialogInfo - An object containing the parameters of the dialog module.
+   * @param submitHandler - This Handler is called when the dialog has been submitted or closed.
+   * @param messageFromChildHandler - Handler that triggers if dialog sends a message to the app.
    *
-   * @returns a Handler that is triggerd to send a message to the dialog.
+   * @returns a function that can be used to send messages to the dialog.
    */
   export function open(
     urlDialogInfo: UrlDialogInfo,

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -29,7 +29,7 @@ export namespace dialog {
   /**
    * Allows an app to open the dialog module.
    *
-   * @param urldialogInfo - An object containing the parameters of the dialog module
+   * @param urlDialogInfo - An object containing the parameters of the dialog module
    * @param submitHandler - Handler to call when the task module is completed
    * @param messageFromChildHandler - Handler that triggers if dialog tries to send a message to the app.
    *

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -32,6 +32,9 @@ export namespace dialog {
    *
    * @param dialogInfo - An object containing the parameters of the dialog module
    * @param submitHandler - Handler to call when the task module is completed
+   * @param messageForChildHandler - Handler that triggers if dialog tries to send a message to the app.
+   *
+   * @returns a Handler that is triggerd to send a message to the dialog.
    */
   export function open(
     dialogInfo: DialogInfo,

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -532,6 +532,49 @@ export interface DeepLinkParameters {
   subEntityWebUrl?: string;
 }
 
+export interface DialogSize {
+  /**
+   * The requested height of the webview/iframe.
+   */
+  height: DialogDimension | number;
+
+  /**
+   * The requested width of the webview/iframe.
+   */
+  width: DialogDimension | number;
+}
+
+export interface UrlDialogInfo {
+  /**
+   * The url to be rendered in the webview/iframe.
+   */
+  url: string;
+
+  /*
+   * The requested height and width of the dialog
+   */
+  size: DialogSize;
+
+  /**
+   * Title of the task module.
+   */
+  title?: string;
+
+  /**
+   * If client doesnt support the URL, the URL that needs to be opened in the browser.
+   */
+  fallbackUrl?: string;
+}
+
+export interface BotUrlDialogInfo extends UrlDialogInfo {
+  /**
+   * Specifies a bot ID to send the result of the user's interaction with the task module.
+   * The bot will receive a task/complete invoke event with a JSON object
+   * in the event payload.
+   */
+  completionBotId: string;
+}
+
 export interface DialogInfo {
   /**
    * The url to be rendered in the webview/iframe.

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -50,7 +50,9 @@ export let runtime: IRuntime = {
     calendar: undefined,
     call: undefined,
     chat: undefined,
-    dialog: undefined,
+    dialog: {
+      bot: undefined,
+    },
     location: undefined,
     logs: undefined,
     mail: undefined,
@@ -87,7 +89,9 @@ export const teamsRuntimeConfig: IRuntime = {
     bot: {},
     call: {},
     chat: {},
-    dialog: {},
+    dialog: {
+      bot: {},
+    },
     files: {},
     location: {},
     logs: {},

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -11,7 +11,9 @@ export interface IRuntime {
     readonly calendar?: {};
     readonly call?: {};
     readonly chat?: {};
-    readonly dialog?: {};
+    readonly dialog?: {
+      readonly bot?: {};
+    };
     readonly files?: {};
     readonly location?: {};
     readonly logs?: {};

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -18,7 +18,7 @@ import { TaskInfo } from './interfaces';
 export namespace tasks {
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link dialog.open dialog.open(dialogInfo: DialogInfo, submitHandler?: (err: string, result: string) => void): IAppWindow} instead.
+   * As of 2.0.0-beta.4, please use {@link dialog.open(dialogInfo: DialogInfo, submitHandler?: DialogSubmitHandler, messageForChildHandler?: PostMessageChannel): PostMessageChannel} instead.
    *
    * Allows an app to open the task module.
    *

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -30,7 +30,7 @@ export namespace tasks {
     submitHandler?: (err: string, result: string | object) => void,
   ): IAppWindow {
     taskInfo = getDefaultSizeIfNotProvided(taskInfo);
-    if (taskInfo.card !== undefined) {
+    if (taskInfo.card !== undefined || taskInfo.url === undefined) {
       ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
       sendMessageToParent('tasks.startTask', [taskInfo as DialogInfo], submitHandler);
     } else if (taskInfo.completionBotId !== undefined) {

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -96,10 +96,9 @@ export namespace tasks {
     };
     return botUrldialogInfo;
   }
-}
-
-export function getDefaultSizeIfNotProvided(taskInfo: TaskInfo): TaskInfo {
-  taskInfo.height = taskInfo.height ? taskInfo.height : TaskModuleDimension.Medium;
-  taskInfo.width = taskInfo.width ? taskInfo.width : TaskModuleDimension.Medium;
-  return taskInfo;
+  export function getDefaultSizeIfNotProvided(taskInfo: TaskInfo): TaskInfo {
+    taskInfo.height = taskInfo.height ? taskInfo.height : TaskModuleDimension.Small;
+    taskInfo.width = taskInfo.width ? taskInfo.width : TaskModuleDimension.Small;
+    return taskInfo;
+  }
 }

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
-import { IAppWindow } from './appWindow';
-import { TaskModuleDimension } from './constants';
+import { sendMessageToParent } from '../internal/communication';
+import { ensureInitialized } from '../internal/internalAPIs';
+import { ChildAppWindow, IAppWindow } from './appWindow';
+import { FrameContexts, TaskModuleDimension } from './constants';
 import { dialog } from './dialog';
 import { TaskInfo } from './interfaces';
 
@@ -27,7 +29,10 @@ export namespace tasks {
     taskInfo: TaskInfo,
     submitHandler?: (err: string, result: string | object) => void,
   ): IAppWindow {
-    return dialog.open(getDialogInfoFromTaskInfo(taskInfo), submitHandler);
+    ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
+
+    sendMessageToParent('tasks.startTask', [getDialogInfoFromTaskInfo(taskInfo)], submitHandler);
+    return new ChildAppWindow();
   }
 
   /**

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -1,10 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
-import { sendMessageToParent } from '../internal/communication';
-import { ensureInitialized } from '../internal/internalAPIs';
 import { ChildAppWindow, IAppWindow } from './appWindow';
-import { FrameContexts, TaskModuleDimension } from './constants';
-import { dialog } from './dialog';
+import { TaskModuleDimension } from './constants';
+import { dialog, SdkResponse } from './dialog';
 import { TaskInfo } from './interfaces';
 
 /**
@@ -18,7 +16,7 @@ import { TaskInfo } from './interfaces';
 export namespace tasks {
   /**
    * @deprecated
-   * As of 2.0.0-beta.4, please use {@link dialog.open(dialogInfo: DialogInfo, submitHandler?: DialogSubmitHandler, messageForChildHandler?: PostMessageChannel): PostMessageChannel} instead.
+   * As of 2.0.0-beta.4, please use {@link dialog.open(dialogInfo: DialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): PostMessageChannel} instead.
    *
    * Allows an app to open the task module.
    *
@@ -29,9 +27,9 @@ export namespace tasks {
     taskInfo: TaskInfo,
     submitHandler?: (err: string, result: string | object) => void,
   ): IAppWindow {
-    ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
-
-    sendMessageToParent('tasks.startTask', [getDialogInfoFromTaskInfo(taskInfo)], submitHandler);
+    dialog.open(getDialogInfoFromTaskInfo(taskInfo), (sdkResponse: SdkResponse) =>
+      submitHandler(sdkResponse.err, sdkResponse.result),
+    );
     return new ChildAppWindow();
   }
 

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -114,9 +114,10 @@ describe('Dialog', () => {
 
       let callbackCalled = false;
       const dialogInfo: DialogInfo = {};
-      dialog.open(dialogInfo, (err, result) => {
-        expect(err).toBeNull();
-        expect(result).toBe('someResult');
+      dialog.open(dialogInfo, resultObj => {
+        expect(resultObj.err).toBeNull();
+        expect(resultObj.result).toBe('someResult');
+
         callbackCalled = true;
       });
 
@@ -131,9 +132,9 @@ describe('Dialog', () => {
 
       let callbackCalled = false;
       const dialogInfo: DialogInfo = {};
-      dialog.open(dialogInfo, (err, result) => {
-        expect(err).toBe('someError');
-        expect(result).toBeUndefined();
+      dialog.open(dialogInfo, resultObj => {
+        expect(resultObj.err).toBe('someError');
+        expect(resultObj.result).toBeUndefined();
         callbackCalled = true;
       });
 

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -1,9 +1,8 @@
-import { DialogInfo } from '../../src/public/interfaces';
+import { app } from '../../src/public/app';
 import { DialogDimension, FrameContexts } from '../../src/public/constants';
 import { dialog } from '../../src/public/dialog';
+import { BotUrlDialogInfo, DialogInfo, UrlDialogInfo } from '../../src/public/interfaces';
 import { Utils } from '../utils';
-import { app } from '../../src/public/app';
-
 describe('Dialog', () => {
   // Use to send a mock message from the app.
 
@@ -27,188 +26,131 @@ describe('Dialog', () => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     const emptyCallback = (): void => {};
 
+    const dialogInfo: UrlDialogInfo = {
+      url: 'someUrl',
+      size: {
+        height: DialogDimension.Small,
+        width: DialogDimension.Small,
+      },
+    };
+
     it('should not allow calls before initialization', () => {
-      const dialogInfo: DialogInfo = {};
       expect(() => dialog.open(dialogInfo)).toThrowError('The library has not yet been initialized');
     });
-
-    it('should not allow calls from settings context', async () => {
-      await utils.initializeWithContext('settings');
-
-      const dialogInfo: DialogInfo = {};
-      expect(() => dialog.open(dialogInfo)).toThrowError(
-        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "settings".',
-      );
-    });
-
-    it('should not allow calls from authentication context', async () => {
-      await utils.initializeWithContext('authentication');
-
-      const dialogInfo: DialogInfo = {};
-      expect(() => dialog.open(dialogInfo)).toThrowError(
-        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "authentication".',
-      );
-    });
-
-    it('should not allow calls from remove context', async () => {
-      await utils.initializeWithContext('remove');
-
-      const dialogInfo: DialogInfo = {};
-      expect(() => dialog.open(dialogInfo)).toThrowError(
-        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "remove".',
-      );
-    });
-
-    it('should not allow calls from task context', async () => {
-      await utils.initializeWithContext('task');
-
-      const dialogInfo: DialogInfo = {};
-      expect(() => dialog.open(dialogInfo)).toThrowError(
-        'This call is only allowed in following contexts: ["content","sidePanel","meetingStage"]. Current context: "task".',
-      );
-    });
-
-    it('should pass along entire DialogInfo parameter in sidePanel context', async () => {
-      await utils.initializeWithContext('sidePanel');
-
-      const dialogInfo: DialogInfo = {
-        card: 'someCard',
-        fallbackUrl: 'someFallbackUrl',
-        height: DialogDimension.Large,
-        width: DialogDimension.Large,
-        title: 'someTitle',
-        url: 'someUrl',
-        completionBotId: 'someCompletionBotId',
-      };
-
-      dialog.open(dialogInfo, () => {
-        return;
-      });
-
-      const openMessage = utils.findMessageByFunc('tasks.startTask');
-      expect(openMessage).not.toBeNull();
-      expect(openMessage.args).toEqual([dialogInfo]);
-    });
-
-    it('should pass along entire DialogInfo parameter in content', async () => {
-      await utils.initializeWithContext('content');
-
-      const dialogInfo: DialogInfo = {
-        card: 'someCard',
-        fallbackUrl: 'someFallbackUrl',
-        height: DialogDimension.Large,
-        width: DialogDimension.Large,
-        title: 'someTitle',
-        url: 'someUrl',
-        completionBotId: 'someCompletionBotId',
-      };
-
-      dialog.open(dialogInfo, () => {
-        return;
-      });
-
-      const openMessage = utils.findMessageByFunc('tasks.startTask');
-      expect(openMessage).not.toBeNull();
-      expect(openMessage.args).toEqual([dialogInfo]);
-    });
-
-    it('should invoke callback with result', async () => {
-      await utils.initializeWithContext('content');
-
-      let callbackCalled = false;
-      const dialogInfo: DialogInfo = {};
-      dialog.open(dialogInfo, resultObj => {
-        expect(resultObj.err).toBeNull();
-        expect(resultObj.result).toBe('someResult');
-
-        callbackCalled = true;
-      });
-
-      const openMessage = utils.findMessageByFunc('tasks.startTask');
-      expect(openMessage).not.toBeNull();
-      utils.respondToMessage(openMessage, null, 'someResult');
-      expect(callbackCalled).toBe(true);
-    });
-
-    it('should invoke callback with error', async () => {
-      await utils.initializeWithContext('content');
-
-      let callbackCalled = false;
-      const dialogInfo: DialogInfo = {};
-      dialog.open(dialogInfo, resultObj => {
-        expect(resultObj.err).toBe('someError');
-        expect(resultObj.result).toBeUndefined();
-        callbackCalled = true;
-      });
-
-      const openMessage = utils.findMessageByFunc('tasks.startTask');
-      expect(openMessage).not.toBeNull();
-      utils.respondToMessage(openMessage, 'someError');
-      expect(callbackCalled).toBe(true);
-    });
-
-    it('Should register messageFromChildHandler if it is passed', async () => {
-      await utils.initializeWithContext('content');
-      const dialogInfo: DialogInfo = {};
-      const messageFromChild = 'MessageFromChild';
-      let returnedMessage: string;
-      let handlerCalled = false;
-      dialog.open(dialogInfo, emptyCallback, messageFromChild => {
-        handlerCalled = true;
-        returnedMessage = messageFromChild;
-      });
-
-      utils.sendMessage('messageForParent', messageFromChild);
-
-      const handlerMessage = utils.findMessageByFunc('registerHandler');
-      expect(handlerMessage).not.toBeNull();
-      expect(handlerCalled).toBe(true);
-      expect(returnedMessage).toEqual(messageFromChild);
-    });
-
-    describe('send a message to dialog using returned fucntion from dialog.open API call', () => {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      const emptyCallback = (): void => {};
-      const dialogInfo: DialogInfo = {};
-
-      it('should successfully send the post the message to dialog', async () => {
-        await utils.initializeWithContext('content');
-        const sendMessageToDialogHandler = dialog.open(dialogInfo, emptyCallback, emptyCallback);
-        sendMessageToDialogHandler('exampleMessage', (success, reason) => {
-          expect(success).toBeTruthy();
-          expect(reason).toBeNull;
+    const allowedContexts = [FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage];
+    Object.values(FrameContexts).forEach(context => {
+      if (allowedContexts.some(allowedContext => allowedContext === context)) {
+        it(`should pass along entire DialogInfo parameter in ${context} context`, async () => {
+          await utils.initializeWithContext(context);
+          const dialogInfo: UrlDialogInfo = {
+            url: 'someUrl',
+            size: { height: DialogDimension.Large, width: DialogDimension.Large },
+            title: 'someTitle',
+            fallbackUrl: 'someFallbackUrl',
+          };
+          dialog.open(dialogInfo, () => {
+            return;
+          });
+          const openMessage = utils.findMessageByFunc('tasks.startTask');
+          expect(openMessage).not.toBeNull();
+          expect(openMessage.args).toEqual([dialogInfo]);
         });
-        const message = utils.findMessageByFunc('messageForChild');
-        utils.respondToMessage(message, true);
-        expect(message).not.toBeUndefined();
-      });
-      it('should successfully receive the error message if the post message to dialog fails', async () => {
-        await utils.initializeWithContext('content');
-        const error = 'some Error Occured';
-        const sendMessageToDialogHandler = dialog.open(dialogInfo, emptyCallback, emptyCallback);
-        sendMessageToDialogHandler('exampleMessage', (success, reason) => {
-          expect(success).toBeFalsy();
-          expect(reason).toBe(error);
+
+        it(`should invoke callback with error. context: ${context}`, async () => {
+          await utils.initializeWithContext(context);
+          let callbackCalled = false;
+          dialog.open(dialogInfo, resultObj => {
+            expect(resultObj.err).toBe('someError');
+            expect(resultObj.result).toBeUndefined();
+            callbackCalled = true;
+          });
+          const openMessage = utils.findMessageByFunc('tasks.startTask');
+          expect(openMessage).not.toBeNull();
+          utils.respondToMessage(openMessage, 'someError');
+          expect(callbackCalled).toBe(true);
         });
-        const message = utils.findMessageByFunc('messageForChild');
-        utils.respondToMessage(message, false, error);
-        expect(message).not.toBeUndefined();
-      });
+
+        it(`Should register messageFromChildHandler if it is passed. context: ${context}`, async () => {
+          await utils.initializeWithContext(context);
+          const messageFromChild = 'MessageFromChild';
+          let returnedMessage: string;
+          let handlerCalled = false;
+          dialog.open(dialogInfo, emptyCallback, messageFromChild => {
+            handlerCalled = true;
+            returnedMessage = messageFromChild;
+          });
+          utils.sendMessage('messageForParent', messageFromChild);
+          const handlerMessage = utils.findMessageByFunc('registerHandler');
+          expect(handlerMessage).not.toBeNull();
+          expect(handlerCalled).toBe(true);
+          expect(returnedMessage).toEqual(messageFromChild);
+        });
+
+        it(`should invoke callback with result. context: ${context} `, async () => {
+          await utils.initializeWithContext(context);
+          let callbackCalled = false;
+          dialog.open(dialogInfo, resultObj => {
+            expect(resultObj.err).toBeNull();
+            expect(resultObj.result).toBe('someResult');
+            callbackCalled = true;
+          });
+          const openMessage = utils.findMessageByFunc('tasks.startTask');
+          expect(openMessage).not.toBeNull();
+          utils.respondToMessage(openMessage, null, 'someResult');
+          expect(callbackCalled).toBe(true);
+        });
+
+        describe('send a message to dialog using returned function from dialog.open API call', () => {
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          const emptyCallback = (): void => {};
+          it(`should successfully send the post the message to dialog. context: ${context}`, async () => {
+            await utils.initializeWithContext(context);
+            const sendMessageToDialogHandler = dialog.open(dialogInfo, emptyCallback, emptyCallback);
+            sendMessageToDialogHandler('exampleMessage', (success, reason) => {
+              expect(success).toBeTruthy();
+              expect(reason).toBeNull;
+            });
+            const message = utils.findMessageByFunc('messageForChild');
+            utils.respondToMessage(message, true);
+            expect(message).not.toBeUndefined();
+          });
+
+          it(`should successfully receive the error message if the post message to dialog fails. context: ${context}`, async () => {
+            await utils.initializeWithContext(context);
+            const error = 'some Error Occured';
+            const sendMessageToDialogHandler = dialog.open(dialogInfo, emptyCallback, emptyCallback);
+            sendMessageToDialogHandler('exampleMessage', (success, reason) => {
+              expect(success).toBeFalsy();
+              expect(reason).toBe(error);
+            });
+            const message = utils.findMessageByFunc('messageForChild');
+            utils.respondToMessage(message, false, error);
+            expect(message).not.toBeUndefined();
+          });
+        });
+      } else {
+        it(`should not allow calls from context ${context}`, async () => {
+          await utils.initializeWithContext(context);
+          expect(() => dialog.open(dialogInfo)).toThrowError(
+            `This call is only allowed in following contexts: ${JSON.stringify(
+              allowedContexts,
+            )}. Current context: ${JSON.stringify(context)}.`,
+          );
+        });
+      }
     });
   });
 
   describe('resize', () => {
     it('should not allow calls before initialization', () => {
-      // tslint:disable-next-line:no-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect(() => dialog.resize({} as any)).toThrowError('The library has not yet been initialized');
     });
 
     it('should successfully pass DialogInfo in Task context', async () => {
       await utils.initializeWithContext('task');
       const dialogInfo = { width: 10, height: 10 };
-
       dialog.resize(dialogInfo);
-
       const resizeMessage = utils.findMessageByFunc('tasks.updateTask');
       expect(resizeMessage).not.toBeNull();
       expect(resizeMessage.args).toEqual([dialogInfo]);
@@ -217,13 +159,11 @@ describe('Dialog', () => {
     it('should throw an error if extra properties are provided', async () => {
       await utils.initializeWithContext('task');
       const dialogInfo = { width: 10, height: 10, title: 'anything' };
-
       expect(() => dialog.resize(dialogInfo)).toThrowError(
         'resize requires a dialogInfo argument containing only width and height',
       );
     });
   });
-
   describe('submit', () => {
     it('should not allow calls before initialization', () => {
       expect(() => dialog.submit()).toThrowError('The library has not yet been initialized');
@@ -231,7 +171,6 @@ describe('Dialog', () => {
 
     it('should not allow calls from settings context', async () => {
       await utils.initializeWithContext('settings');
-
       expect(() => dialog.submit()).toThrowError(
         'This call is only allowed in following contexts: ["content","sidePanel","task","meetingStage"]. Current context: "settings".',
       );
@@ -239,7 +178,6 @@ describe('Dialog', () => {
 
     it('should not allow calls from authentication context', async () => {
       await utils.initializeWithContext('authentication');
-
       expect(() => dialog.submit()).toThrowError(
         'This call is only allowed in following contexts: ["content","sidePanel","task","meetingStage"]. Current context: "authentication".',
       );
@@ -247,7 +185,6 @@ describe('Dialog', () => {
 
     it('should not allow calls from remove context', async () => {
       await utils.initializeWithContext('remove');
-
       expect(() => dialog.submit()).toThrowError(
         'This call is only allowed in following contexts: ["content","sidePanel","task","meetingStage"]. Current context: "remove".',
       );
@@ -255,9 +192,7 @@ describe('Dialog', () => {
 
     it('should successfully pass result and appIds parameters when called from Task context', async () => {
       await utils.initializeWithContext('task');
-
       dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
-
       const submitMessage = utils.findMessageByFunc('tasks.completeTask');
       expect(submitMessage).not.toBeNull();
       expect(submitMessage.args).toEqual(['someResult', ['someAppId', 'someOtherAppId']]);
@@ -265,12 +200,148 @@ describe('Dialog', () => {
 
     it('should handle a single string passed as appIds parameter', async () => {
       await utils.initializeWithContext('task');
-
       dialog.submit('someResult', 'someAppId');
-
       const submitMessage = utils.findMessageByFunc('tasks.completeTask');
       expect(submitMessage).not.toBeNull();
       expect(submitMessage.args).toEqual(['someResult', ['someAppId']]);
+    });
+  });
+
+  describe('Open dialog with bot', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const emptyCallback = (): void => {};
+    const dialogInfo: BotUrlDialogInfo = {
+      url: 'someUrl',
+      size: {
+        height: DialogDimension.Small,
+        width: DialogDimension.Small,
+      },
+      completionBotId: 'botId',
+    };
+
+    it('should not allow calls before initialization', () => {
+      expect(() => dialog.open(dialogInfo)).toThrowError('The library has not yet been initialized');
+    });
+
+    const allowedContexts = [FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage];
+    Object.values(FrameContexts).forEach(context => {
+      if (allowedContexts.some(allowedContext => allowedContext === context)) {
+        it(`should pass along entire DialogInfo parameter in ${context} context`, async () => {
+          await utils.initializeWithContext(context);
+          const dialogInfo: BotUrlDialogInfo = {
+            url: 'someUrl',
+            size: { height: DialogDimension.Large, width: DialogDimension.Large },
+            title: 'someTitle',
+            fallbackUrl: 'someFallbackUrl',
+            completionBotId: 'botId',
+          };
+          dialog.open(dialogInfo, () => {
+            return;
+          });
+          const openMessage = utils.findMessageByFunc('tasks.startTask');
+          expect(openMessage).not.toBeNull();
+          expect(openMessage.args).toEqual([dialogInfo]);
+        });
+
+        it(`should invoke callback with error. context: ${context}`, async () => {
+          await utils.initializeWithContext(context);
+          let callbackCalled = false;
+          dialog.open(dialogInfo, resultObj => {
+            expect(resultObj.err).toBe('someError');
+            expect(resultObj.result).toBeUndefined();
+            callbackCalled = true;
+          });
+          const openMessage = utils.findMessageByFunc('tasks.startTask');
+          expect(openMessage).not.toBeNull();
+          utils.respondToMessage(openMessage, 'someError');
+          expect(callbackCalled).toBe(true);
+        });
+
+        it(`Should register messageFromChildHandler if it is passed. context: ${context}`, async () => {
+          await utils.initializeWithContext(context);
+          const messageFromChild = 'MessageFromChild';
+          let returnedMessage: string;
+          let handlerCalled = false;
+          dialog.open(dialogInfo, emptyCallback, messageFromChild => {
+            handlerCalled = true;
+            returnedMessage = messageFromChild;
+          });
+          utils.sendMessage('messageForParent', messageFromChild);
+          const handlerMessage = utils.findMessageByFunc('registerHandler');
+          expect(handlerMessage).not.toBeNull();
+          expect(handlerCalled).toBe(true);
+          expect(returnedMessage).toEqual(messageFromChild);
+        });
+
+        it(`should invoke callback with result. context: ${context} `, async () => {
+          await utils.initializeWithContext(context);
+          let callbackCalled = false;
+          dialog.open(dialogInfo, resultObj => {
+            expect(resultObj.err).toBeNull();
+            expect(resultObj.result).toBe('someResult');
+            callbackCalled = true;
+          });
+          const openMessage = utils.findMessageByFunc('tasks.startTask');
+          expect(openMessage).not.toBeNull();
+          utils.respondToMessage(openMessage, null, 'someResult');
+          expect(callbackCalled).toBe(true);
+        });
+
+        describe('send a message to dialog using returned function from dialog.open API call', () => {
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          const emptyCallback = (): void => {};
+          it(`should successfully send the post the message to dialog. context: ${context}`, async () => {
+            await utils.initializeWithContext(context);
+            const sendMessageToDialogHandler = dialog.open(dialogInfo, emptyCallback, emptyCallback);
+            sendMessageToDialogHandler('exampleMessage', (success, reason) => {
+              expect(success).toBeTruthy();
+              expect(reason).toBeNull;
+            });
+            const message = utils.findMessageByFunc('messageForChild');
+            utils.respondToMessage(message, true);
+            expect(message).not.toBeUndefined();
+          });
+
+          it(`should successfully receive the error message if the post message to dialog fails. context: ${context}`, async () => {
+            await utils.initializeWithContext(context);
+            const error = 'some Error Occured';
+            const sendMessageToDialogHandler = dialog.open(dialogInfo, emptyCallback, emptyCallback);
+            sendMessageToDialogHandler('exampleMessage', (success, reason) => {
+              expect(success).toBeFalsy();
+              expect(reason).toBe(error);
+            });
+            const message = utils.findMessageByFunc('messageForChild');
+            utils.respondToMessage(message, false, error);
+            expect(message).not.toBeUndefined();
+          });
+        });
+      } else {
+        it(`should not allow calls from context ${context}`, async () => {
+          await utils.initializeWithContext(context);
+          expect(() => dialog.open(dialogInfo)).toThrowError(
+            `This call is only allowed in following contexts: ${JSON.stringify(
+              allowedContexts,
+            )}. Current context: ${JSON.stringify(context)}.`,
+          );
+        });
+      }
+    });
+
+    describe('dialog.bot.isSupported function', () => {
+      it('dialog.bot.isSupported should return false if the runtime says dialog is not supported', () => {
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+        expect(dialog.bot.isSupported()).not.toBeTruthy();
+      });
+
+      it('dialog.bot.isSupported should return false if the runtime says dialog.bot is not supported', () => {
+        utils.setRuntimeConfig({ apiVersion: 1, supports: { dialog: {} } });
+        expect(dialog.bot.isSupported()).not.toBeTruthy();
+      });
+
+      it('dialog.bot.isSupported should return true if the runtime says dialog and dialog.bot is supported', () => {
+        utils.setRuntimeConfig({ apiVersion: 1, supports: { dialog: { bot: {} } } });
+        expect(dialog.bot.isSupported()).toBeTruthy();
+      });
     });
   });
 });

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -1,7 +1,7 @@
 import { app } from '../../src/public/app';
 import { DialogDimension, FrameContexts } from '../../src/public/constants';
 import { dialog } from '../../src/public/dialog';
-import { BotUrlDialogInfo, DialogInfo, UrlDialogInfo } from '../../src/public/interfaces';
+import { BotUrlDialogInfo, UrlDialogInfo } from '../../src/public/interfaces';
 import { Utils } from '../utils';
 describe('Dialog', () => {
   // Use to send a mock message from the app.

--- a/packages/teams-js/test/public/tasks.spec.ts
+++ b/packages/teams-js/test/public/tasks.spec.ts
@@ -56,6 +56,23 @@ describe('tasks', () => {
           expect(startTaskMessage.args).toEqual([taskInfo]);
         });
 
+        it(`should pass along the taskInfo correctly when URL is not specified. ${context} context`, async () => {
+          await utils.initializeWithContext(context);
+
+          const taskInfo: TaskInfo = {
+            height: TaskModuleDimension.Large,
+            width: TaskModuleDimension.Large,
+          };
+
+          tasks.startTask(taskInfo, () => {
+            return;
+          });
+
+          const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
+          expect(startTaskMessage).not.toBeNull();
+          expect(startTaskMessage.args).toEqual([taskInfo]);
+        });
+
         it(`should pass along the taskInfo correctly when completionBotid is specified. context: ${context}`, async () => {
           await utils.initializeWithContext(context);
 
@@ -77,7 +94,7 @@ describe('tasks', () => {
           expect(startTaskMessage.args).toEqual([tasks.getBotUrlDialogInfoFromTaskInfo(taskInfo)]);
         });
 
-        it(`should pass along the taskInfo correctly when there is no card or completionBotID. context: ${context}`, async () => {
+        it(`should pass along the taskInfo correctly when URL is provided without Bot. context: ${context}`, async () => {
           await utils.initializeWithContext(context);
 
           const taskInfo: TaskInfo = {

--- a/packages/teams-js/test/public/tasks.spec.ts
+++ b/packages/teams-js/test/public/tasks.spec.ts
@@ -2,7 +2,7 @@ import { app } from '../../src/public/app';
 import { TaskModuleDimension } from '../../src/public/constants';
 import { FrameContexts } from '../../src/public/constants';
 import { TaskInfo } from '../../src/public/interfaces';
-import { getDefaultSizeIfNotProvided, tasks } from '../../src/public/tasks';
+import { tasks } from '../../src/public/tasks';
 import { Utils } from '../utils';
 
 describe('tasks', () => {
@@ -127,7 +127,7 @@ describe('tasks', () => {
           tasks.startTask(taskInfo, () => {
             return;
           });
-          const taskInfoWithSize = getDefaultSizeIfNotProvided(taskInfo);
+          const taskInfoWithSize = tasks.getDefaultSizeIfNotProvided(taskInfo);
           const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
 
           expect(startTaskMessage).not.toBeNull();

--- a/packages/teams-js/test/public/tasks.spec.ts
+++ b/packages/teams-js/test/public/tasks.spec.ts
@@ -1,9 +1,9 @@
-import { TaskInfo } from '../../src/public/interfaces';
-import { TaskModuleDimension } from '../../src/public/constants';
-import { tasks } from '../../src/public/tasks';
-import { Utils } from '../utils';
 import { app } from '../../src/public/app';
+import { TaskModuleDimension } from '../../src/public/constants';
 import { FrameContexts } from '../../src/public/constants';
+import { TaskInfo } from '../../src/public/interfaces';
+import { getDefaultSizeIfNotProvided, tasks } from '../../src/public/tasks';
+import { Utils } from '../utils';
 
 describe('tasks', () => {
   // Use to send a mock message from the app.
@@ -33,7 +33,125 @@ describe('tasks', () => {
     });
 
     Object.values(FrameContexts).forEach(context => {
-      if (!allowedContexts.some(allowedContexts => allowedContexts === context)) {
+      if (allowedContexts.some(allowedContexts => allowedContexts === context)) {
+        it(`should pass along the taskInfo correctly when card is specified. ${context} context`, async () => {
+          await utils.initializeWithContext(context);
+
+          const taskInfo: TaskInfo = {
+            card: 'someCard',
+            fallbackUrl: 'someFallbackUrl',
+            height: TaskModuleDimension.Large,
+            width: TaskModuleDimension.Large,
+            title: 'someTitle',
+            url: 'someUrl',
+            completionBotId: 'someCompletionBotId',
+          };
+
+          tasks.startTask(taskInfo, () => {
+            return;
+          });
+
+          const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
+          expect(startTaskMessage).not.toBeNull();
+          expect(startTaskMessage.args).toEqual([taskInfo]);
+        });
+
+        it(`should pass along the taskInfo correctly when completionBotid is specified. context: ${context}`, async () => {
+          await utils.initializeWithContext(context);
+
+          const taskInfo: TaskInfo = {
+            fallbackUrl: 'someFallbackUrl',
+            height: TaskModuleDimension.Large,
+            width: TaskModuleDimension.Large,
+            title: 'someTitle',
+            url: 'someUrl',
+            completionBotId: 'someCompletionBotId',
+          };
+
+          tasks.startTask(taskInfo, () => {
+            return;
+          });
+
+          const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
+          expect(startTaskMessage).not.toBeNull();
+          expect(startTaskMessage.args).toEqual([tasks.getBotUrlDialogInfoFromTaskInfo(taskInfo)]);
+        });
+
+        it(`should pass along the taskInfo correctly when there is no card or completionBotID. context: ${context}`, async () => {
+          await utils.initializeWithContext(context);
+
+          const taskInfo: TaskInfo = {
+            fallbackUrl: 'someFallbackUrl',
+            height: TaskModuleDimension.Large,
+            width: TaskModuleDimension.Large,
+            title: 'someTitle',
+            url: 'someUrl',
+          };
+
+          tasks.startTask(taskInfo, () => {
+            return;
+          });
+
+          const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
+          expect(startTaskMessage).not.toBeNull();
+          expect(startTaskMessage.args).toEqual([tasks.getUrlDialogInfoFromTaskInfo(taskInfo)]);
+        });
+
+        it(`should Provide default Size if taskInfo doesn't have length or width. ${context} context`, async () => {
+          await utils.initializeWithContext(context);
+
+          const taskInfo: TaskInfo = {
+            fallbackUrl: 'someFallbackUrl',
+            height: TaskModuleDimension.Large,
+            url: 'someUrl',
+            card: 'someCard',
+          };
+
+          tasks.startTask(taskInfo, () => {
+            return;
+          });
+          const taskInfoWithSize = getDefaultSizeIfNotProvided(taskInfo);
+          const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
+
+          expect(startTaskMessage).not.toBeNull();
+          expect(startTaskMessage.args).toEqual([taskInfo]);
+          expect(startTaskMessage.args).toEqual([taskInfoWithSize]);
+        });
+
+        it(`should invoke callback with result. context: ${context}`, async () => {
+          await utils.initializeWithContext(context);
+
+          let callbackCalled = false;
+          const taskInfo: TaskInfo = {};
+          tasks.startTask(taskInfo, (err, result) => {
+            expect(err).toBeNull();
+            expect(result).toBe('someResult');
+            callbackCalled = true;
+          });
+
+          const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
+          expect(startTaskMessage).not.toBeNull();
+          utils.respondToMessage(startTaskMessage, null, 'someResult');
+          expect(callbackCalled).toBe(true);
+        });
+
+        it(`should invoke callback with error. context: ${context}`, async () => {
+          await utils.initializeWithContext(context);
+
+          let callbackCalled = false;
+          const taskInfo: TaskInfo = {};
+          tasks.startTask(taskInfo, (err, result) => {
+            expect(err).toBe('someError');
+            expect(result).toBeUndefined();
+            callbackCalled = true;
+          });
+
+          const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
+          expect(startTaskMessage).not.toBeNull();
+          utils.respondToMessage(startTaskMessage, 'someError');
+          expect(callbackCalled).toBe(true);
+        });
+      } else {
         it(`should not allow calls from ${context} context`, async () => {
           await utils.initializeWithContext(context);
           const taskInfo: TaskInfo = {};
@@ -45,84 +163,6 @@ describe('tasks', () => {
         });
       }
     });
-
-    it('should pass along entire TaskInfo parameter in sidePanel context', async () => {
-      await utils.initializeWithContext(FrameContexts.sidePanel);
-
-      const taskInfo: TaskInfo = {
-        card: 'someCard',
-        fallbackUrl: 'someFallbackUrl',
-        height: TaskModuleDimension.Large,
-        width: TaskModuleDimension.Large,
-        title: 'someTitle',
-        url: 'someUrl',
-        completionBotId: 'someCompletionBotId',
-      };
-
-      tasks.startTask(taskInfo, () => {
-        return;
-      });
-
-      const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
-      expect(startTaskMessage).not.toBeNull();
-      expect(startTaskMessage.args).toEqual([taskInfo]);
-    });
-
-    it('should pass along entire TaskInfo parameter in content', async () => {
-      await utils.initializeWithContext(FrameContexts.content);
-
-      const taskInfo: TaskInfo = {
-        card: 'someCard',
-        fallbackUrl: 'someFallbackUrl',
-        height: TaskModuleDimension.Large,
-        width: TaskModuleDimension.Large,
-        title: 'someTitle',
-        url: 'someUrl',
-        completionBotId: 'someCompletionBotId',
-      };
-
-      tasks.startTask(taskInfo, () => {
-        return;
-      });
-
-      const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
-      expect(startTaskMessage).not.toBeNull();
-      expect(startTaskMessage.args).toEqual([taskInfo]);
-    });
-
-    it('should invoke callback with result', async () => {
-      await utils.initializeWithContext(FrameContexts.content);
-
-      let callbackCalled = false;
-      const taskInfo: TaskInfo = {};
-      tasks.startTask(taskInfo, (err, result) => {
-        expect(err).toBeNull();
-        expect(result).toBe('someResult');
-        callbackCalled = true;
-      });
-
-      const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
-      expect(startTaskMessage).not.toBeNull();
-      utils.respondToMessage(startTaskMessage, null, 'someResult');
-      expect(callbackCalled).toBe(true);
-    });
-
-    it('should invoke callback with error', async () => {
-      await utils.initializeWithContext(FrameContexts.content);
-
-      let callbackCalled = false;
-      const taskInfo: TaskInfo = {};
-      tasks.startTask(taskInfo, (err, result) => {
-        expect(err).toBe('someError');
-        expect(result).toBeUndefined();
-        callbackCalled = true;
-      });
-
-      const startTaskMessage = utils.findMessageByFunc('tasks.startTask');
-      expect(startTaskMessage).not.toBeNull();
-      utils.respondToMessage(startTaskMessage, 'someError');
-      expect(callbackCalled).toBe(true);
-    });
   });
 
   describe('updateTask', () => {
@@ -133,7 +173,7 @@ describe('tasks', () => {
       FrameContexts.meetingStage,
     ];
     it('should not allow calls before initialization', () => {
-      // tslint:disable-next-line:no-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect(() => tasks.updateTask({} as any)).toThrowError('The library has not yet been initialized');
     });
 


### PR DESCRIPTION
1. Dialog capability has been split into a main capability (dialog) for supporting HTML-based dialogs and a subcapability dialog.bot for bot based dialogs. For now, dialog capability does not support adaptive card based dialogs
2. Changed Dialog.open function is changed to
- take UrlDialogInfo instead of DialogInfo to enforce only HTML based dialogs
-  take messageFromChildHandler optional parameter,
- return equivalent of ChildAppWindow.postMessage (instead of a childAppWindow),
- submitHandler takes a single object containing both err and result
- dialog.bot.open has the same function signature except it takes BotUrlDialogInfo instead of UrlDialogInfo
4. tasks.startTask works like the same but does not call dialog.open. 
5. Updated open function in test-app according to the new parameter and return function. 
6. Updated unit tests for open function because of different submitHandler parameters. 