### PR TITLE
Improvements to openDownloadFolder API

### DIFF
--- a/src/private/files.ts
+++ b/src/private/files.ts
@@ -487,11 +487,17 @@ export namespace files {
    * @private
    * Hide from docs
    *
-   * Open download preference folder
+   * Open download preference folder or filePath if its value is non-null
+   * @param filePath: Path of the file which should be opened
+   * @param callback Callback that will be triggered post open download folder/path
    */
-  export function openDownloadFolder(): void {
+  export function openDownloadFolder(filePath: string, callback: (error?: SdkError) => void): void {
     ensureInitialized(FrameContexts.content);
 
-    sendMessageToParent('files.openDownloadFolder', []);
+    if (!callback) {
+      throw new Error('[files.openDownloadFolder] Callback cannot be null');
+    }
+
+    sendMessageToParent('files.openDownloadFolder', [filePath], callback);
   }
 }

--- a/src/private/files.ts
+++ b/src/private/files.ts
@@ -487,8 +487,8 @@ export namespace files {
    * @private
    * Hide from docs
    *
-   * Open download preference folder or filePath if its value is non-null
-   * @param filePath: Path of the file which should be opened
+   * Open download preference folder or folder containing filePath if its value is non-null
+   * @param filePath: Path of the file whose containing folder should be opened
    * @param callback Callback that will be triggered post open download folder/path
    */
   export function openDownloadFolder(filePath: string, callback: (error?: SdkError) => void): void {

--- a/src/private/files.ts
+++ b/src/private/files.ts
@@ -491,7 +491,7 @@ export namespace files {
    * @param filePath: Path of the file whose containing folder should be opened
    * @param callback Callback that will be triggered post open download folder/path
    */
-  export function openDownloadFolder(filePath: string, callback: (error?: SdkError) => void): void {
+  export function openDownloadFolder(filePath: string = null, callback: (error?: SdkError) => void): void {
     ensureInitialized(FrameContexts.content);
 
     if (!callback) {

--- a/test/private/files.spec.ts
+++ b/test/private/files.spec.ts
@@ -484,7 +484,8 @@ describe('files', () => {
       );
     });
 
-    it('should send the message to parent correctly', () => {
+    // null file path value is interpreted as opening cofigured download preference folder 
+    it('should send the message to parent correctly with file path as null', () => {
       utils.initializeWithContext('content');
 
       const callback = jest.fn((err) => {
@@ -492,6 +493,22 @@ describe('files', () => {
       });
 
       files.openDownloadFolder(null, callback);
+
+      const openDownloadFolderMessage = utils.findMessageByFunc('files.openDownloadFolder');
+      expect(openDownloadFolderMessage).not.toBeNull();
+      utils.respondToMessage(openDownloadFolderMessage, false);
+      expect(callback).toHaveBeenCalled();
+    });
+
+    // non-null file path value is interpreted as opening containing folder for the given file path
+    it('should send the message to parent correctly with non-null file path', () => {
+      utils.initializeWithContext('content');
+
+      const callback = jest.fn((err) => {
+        expect(err).toBeFalsy();
+      });
+
+      files.openDownloadFolder("C:\\Downloads\\abc.txt", callback);
 
       const openDownloadFolderMessage = utils.findMessageByFunc('files.openDownloadFolder');
       expect(openDownloadFolderMessage).not.toBeNull();

--- a/test/private/files.spec.ts
+++ b/test/private/files.spec.ts
@@ -467,14 +467,19 @@ describe('files', () => {
 
   describe('openDownloadFolder', () => {
     it('should not allow calls before initialization', () => {
-      expect(() => files.openDownloadFolder()).toThrowError(
+      expect(() => files.openDownloadFolder(null, emptyCallback)).toThrowError(
         'The library has not yet been initialized',
       );
     });
 
+    it('should not allow calls with empty callback', () => {
+      utils.initializeWithContext('content');
+      expect(() => files.openDownloadFolder(null, null)).toThrowError();
+    });
+
     it('should not allow calls without frame context initialization', () => {
       utils.initializeWithContext('settings');
-      expect(() => files.openDownloadFolder()).toThrowError(
+      expect(() => files.openDownloadFolder(null, emptyCallback)).toThrowError(
         "This call is not allowed in the 'settings' context",
       );
     });
@@ -482,12 +487,18 @@ describe('files', () => {
     it('should send the message to parent correctly', () => {
       utils.initializeWithContext('content');
 
-      files.openDownloadFolder();
+      const callback = jest.fn((err) => {
+        expect(err).toBeFalsy();
+      });
+
+      files.openDownloadFolder(null, callback);
 
       const openDownloadFolderMessage = utils.findMessageByFunc('files.openDownloadFolder');
       expect(openDownloadFolderMessage).not.toBeNull();
-      expect(openDownloadFolderMessage.args).toEqual([]);
+      utils.respondToMessage(openDownloadFolderMessage, false);
+      expect(callback).toHaveBeenCalled();
     });
+
   });
 
 });


### PR DESCRIPTION
This PR contains improvements to openDownloadFolder API which is added in [this](https://github.com/OfficeDev/microsoft-teams-library-js/pull/858) PR. The improvements are :
1. Added file path open support 
2. Added callback to openDownloadFolder