### PR TITLE
add npmrc and enforce node and npm versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# will force display errors if there is a version mismatch
+#  with node or npm defined in the package.json
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "packages/*",
     "tools/**/*"
   ],
+  "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=8.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/OfficeDev/microsoft-teams-library-js/tree/2.0-preview"


### PR DESCRIPTION
Enforce a node version above 16, lts is 16.14.  When a user goes to run a yarn install in any of the directories, an error will be returned: 
![image](https://user-images.githubusercontent.com/9360417/158907656-b12751c1-27d1-44ca-a86b-7ae2a784fef9.png)


I would like input on whether I should add an upper constraint of 17.0, v16 goes into maintenance in october: 
![image](https://user-images.githubusercontent.com/9360417/158907476-0453b980-8987-448b-a152-f9e42784ec12.png)


