### PR TITLE
Adds office365 domains to whitelist

### DIFF
--- a/change/@microsoft-teams-js-1aa1bef9-f735-4ec8-8750-c52beaefc9cc.json
+++ b/change/@microsoft-teams-js-1aa1bef9-f735-4ec8-8750-c52beaefc9cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adds office365 Outlook to domain whitelist",
+  "packageName": "@microsoft/teams-js",
+  "email": "ruiconti@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/constants.ts
+++ b/packages/teams-js/src/internal/constants.ts
@@ -110,6 +110,8 @@ export const validOrigins = [
   '*.sharepointonline.com',
   'outlook.office.com',
   'outlook-sdf.office.com',
+  'outlook.office365.com',
+  'outlook-sdf.office365.com',
   '*.teams.microsoft.com',
   'www.office.com',
   'word.office.com',


### PR DESCRIPTION
Considering this is a very small change, I thought it wouldn't make sense to create an issue for it.

### Issue

Unable to load any multi-host app in OWA at office365 domain.

#### Repro steps

Navigate to any app using office365's domain, e.g. https://outlook.office365.com/host/f3a6e67f-850d-4dd9-960a-04c6638ded36/browse?actSwt=true

### Diagnostic

For every message an App receives from the Host (sender), i[t's performed a check as to whether it is sent by a verified sender](https://github.com/OfficeDev/microsoft-teams-library-js/blob/690a641386b2e37dc166837fdcdc52d2ef951462/src/internal/communication.ts#L122). Among other things, it [checks whether the sender's origin matches a list of valid origins](https://github.com/OfficeDev/microsoft-teams-library-js/blob/690a641386b2e37dc166837fdcdc52d2ef951462/src/internal/communication.ts#L153). This check is done using a [regex](https://github.com/OfficeDev/microsoft-teams-library-js/blob/690a641386b2e37dc166837fdcdc52d2ef951462/src/internal/constants.ts#L92) and this [list doesn't contemplate](https://github.com/OfficeDev/microsoft-teams-library-js/blob/690a641386b2e37dc166837fdcdc52d2ef951462/src/internal/constants.ts#L64) `outlook.office365.com` neither `outlook-sdf.office365.com`.

### Solution

It was confirmed that after adding those to entries, apps were able to establish communication and successfully load.