### PR TITLE
Enabling Share App Content to Stage in Meeting Stage

### DIFF
--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -267,7 +267,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[share app content to stage] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel);
+    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
     sendMessageToParent('meeting.shareAppContentToStage', [appContentUrl], callback);
   }
 

--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -287,7 +287,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[get app content stage sharing capabilities] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel);
+    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
     sendMessageToParent('meeting.getAppContentStageSharingCapabilities', callback);
   }
 
@@ -305,7 +305,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[stop sharing app content to stage] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel);
+    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
     sendMessageToParent('meeting.stopSharingAppContentToStage', callback);
   }
 
@@ -322,7 +322,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[get app content stage sharing state] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel);
+    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
     sendMessageToParent('meeting.getAppContentStageSharingState', callback);
   }
 }

--- a/test/public/meeting.spec.ts
+++ b/test/public/meeting.spec.ts
@@ -735,6 +735,40 @@ describe('meeting', () => {
         expect(returnedSdkError).toBeNull();
         expect(returnedResult).toStrictEqual(appContentStageSharingCapabilities);
       });
+      it('should successfully get info in meeting stage', () => {
+        desktopPlatformMock.initializeWithContext(FrameContexts.meetingStage);
+
+        let callbackCalled = false;
+        let returnedSdkError: SdkError | null;
+        let returnedResult: meeting.IAppContentStageSharingCapabilities | null;
+        meeting.getAppContentStageSharingCapabilities(
+          (error: SdkError, appContentStageSharingCapabilities: meeting.IAppContentStageSharingCapabilities) => {
+            callbackCalled = true;
+            returnedSdkError = error;
+            returnedResult = appContentStageSharingCapabilities;
+          },
+        );
+
+        const appContentStageSharingCapabilities = {
+          doesAppHaveSharePermission: true,
+        };
+
+        const appContentStageSharingCapabilitiesMessage = desktopPlatformMock.findMessageByFunc(
+          'meeting.getAppContentStageSharingCapabilities',
+        );
+        expect(appContentStageSharingCapabilitiesMessage).not.toBeNull();
+        let callbackId = appContentStageSharingCapabilitiesMessage.id;
+        desktopPlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [null, appContentStageSharingCapabilities],
+          },
+        } as DOMMessageEvent);
+
+        expect(callbackCalled).toBe(true);
+        expect(returnedSdkError).toBeNull();
+        expect(returnedResult).toStrictEqual(appContentStageSharingCapabilities);
+      });
     });
 
     describe('stopSharingAppContentToStage', () => {
@@ -754,6 +788,34 @@ describe('meeting', () => {
 
       it('should successfully terminate app content stage sharing session', () => {
         desktopPlatformMock.initializeWithContext(FrameContexts.sidePanel);
+
+        let callbackCalled = false;
+        let returnedSdkError: SdkError | null;
+        let returnedResult: boolean | null;
+        meeting.stopSharingAppContentToStage((error: SdkError, result: boolean) => {
+          callbackCalled = true;
+          returnedResult = result;
+          returnedSdkError = error;
+        });
+
+        let stopSharingAppContentToStageMessage = desktopPlatformMock.findMessageByFunc(
+          'meeting.stopSharingAppContentToStage',
+        );
+        expect(stopSharingAppContentToStageMessage).not.toBeNull();
+        let callbackId = stopSharingAppContentToStageMessage.id;
+        desktopPlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [null, true],
+          },
+        } as DOMMessageEvent);
+        expect(callbackCalled).toBe(true);
+        expect(returnedSdkError).toBeNull();
+        expect(returnedResult).toBe(true);
+      });
+
+      it('should successfully terminate app content stage sharing session in meeting stage', () => {
+        desktopPlatformMock.initializeWithContext(FrameContexts.meetingStage);
 
         let callbackCalled = false;
         let returnedSdkError: SdkError | null;
@@ -827,6 +889,40 @@ describe('meeting', () => {
 
       it('should successfully get current stage sharing state information', () => {
         desktopPlatformMock.initializeWithContext(FrameContexts.sidePanel);
+
+        let callbackCalled = false;
+        let returnedSdkError: SdkError | null;
+        let returnedResult: meeting.IAppContentStageSharingState | null;
+        meeting.getAppContentStageSharingState(
+          (error: SdkError, appContentStageSharingState: meeting.IAppContentStageSharingState) => {
+            callbackCalled = true;
+            returnedSdkError = error;
+            returnedResult = appContentStageSharingState;
+          },
+        );
+
+        const appContentStageSharingState = {
+          isAppSharing: true,
+        };
+
+        const appContentStageSharingStateMessage = desktopPlatformMock.findMessageByFunc(
+          'meeting.getAppContentStageSharingState',
+        );
+        expect(appContentStageSharingStateMessage).not.toBeNull();
+        let callbackId = appContentStageSharingStateMessage.id;
+        desktopPlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [null, appContentStageSharingState],
+          },
+        } as DOMMessageEvent);
+
+        expect(callbackCalled).toBe(true);
+        expect(returnedSdkError).toBeNull();
+        expect(returnedResult).toStrictEqual(appContentStageSharingState);
+      });
+      it('should successfully get current stage sharing state information in meeting stage', () => {
+        desktopPlatformMock.initializeWithContext(FrameContexts.meetingStage);
 
         let callbackCalled = false;
         let returnedSdkError: SdkError | null;

--- a/test/public/meeting.spec.ts
+++ b/test/public/meeting.spec.ts
@@ -595,6 +595,34 @@ describe('meeting', () => {
         expect(shareAppContentToStageMessage.args).toContain(requestUrl);
       });
 
+      it('should successfully share app content to stage', () => {
+        desktopPlatformMock.initializeWithContext('meetingStage');
+
+        let callbackCalled = false;
+        let returnedSdkError: SdkError | null;
+        let returnedResult: boolean | null;
+        let requestUrl = 'validUrl';
+        meeting.shareAppContentToStage((error: SdkError, result: boolean) => {
+          callbackCalled = true;
+          returnedResult = result;
+          returnedSdkError = error;
+        }, requestUrl);
+
+        let shareAppContentToStageMessage = desktopPlatformMock.findMessageByFunc('meeting.shareAppContentToStage');
+        expect(shareAppContentToStageMessage).not.toBeNull();
+        let callbackId = shareAppContentToStageMessage.id;
+        desktopPlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [null, true],
+          },
+        } as DOMMessageEvent);
+        expect(callbackCalled).toBe(true);
+        expect(returnedSdkError).toBeNull();
+        expect(returnedResult).toBe(true);
+        expect(shareAppContentToStageMessage.args).toContain(requestUrl);
+      });
+
       it('should return error code 500', () => {
         desktopPlatformMock.initializeWithContext('sidePanel');
 


### PR DESCRIPTION
Enabling below API's in meeting stage.
1. shareAppContentToStage
2. getAppContentStageSharingCapabilities
3. stopSharingAppContentToStage
4. getAppContentStageSharingState

There are apps who want to switch from one url to another and stage will be replaced with new url.
One of the sharing api provides capabilities and app want to know on stage "Am I the current presenter?" This helps app to change the UI based on presenter and attendee.
Co-watch wants this capability.