### PR TITLE
Modified openDownloadFolder API input parameter

### DIFF
--- a/src/private/files.ts
+++ b/src/private/files.ts
@@ -487,17 +487,17 @@ export namespace files {
    * @private
    * Hide from docs
    *
-   * Open download preference folder or folder containing filePath if its value is non-null
-   * @param filePath: Path of the file whose containing folder should be opened
+   * Open download preference folder if fileObjectId value is undefined else open folder containing the file with id fileObjectId
+   * @param fileObjectId: Id of the file whose containing folder should be opened
    * @param callback Callback that will be triggered post open download folder/path
    */
-  export function openDownloadFolder(filePath: string = null, callback: (error?: SdkError) => void): void {
+  export function openDownloadFolder(fileObjectId: string = undefined, callback: (error?: SdkError) => void): void {
     ensureInitialized(FrameContexts.content);
 
     if (!callback) {
       throw new Error('[files.openDownloadFolder] Callback cannot be null');
     }
 
-    sendMessageToParent('files.openDownloadFolder', [filePath], callback);
+    sendMessageToParent('files.openDownloadFolder', [fileObjectId], callback);
   }
 }

--- a/test/private/files.spec.ts
+++ b/test/private/files.spec.ts
@@ -508,7 +508,7 @@ describe('files', () => {
         expect(err).toBeFalsy();
       });
 
-      files.openDownloadFolder("C:\\Downloads\\abc.txt", callback);
+      files.openDownloadFolder("fileObjectId", callback);
 
       const openDownloadFolderMessage = utils.findMessageByFunc('files.openDownloadFolder');
       expect(openDownloadFolderMessage).not.toBeNull();


### PR DESCRIPTION
Modified openDownloadFolder API to accept fileObjectId instead of filePath to address security concerns and spamming via  API calls.

These changes are linked to feature related to following two PRs:
[Added file download API : To be used in Files app 2.0](https://github.com/OfficeDev/microsoft-teams-library-js/pull/858) 
[Improvements to openDownloadFolder API](https://github.com/OfficeDev/microsoft-teams-library-js/pull/999)