### PR TITLE
Prepare to release version 1.12.0-beta.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Reference the SDK inside of your `.html` page using:
 <script src="https://statics.teams.cdn.office.net/sdk/v1.11.0/js/MicrosoftTeams.min.js" integrity="sha384-SCVF3m7OvDKnfAilUzYn2yozEvBeP8n/Oq0yTH8VUI70J4AzrqR70jzjdQ6DI8s2" crossorigin="anonymous"></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@1.11.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@1.12.0-beta.4/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "1.11.0",
+  "version": "1.12.0-beta.4",
   "description": "Microsoft Client SDK for building app for Microsoft teams",
   "main": "./dist/MicrosoftTeams.min.js",
   "typings": "./dist/MicrosoftTeams.d.ts",

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -1,6 +1,6 @@
 import { generateRegExpFromUrls } from './utils';
 
-export const version = '1.11.0';
+export const version = '1.12.0-beta.4';
 /**
  * The client version when all SDK APIs started to check platform compatibility for the APIs was 1.6.0.
  * Modified to 2.0.1 which is hightest till now so that if any client doesn't pass version in initialize function, it will be set to highest.


### PR DESCRIPTION
This Beta Release PR is mainly necessitated by following two Download API addition to SDK:
1. getFileDownloads
2. openDownloadFolder

The link to the PR for the above APIs:
1. https://github.com/OfficeDev/microsoft-teams-library-js/pull/858
2. https://github.com/OfficeDev/microsoft-teams-library-js/pull/999
3. https://github.com/OfficeDev/microsoft-teams-library-js/pull/1010