### PR TITLE
Git magic march 22 2022

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/FilesAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/FilesAPIs.tsx
@@ -192,7 +192,8 @@ const OpenDownloadFolder = (): ReactElement =>
     name: 'openDownloadFolder',
     title: 'Open Download Folder',
     onClick: async () => {
-      files.openDownloadFolder();
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      files.openDownloadFolder('fileObjectId', () => {});
       return 'Opened download folder';
     },
   });

--- a/change/@microsoft-teams-js-cb547610-dd2b-4c88-881f-382c0d0b3490.json
+++ b/change/@microsoft-teams-js-cb547610-dd2b-4c88-881f-382c0d0b3490.json
@@ -1,0 +1,10 @@
+{
+  "type": "none",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "@microsoft/teams-js",
+  "email": "aeun@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/private/files.ts
+++ b/packages/teams-js/src/private/files.ts
@@ -549,12 +549,18 @@ export namespace files {
   /**
    * @hidden
    * Hide from docs
-   * ------
-   * Open download preference folder
+   *
+   * Open download preference folder if fileObjectId value is undefined else open folder containing the file with id fileObjectId
+   * @param fileObjectId Id of the file whose containing folder should be opened
+   * @param callback Callback that will be triggered post open download folder/path
    */
-  export function openDownloadFolder(): void {
+  export function openDownloadFolder(fileObjectId: string = undefined, callback: (error?: SdkError) => void): void {
     ensureInitialized(FrameContexts.content);
 
-    sendMessageToParent('files.openDownloadFolder', []);
+    if (!callback) {
+      throw new Error('[files.openDownloadFolder] Callback cannot be null');
+    }
+
+    sendMessageToParent('files.openDownloadFolder', [fileObjectId], callback);
   }
 }

--- a/packages/teams-js/test/private/files.spec.ts
+++ b/packages/teams-js/test/private/files.spec.ts
@@ -549,24 +549,53 @@ describe('files', () => {
 
   describe('openDownloadFolder', () => {
     it('should not allow calls before initialization', () => {
-      expect(() => files.openDownloadFolder()).toThrowError('The library has not yet been initialized');
+      expect(() => files.openDownloadFolder(null, emptyCallback)).toThrowError(
+        'The library has not yet been initialized',
+      );
+    });
+
+    it('should not allow calls with empty callback', () => {
+      utils.initializeWithContext('content');
+      expect(() => files.openDownloadFolder(null, null)).toThrowError();
     });
 
     it('should not allow calls without frame context initialization', async () => {
       await utils.initializeWithContext('settings');
-      expect(() => files.openDownloadFolder()).toThrowError(
+      expect(() => files.openDownloadFolder(null, emptyCallback)).toThrowError(
         'This call is only allowed in following contexts: ["content"]. Current context: "settings"',
       );
     });
 
-    it('should send the message to parent correctly', async () => {
-      await utils.initializeWithContext('content');
+    // null file path value is interpreted as opening cofigured download preference folder
+    it('should send the message to parent correctly with file path as null', () => {
+      utils.initializeWithContext('content');
 
-      files.openDownloadFolder();
+      const callback = jest.fn(err => {
+        expect(err).toBeFalsy();
+      });
+
+      files.openDownloadFolder(null, callback);
 
       const openDownloadFolderMessage = utils.findMessageByFunc('files.openDownloadFolder');
       expect(openDownloadFolderMessage).not.toBeNull();
-      expect(openDownloadFolderMessage.args).toEqual([]);
+      utils.respondToMessage(openDownloadFolderMessage, false);
+      expect(callback).toHaveBeenCalled();
+    });
+
+    // non-null file path value is interpreted as opening containing folder for the given file path
+    it('should send the message to parent correctly with non-null file path', () => {
+      utils.initializeWithContext('content');
+
+      const callback = jest.fn(err => {
+        expect(err).toBeFalsy();
+      });
+
+      files.openDownloadFolder('fileObjectId', callback);
+
+      const openDownloadFolderMessage = utils.findMessageByFunc('files.openDownloadFolder');
+      expect(openDownloadFolderMessage).not.toBeNull();
+      utils.respondToMessage(openDownloadFolderMessage, false);
+      expect(callback).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Changes from master being merge into 2.0-preview can be found [here](https://github.com/OfficeDev/microsoft-teams-library-js/compare/cdefbda01168484014464ab42450b9fc9c85fa12...ee7e04cbf18098d7ada2cac12329be387cb92a6a).

Includes changes to files.openDownload(). Changes to contributing.md were ignored as per offline discussion- those changes were master-specific.

Changefile says "none" for changes to package because openDownload() was created after 2.0-preview's latest release, and this change won't break any beta packages.