### PR TITLE
Disable the post bundle analysis task

### DIFF
--- a/tools/yaml-templates/build-test-publish.yml
+++ b/tools/yaml-templates/build-test-publish.yml
@@ -80,6 +80,7 @@ steps:
       id: '$(System.PullRequest.PullRequestNumber)'
       comment: '$(bundleAnalysisTask.bundleAnalysisComment)'
     displayName: 'Post bundle analysis result as PR comment on GitHub'
+    enabled: false
 
   - task: PublishBuildArtifacts@1
     condition: and(


### PR DESCRIPTION
Disable the command that posts the bundle analysis report because it's failing due to an external issue. Prefer that we stop seeing a failure to post, which we might get used to. 

When that issue is resolved, I will re-enable the task.