### PR TITLE
Adding call types to meeting details

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -335,7 +335,7 @@ export interface Context {
 
   /**
    * The type of the host client. Possible values are : android, ios, web, desktop, rigel(deprecated, use teamsRoomsWindows instead),
-   * teamsRoomsWindows, teamsRoomsAndroid, teamsPhones, teamsDisplays
+   * surfaceHub, teamsRoomsWindows, teamsRoomsAndroid, teamsPhones, teamsDisplays
    */
   hostClientType?: HostClientType;
 

--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -267,7 +267,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[share app content to stage] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel);
+    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
     sendMessageToParent('meeting.shareAppContentToStage', [appContentUrl], callback);
   }
 
@@ -287,7 +287,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[get app content stage sharing capabilities] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel);
+    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
     sendMessageToParent('meeting.getAppContentStageSharingCapabilities', callback);
   }
 
@@ -305,7 +305,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[stop sharing app content to stage] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel);
+    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
     sendMessageToParent('meeting.stopSharingAppContentToStage', callback);
   }
 
@@ -322,7 +322,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[get app content stage sharing state] Callback cannot be null');
     }
-    ensureInitialized(FrameContexts.sidePanel);
+    ensureInitialized(FrameContexts.sidePanel, FrameContexts.meetingStage);
     sendMessageToParent('meeting.getAppContentStageSharingState', callback);
   }
 }

--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -10,7 +10,7 @@ export namespace meeting {
    * Hide from docs
    * Data structure to represent a meeting details
    */
-  export interface IMeetingDetails {
+  export interface IMeetingDetailsResponse {
     /**
      * details object
      */
@@ -186,12 +186,12 @@ export namespace meeting {
    * @private
    * Hide from docs
    * Allows an app to get the meeting details for the meeting
-   * @param callback Callback contains 2 parameters, error and meetingDetails.
+   * @param callback Callback contains 2 parameters, error and meetingDetailsResponse.
    * error can either contain an error of type SdkError, incase of an error, or null when get is successful
-   * result can either contain a IMeetingDetails value, incase of a successful get or null when the get fails
+   * result can either contain a IMeetingDetailsResponse value, incase of a successful get or null when the get fails
    */
   export function getMeetingDetails(
-    callback: (error: SdkError | null, meetingDetails: IMeetingDetails | null) => void,
+    callback: (error: SdkError | null, meetingDetails: IMeetingDetailsResponse | null) => void,
   ): void {
     if (!callback) {
       throw new Error('[get meeting details] Callback cannot be null');

--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -8,13 +8,13 @@ export namespace meeting {
   /**
    * @private
    * Hide from docs
-   * Data structure to represent a meeting details.
+   * Data structure to represent a meeting details
    */
   export interface IMeetingDetails {
     /**
      * details object
      */
-    details: IDetails;
+    details: IMeetingDetails | ICallDetails;
     /**
      * conversation object
      */
@@ -24,32 +24,50 @@ export namespace meeting {
      */
     organizer: IOrganizer;
   }
+
   /**
    * @private
    * Hide from docs
-   * Data structure to represent details.
+   * Base data structure to represent a meeting or call detail
    */
-  export interface IDetails {
+  export interface IMeetingOrCallDetailsBase<T> {
     /**
-     * Scheduled start time of the meeting
+     * Scheduled start time of the meeting or start time of the call
      */
     scheduledStartTime: string;
+
+    /**
+     * url to join the current meeting or call
+     */
+    joinUrl?: string;
+
+    /**
+     * type of the meeting or call
+     */
+    type?: T;
+  }
+
+  /**
+   * @private
+   * Hide from docs
+   * Data structure to represent call details
+   */
+  export type ICallDetails = IMeetingOrCallDetailsBase<CallType>;
+
+  /**
+   * @private
+   * Hide from docs
+   * Data structure to represent meeting details.
+   */
+  export interface IMeetingDetails extends IMeetingOrCallDetailsBase<MeetingType> {
     /**
      * Scheduled end time of the meeting
      */
     scheduledEndTime: string;
     /**
-     * url to join the current meeting
-     */
-    joinUrl?: string;
-    /**
      * meeting title name of the meeting
      */
     title?: string;
-    /**
-     * type of the meeting
-     */
-    type?: MeetingType | MeetingDetailsCallType;
   }
 
   /**
@@ -120,7 +138,7 @@ export namespace meeting {
     MeetNow = 'MeetNow',
   }
 
-  export enum MeetingDetailsCallType {
+  export enum CallType {
     OneOnOneCall = 'oneOnOneCall',
     GroupCall = 'groupCall',
   }

--- a/src/public/meeting.ts
+++ b/src/public/meeting.ts
@@ -49,7 +49,7 @@ export namespace meeting {
     /**
      * type of the meeting
      */
-    type?: MeetingType;
+    type?: MeetingType | MeetingDetailsCallType;
   }
 
   /**
@@ -118,6 +118,11 @@ export namespace meeting {
     Recurring = 'Recurring',
     Broadcast = 'Broadcast',
     MeetNow = 'MeetNow',
+  }
+
+  export enum MeetingDetailsCallType {
+    OneOnOneCall = 'oneOnOneCall',
+    GroupCall = 'groupCall',
   }
 
   /**

--- a/test/public/meeting.spec.ts
+++ b/test/public/meeting.spec.ts
@@ -173,8 +173,8 @@ describe('meeting', () => {
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
-      let returnedMeetingResult: meeting.IMeetingDetails | null;
-      meeting.getMeetingDetails((error: SdkError, meetingDetails: meeting.IMeetingDetails) => {
+      let returnedMeetingResult: meeting.IMeetingDetailsResponse | null;
+      meeting.getMeetingDetails((error: SdkError, meetingDetails: meeting.IMeetingDetailsResponse) => {
         callbackCalled = true;
         returnedMeetingResult = meetingDetails;
         returnedSdkError = error;
@@ -183,7 +183,7 @@ describe('meeting', () => {
       let getMeetingDetailsMessage = desktopPlatformMock.findMessageByFunc('meeting.getMeetingDetails');
       expect(getMeetingDetailsMessage).not.toBeNull();
       let callbackId = getMeetingDetailsMessage.id;
-      const details: meeting.IDetails = {
+      const details: meeting.IMeetingDetails = {
         scheduledStartTime: '2020-12-21T21:30:00+00:00',
         scheduledEndTime: '2020-12-21T22:00:00+00:00',
         joinUrl:
@@ -198,7 +198,7 @@ describe('meeting', () => {
       const conversation: meeting.IConversation = {
         id: `convId`,
       };
-      const meetingDetails: meeting.IMeetingDetails = {
+      const meetingDetails: meeting.IMeetingDetailsResponse = {
         details,
         conversation,
         organizer,
@@ -219,8 +219,8 @@ describe('meeting', () => {
 
       let callbackCalled = false;
       let returnedSdkError: SdkError | null;
-      let returnedMeetingDetails: meeting.IMeetingDetails | null;
-      meeting.getMeetingDetails((error: SdkError, meetingDetails: meeting.IMeetingDetails) => {
+      let returnedMeetingDetails: meeting.IMeetingDetailsResponse | null;
+      meeting.getMeetingDetails((error: SdkError, meetingDetails: meeting.IMeetingDetailsResponse) => {
         callbackCalled = true;
         returnedMeetingDetails = meetingDetails;
         returnedSdkError = error;

--- a/test/public/meeting.spec.ts
+++ b/test/public/meeting.spec.ts
@@ -595,6 +595,34 @@ describe('meeting', () => {
         expect(shareAppContentToStageMessage.args).toContain(requestUrl);
       });
 
+      it('should successfully share app content to stage', () => {
+        desktopPlatformMock.initializeWithContext('meetingStage');
+
+        let callbackCalled = false;
+        let returnedSdkError: SdkError | null;
+        let returnedResult: boolean | null;
+        let requestUrl = 'validUrl';
+        meeting.shareAppContentToStage((error: SdkError, result: boolean) => {
+          callbackCalled = true;
+          returnedResult = result;
+          returnedSdkError = error;
+        }, requestUrl);
+
+        let shareAppContentToStageMessage = desktopPlatformMock.findMessageByFunc('meeting.shareAppContentToStage');
+        expect(shareAppContentToStageMessage).not.toBeNull();
+        let callbackId = shareAppContentToStageMessage.id;
+        desktopPlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [null, true],
+          },
+        } as DOMMessageEvent);
+        expect(callbackCalled).toBe(true);
+        expect(returnedSdkError).toBeNull();
+        expect(returnedResult).toBe(true);
+        expect(shareAppContentToStageMessage.args).toContain(requestUrl);
+      });
+
       it('should return error code 500', () => {
         desktopPlatformMock.initializeWithContext('sidePanel');
 
@@ -707,6 +735,40 @@ describe('meeting', () => {
         expect(returnedSdkError).toBeNull();
         expect(returnedResult).toStrictEqual(appContentStageSharingCapabilities);
       });
+      it('should successfully get info in meeting stage', () => {
+        desktopPlatformMock.initializeWithContext(FrameContexts.meetingStage);
+
+        let callbackCalled = false;
+        let returnedSdkError: SdkError | null;
+        let returnedResult: meeting.IAppContentStageSharingCapabilities | null;
+        meeting.getAppContentStageSharingCapabilities(
+          (error: SdkError, appContentStageSharingCapabilities: meeting.IAppContentStageSharingCapabilities) => {
+            callbackCalled = true;
+            returnedSdkError = error;
+            returnedResult = appContentStageSharingCapabilities;
+          },
+        );
+
+        const appContentStageSharingCapabilities = {
+          doesAppHaveSharePermission: true,
+        };
+
+        const appContentStageSharingCapabilitiesMessage = desktopPlatformMock.findMessageByFunc(
+          'meeting.getAppContentStageSharingCapabilities',
+        );
+        expect(appContentStageSharingCapabilitiesMessage).not.toBeNull();
+        let callbackId = appContentStageSharingCapabilitiesMessage.id;
+        desktopPlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [null, appContentStageSharingCapabilities],
+          },
+        } as DOMMessageEvent);
+
+        expect(callbackCalled).toBe(true);
+        expect(returnedSdkError).toBeNull();
+        expect(returnedResult).toStrictEqual(appContentStageSharingCapabilities);
+      });
     });
 
     describe('stopSharingAppContentToStage', () => {
@@ -726,6 +788,34 @@ describe('meeting', () => {
 
       it('should successfully terminate app content stage sharing session', () => {
         desktopPlatformMock.initializeWithContext(FrameContexts.sidePanel);
+
+        let callbackCalled = false;
+        let returnedSdkError: SdkError | null;
+        let returnedResult: boolean | null;
+        meeting.stopSharingAppContentToStage((error: SdkError, result: boolean) => {
+          callbackCalled = true;
+          returnedResult = result;
+          returnedSdkError = error;
+        });
+
+        let stopSharingAppContentToStageMessage = desktopPlatformMock.findMessageByFunc(
+          'meeting.stopSharingAppContentToStage',
+        );
+        expect(stopSharingAppContentToStageMessage).not.toBeNull();
+        let callbackId = stopSharingAppContentToStageMessage.id;
+        desktopPlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [null, true],
+          },
+        } as DOMMessageEvent);
+        expect(callbackCalled).toBe(true);
+        expect(returnedSdkError).toBeNull();
+        expect(returnedResult).toBe(true);
+      });
+
+      it('should successfully terminate app content stage sharing session in meeting stage', () => {
+        desktopPlatformMock.initializeWithContext(FrameContexts.meetingStage);
 
         let callbackCalled = false;
         let returnedSdkError: SdkError | null;
@@ -799,6 +889,40 @@ describe('meeting', () => {
 
       it('should successfully get current stage sharing state information', () => {
         desktopPlatformMock.initializeWithContext(FrameContexts.sidePanel);
+
+        let callbackCalled = false;
+        let returnedSdkError: SdkError | null;
+        let returnedResult: meeting.IAppContentStageSharingState | null;
+        meeting.getAppContentStageSharingState(
+          (error: SdkError, appContentStageSharingState: meeting.IAppContentStageSharingState) => {
+            callbackCalled = true;
+            returnedSdkError = error;
+            returnedResult = appContentStageSharingState;
+          },
+        );
+
+        const appContentStageSharingState = {
+          isAppSharing: true,
+        };
+
+        const appContentStageSharingStateMessage = desktopPlatformMock.findMessageByFunc(
+          'meeting.getAppContentStageSharingState',
+        );
+        expect(appContentStageSharingStateMessage).not.toBeNull();
+        let callbackId = appContentStageSharingStateMessage.id;
+        desktopPlatformMock.respondToMessage({
+          data: {
+            id: callbackId,
+            args: [null, appContentStageSharingState],
+          },
+        } as DOMMessageEvent);
+
+        expect(callbackCalled).toBe(true);
+        expect(returnedSdkError).toBeNull();
+        expect(returnedResult).toStrictEqual(appContentStageSharingState);
+      });
+      it('should successfully get current stage sharing state information in meeting stage', () => {
+        desktopPlatformMock.initializeWithContext(FrameContexts.meetingStage);
 
         let callbackCalled = false;
         let returnedSdkError: SdkError | null;


### PR DESCRIPTION
This PR adds an additional type of MeetingDetailsCallType to support calls in meetings. This keeps the original MeetingType of getMeetingDetails, while adding the types of oneOnOneCall and groupCall to possible types returned by the getMeetingDetails API. 