### PR TITLE
Changes to the location capability in prep for device permissions work

### DIFF
--- a/apps/teams-test-app/src/components/LocationAPIs.tsx
+++ b/apps/teams-test-app/src/components/LocationAPIs.tsx
@@ -1,6 +1,7 @@
 import { location, SdkError } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
+// update these
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
 const CheckLocationCapability = (): React.ReactElement =>

--- a/packages/teams-js/src/public/barcode.ts
+++ b/packages/teams-js/src/public/barcode.ts
@@ -24,7 +24,7 @@ export namespace barcode {
       }
 
       // Decided not to use the old message format here and totally break from media.ts
-      resolve(sendAndHandleSdkError('barcode.scanBarCode', barcodeConfig));
+      resolve(sendAndHandleSdkError('barcode.scan', barcodeConfig));
     });
   }
 

--- a/packages/teams-js/src/public/barcode.ts
+++ b/packages/teams-js/src/public/barcode.ts
@@ -2,7 +2,7 @@ import { sendAndHandleSdkError } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { validateScanBarCodeInput } from '../internal/mediaUtil';
 import { FrameContexts } from './constants';
-import { ErrorCode } from './interfaces';
+import { DevicePermission, DevicePermissionType, ErrorCode } from './interfaces';
 import { runtime } from './runtime';
 
 export namespace barcode {
@@ -23,15 +23,16 @@ export namespace barcode {
         throw { errorCode: ErrorCode.INVALID_ARGUMENTS };
       }
 
-      // could also not use the old message format here and totally break from media.ts, open to opinions
-      // actually thinking it might be good to totally break from media. Leaving in now to provoke discussion
-      resolve(sendAndHandleSdkError('media.scanBarCode', barcodeConfig));
+      // Decided not to use the old message format here and totally break from media.ts
+      resolve(sendAndHandleSdkError('barcode.scanBarCode', barcodeConfig));
     });
   }
 
   export function hasPermission(): Promise<boolean> {
+    const permissions: DevicePermission[] = [{ type: DevicePermissionType.Media }];
+
     return new Promise<boolean>(resolve => {
-      resolve(sendAndHandleSdkError('barcode.hasPermission'));
+      resolve(sendAndHandleSdkError('permission.has', permissions));
     });
   }
 
@@ -40,8 +41,10 @@ export namespace barcode {
   // would have the new allow parameters, but only the AppPermissions dialog should trigger the
   // "ask the user to refresh" flow
   export function requestPermission(): Promise<boolean> {
+    const permissions: DevicePermission[] = [{ type: DevicePermissionType.Media }];
+
     return new Promise<boolean>(resolve => {
-      resolve(sendAndHandleSdkError('barcode.requestPermission'));
+      resolve(sendAndHandleSdkError('permission.request', permissions));
     });
   }
 

--- a/packages/teams-js/src/public/barcode.ts
+++ b/packages/teams-js/src/public/barcode.ts
@@ -1,0 +1,51 @@
+import { sendAndHandleSdkError } from '../internal/communication';
+import { ensureInitialized } from '../internal/internalAPIs';
+import { validateScanBarCodeInput } from '../internal/mediaUtil';
+import { FrameContexts } from './constants';
+import { ErrorCode } from './interfaces';
+import { runtime } from './runtime';
+
+export namespace barcode {
+  export interface BarCodeConfig {
+    /**
+     * Optional; Lets the developer specify the scan timeout interval in seconds
+     * Default value is 30 seconds and max allowed value is 60 seconds
+     * these defaults came from media, can be changed /removed if we want to push this up to the hosts
+     */
+    timeOutIntervalInSec?: number;
+  }
+
+  export function scanBarCode(barcodeConfig: BarCodeConfig): Promise<string> {
+    return new Promise<string>(resolve => {
+      ensureInitialized(FrameContexts.content, FrameContexts.task);
+
+      if (!validateScanBarCodeInput(barcodeConfig)) {
+        throw { errorCode: ErrorCode.INVALID_ARGUMENTS };
+      }
+
+      // could also not use the old message format here and totally break from media.ts, open to opinions
+      // actually thinking it might be good to totally break from media. Leaving in now to provoke discussion
+      resolve(sendAndHandleSdkError('media.scanBarCode', barcodeConfig));
+    });
+  }
+
+  export function hasPermission(): Promise<boolean> {
+    return new Promise<boolean>(resolve => {
+      resolve(sendAndHandleSdkError('barcode.hasPermission'));
+    });
+  }
+
+  // This should not trigger the "refresh the app scenario" because this is for setting things up
+  // for use through teamsjs-sdk 2.0. If the user DOES refresh the app after calling this the iframe
+  // would have the new allow parameters, but only the AppPermissions dialog should trigger the
+  // "ask the user to refresh" flow
+  export function requestPermission(): Promise<boolean> {
+    return new Promise<boolean>(resolve => {
+      resolve(sendAndHandleSdkError('barcode.requestPermission'));
+    });
+  }
+
+  export function isSupported(): boolean {
+    return runtime.supports.barcode ? true : false;
+  }
+}

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -746,3 +746,14 @@ export enum ErrorCode {
    */
   SIZE_EXCEEDED = 10000,
 }
+
+/** @hidden */
+export enum DevicePermissionType {
+  GeoLocation = 'geolocation',
+  Media = 'media',
+}
+
+/** @hidden */
+export interface DevicePermission {
+  type: DevicePermissionType;
+}

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -48,25 +48,71 @@ export namespace location {
   }
 
   /**
-   * Fetches current user coordinates or allows user to choose location on map
-   *
-   * @param props {@link LocationProps} - Specifying how the location request is handled
-   * @returns Promise that will be fulfilled when the operation has completed
+   * Fetches current user coordinates
+   * @returns User's current location
    */
-  export function getLocation(props: LocationProps): Promise<Location>;
+  export function getCurrentLocation(): Promise<Location> {
+    ensureInitialized(FrameContexts.content, FrameContexts.task);
+    return sendAndHandleError('location.getLocation', { allowChooseLocation: false, showMap: false });
+  }
+
+  export function hasPermission(): Promise<boolean> {
+    return new Promise<boolean>(resolve => {
+      resolve(sendAndHandleError('location.hasPermission'));
+    });
+  }
+
+  // This should not trigger the "refresh the app scenario" because this is for setting things up
+  // for use through teamsjs-sdk 2.0. If the user DOES refresh the app after calling this the iframe
+  // would have the new allow parameters, but only the AppPermissions dialog should trigger the
+  // "ask the user to refresh" flow
+  export function requestPermission(): Promise<boolean> {
+    return new Promise<boolean>(resolve => {
+      resolve(sendAndHandleError('location.requestPermission'));
+    });
+  }
+
+  // Example of how developer would use permissions functions
+  // export async function permissionExample(): Promise<void> {
+  //   hasPermission().then(alreadyHadPermission => {
+  //     if (!alreadyHadPermission) {
+  //       requestPermission().then(permissionStatus => {
+  //         if (permissionStatus) {
+  //           alert('Use function that required permission');
+  //         } else {
+  //           alert('User was asked to grant permission and refused');
+  //         }
+  //       });
+  //     } else {
+  //       alert('User has previously granted permission, call function that required permission');
+  //     }
+  //   });
+  // }
+
+  export function isSupported(): boolean {
+    return runtime.supports.location ? true : false;
+  }
+
   /**
+   * IMPLEMENTATION NOTE: this should really just be "the unpromisified version of getLocation". I think this is basically correct
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link location.getLocation location.getLocation(props: LocationProps): Promise\<Location\>} instead.
+   * As of 2.0.0-beta.4, please use one of the following functions:
+   * - {@link location.getCurrentLocation location.getCurrentLocation(): Promise\<Location\>}
+   * - {@link location.map.chooseLocation location.map.chooseLocation(): Promise\<Location\>}
    * @param props {@link LocationProps} - Specifying how the location request is handled
    * @param callback - Callback to invoke when current user location is fetched
    */
-  export function getLocation(props: LocationProps, callback: (error: SdkError, location: Location) => void): void;
-  export function getLocation(
-    props: LocationProps,
-    callback?: (error: SdkError, location: Location) => void,
-  ): Promise<Location> {
+  export function getLocation(props: LocationProps, callback: (error: SdkError, location: Location) => void): void {
     ensureInitialized(FrameContexts.content, FrameContexts.task);
-    return callCallbackWithErrorOrResultFromPromiseAndReturnPromise<Location>(getLocationHelper, callback, props);
+
+    if (!isCurrentSDKVersionAtLeast(locationAPIsRequiredVersion)) {
+      throw { errorCode: ErrorCode.OLD_PLATFORM };
+    }
+    if (!props) {
+      throw { errorCode: ErrorCode.INVALID_ARGUMENTS };
+    }
+
+    callCallbackWithErrorOrResultFromPromiseAndReturnPromise<Location>(getLocationHelper, callback, props);
   }
 
   function getLocationHelper(props: LocationProps): Promise<Location> {
@@ -82,29 +128,19 @@ export namespace location {
   }
 
   /**
-   * Shows the location on map corresponding to the given coordinates
-   *
-   * @param location {@link Location} - which needs to be shown on map
-   * @returns Promise that will be fulfilled when the operation has completed
-   */
-  export function showLocation(location: Location): Promise<void>;
-  /**
+   * * IMPLEMENTATION NOTE: this should really just be "the unpromisified version of showLocation". I think this is basically correct
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link location.showLocation location.showLocation(location: Location): Promise\<void\>} instead.
+   * As of 2.0.0-beta.4, please use {@link location.map.showLocation location.map.showLocation(location: Location): Promise\<void\>} instead.
    * Shows the location on map corresponding to the given coordinates
    * @param location {@link Location} - which needs to be shown on map
    * @param callback - Callback to invoke when the location is opened on map
    */
-  export function showLocation(location: Location, callback: (error: SdkError, status: boolean) => void): void;
-  export function showLocation(
-    location: Location,
-    callback?: (error: SdkError, status: boolean) => void,
-  ): Promise<void> {
+  export function showLocation(location: Location, callback: (error: SdkError, status: boolean) => void): void {
     ensureInitialized(FrameContexts.content, FrameContexts.task);
-    return callCallbackWithErrorOrBooleanFromPromiseAndReturnPromise<void>(showLocationHelper, callback, location);
+    callCallbackWithErrorOrBooleanFromPromiseAndReturnPromise<void>(showLocationHelper, callback, location);
   }
 
-  export function showLocationHelper(location: Location): Promise<void> {
+  function showLocationHelper(location: Location): Promise<void> {
     return new Promise<void>(resolve => {
       if (!isCurrentSDKVersionAtLeast(locationAPIsRequiredVersion)) {
         throw { errorCode: ErrorCode.OLD_PLATFORM };
@@ -116,7 +152,31 @@ export namespace location {
     });
   }
 
-  export function isSupported(): boolean {
-    return runtime.supports.location ? true : false;
+  export namespace map {
+    /**
+     * Allows user to choose location on map
+     * @returns The location chosen by the user after closing the map
+     */
+    export function chooseLocation(): Promise<Location> {
+      ensureInitialized(FrameContexts.content, FrameContexts.task);
+      return sendAndHandleError('location.getLocation', { allowChooseLocation: true, showMap: true });
+    }
+
+    /**
+     * Shows the location on map corresponding to the given coordinates
+     * @param location {@link Location} - which needs to be shown on map
+     * @returns Promise that resolves when the location dialog has been closed TODO VERIFY
+     */
+    export function showLocation(location: Location): Promise<void> {
+      ensureInitialized(FrameContexts.content, FrameContexts.task);
+      if (!location) {
+        throw { errorCode: ErrorCode.INVALID_ARGUMENTS };
+      }
+      return sendAndHandleError('location.showLocation', location);
+    }
+
+    export function isSupported(): boolean {
+      return runtime.supports.location ? true : false;
+    }
   }
 }

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -6,7 +6,7 @@ import {
   callCallbackWithErrorOrResultFromPromiseAndReturnPromise,
 } from '../internal/utils';
 import { FrameContexts } from './constants';
-import { ErrorCode, SdkError } from './interfaces';
+import { DevicePermission, DevicePermissionType, ErrorCode, SdkError } from './interfaces';
 import { runtime } from './runtime';
 /**
  * @alpha
@@ -57,8 +57,10 @@ export namespace location {
   }
 
   export function hasPermission(): Promise<boolean> {
+    const permissions: DevicePermission[] = [{ type: DevicePermissionType.GeoLocation }];
+
     return new Promise<boolean>(resolve => {
-      resolve(sendAndHandleError('location.hasPermission'));
+      resolve(sendAndHandleError('permission.has', permissions));
     });
   }
 
@@ -67,8 +69,10 @@ export namespace location {
   // would have the new allow parameters, but only the AppPermissions dialog should trigger the
   // "ask the user to refresh" flow
   export function requestPermission(): Promise<boolean> {
+    const permissions: DevicePermission[] = [{ type: DevicePermissionType.GeoLocation }];
+
     return new Promise<boolean>(resolve => {
-      resolve(sendAndHandleError('location.requestPermission'));
+      resolve(sendAndHandleError('permission.request', permissions));
     });
   }
 
@@ -94,7 +98,8 @@ export namespace location {
   }
 
   /**
-   * IMPLEMENTATION NOTE: this should really just be "the unpromisified version of getLocation". I think this is basically correct
+   * IMPLEMENTATION NOTE: this should really just be "the unpromisified version of getLocation".
+   * There's no reason to go from callback to promise back to callback in the "real" implementation
    * @deprecated
    * As of 2.0.0-beta.4, please use one of the following functions:
    * - {@link location.getCurrentLocation location.getCurrentLocation(): Promise\<Location\>}
@@ -128,7 +133,8 @@ export namespace location {
   }
 
   /**
-   * * IMPLEMENTATION NOTE: this should really just be "the unpromisified version of showLocation". I think this is basically correct
+   * IMPLEMENTATION NOTE: this should really just be "the unpromisified version of getLocation".
+   * There's no reason to go from callback to promise back to callback in the "real" implementation
    * @deprecated
    * As of 2.0.0-beta.4, please use {@link location.map.showLocation location.map.showLocation(location: Location): Promise\<void\>} instead.
    * Shows the location on map corresponding to the given coordinates

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -17,7 +17,9 @@ export interface IRuntime {
       readonly update?: {};
     };
     readonly files?: {};
-    readonly location?: {};
+    readonly location?: {
+      readonly map?: {};
+    };
     readonly logs?: {};
     readonly mail?: {};
     readonly media?: {};
@@ -59,7 +61,9 @@ export let runtime: IRuntime = {
       bot: undefined,
       update: undefined,
     },
-    location: undefined,
+    location: {
+      map: undefined,
+    },
     logs: undefined,
     mail: undefined,
     media: undefined,
@@ -103,7 +107,9 @@ export const teamsRuntimeConfig: IRuntime = {
       update: {},
     },
     files: {},
-    location: {},
+    location: {
+      map: {},
+    },
     logs: {},
     media: {},
     meeting: {},

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -7,6 +7,7 @@ export interface IRuntime {
   readonly supports: {
     readonly appInstallDialog?: {};
     readonly appEntity?: {};
+    readonly barcode?: {};
     readonly calendar?: {};
     readonly call?: {};
     readonly chat?: {
@@ -52,6 +53,7 @@ export let runtime: IRuntime = {
   apiVersion: 1,
   supports: {
     appInstallDialog: undefined,
+    barcode: undefined,
     calendar: undefined,
     call: undefined,
     chat: {
@@ -98,6 +100,8 @@ export const teamsRuntimeConfig: IRuntime = {
   supports: {
     appInstallDialog: {},
     appEntity: {},
+    // I'm actually not sure what the right thing to put here, if we don't use the old format I think we would want this to say false in legacy teams
+    barcode: {},
     call: {},
     chat: {
       conversation: {},

--- a/packages/teams-js/test/public/location.spec.ts
+++ b/packages/teams-js/test/public/location.spec.ts
@@ -8,6 +8,7 @@ import { Utils } from '../utils';
 
 /**
  * Test cases for location APIs
+ * Need to update tests
  */
 describe('location', () => {
   const mobilePlatformMock = new FramelessPostMocks();


### PR DESCRIPTION
- The location capability now has hasPermission() and requestPermission() functions. The app developer doesn't have to specify *which* permissions they are requesting, the host grants the correct permissions for all functions in this capability
-location.getLocation and location.showLocation are now strictly deprecated back-compat functions
location.getCurrentLocation gets the user's current location *without* showing any UI such as maps. Hosts can choose to implement this without having any map based UI
- location.map now contains all functions that show UI to the user
- location.map.chooseLocation shows the user's current location on the map and allows the user to manipulate the map in order to change that location. When the promise resolves the map has been closed and the function returns the location the user chose
- location.map.showLocation shows the user's current location on the map but does not allow the user to change the location