### PR TITLE
Adding userSessionId as part of Context in getContextAPI

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -294,7 +294,7 @@ export interface Context {
   /**
    * Unique ID which is tied to the login/logout session of the user for the Host Teams Native App.
    */
-   userSessionId?: string;
+  userSessionId?: string;
 
   /**
    * The user's role in the team.

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -292,6 +292,11 @@ export interface Context {
   sessionId?: string;
 
   /**
+   * Unique ID which is tied to the login/logout session of the user for the Host Teams Native App.
+   */
+   userSessionId?: string;
+
+  /**
    * The user's role in the team.
    * Because a malicious party can run your content in a browser, this value should
    * be used only as a hint as to the user's role, and never as proof of her role.


### PR DESCRIPTION
- Adding a userSessionID as a part of the Context Object via getContext API
- This id would be unique per user & per platform application
- It would be scoped to the login/logout session of the teams native app user & would be cleared after the user logs out of the teams native app.  

- This is part of a requirement from one of the partner apps (Assignments) 

