### PR TITLE
Create utility function for constructing a chat deep link URL

### DIFF
--- a/change/@microsoft-teams-js-05fb4856-6573-46c7-bcf9-5398222e0a3b.json
+++ b/change/@microsoft-teams-js-05fb4856-6573-46c7-bcf9-5398222e0a3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add utility function for creating a chat deeplink; not used yet beyond validation.",
+  "packageName": "@microsoft/teams-js",
+  "email": "aaroner@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/internal/chatConstants.ts
+++ b/packages/teams-js/src/internal/chatConstants.ts
@@ -1,0 +1,4 @@
+export const deepLinkUrlPathForChat = '/l/chat/0/0';
+export const usersUrlParameterName = 'users';
+export const topicUrlParameterName = 'topic';
+export const messageUrlParameterName = 'message';

--- a/packages/teams-js/src/internal/chatConstants.ts
+++ b/packages/teams-js/src/internal/chatConstants.ts
@@ -1,4 +1,4 @@
-export const deepLinkUrlPathForChat = '/l/chat/0/0';
-export const usersUrlParameterName = 'users';
-export const topicUrlParameterName = 'topic';
-export const messageUrlParameterName = 'message';
+export const teamsDeepLinkUrlPathForChat = '/l/chat/0/0';
+export const teamsDeepLinkUsersUrlParameterName = 'users';
+export const teamsDeepLinkTopicUrlParameterName = 'topic';
+export const teamsDeepLinkMessageUrlParameterName = 'message';

--- a/packages/teams-js/src/internal/chatUtilities.ts
+++ b/packages/teams-js/src/internal/chatUtilities.ts
@@ -1,8 +1,8 @@
 import {
-  deepLinkUrlPathForChat,
-  messageUrlParameterName,
-  topicUrlParameterName,
-  usersUrlParameterName,
+  teamsDeepLinkMessageUrlParameterName,
+  teamsDeepLinkTopicUrlParameterName,
+  teamsDeepLinkUrlPathForChat,
+  teamsDeepLinkUsersUrlParameterName,
 } from './chatConstants';
 import { teamsDeepLinkHost, teamsDeepLinkProtocol } from './constants';
 
@@ -11,10 +11,12 @@ export function createTeamsDeepLinkForChat(users: string[], topic?: string, mess
     throw new Error('Must have at least one user when creating a chat deep link');
   }
 
-  const usersSearchParameter = `${usersUrlParameterName}=` + users.map(user => encodeURIComponent(user)).join(',');
-  const topicSearchParameter = topic === undefined ? '' : `&${topicUrlParameterName}=${encodeURIComponent(topic)}`;
+  const usersSearchParameter =
+    `${teamsDeepLinkUsersUrlParameterName}=` + users.map(user => encodeURIComponent(user)).join(',');
+  const topicSearchParameter =
+    topic === undefined ? '' : `&${teamsDeepLinkTopicUrlParameterName}=${encodeURIComponent(topic)}`;
   const messageSearchParameter =
-    message === undefined ? '' : `&${messageUrlParameterName}=${encodeURIComponent(message)}`;
+    message === undefined ? '' : `&${teamsDeepLinkMessageUrlParameterName}=${encodeURIComponent(message)}`;
 
-  return `${teamsDeepLinkProtocol}://${teamsDeepLinkHost}${deepLinkUrlPathForChat}?${usersSearchParameter}${topicSearchParameter}${messageSearchParameter}`;
+  return `${teamsDeepLinkProtocol}://${teamsDeepLinkHost}${teamsDeepLinkUrlPathForChat}?${usersSearchParameter}${topicSearchParameter}${messageSearchParameter}`;
 }

--- a/packages/teams-js/src/internal/chatUtilities.ts
+++ b/packages/teams-js/src/internal/chatUtilities.ts
@@ -1,0 +1,20 @@
+import {
+  deepLinkUrlPathForChat,
+  messageUrlParameterName,
+  topicUrlParameterName,
+  usersUrlParameterName,
+} from './chatConstants';
+import { teamsDeepLinkHost, teamsDeepLinkProtocol } from './constants';
+
+export function createTeamsDeepLinkForChat(users: string[], topic?: string, message?: string): string {
+  if (users.length === 0) {
+    throw new Error('Must have at least one user when creating a chat deep link');
+  }
+
+  const usersSearchParameter = `${usersUrlParameterName}=` + users.map(user => encodeURIComponent(user)).join(',');
+  const topicSearchParameter = topic === undefined ? '' : `&${topicUrlParameterName}=${encodeURIComponent(topic)}`;
+  const messageSearchParameter =
+    message === undefined ? '' : `&${messageUrlParameterName}=${encodeURIComponent(message)}`;
+
+  return `${teamsDeepLinkProtocol}://${teamsDeepLinkHost}${deepLinkUrlPathForChat}?${usersSearchParameter}${topicSearchParameter}${messageSearchParameter}`;
+}

--- a/packages/teams-js/src/internal/constants.ts
+++ b/packages/teams-js/src/internal/constants.ts
@@ -128,3 +128,19 @@ export const validOrigins = [
  * @internal
  */
 export const userOriginUrlValidationRegExp = /^https:\/\//;
+
+/**
+ * @hidden
+ * The protocol used for deep links into Teams
+ *
+ * @internal
+ */
+export const teamsDeepLinkProtocol = 'https';
+
+/**
+ * @hidden
+ * The host used for deep links into Teams
+ *
+ * @internal
+ */
+export const teamsDeepLinkHost = 'teams.microsoft.com';

--- a/packages/teams-js/src/public/chat.ts
+++ b/packages/teams-js/src/public/chat.ts
@@ -57,7 +57,7 @@ export namespace chat {
    * Allows the user to open a chat with a single user and allows
    * for the user to specify the message they wish to send.
    *
-   *@param openChatRequest: {@link OpenSingleChatRequest}- a request object that contains a user's email as well as an optional message parameter.
+   * @param openChatRequest: {@link OpenSingleChatRequest}- a request object that contains a user's email as well as an optional message parameter.
    *
    * @returns Promise resolved upon completion
    */

--- a/packages/teams-js/test/internal/chatUtilities.spec.ts
+++ b/packages/teams-js/test/internal/chatUtilities.spec.ts
@@ -1,8 +1,8 @@
 import {
-  deepLinkUrlPathForChat,
-  messageUrlParameterName,
-  topicUrlParameterName,
-  usersUrlParameterName,
+  teamsDeepLinkMessageUrlParameterName,
+  teamsDeepLinkTopicUrlParameterName,
+  teamsDeepLinkUrlPathForChat,
+  teamsDeepLinkUsersUrlParameterName,
 } from '../../src/internal/chatConstants';
 import { createTeamsDeepLinkForChat } from '../../src/internal/chatUtilities';
 import { teamsDeepLinkHost, teamsDeepLinkProtocol } from '../../src/internal/constants';
@@ -18,12 +18,12 @@ describe('chatUtilities', () => {
     function validateChatDeepLinkPrefix(chatDeepLink: URL): void {
       expect(chatDeepLink.protocol.toLowerCase() === teamsDeepLinkProtocol);
       expect(chatDeepLink.host.toLowerCase() === teamsDeepLinkHost);
-      expect(chatDeepLink.pathname.toLowerCase() === deepLinkUrlPathForChat);
+      expect(chatDeepLink.pathname.toLowerCase() === teamsDeepLinkUrlPathForChat);
     }
 
     function validateChatDeepLinkUsers(chatDeepLink: URL, expectedUsers: string[]): void {
       const searchParams = chatDeepLink.searchParams;
-      const userUrlValues: string[] = searchParams.getAll(usersUrlParameterName);
+      const userUrlValues: string[] = searchParams.getAll(teamsDeepLinkUsersUrlParameterName);
       expect(userUrlValues).toHaveLength(1);
 
       const users: string[] = userUrlValues[0].split(',');
@@ -36,7 +36,7 @@ describe('chatUtilities', () => {
 
     function validateChatDeepLinkTopic(chatDeepLink: URL, expectedTopic?: string): void {
       const searchParams = chatDeepLink.searchParams;
-      const topicUrlValues: string[] = searchParams.getAll(topicUrlParameterName);
+      const topicUrlValues: string[] = searchParams.getAll(teamsDeepLinkTopicUrlParameterName);
 
       if (expectedTopic !== undefined) {
         expect(topicUrlValues).toHaveLength(1);
@@ -49,7 +49,7 @@ describe('chatUtilities', () => {
 
     function validateChatDeepLinkMessage(chatDeepLink: URL, expectedMessage?: string): void {
       const searchParams = chatDeepLink.searchParams;
-      const messageUrlValues: string[] = searchParams.getAll(messageUrlParameterName);
+      const messageUrlValues: string[] = searchParams.getAll(teamsDeepLinkMessageUrlParameterName);
 
       if (expectedMessage !== undefined) {
         expect(messageUrlValues).toHaveLength(1);

--- a/packages/teams-js/test/internal/chatUtilities.spec.ts
+++ b/packages/teams-js/test/internal/chatUtilities.spec.ts
@@ -1,0 +1,119 @@
+import {
+  deepLinkUrlPathForChat,
+  messageUrlParameterName,
+  topicUrlParameterName,
+  usersUrlParameterName,
+} from '../../src/internal/chatConstants';
+import { createTeamsDeepLinkForChat } from '../../src/internal/chatUtilities';
+import { teamsDeepLinkHost, teamsDeepLinkProtocol } from '../../src/internal/constants';
+
+describe('chatUtilities', () => {
+  describe('createTeamsDeepLinkForChat', () => {
+    const user1 = 'user1';
+    const user2 = 'user2first user2last';
+    const user3 = 'my name has & special characters in = it';
+    const topic = 'this is &= a topic !! with some % characters # that can be $tricky';
+    const message = 'a message with &&&& some = ? special + characters in it';
+
+    function validateChatDeepLinkPrefix(chatDeepLink: URL): void {
+      expect(chatDeepLink.protocol.toLowerCase() === teamsDeepLinkProtocol);
+      expect(chatDeepLink.host.toLowerCase() === teamsDeepLinkHost);
+      expect(chatDeepLink.pathname.toLowerCase() === deepLinkUrlPathForChat);
+    }
+
+    function validateChatDeepLinkUsers(chatDeepLink: URL, expectedUsers: string[]): void {
+      const searchParams = chatDeepLink.searchParams;
+      const userUrlValues: string[] = searchParams.getAll(usersUrlParameterName);
+      expect(userUrlValues).toHaveLength(1);
+
+      const users: string[] = userUrlValues[0].split(',');
+      expect(users).toHaveLength(expectedUsers.length);
+
+      for (const expectedUser of expectedUsers) {
+        expect(users).toContain(expectedUser);
+      }
+    }
+
+    function validateChatDeepLinkTopic(chatDeepLink: URL, expectedTopic?: string): void {
+      const searchParams = chatDeepLink.searchParams;
+      const topicUrlValues: string[] = searchParams.getAll(topicUrlParameterName);
+
+      if (expectedTopic !== undefined) {
+        expect(topicUrlValues).toHaveLength(1);
+        const topic: string = topicUrlValues[0];
+        expect(topic).toEqual(expectedTopic);
+      } else {
+        expect(topicUrlValues).toHaveLength(0);
+      }
+    }
+
+    function validateChatDeepLinkMessage(chatDeepLink: URL, expectedMessage?: string): void {
+      const searchParams = chatDeepLink.searchParams;
+      const messageUrlValues: string[] = searchParams.getAll(messageUrlParameterName);
+
+      if (expectedMessage !== undefined) {
+        expect(messageUrlValues).toHaveLength(1);
+        const message: string = messageUrlValues[0];
+        expect(message).toEqual(expectedMessage);
+      } else {
+        expect(messageUrlValues).toHaveLength(0);
+      }
+    }
+
+    it('should create a deep link for a single user with no topic and no message', () => {
+      const userList: string[] = [user1];
+      const generatedChatDeepLinkUrl = new URL(createTeamsDeepLinkForChat(userList));
+
+      validateChatDeepLinkPrefix(generatedChatDeepLinkUrl);
+      validateChatDeepLinkUsers(generatedChatDeepLinkUrl, userList);
+      validateChatDeepLinkTopic(generatedChatDeepLinkUrl, undefined);
+      validateChatDeepLinkMessage(generatedChatDeepLinkUrl, undefined);
+    });
+
+    it('should create a deep link for a multiple users with no topic and no message', () => {
+      const userList: string[] = [user1, user2, user3];
+      const generatedChatDeepLinkUrl = new URL(createTeamsDeepLinkForChat(userList));
+
+      validateChatDeepLinkPrefix(generatedChatDeepLinkUrl);
+      validateChatDeepLinkUsers(generatedChatDeepLinkUrl, userList);
+      validateChatDeepLinkTopic(generatedChatDeepLinkUrl, undefined);
+      validateChatDeepLinkMessage(generatedChatDeepLinkUrl, undefined);
+    });
+
+    it('should create a deep link for one user with the given message', () => {
+      const userList: string[] = [user1];
+      const generatedChatDeepLinkUrl = new URL(createTeamsDeepLinkForChat(userList, undefined, message));
+
+      validateChatDeepLinkPrefix(generatedChatDeepLinkUrl);
+      validateChatDeepLinkUsers(generatedChatDeepLinkUrl, userList);
+      validateChatDeepLinkTopic(generatedChatDeepLinkUrl, undefined);
+      validateChatDeepLinkMessage(generatedChatDeepLinkUrl, message);
+    });
+
+    it('should create a deep link for multiple users with the given topic', () => {
+      const userList: string[] = [user3, user1, user2];
+      const generatedChatDeepLinkUrl = new URL(createTeamsDeepLinkForChat(userList, topic, undefined));
+
+      validateChatDeepLinkPrefix(generatedChatDeepLinkUrl);
+      validateChatDeepLinkUsers(generatedChatDeepLinkUrl, userList);
+      validateChatDeepLinkTopic(generatedChatDeepLinkUrl, topic);
+      validateChatDeepLinkMessage(generatedChatDeepLinkUrl, undefined);
+    });
+
+    it('should create a deep link for multiple users with the given topic and message', () => {
+      const userList: string[] = [user3, user2, user1];
+      const generatedChatDeepLinkUrl = new URL(createTeamsDeepLinkForChat(userList, topic, message));
+
+      validateChatDeepLinkPrefix(generatedChatDeepLinkUrl);
+      validateChatDeepLinkUsers(generatedChatDeepLinkUrl, userList);
+      validateChatDeepLinkTopic(generatedChatDeepLinkUrl, topic);
+      validateChatDeepLinkMessage(generatedChatDeepLinkUrl, message);
+    });
+
+    it('should throw an error when given no users', () => {
+      expect.assertions(1);
+
+      expect(() => createTeamsDeepLinkForChat([], topic, message)).toThrowError();
+    });
+  });
+});


### PR DESCRIPTION
Create utility function for constructing a chat deep link URL

This utility function will be used to create a deep link URL that will
be sent to the host if it is determined that the host is "legacy teams"
and would not understand the chat capability messages.
This change does not actually execute the deep link (that will be in
the next change), it only constructs the deep link. It also includes
unit tests to validate the construction.