### PR TITLE
dialog.submit sends an empty array in case of no appIds

### DIFF
--- a/change/@microsoft-teams-js-aa2116d9-a745-445b-8ff6-e9acf702cd08.json
+++ b/change/@microsoft-teams-js-aa2116d9-a745-445b-8ff6-e9acf702cd08.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "none",
   "comment": "dialog.submit sends an empty array to host instead of `[undefined]` in case there is no appIds specified",
   "packageName": "@microsoft/teams-js",
   "email": "lakhveerkaur@microsoft.com",

--- a/change/@microsoft-teams-js-aa2116d9-a745-445b-8ff6-e9acf702cd08.json
+++ b/change/@microsoft-teams-js-aa2116d9-a745-445b-8ff6-e9acf702cd08.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "dialog.submit sends an empty array to host instead of `[undefined]` in case there is no appIds specified",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -79,7 +79,7 @@ export namespace dialog {
     ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.task, FrameContexts.meetingStage);
 
     // Send tasks.completeTask instead of tasks.submitTask message for backward compatibility with Mobile clients
-    sendMessageToParent('tasks.completeTask', [result, Array.isArray(appIds) ? appIds : [appIds]]);
+    sendMessageToParent('tasks.completeTask', [result, appIds ? (Array.isArray(appIds) ? appIds : [appIds]) : []]);
   }
 
   /**

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -251,6 +251,25 @@ describe('Dialog', () => {
           expect(submitMessage).not.toBeNull();
           expect(submitMessage.args).toEqual(['someResult', ['someAppId']]);
         });
+        it(`FRAMED: should successfully pass results when no appIds parameters are provided ${JSON.stringify(
+          context,
+        )}`, async () => {
+          await framedMock.initializeWithContext(context);
+          dialog.submit('someResult');
+          const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
+          expect(submitMessage).not.toBeNull();
+          expect(submitMessage.args).toEqual(['someResult', []]);
+        });
+
+        it(`FRAMELESS: should successfully pass results when no appIds parameters are provided ${JSON.stringify(
+          context,
+        )}`, async () => {
+          await framelessMock.initializeWithContext(context);
+          dialog.submit('someResult');
+          const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
+          expect(submitMessage).not.toBeNull();
+          expect(submitMessage.args).toEqual(['someResult', []]);
+        });
       } else {
         it(`FRAMED: should not allow calls from context context: ${JSON.stringify(context)}`, async () => {
           await framedMock.initializeWithContext(context);


### PR DESCRIPTION
Sending an empty array is less error prone than sending `undefined` in an array. 