### PR TITLE
Allow openFilePreview calls from the task frame context

### DIFF
--- a/src/private/privateAPIs.ts
+++ b/src/private/privateAPIs.ts
@@ -78,7 +78,7 @@ export function exitFullscreen(): void {
  * @param file The file to preview.
  */
 export function openFilePreview(filePreviewParameters: FilePreviewParameters): void {
-  ensureInitialized(FrameContexts.content);
+  ensureInitialized(FrameContexts.content, FrameContexts.task);
 
   const params = [
     filePreviewParameters.entityId,


### PR DESCRIPTION
This change allows the openFilePreview API to be called from task modules.