### PR TITLE
topic param name was wrong for group chat deep links

### DIFF
--- a/change/@microsoft-teams-js-a1c16808-8fc1-4d4d-8638-ff5b68c0e802.json
+++ b/change/@microsoft-teams-js-a1c16808-8fc1-4d4d-8638-ff5b68c0e802.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed topic parameter name to `topicName` for `executeDeepLink` call in `chat.ts`",
+  "packageName": "@microsoft/teams-js",
+  "email": "jdahiya8719@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/deepLinkConstants.ts
+++ b/packages/teams-js/src/internal/deepLinkConstants.ts
@@ -25,5 +25,5 @@ export const teamsDeepLinkWithVideoUrlParameterName = 'withVideo';
  */
 export const teamsDeepLinkUrlPathForChat = '/l/chat/0/0';
 export const teamsDeepLinkUsersUrlParameterName = 'users';
-export const teamsDeepLinkTopicUrlParameterName = 'topic';
+export const teamsDeepLinkTopicUrlParameterName = 'topicName';
 export const teamsDeepLinkMessageUrlParameterName = 'message';


### PR DESCRIPTION
According to this, should be topicName: https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/deep-links