### PR TITLE
Add displayCapture namespace and getDisplayCapture API

### DIFF
--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -59,6 +59,11 @@ export const getMediaCallbackSupportVersion = '2.0.0';
 export const scanBarCodeAPIMobileSupportVersion = '1.9.0';
 
 /**
+ * This is the client version when displayCapture API are supported.
+ */
+export const displayCaptureAPIRequiredVersion = '2.0.0';
+
+/**
  * List of supported Host origins
  */
 export const validOrigins = [

--- a/src/public/displayCapture.ts
+++ b/src/public/displayCapture.ts
@@ -1,0 +1,57 @@
+import { SdkError, ErrorCode } from './interfaces';
+import { ensureInitialized, isAPISupportedByPlatform } from '../internal/internalAPIs';
+import { FrameContexts } from './constants';
+import { sendMessageToParent } from '../internal/communication';
+import { displayCaptureAPIRequiredVersion } from '../internal/constants';
+
+export namespace displayCapture {
+  export interface DisplayCaptureProps {
+    audio?: boolean | MediaTrackConstraints;
+    video?: boolean | MediaTrackConstraints;
+  }
+
+  export interface Location {
+    /**
+    Latitude of the location
+    */
+    latitude: number;
+    /**
+    Longitude of the location
+    */
+    longitude: number;
+    /**
+    Accuracy of the coordinates captured
+    */
+    accuracy?: number;
+    /**
+    Time stamp when the location was captured
+    */
+    timestamp?: number;
+  }
+
+  /**
+   * Fetches current user coordinates or allows user to choose location on map
+   * @param callback Callback to invoke when the stream of selected display is fetched
+   */
+  export function getDisplayCapture(
+    props: DisplayCaptureProps,
+    callback: (error: SdkError, displayCapture: MediaStream) => void,
+  ): void {
+    if (!callback) {
+      throw new Error('[displayCapture.getDisplayCapture] Callback cannot be null');
+    }
+    ensureInitialized(FrameContexts.content, FrameContexts.task);
+
+    if (!isAPISupportedByPlatform(displayCaptureAPIRequiredVersion)) {
+      const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
+      callback(oldPlatformError, undefined);
+      return;
+    }
+    if (!props) {
+      const invalidInput: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
+      callback(invalidInput, undefined);
+      return;
+    }
+    sendMessageToParent('displayCapture.getDisplayCapture', [props], callback);
+  }
+}

--- a/src/public/displayCapture.ts
+++ b/src/public/displayCapture.ts
@@ -10,25 +10,6 @@ export namespace displayCapture {
     video?: boolean | MediaTrackConstraints;
   }
 
-  export interface Location {
-    /**
-    Latitude of the location
-    */
-    latitude: number;
-    /**
-    Longitude of the location
-    */
-    longitude: number;
-    /**
-    Accuracy of the coordinates captured
-    */
-    accuracy?: number;
-    /**
-    Time stamp when the location was captured
-    */
-    timestamp?: number;
-  }
-
   /**
    * Fetches current user coordinates or allows user to choose location on map
    * @param callback Callback to invoke when the stream of selected display is fetched

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -44,6 +44,7 @@ export { ChildAppWindow, IAppWindow, ParentAppWindow } from './appWindow';
 export { menus } from './menus';
 export { media } from './media';
 export { location } from './location';
+export { displayCapture } from './displayCapture';
 export { meeting } from './meeting';
 export { monetization } from './monetization';
 export { people } from './people';


### PR DESCRIPTION
getDisplayCapture method prompts the user to select and grant permission to capture the content of a display (screen or window) as MediaStream.