### PR TITLE
Add info to changelog about outputting ES6 modules from TS

### DIFF
--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -245,6 +245,7 @@ Tue, 01 Mar 2022 19:50:49 GMT
     - `applyRuntimeConfig` is added
 
 - Promises introduced
+
   - The following APIs that took in a callback function as a parameter now instead return a Promise.
     - app APIs:
       - app.initialize
@@ -309,3 +310,5 @@ Tue, 01 Mar 2022 19:50:49 GMT
       - core.executeDeepLink
       - appInstallDialog.openAppInstallDialog
       - call.startCall
+
+- Changed TypeScript to output ES6 modules instead of CommonJS


### PR DESCRIPTION
This change was introduced prior to Public Preview, however it was never documented in the changelog.

We recently discovered they may be other side effects of outputting ES6 modules from TypeScript instead of CommonJS, so this may be useful for developers.