### PR TITLE
Add getDisplayCapture API

### DIFF
--- a/change/@microsoft-teams-js-ff6438cc-9d74-4730-9868-af389c73c44a.json
+++ b/change/@microsoft-teams-js-ff6438cc-9d74-4730-9868-af389c73c44a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add displayCapture namespace and getDisplayCapture API",
+  "packageName": "@microsoft/teams-js",
+  "email": "yujin1@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/constants.ts
+++ b/packages/teams-js/src/internal/constants.ts
@@ -86,6 +86,11 @@ export const getMediaCallbackSupportVersion = '2.0.0';
 export const scanBarCodeAPIMobileSupportVersion = '1.9.0';
 
 /**
+ * This is the client version when displayCapture API are supported.
+ */
+ export const displayCaptureAPIRequiredVersion = '2.0.0';
+
+/**
  * @hidden
  * List of supported Host origins
  *

--- a/packages/teams-js/src/internal/constants.ts
+++ b/packages/teams-js/src/internal/constants.ts
@@ -88,7 +88,7 @@ export const scanBarCodeAPIMobileSupportVersion = '1.9.0';
 /**
  * This is the client version when displayCapture API are supported.
  */
- export const displayCaptureAPIRequiredVersion = '2.0.0';
+export const displayCaptureAPIRequiredVersion = '2.0.0';
 
 /**
  * @hidden

--- a/packages/teams-js/src/public/displayCapture.ts
+++ b/packages/teams-js/src/public/displayCapture.ts
@@ -1,0 +1,37 @@
+import { SdkError, ErrorCode } from './interfaces';
+import { ensureInitialized, isCurrentSDKVersionAtLeast } from '../internal/internalAPIs';
+import { FrameContexts } from './constants';
+import { sendMessageToParent } from '../internal/communication';
+import { displayCaptureAPIRequiredVersion } from '../internal/constants';
+
+export namespace displayCapture {
+  export interface DisplayCaptureProps {
+    audio?: boolean | MediaTrackConstraints;
+    video?: boolean | MediaTrackConstraints;
+  }
+
+  /**
+   * @param callback Callback to invoke when the stream of selected display is fetched
+   */
+  export function getDisplayCapture(
+    props: DisplayCaptureProps,
+    callback: (error: SdkError, displayCapture: MediaStream) => void,
+  ): void {
+    if (!callback) {
+      throw new Error('[displayCapture.getDisplayCapture] Callback cannot be null');
+    }
+    ensureInitialized(FrameContexts.content, FrameContexts.task);
+
+    if (!isCurrentSDKVersionAtLeast(displayCaptureAPIRequiredVersion)) {
+      const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
+      callback(oldPlatformError, undefined);
+      return;
+    }
+    if (!props) {
+      const invalidInput: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
+      callback(invalidInput, undefined);
+      return;
+    }
+    sendMessageToParent('displayCapture.getDisplayCapture', [props], callback);
+  }
+}

--- a/packages/teams-js/src/public/displayCapture.ts
+++ b/packages/teams-js/src/public/displayCapture.ts
@@ -1,8 +1,8 @@
-import { SdkError, ErrorCode } from './interfaces';
-import { ensureInitialized, isCurrentSDKVersionAtLeast } from '../internal/internalAPIs';
-import { FrameContexts } from './constants';
 import { sendMessageToParent } from '../internal/communication';
 import { displayCaptureAPIRequiredVersion } from '../internal/constants';
+import { ensureInitialized, isCurrentSDKVersionAtLeast } from '../internal/internalAPIs';
+import { FrameContexts } from './constants';
+import { ErrorCode, SdkError } from './interfaces';
 
 export namespace displayCapture {
   export interface DisplayCaptureProps {

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -35,6 +35,7 @@ export { ChildAppWindow, IAppWindow, ParentAppWindow } from './appWindow';
 export { menus } from './menus';
 export { media } from './media';
 export { location } from './location';
+export { displayCapture } from './displayCapture';
 export { meeting } from './meeting';
 export { monetization } from './monetization';
 export { calendar } from './calendar';


### PR DESCRIPTION
This is API is used to get user's selected display content(screen or window)
When it's called, Teams prompts the user to select and grant permission to capture the content of a display (screen or window) as MediaStream.

The SDK design has not been review yet, this PR is created to serve as the "Code Snippet" section of SDK design document,
