### PR TITLE
WIP: Exposing hostClientVersion via GetContext API (Context)

### DIFF
--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -340,6 +340,11 @@ export interface Context {
   hostClientType?: HostClientType;
 
   /**
+   * The application version of the host client.
+   */
+  hostClientVersion?: string;
+
+  /**
    * The context where tab url is loaded (content, task, setting, remove, sidePanel)
    */
   frameContext?: FrameContexts;

--- a/src/public/interfaces.ts
+++ b/src/public/interfaces.ts
@@ -341,6 +341,7 @@ export interface Context {
 
   /**
    * The application version of the host client.
+   * This property should be used along with hostClientType as versioning would be different across the various host client types.
    */
   hostClientVersion?: string;
 


### PR DESCRIPTION
- Adding hostClientVersion for Web Apps to identify the version of the Host Client App.
- Used in conjunction with existing property hostClientType