### PR TITLE
adaptive card based dialogs shouldn't have small (default) dialog height, if the height is not provided. 

### DIFF
--- a/change/@microsoft-teams-js-4eaeabce-50a9-4ef9-af6b-a1d1da4d1309.json
+++ b/change/@microsoft-teams-js-4eaeabce-50a9-4ef9-af6b-a1d1da4d1309.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "In adaptive card based dialogs, height will not be set to small (default value) if not provided. It will fit all card content on a dialog. ",
+  "comment": "In adaptive card based task modules, if the height is not provided in `taskInfo`, it wil not be set to a default small size. Instead the card content will be fit on a Task Module. ",
   "packageName": "@microsoft/teams-js",
   "email": "lakhveerkaur@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-4eaeabce-50a9-4ef9-af6b-a1d1da4d1309.json
+++ b/change/@microsoft-teams-js-4eaeabce-50a9-4ef9-af6b-a1d1da4d1309.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "In adaptive card based dialogs, height will not be set to small (default value) if not provided. It will fit all card content on a dialog. ",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -30,7 +30,6 @@ export namespace tasks {
     taskInfo: TaskInfo,
     submitHandler?: (err: string, result: string | object) => void,
   ): IAppWindow {
-    taskInfo = getDefaultSizeIfNotProvided(taskInfo);
     if (taskInfo.card !== undefined || taskInfo.url === undefined) {
       ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
       sendMessageToParent('tasks.startTask', [taskInfo as DialogInfo], submitHandler);
@@ -82,8 +81,8 @@ export namespace tasks {
     const urldialogInfo: UrlDialogInfo = {
       url: taskInfo.url,
       size: {
-        height: taskInfo.height,
-        width: taskInfo.width,
+        height: taskInfo.height ? taskInfo.height : TaskModuleDimension.Small,
+        width: taskInfo.width ? taskInfo.width : TaskModuleDimension.Small,
       },
       title: taskInfo.title,
       fallbackUrl: taskInfo.fallbackUrl,
@@ -95,8 +94,8 @@ export namespace tasks {
     const botUrldialogInfo: BotUrlDialogInfo = {
       url: taskInfo.url,
       size: {
-        height: taskInfo.height,
-        width: taskInfo.width,
+        height: taskInfo.height ? taskInfo.height : TaskModuleDimension.Small,
+        width: taskInfo.width ? taskInfo.width : TaskModuleDimension.Small,
       },
       title: taskInfo.title,
       fallbackUrl: taskInfo.fallbackUrl,


### PR DESCRIPTION
the host should size the dialog to fit the requested adaptive card if no size is specified. This is how it was in v1. 