### PR TITLE
Remove deprecated tags from media.ts and meeting.ts

### DIFF
--- a/change/@microsoft-teams-js-c0aa6182-1a47-4745-bb95-33ef415bb07e.json
+++ b/change/@microsoft-teams-js-c0aa6182-1a47-4745-bb95-33ef415bb07e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed `@deprecated` tags from meeting.ts and media.ts",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -29,10 +29,6 @@ import { generateGUID } from '../internal/utils';
 import { FrameContexts, HostClientType } from './constants';
 import { ErrorCode, SdkError } from './interfaces';
 
-/**
- * @deprecated
- * As of 2.0.0-beta.6, use media only for backwards compatibility of existing code.
- */
 export namespace media {
   /**
    * Enum for file formats supported
@@ -75,9 +71,6 @@ export namespace media {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Launch camera, capture image or choose image from gallery and return the images as a File[] object to the callback.
    *
    * @params callback - Callback will be called with an @see SdkError if there are any.
@@ -588,9 +581,6 @@ export namespace media {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Select an attachment using camera/gallery
    *
    * @param mediaInputs - The input params to customize the media to be selected
@@ -654,10 +644,8 @@ export namespace media {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * View images using native image viewer
+   *
    * @param uriList - list of URIs for images to be viewed - can be content URI or server URL. Supports up to 10 Images in a single call
    * @param callback - returns back error if encountered, returns null in case of success
    */
@@ -695,10 +683,8 @@ export namespace media {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Scan Barcode/QRcode using camera
+   *
    * @remarks
    * Note: For desktop and web, this API is not supported. Callback will be resolved with ErrorCode.NotSupported.
    *

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -4,10 +4,6 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { FrameContexts } from './constants';
 import { SdkError } from './interfaces';
 
-/**
- * @deprecated
- * As of 2.0.0-beta.6, use meeting only for backwards compatibility of existing code.
- */
 export namespace meeting {
   /**
    * @hidden
@@ -175,9 +171,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Allows an app to get the incoming audio speaker setting for the meeting user
    *
    * @param callback - Callback contains 2 parameters, error and result.
@@ -197,9 +190,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Allows an app to toggle the incoming audio speaker setting for the meeting user from mute to unmute or vice-versa
    *
    * @param callback - Callback contains 2 parameters, error and result.
@@ -216,9 +206,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * @hidden
    * Hide from docs
    *
@@ -246,9 +233,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * @hidden
    * Allows an app to get the authentication token for the anonymous or guest user in the meeting
    *
@@ -269,9 +253,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Allows an app to get the state of the live stream in the current meeting
    *
    * @param callback - Callback contains 2 parameters: error and liveStreamState.
@@ -289,9 +270,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Allows an app to request the live streaming be started at the given streaming url
    *
    * @remarks
@@ -314,9 +292,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Allows an app to request the live streaming be stopped at the given streaming url
    *
    * @remarks
@@ -333,9 +308,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Registers a handler for changes to the live stream.
    *
    * @remarks
@@ -352,9 +324,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Allows an app to share contents in the meeting
    *
    * @param callback - Callback contains 2 parameters, error and result.
@@ -374,9 +343,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Provides information related app's in-meeting sharing capabilities
    *
    * @param callback - Callback contains 2 parameters, error and result.
@@ -398,9 +364,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * @hidden
    * Hide from docs.
    * Terminates current stage sharing session in meeting
@@ -420,9 +383,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Provides information related to current stage sharing state for app
    *
    * @param callback - Callback contains 2 parameters, error and result.
@@ -441,9 +401,6 @@ export namespace meeting {
   }
 
   /**
-   * @deprecated
-   * As of 2.0.0-beta.6, use only for backwards compatibility of existing code.
-   *
    * Registers a handler for changes to paticipant speaking states. If any participant is speaking, isSpeakingDetected
    * will be true. If no participants are speaking, isSpeakingDetected will be false. Only one handler can be registered
    * at a time. A subsequent registration replaces an existing registration.


### PR DESCRIPTION
We received feedback that while the functions in media.ts will not currently work in a cross-host environment, there is still active 3P development occurring involving these APIs and it would be confusing for developers to have them marked `@deprecated` without pointing to replacement functions.

The functions in meeting.ts aren't actually problematic, but the current structure doesn't lend itself to the capability model across all hosts. We don't really need the `@deprecated` tag to convey this to developers.