### PR TITLE
Remove @alpha tags from docs comments

### DIFF
--- a/change/@microsoft-teams-js-ccca7dc2-0d2d-45a2-b7e7-74463ea5fb5f.json
+++ b/change/@microsoft-teams-js-ccca7dc2-0d2d-45a2-b7e7-74463ea5fb5f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed @alpha tags as they are not supported in the SDK reference doc generation system",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/appEntity.ts
+++ b/packages/teams-js/src/private/appEntity.ts
@@ -5,8 +5,6 @@ import { runtime } from '../public/runtime';
 /**
  * @hidden
  * Namespace to interact with the application entities specific part of the SDK.
- *
- * @alpha
  */
 export namespace appEntity {
   /**
@@ -14,8 +12,6 @@ export namespace appEntity {
    * Hide from docs
    * --------
    * Information on an app entity
-   *
-   * @alpha
    */
   export interface AppEntity {
     /**
@@ -61,8 +57,6 @@ export namespace appEntity {
    * @param callback Callback that will be triggered once the app entity information is available.
    *                 The callback takes two arguments: an SdkError in case something happened (i.e.
    *                 no permissions to execute the API) and the app entity configuration, if available
-   *
-   * @alpha
    */
   export function selectAppEntity(
     threadId: string,

--- a/packages/teams-js/src/private/conversations.ts
+++ b/packages/teams-js/src/private/conversations.ts
@@ -96,8 +96,6 @@ export interface ConversationResponse {
 /**
  * @hidden
  * Namespace to interact with the conversational subEntities inside the tab
- *
- * @alpha
  */
 export namespace conversations {
   /**

--- a/packages/teams-js/src/private/interfaces.ts
+++ b/packages/teams-js/src/private/interfaces.ts
@@ -5,8 +5,6 @@ import { FileOpenPreference, TeamInformation } from '../public/interfaces';
  * Hide from docs
  * --------
  * Information about all members in a chat
- *
- * @alpha
  */
 export interface ChatMembersInformation {
   members: ThreadMember[];
@@ -17,8 +15,6 @@ export interface ChatMembersInformation {
  * Hide from docs
  * --------
  * Information about a chat member
- *
- * @alpha
  */
 export interface ThreadMember {
   /**
@@ -28,17 +24,11 @@ export interface ThreadMember {
   upn: string;
 }
 
-/**
- * @alpha
- */
 export enum NotificationTypes {
   fileDownloadStart = 'fileDownloadStart',
   fileDownloadComplete = 'fileDownloadComplete',
 }
 
-/**
- * @alpha
- */
 export interface ShowNotificationParameters {
   message: string;
   notificationType: NotificationTypes;
@@ -47,8 +37,6 @@ export interface ShowNotificationParameters {
 /**
  * @hidden
  * Hide from docs.
- * ------
- * @alpha
  */
 export enum ViewerActionTypes {
   view = 'view',
@@ -60,8 +48,7 @@ export enum ViewerActionTypes {
  * @hidden
  * Hide from docs.
  * ------
- * User setting changes that can be subscribed to,
- * @alpha
+ * User setting changes that can be subscribed to
  */
 export enum UserSettingTypes {
   /**
@@ -79,8 +66,6 @@ export enum UserSettingTypes {
 /**
  * @hidden
  * Hide from docs.
- * ------
- * @alpha
  */
 export interface FilePreviewParameters {
   /**
@@ -174,7 +159,6 @@ export interface FilePreviewParameters {
  * Hide from docs
  * --------
  * Query parameters used when fetching team information
- * @alpha
  */
 export interface TeamInstanceParameters {
   /**
@@ -189,7 +173,6 @@ export interface TeamInstanceParameters {
  * Hide from docs
  * --------
  * Information on userJoined Teams
- * @alpha
  */
 export interface UserJoinedTeamsInformation {
   /**

--- a/packages/teams-js/src/private/meetingRoom.ts
+++ b/packages/teams-js/src/private/meetingRoom.ts
@@ -4,9 +4,6 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { errorNotSupportedOnPlatform } from '../public/constants';
 import { runtime } from '../public/runtime';
 
-/**
- * @alpha
- */
 export namespace meetingRoom {
   /**
    * @hidden

--- a/packages/teams-js/src/private/remoteCamera.ts
+++ b/packages/teams-js/src/private/remoteCamera.ts
@@ -5,9 +5,6 @@ import { FrameContexts } from '../public/constants';
 import { SdkError } from '../public/interfaces';
 import { runtime } from '../public/runtime';
 
-/**
- * @alpha
- */
 export namespace remoteCamera {
   /**
    * @hidden

--- a/packages/teams-js/src/public/appInstallDialog.ts
+++ b/packages/teams-js/src/public/appInstallDialog.ts
@@ -5,9 +5,6 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { FrameContexts } from './constants';
 import { runtime } from './runtime';
 
-/**
- * @alpha
- */
 export namespace appInstallDialog {
   export interface OpenAppInstallDialogParams {
     appId: string;

--- a/packages/teams-js/src/public/appWindow.ts
+++ b/packages/teams-js/src/public/appWindow.ts
@@ -7,9 +7,7 @@ import { registerHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { getGenericOnCompleteHandler } from '../internal/utils';
 import { FrameContexts } from './constants';
-/**
- * @alpha
- */
+
 export interface IAppWindow {
   /**
    * Send a message to the AppWindow.

--- a/packages/teams-js/src/public/calendar.ts
+++ b/packages/teams-js/src/public/calendar.ts
@@ -4,9 +4,6 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { FrameContexts } from './constants';
 import { runtime } from './runtime';
 
-/**
- * @alpha
- */
 export namespace calendar {
   export function openCalendarItem(openCalendarItemParams: OpenCalendarItemParams): Promise<void> {
     return new Promise<void>(resolve => {

--- a/packages/teams-js/src/public/call.ts
+++ b/packages/teams-js/src/public/call.ts
@@ -5,9 +5,6 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { FrameContexts } from './constants';
 import { runtime } from './runtime';
 
-/**
- * @alpha
- */
 export namespace call {
   export enum CallModalities {
     Unknown = 'unknown',

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -5,8 +5,6 @@ import { FrameContexts } from './constants';
 
 /**
  * Represents information about tabs for an app
- *
- * @alpha
  */
 export interface TabInformation {
   teamTabs: TabInstance[];

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -8,9 +8,7 @@ import {
 import { errorNotSupportedOnPlatform, FrameContexts } from './constants';
 import { ErrorCode, SdkError } from './interfaces';
 import { runtime } from './runtime';
-/**
- * @alpha
- */
+
 export namespace location {
   export interface LocationProps {
     /**

--- a/packages/teams-js/src/public/mail.ts
+++ b/packages/teams-js/src/public/mail.ts
@@ -3,9 +3,6 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { FrameContexts } from './constants';
 import { runtime } from './runtime';
 
-/**
- * @alpha
- */
 export namespace mail {
   export function openMailItem(openMailItemParams: OpenMailItemParams): Promise<void> {
     return new Promise<void>(resolve => {

--- a/packages/teams-js/src/public/monetization.ts
+++ b/packages/teams-js/src/public/monetization.ts
@@ -5,9 +5,6 @@ import { FrameContexts } from './constants';
 import { SdkError } from './interfaces';
 import { runtime } from './runtime';
 
-/**
- * @alpha
- */
 export namespace monetization {
   /**
    * @hidden

--- a/packages/teams-js/src/public/people.ts
+++ b/packages/teams-js/src/public/people.ts
@@ -7,9 +7,6 @@ import { FrameContexts } from './constants';
 import { ErrorCode, SdkError } from './interfaces';
 import { runtime } from './runtime';
 
-/**
- * @alpha
- */
 export namespace people {
   /**
    * Launches a people picker and allows the user to select one or more people from the list

--- a/packages/teams-js/src/public/sharing.ts
+++ b/packages/teams-js/src/public/sharing.ts
@@ -5,9 +5,6 @@ import { errorNotSupportedOnPlatform, FrameContexts } from './constants';
 import { ErrorCode, SdkError } from './interfaces';
 import { runtime } from './runtime';
 
-/**
- * @alpha
- */
 export namespace sharing {
   export const SharingAPIMessages = {
     shareWebContent: 'sharing.shareWebContent',

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -6,8 +6,6 @@ import { runtime } from './runtime';
 
 /**
  * Namespace containing the set of APIs that support Teams-specific functionalities.
- *
- * @alpha
  */
 
 export namespace teamsCore {

--- a/packages/teams-js/src/public/video.ts
+++ b/packages/teams-js/src/public/video.ts
@@ -5,22 +5,19 @@ import { errorNotSupportedOnPlatform, FrameContexts } from './constants';
 import { runtime } from './runtime';
 
 /**
- * Namespace to video extensibility of the SDK.
- *
- * @alpha
- *
+ * Namespace to video extensibility of the SDK
  */
 export namespace video {
   /**
-   * Represents a video frame.
+   * Represents a video frame
    */
   export interface VideoFrame {
     /**
-     * Video frame width.
+     * Video frame width
      */
     width: number;
     /**
-     * Video frame height.
+     * Video frame height
      */
     height: number;
     /**
@@ -49,7 +46,7 @@ export namespace video {
   }
 
   /**
-   * Video frame configuration supplied to Teams to customize the generated video frame parameters, like format.
+   * Video frame configuration supplied to Teams to customize the generated video frame parameters, like format
    */
   export interface VideoFrameConfig {
     /**
@@ -63,7 +60,7 @@ export namespace video {
    */
   export enum EffectChangeType {
     /**
-     * current video effect changed.
+     * current video effect changed
      */
     EffectChanged,
     /**
@@ -87,7 +84,7 @@ export namespace video {
   export type VideoEffectCallBack = (effectId: string | undefined) => void;
 
   /**
-   * register to read the video frames in Permissions section.
+   * Register to read the video frames in Permissions section
    */
   export function registerForVideoFrame(frameCallback: VideoFrameCallback, config: VideoFrameConfig): void {
     ensureInitialized(FrameContexts.sidePanel);
@@ -123,7 +120,7 @@ export namespace video {
   }
 
   /**
-   * Register the video effect callback, Teams client uses this to notify the video extension the new video effect will by applied.
+   * Register the video effect callback, Teams client uses this to notify the video extension the new video effect will by applied
    */
   export function registerForVideoEffect(callback: VideoEffectCallBack): void {
     ensureInitialized(FrameContexts.sidePanel);
@@ -134,15 +131,15 @@ export namespace video {
   }
 
   /**
-   * sending notification to Teams client finished the video frame processing, now Teams client can render this video frame
-   * or pass the video frame to next one in video pipeline.
+   * Sending notification to Teams client finished the video frame processing, now Teams client can render this video frame
+   * or pass the video frame to next one in video pipeline
    */
   function notifyVideoFrameProcessed(): void {
     sendMessageToParent('video.videoFrameProcessed');
   }
 
   /**
-   * sending error notification to Teams client.
+   * Sending error notification to Teams client
    */
   function notifyError(errorMessage: string): void {
     sendMessageToParent('video.notifyError', [errorMessage]);


### PR DESCRIPTION
Remove @alpha tags as they are not supported in the SDK reference doc generation system.

As far as I can tell, they were added when we made the code changes to support TSDoc instead of JSDoc for Public Preview, however we later learned that the documentation generation tools support TypeDoc with a few exceptions.

I believe the motivation when we added these tags was to identify APIs that were newer, but I don't think we  have a formal approach for this, we did not use alpha or beta tags in v1, and the selection seems rather arbitrary, so I am just removing them. 