### PR TITLE
Reverting to original name - registerChangeSettingsHandler

### DIFF
--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -27,7 +27,7 @@ export {
   registerBackButtonHandler,
   registerBeforeUnloadHandler,
   registerFocusEnterHandler,
-  registerEnterSettingsHandler,
+  registerChangeSettingsHandler,
   registerFullScreenHandler,
   registerOnLoadHandler,
   registerOnThemeChangeHandler,

--- a/src/public/publicAPIs.ts
+++ b/src/public/publicAPIs.ts
@@ -267,7 +267,7 @@ export function registerFocusEnterHandler(handler: (navigateForward: boolean) =>
  * Registers a handler for when the user reconfigurated tab
  * @param handler The handler to invoke when the user click on Settings.
  */
-export function registerEnterSettingsHandler(handler: () => void): void {
+export function registerChangeSettingsHandler(handler: () => void): void {
   ensureInitialized(FrameContexts.content);
   Handlers.registerHandler('changeSettings', handler);
 }

--- a/test/public/publicAPIs.spec.ts
+++ b/test/public/publicAPIs.spec.ts
@@ -9,7 +9,7 @@ import {
   registerOnLoadHandler,
   registerBeforeUnloadHandler,
   enablePrintCapability,
-  registerEnterSettingsHandler,
+  registerChangeSettingsHandler,
   getContext,
   _initialize,
   _uninitialize,
@@ -142,7 +142,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
     utils.initializeWithContext('content');
     let handlerCalled = false;
 
-    registerEnterSettingsHandler(() => {
+    registerChangeSettingsHandler(() => {
       handlerCalled = true;
     });
 


### PR DESCRIPTION
This change reverts an accidental rename of an existing API.