### PR TITLE
Update all deprecated tags to reference version 2.0.0

### DIFF
--- a/change/@microsoft-teams-js-7bb78d87-087d-498a-aede-24ea1245c3c3.json
+++ b/change/@microsoft-teams-js-7bb78d87-087d-498a-aede-24ea1245c3c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update all deprecated tags to reference version 2.0.0",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/appInitialization.ts
+++ b/packages/teams-js/src/public/appInitialization.ts
@@ -2,41 +2,41 @@ import { app } from './app';
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link app} namespace instead.
+ * As of 2.0.0, please use {@link app} namespace instead.
  */
 export namespace appInitialization {
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link app.Messages} instead.
+   * As of 2.0.0, please use {@link app.Messages} instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export import Messages = app.Messages;
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link app.FailedReason} instead.
+   * As of 2.0.0, please use {@link app.FailedReason} instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export import FailedReason = app.FailedReason;
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link app.ExpectedFailureReason} instead.
+   * As of 2.0.0, please use {@link app.ExpectedFailureReason} instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export import ExpectedFailureReason = app.ExpectedFailureReason;
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link app.IFailedRequest} instead.
+   * As of 2.0.0, please use {@link app.IFailedRequest} instead.
    */
   export import IFailedRequest = app.IFailedRequest;
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link app.IExpectedFailureRequest} instead.
+   * As of 2.0.0, please use {@link app.IExpectedFailureRequest} instead.
    */
   export import IExpectedFailureRequest = app.IExpectedFailureRequest;
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link app.notifyAppLoaded app.notifyAppLoaded(): void} instead.
+   * As of 2.0.0, please use {@link app.notifyAppLoaded app.notifyAppLoaded(): void} instead.
    *
    * Notifies the frame that app has loaded and to hide the loading indicator if one is shown.
    */
@@ -46,7 +46,7 @@ export namespace appInitialization {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link app.notifySuccess app.notifySuccess(): void} instead.
+   * As of 2.0.0, please use {@link app.notifySuccess app.notifySuccess(): void} instead.
    *
    * Notifies the frame that app initialization is successful and is ready for user interaction.
    */
@@ -56,7 +56,7 @@ export namespace appInitialization {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link app.notifyFailure app.notifyFailure(appInitializationFailedRequest: IFailedRequest): void} instead.
+   * As of 2.0.0, please use {@link app.notifyFailure app.notifyFailure(appInitializationFailedRequest: IFailedRequest): void} instead.
    *
    * Notifies the frame that app initialization has failed and to show an error page in its place.
    * @param appInitializationFailedRequest - The failure request containing the reason for why the app failed
@@ -68,7 +68,7 @@ export namespace appInitialization {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link app.notifyExpectedFailure app.notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void} instead.
+   * As of 2.0.0, please use {@link app.notifyExpectedFailure app.notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void} instead.
    *
    * Notifies the frame that app initialized with some expected errors.
    * @param expectedFailureRequest - The expected failure request containing the reason and an optional message

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -6,7 +6,7 @@ export enum HostClientType {
   ipados = 'ipados',
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link teamsRoomsWindows} instead.
+   * As of 2.0.0, please use {@link teamsRoomsWindows} instead.
    */
   rigel = 'rigel',
   surfaceHub = 'surfaceHub',
@@ -68,7 +68,7 @@ export enum DialogDimension {
 import { ErrorCode, SdkError } from './interfaces';
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link DialogDimension} instead.
+ * As of 2.0.0, please use {@link DialogDimension} instead.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export import TaskModuleDimension = DialogDimension;

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -171,7 +171,7 @@ export enum FileOpenPreference {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link app.Context} instead.
+ * As of 2.0.0, please use {@link app.Context} instead.
  * Represents structure of the received context message.
  */
 export interface Context {
@@ -244,7 +244,7 @@ export interface Context {
   /**
    * @hidden
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link loginHint} or {@link userPrincipalName} instead.
+   * As of 2.0.0, please use {@link loginHint} or {@link userPrincipalName} instead.
    * The UPN of the current user.
    * Because a malicious party can run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
@@ -537,7 +537,7 @@ export interface ShareDeepLinkParameters {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.5, please use {@link ShareDeepLinkParameters} instead.
+ * As of 2.0.0, please use {@link ShareDeepLinkParameters} instead.
  */
 export interface DeepLinkParameters {
   /**
@@ -659,7 +659,7 @@ export interface DialogInfo {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link DialogInfo} instead.
+ * As of 2.0.0, please use {@link DialogInfo} instead.
  */
 export type TaskInfo = DialogInfo;
 
@@ -701,7 +701,7 @@ export interface FrameInfo {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link FrameInfo} instead.
+ * As of 2.0.0, please use {@link FrameInfo} instead.
  */
 export type FrameContext = FrameInfo;
 

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -54,7 +54,7 @@ export namespace location {
   export function getLocation(props: LocationProps): Promise<Location>;
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link location.getLocation location.getLocation(props: LocationProps): Promise\<Location\>} instead.
+   * As of 2.0.0, please use {@link location.getLocation location.getLocation(props: LocationProps): Promise\<Location\>} instead.
    * @param props {@link LocationProps} - Specifying how the location request is handled
    * @param callback - Callback to invoke when current user location is fetched
    */
@@ -92,7 +92,7 @@ export namespace location {
   export function showLocation(location: Location): Promise<void>;
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link location.showLocation location.showLocation(location: Location): Promise\<void\>} instead.
+   * As of 2.0.0, please use {@link location.showLocation location.showLocation(location: Location): Promise\<void\>} instead.
    * Shows the location on map corresponding to the given coordinates
    * @param location {@link Location} - which needs to be shown on map
    * @param callback - Callback to invoke when the location is opened on map

--- a/packages/teams-js/src/public/monetization.ts
+++ b/packages/teams-js/src/public/monetization.ts
@@ -40,7 +40,7 @@ export namespace monetization {
   export function openPurchaseExperience(planInfo?: PlanInfo): Promise<void>;
   /**
    * @deprecated
-   * As of 2.0.0-beta.3, please use {@link monetization.openPurchaseExperience monetization.openPurchaseExperience(planInfo?: PlanInfo): Promise\<void\>} instead.
+   * As of 2.0.0, please use {@link monetization.openPurchaseExperience monetization.openPurchaseExperience(planInfo?: PlanInfo): Promise\<void\>} instead.
    *
    * @hidden
    * Hide from docs

--- a/packages/teams-js/src/public/navigation.ts
+++ b/packages/teams-js/src/public/navigation.ts
@@ -9,7 +9,7 @@ import { pages } from './pages';
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.returnFocus pages.returnFocus(navigateForward?: boolean): void} instead.
+ * As of 2.0.0, please use {@link pages.returnFocus pages.returnFocus(navigateForward?: boolean): void} instead.
  *
  * Return focus to the main Teams app. Will focus search bar if navigating foward and app bar if navigating back.
  *
@@ -21,7 +21,7 @@ export function returnFocus(navigateForward?: boolean): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.tabs.navigateToTab pages.tabs.navigateToTab(tabInstance: TabInstance): Promise\<void\>} instead.
+ * As of 2.0.0, please use {@link pages.tabs.navigateToTab pages.tabs.navigateToTab(tabInstance: TabInstance): Promise\<void\>} instead.
  *
  * Navigates the Microsoft Teams app to the specified tab instance.
  *
@@ -43,7 +43,7 @@ export function navigateToTab(tabInstance: TabInstance, onComplete?: (status: bo
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.navigateCrossDomain pages.navigateCrossDomain(url: string): Promise\<void\>} instead.
+ * As of 2.0.0, please use {@link pages.navigateCrossDomain pages.navigateCrossDomain(url: string): Promise\<void\>} instead.
  *
  * Navigates the frame to a new cross-domain URL. The domain of this URL must match at least one of the
  * valid domains specified in the validDomains block of the manifest; otherwise, an exception will be
@@ -77,7 +77,7 @@ export function navigateCrossDomain(url: string, onComplete?: (status: boolean, 
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.backStack.navigateBack pages.backStack.navigateBack(): Promise\<void\>} instead.
+ * As of 2.0.0, please use {@link pages.backStack.navigateBack pages.backStack.navigateBack(): Promise\<void\>} instead.
  *
  * Navigates back in the Teams client.
  * See registerBackButtonHandler for more information on when it's appropriate to use this method.

--- a/packages/teams-js/src/public/people.ts
+++ b/packages/teams-js/src/public/people.ts
@@ -19,7 +19,7 @@ export namespace people {
   export function selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise<PeoplePickerResult[]>;
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link people.selectPeople people.selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise\<PeoplePickerResult[]\>} instead.
+   * As of 2.0.0, please use {@link people.selectPeople people.selectPeople(peoplePickerInputs?: PeoplePickerInputs): Promise\<PeoplePickerResult[]\>} instead.
    *
    * Launches a people picker and allows the user to select one or more people from the list
    * If the app is added to personal app scope the people picker launched is org wide and if the app is added to a chat/channel, people picker launched is also limited to the members of chat/channel

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -15,7 +15,7 @@ import { teamsCore } from './teamsAPIs';
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link app.initialize app.initialize(validMessageOrigins?: string[]): Promise\<void\>} instead.
+ * As of 2.0.0, please use {@link app.initialize app.initialize(validMessageOrigins?: string[]): Promise\<void\>} instead.
  *
  * Initializes the library. This must be called before any other SDK calls
  * but after the frame is loaded successfully.
@@ -33,7 +33,7 @@ export function initialize(callback?: () => void, validMessageOrigins?: string[]
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link app._initialize app._initialize(hostWindow: any): void} instead.
+ * As of 2.0.0, please use {@link app._initialize app._initialize(hostWindow: any): void} instead.
  *
  * @hidden
  * Hide from docs.
@@ -49,7 +49,7 @@ export function _initialize(hostWindow: any): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link app._uninitialize app._uninitialize(): void} instead.
+ * As of 2.0.0, please use {@link app._uninitialize app._uninitialize(): void} instead.
  *
  * @hidden
  * Hide from docs.
@@ -64,7 +64,7 @@ export function _uninitialize(): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link teamsCore.enablePrintCapability teamsCore.enablePrintCapability(): void} instead.
+ * As of 2.0.0, please use {@link teamsCore.enablePrintCapability teamsCore.enablePrintCapability(): void} instead.
  *
  * Enable print capability to support printing page using Ctrl+P and cmd+P
  */
@@ -74,7 +74,7 @@ export function enablePrintCapability(): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link teamsCore.print teamsCore.print(): void} instead.
+ * As of 2.0.0, please use {@link teamsCore.print teamsCore.print(): void} instead.
  *
  * Default print handler
  */
@@ -84,7 +84,7 @@ export function print(): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link app.getContext app.getContext(): Promise\<app.Context\>} instead.
+ * As of 2.0.0, please use {@link app.getContext app.getContext(): Promise\<app.Context\>} instead.
  *
  * Retrieves the current context the frame is running in.
  *
@@ -101,7 +101,7 @@ export function getContext(callback: (context: Context) => void): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link app.registerOnThemeChangeHandler app.registerOnThemeChangeHandler(handler: (theme: string) => void): void} instead.
+ * As of 2.0.0, please use {@link app.registerOnThemeChangeHandler app.registerOnThemeChangeHandler(handler: (theme: string) => void): void} instead.
  *
  * Registers a handler for theme changes.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -114,7 +114,7 @@ export function registerOnThemeChangeHandler(handler: (theme: string) => void): 
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.registerFullScreenHandler pages.registerFullScreenHandler(handler: (isFullScreen: boolean) => void): void} instead.
+ * As of 2.0.0, please use {@link pages.registerFullScreenHandler pages.registerFullScreenHandler(handler: (isFullScreen: boolean) => void): void} instead.
  *
  * Registers a handler for changes from or to full-screen view for a tab.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -127,7 +127,7 @@ export function registerFullScreenHandler(handler: (isFullScreen: boolean) => vo
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.appButton.onClick pages.appButton.onClick(handler: () => void): void} instead.
+ * As of 2.0.0, please use {@link pages.appButton.onClick pages.appButton.onClick(handler: () => void): void} instead.
  *
  * Registers a handler for clicking the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -140,7 +140,7 @@ export function registerAppButtonClickHandler(handler: () => void): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.appButton.onHoverEnter pages.appButton.onHoverEnter(handler: () => void): void} instead.
+ * As of 2.0.0, please use {@link pages.appButton.onHoverEnter pages.appButton.onHoverEnter(handler: () => void): void} instead.
  *
  * Registers a handler for entering hover of the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -153,7 +153,7 @@ export function registerAppButtonHoverEnterHandler(handler: () => void): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.appButton.onHoverLeave pages.appButton.onHoverLeave(handler: () => void): void} instead.
+ * As of 2.0.0, please use {@link pages.appButton.onHoverLeave pages.appButton.onHoverLeave(handler: () => void): void} instead.
  *
  * Registers a handler for exiting hover of the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
@@ -166,7 +166,7 @@ export function registerAppButtonHoverLeaveHandler(handler: () => void): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.backStack.registerBackButtonHandler pages.backStack.registerBackButtonHandler(handler: () => boolean): void} instead.
+ * As of 2.0.0, please use {@link pages.backStack.registerBackButtonHandler pages.backStack.registerBackButtonHandler(handler: () => boolean): void} instead.
  *
  * Registers a handler for user presses of the Team client's back button. Experiences that maintain an internal
  * navigation stack should use this handler to navigate the user back within their frame. If an app finds
@@ -181,7 +181,7 @@ export function registerBackButtonHandler(handler: () => boolean): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link teamsCore.registerOnLoadHandler teamsCore.registerOnLoadHandler(handler: (context: LoadContext) => void): void} instead.
+ * As of 2.0.0, please use {@link teamsCore.registerOnLoadHandler teamsCore.registerOnLoadHandler(handler: (context: LoadContext) => void): void} instead.
  *
  * @hidden
  * Registers a handler to be called when the page has been requested to load.
@@ -194,7 +194,7 @@ export function registerOnLoadHandler(handler: (context: LoadContext) => void): 
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link teamsCore.registerBeforeUnloadHandler teamsCore.registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void} instead.
+ * As of 2.0.0, please use {@link teamsCore.registerBeforeUnloadHandler teamsCore.registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void} instead.
  *
  * @hidden
  * Registers a handler to be called before the page is unloaded.
@@ -208,7 +208,7 @@ export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void)
 
 /**
  * @deprecated
- * As of 2.0.0-beta.3, please use {@link pages.registerFocusEnterHandler pages.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void} instead.
+ * As of 2.0.0, please use {@link pages.registerFocusEnterHandler pages.registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void} instead.
  *
  * @hidden
  * Registers a handler when focus needs to be passed from teams to the place of choice on app.
@@ -221,7 +221,7 @@ export function registerFocusEnterHandler(handler: (navigateForward: boolean) =>
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.config.registerChangeConfigHandler pages.config.registerChangeConfigHandler(handler: () => void): void} instead.
+ * As of 2.0.0, please use {@link pages.config.registerChangeConfigHandler pages.config.registerChangeConfigHandler(handler: () => void): void} instead.
  *
  * Registers a handler for when the user reconfigurated tab.
  *
@@ -233,7 +233,7 @@ export function registerEnterSettingsHandler(handler: () => void): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.tabs.getTabInstances pages.tabs.getTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise\<TabInformation\>} instead.
+ * As of 2.0.0, please use {@link pages.tabs.getTabInstances pages.tabs.getTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise\<TabInformation\>} instead.
  *
  * Allows an app to retrieve for this user tabs that are owned by this app.
  * If no TabInstanceParameters are passed, the app defaults to favorite teams and favorite channels.
@@ -253,7 +253,7 @@ export function getTabInstances(
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.tabs.getMruTabInstances pages.tabs.getMruTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise\<TabInformation\>} instead.
+ * As of 2.0.0, please use {@link pages.tabs.getMruTabInstances pages.tabs.getMruTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise\<TabInformation\>} instead.
  *
  * Allows an app to retrieve the most recently used tabs for this user.
  *
@@ -272,7 +272,7 @@ export function getMruTabInstances(
 
 /**
  * @deprecated
- * As of 2.0.0-beta.3, please use {@link pages.shareDeepLink pages.shareDeepLink(deepLinkParameters: DeepLinkParameters): void} instead.
+ * As of 2.0.0, please use {@link pages.shareDeepLink pages.shareDeepLink(deepLinkParameters: DeepLinkParameters): void} instead.
  *
  * Shares a deep link that a user can use to navigate back to a specific state in this page.
  *
@@ -288,7 +288,7 @@ export function shareDeepLink(deepLinkParameters: DeepLinkParameters): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.3, please use {@link app.openLink core.openLink(deepLink: string): Promise\<void\>} instead.
+ * As of 2.0.0, please use {@link app.openLink core.openLink(deepLink: string): Promise\<void\>} instead.
  *
  * Execute deep link API.
  *
@@ -316,7 +316,7 @@ export function executeDeepLink(deepLink: string, onComplete?: (status: boolean,
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.setCurrentFrame pages.setCurrentFrame(frameInfo: FrameInfo): void} instead.
+ * As of 2.0.0, please use {@link pages.setCurrentFrame pages.setCurrentFrame(frameInfo: FrameInfo): void} instead.
  *
  * Set the current Frame Context
  *
@@ -328,7 +328,7 @@ export function setFrameContext(frameContext: FrameContext): void {
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.initializeWithFrameContext pages.initializeWithFrameContext(frameInfo: FrameInfo, callback?: () => void, validMessageOrigins?: string[],): void} instead.
+ * As of 2.0.0, please use {@link pages.initializeWithFrameContext pages.initializeWithFrameContext(frameInfo: FrameInfo, callback?: () => void, validMessageOrigins?: string[],): void} instead.
  *
  * Initilize with FrameContext
  *

--- a/packages/teams-js/src/public/settings.ts
+++ b/packages/teams-js/src/public/settings.ts
@@ -5,7 +5,7 @@ import { pages } from './pages';
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link pages.config} namespace instead.
+ * As of 2.0.0, please use {@link pages.config} namespace instead.
  *
  * Namespace to interact with the settings-specific part of the SDK.
  * This object is usable only on the settings frame.
@@ -13,7 +13,7 @@ import { pages } from './pages';
 export namespace settings {
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link pages.config.Config} instead.
+   * As of 2.0.0, please use {@link pages.config.Config} instead.
    * @remarks
    * Renamed to config in pages.Config
    */
@@ -21,7 +21,7 @@ export namespace settings {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link pages.config.SaveEvent} instead.
+   * As of 2.0.0, please use {@link pages.config.SaveEvent} instead.
    * @remarks
    * See pages.SaveEvent
    */
@@ -29,7 +29,7 @@ export namespace settings {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link pages.config.RemoveEvent} instead.
+   * As of 2.0.0, please use {@link pages.config.RemoveEvent} instead.
    * @remarks
    * See pages.RemoveEvent
    */
@@ -37,7 +37,7 @@ export namespace settings {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link pages.config.SaveParameters} instead.
+   * As of 2.0.0, please use {@link pages.config.SaveParameters} instead.
    * @remarks
    * See pages.SaveParameters
    */
@@ -46,7 +46,7 @@ export namespace settings {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link pages.config.setValidityState pages.config.setValidityState(validityState: boolean): void} instead.
+   * As of 2.0.0, please use {@link pages.config.setValidityState pages.config.setValidityState(validityState: boolean): void} instead.
    *
    * Sets the validity state for the settings.
    * The initial value is false, so the user cannot save the settings until this is called with true.
@@ -59,7 +59,7 @@ export namespace settings {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link pages.config.getConfig pages.config.getConfig(): Promise\<Config\>} instead.
+   * As of 2.0.0, please use {@link pages.config.getConfig pages.config.getConfig(): Promise\<Config\>} instead.
    *
    * Gets the settings for the current instance.
    *
@@ -74,7 +74,7 @@ export namespace settings {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link pages.config.setConfig pages.config.setConfig(instanceSettings: Config): Promise\<void\>} instead.
+   * As of 2.0.0, please use {@link pages.config.setConfig pages.config.setConfig(instanceSettings: Config): Promise\<void\>} instead.
    *
    * Sets the settings for the current instance.
    * This is an asynchronous operation; calls to getSettings are not guaranteed to reflect the changed state.
@@ -99,7 +99,7 @@ export namespace settings {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link pages.config.registerOnSaveHandler pages.config.registerOnSaveHandler(handler: (evt: SaveEvent) => void): void} instead.
+   * As of 2.0.0, please use {@link pages.config.registerOnSaveHandler pages.config.registerOnSaveHandler(handler: (evt: SaveEvent) => void): void} instead.
    *
    * Registers a handler for when the user attempts to save the settings. This handler should be used
    * to create or update the underlying resource powering the content.
@@ -114,7 +114,7 @@ export namespace settings {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link pages.config.registerOnRemoveHandler pages.config.registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void} instead.
+   * As of 2.0.0, please use {@link pages.config.registerOnRemoveHandler pages.config.registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void} instead.
    *
    * Registers a handler for user attempts to remove content. This handler should be used
    * to remove the underlying resource powering the content.

--- a/packages/teams-js/src/public/sharing.ts
+++ b/packages/teams-js/src/public/sharing.ts
@@ -53,7 +53,7 @@ export namespace sharing {
   export function shareWebContent(shareWebContentRequest: IShareRequest<IShareRequestContentType>): Promise<void>;
   /**
    * @deprecated
-   * As of 2.0.0-beta.3, please use {@link sharing.shareWebContent sharing.shareWebContent(shareWebContentRequest: IShareRequest\<IShareRequestContentType\>): Promise\<void\>} instead.
+   * As of 2.0.0, please use {@link sharing.shareWebContent sharing.shareWebContent(shareWebContentRequest: IShareRequest\<IShareRequestContentType\>): Promise\<void\>} instead.
    *
    * Feature is under development
    * Opens a share dialog for web content

--- a/packages/teams-js/src/public/stageView.ts
+++ b/packages/teams-js/src/public/stageView.ts
@@ -57,7 +57,7 @@ export namespace stageView {
    * Feature is under development
    *
    * @deprecated
-   * As of 2.0.0-beta.3, please use {@link stageView.open stageView.open(): Promise\<void\>} instead.
+   * As of 2.0.0, please use {@link stageView.open stageView.open(): Promise\<void\>} instead.
    *
    * Opens a stage view to display a Teams app
    * @param stageViewParams The parameters to pass into the stage view.

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -9,7 +9,7 @@ import { BotUrlDialogInfo, DialogInfo, DialogSize, TaskInfo, UrlDialogInfo } fro
 
 /**
  * @deprecated
- * As of 2.0.0-beta.1, please use {@link dialog} namespace instead.
+ * As of 2.0.0, please use {@link dialog} namespace instead.
  *
  * Namespace to interact with the task module-specific part of the SDK.
  * This object is usable only on the content frame.
@@ -18,7 +18,7 @@ import { BotUrlDialogInfo, DialogInfo, DialogSize, TaskInfo, UrlDialogInfo } fro
 export namespace tasks {
   /**
    * @deprecated
-   * As of 2.0.0-beta.4, please use {@link dialog.open(urlDialogInfo: UrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): PostMessageChannel} for url based dialogs
+   * As of 2.0.0, please use {@link dialog.open(urlDialogInfo: UrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): PostMessageChannel} for url based dialogs
    * and {@link dialog.bot.open(botUrlDialogInfo: BotUrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): PostMessageChannel} for bot based dialogs.
    *
    * Allows an app to open the task module.
@@ -47,7 +47,7 @@ export namespace tasks {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.4, please use {@link dialog.update.resize dialog.update.resize(dimensions: DialogSize): void} instead.
+   * As of 2.0.0, please use {@link dialog.update.resize dialog.update.resize(dimensions: DialogSize): void} instead.
    *
    * Update height/width task info properties.
    *
@@ -66,7 +66,7 @@ export namespace tasks {
 
   /**
    * @deprecated
-   * As of 2.0.0-beta.1, please use {@link dialog.submit dialog.submit(result?: string | object, appIds?: string | string[]): void} instead.
+   * As of 2.0.0, please use {@link dialog.submit dialog.submit(result?: string | object, appIds?: string | string[]): void} instead.
    *
    * Submit the task module.
    *


### PR DESCRIPTION
We received guidance that in preparation for release v2.0, all @deprecated tags that were introduced in 2.0 beta versions should now point to v2.0. This should be clearer for developers who upgrade from v1 to v2.