### PR TITLE
Update GitHub actions for archive/v1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,9 @@ name: Microsoft Teams Library JS CI
 on:
   # Triggers the workflow on push or pull request events but only for the master and release-* branch
   push:
-    branches: [ master, release-* ]
+    branches: [ archive/v1, release-* ]
   pull_request:
-    branches: [ master, release-* ]
+    branches: [ archive/v1, release-* ]
 
 jobs:
   build:


### PR DESCRIPTION
After `master` was renamed to `archive/v1`, the status checks that are triggered on the branch need to be updated to trigger on the new branch name.