### PR TITLE
Added a link to info about the updated Context

### DIFF
--- a/change/@microsoft-teams-js-6cfdd495-e295-4ae6-b1a2-1721a2f1eae8.json
+++ b/change/@microsoft-teams-js-6cfdd495-e295-4ae6-b1a2-1721a2f1eae8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added a link to info about the updated Context",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -172,7 +172,12 @@ export enum FileOpenPreference {
 /**
  * @deprecated
  * As of 2.0.0, please use {@link app.Context} instead.
- * Represents structure of the received context message.
+ *
+ * @remarks
+ * For more details on the updated {@link app.Context} interface, visit
+ * {@link https://docs.microsoft.com/microsoftteams/platform/tabs/how-to/using-teams-client-sdk}.
+ *
+ * Represents the structure of the received context message.
  */
 export interface Context {
   /**

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -175,7 +175,7 @@ export enum FileOpenPreference {
  *
  * @remarks
  * For more details on the updated {@link app.Context} interface, visit
- * {@link https://docs.microsoft.com/microsoftteams/platform/tabs/how-to/using-teams-client-sdk}.
+ * {@link https://docs.microsoft.com/microsoftteams/platform/tabs/how-to/using-teams-client-sdk#updates-to-the-context-interface}.
  *
  * Represents the structure of the received context message.
  */


### PR DESCRIPTION
Since the global `Context` interface is deprecated, this change provides a link to more information about the differences between the deprecated `Context` and `app.Context` interfaces.