### PR TITLE
Release 1.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Reference the SDK inside of your `.html` page using:
 
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
-<script src="https://statics.teams.cdn.office.net/sdk/v1.11.0/js/MicrosoftTeams.min.js" integrity="sha384-SCVF3m7OvDKnfAilUzYn2yozEvBeP8n/Oq0yTH8VUI70J4AzrqR70jzjdQ6DI8s2" crossorigin="anonymous"></script>
+<script src="https://statics.teams.cdn.office.net/sdk/v1.12.1/js/MicrosoftTeams.min.js" integrity="sha384-HmRb1xX74v8jZiukR88bXWmRgVO/3uU7eHP64Ng+fnU0kc9JPBauRiQCPkvEtSGF" crossorigin="anonymous"></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
 <script src="node_modules/@microsoft/teams-js@1.11.0/dist/MicrosoftTeams.min.js"></script>

--- a/deploy-to-cdn.js
+++ b/deploy-to-cdn.js
@@ -11,12 +11,14 @@ const vaultUri = argv.vaultUri;
 const secretName = argv.vaultSecretName;
 
 function getConnectionString() {
+  console.log('Getting connection string.');
   const authenticator = function(challenge, callback) {
     const context = new AuthenticationContext(challenge.authorization);
     return context.acquireTokenWithClientCredentials(challenge.resource, clientId, clientSecret, function(
       err,
       tokenResponse,
     ) {
+      console.error('Failed to acquire token w/ error: ' + JSON.stringify(err));
       if (err) throw err;
       const authorizationValue = tokenResponse.tokenType + ' ' + tokenResponse.accessToken;
       return callback(null, authorizationValue);
@@ -38,10 +40,11 @@ function getConnectionString() {
   const files = await fs.listAsync('./dist');
   files.forEach(file => {
     filePaths.push({path: path.resolve(__dirname, 'dist', file)});
-  })
+  });
   const logger = console.log;
 
   getConnectionString().then(connectionString => {
+    console.log('Deploying to CDN.');
     const opts = {
       serviceOptions: [connectionString], // custom arguments to azure.createBlobService
       containerName: 'sdk', // container name in blob
@@ -55,6 +58,7 @@ function getConnectionString() {
     };
 
     deploy(opts, filePaths, logger, function(err) {
+      console.error('Failed to deploy w/ error: ' + JSON.stringify(err));
       if (err) throw err;
       console.log('Deployment Successful.');
     });

--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
     "transform": {
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/.git"
+    ],
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$",
     "moduleFileExtensions": [
       "ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "1.11.0",
+  "version": "1.12.1",
   "description": "Microsoft Client SDK for building app for Microsoft teams",
   "main": "./dist/MicrosoftTeams.min.js",
   "typings": "./dist/MicrosoftTeams.d.ts",

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -1,6 +1,6 @@
 import { generateRegExpFromUrls } from './utils';
 
-export const version = '1.11.0';
+export const version = '1.12.1';
 /**
  * The client version when all SDK APIs started to check platform compatibility for the APIs was 1.6.0.
  * Modified to 2.0.1 which is hightest till now so that if any client doesn't pass version in initialize function, it will be set to highest.


### PR DESCRIPTION
This change updates the SDK version to 1.12.1 which will be the last release of the v1.x SDK. This minor version bump is needed to address an accidental regression introduced in v1.12.0 around the registerChangeSettingsHandler API.