### PR TITLE
Updated reference doc comments to rationalize "Teams" vs "host" occurrences

### DIFF
--- a/change/@microsoft-teams-js-fad26258-8531-4882-98d5-8df4e225fba8.json
+++ b/change/@microsoft-teams-js-fad26258-8531-4882-98d5-8df4e225fba8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reference doc updates to rationalize 'Teams' vs 'host' occurrences and other minor edits",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/appEntity.ts
+++ b/packages/teams-js/src/private/appEntity.ts
@@ -83,7 +83,7 @@ export namespace appEntity {
   }
 
   /**
-   * Checks if appEntity capability is supported currently
+   * Checks if appEntity capability is supported by the host
    * @returns true if the appEntity capability is enabled in runtime.supports.appEntity and
    * false if it is disabled
    */

--- a/packages/teams-js/src/private/appEntity.ts
+++ b/packages/teams-js/src/private/appEntity.ts
@@ -17,7 +17,7 @@ export namespace appEntity {
   export interface AppEntity {
     /**
      * @hidden
-     * Application ID of the application
+     * ID of the application
      */
     appId: string;
 

--- a/packages/teams-js/src/private/appEntity.ts
+++ b/packages/teams-js/src/private/appEntity.ts
@@ -17,7 +17,7 @@ export namespace appEntity {
   export interface AppEntity {
     /**
      * @hidden
-     * App ID of the application
+     * Application ID of the application
      */
     appId: string;
 
@@ -52,9 +52,9 @@ export namespace appEntity {
    * --------
    * Open the Tab Gallery and retrieve the app entity
    * @param threadId ID of the thread where the app entity will be created
-   * @param categories A list of app categories that will be displayed in the opened tab gallery
+   * @param categories A list of application categories that will be displayed in the opened tab gallery
    * @param subEntityId An object that will be made available to the application being configured
-   *                      through the Teams Context's subEntityId field.
+   *                      through the Context's subEntityId field.
    * @param callback Callback that will be triggered once the app entity information is available.
    *                 The callback takes two arguments: an SdkError in case something happened (i.e.
    *                 no permissions to execute the API) and the app entity configuration, if available
@@ -82,6 +82,11 @@ export namespace appEntity {
     sendMessageToParent('appEntity.selectAppEntity', [threadId, categories, subEntityId], callback);
   }
 
+  /**
+   * Checks if appEntity capability is supported currently
+   * @returns true if the appEntity capability is enabled in runtime.supports.appEntity and
+   * false if it is disabled
+   */
   export function isSupported(): boolean {
     return runtime.supports.appEntity ? true : false;
   }

--- a/packages/teams-js/src/private/files.ts
+++ b/packages/teams-js/src/private/files.ts
@@ -414,7 +414,7 @@ export namespace files {
    * Hide from docs
    * ------
    *
-   * Open a cloud storage file in teams
+   * Open a cloud storage file in Teams
    *
    * @param file - cloud storage file that should be opened
    * @param providerCode - Code of the cloud storage folder provider

--- a/packages/teams-js/src/private/legacy.ts
+++ b/packages/teams-js/src/private/legacy.ts
@@ -8,6 +8,9 @@ import { runtime } from '../public/runtime';
 import { TeamInstanceParameters, UserJoinedTeamsInformation } from './interfaces';
 
 /**
+ * @hidden
+ * Hide from docs
+ * ------
  * @internal
  */
 export namespace legacy {
@@ -46,6 +49,14 @@ export namespace legacy {
         });
       }
 
+      /**
+       * @hidden
+       * Hide from docs
+       * ------
+       * Checks if teams.fullTrust.joinedTeams capability is supported currently
+       * @returns true if the teams.fullTrust.joinedTeams capability is enabled in
+       * runtime.supports.teams.fullTrust.joinedTeams and false if it is disabled
+       */
       export function isSupported(): boolean {
         return runtime.supports.teams
           ? runtime.supports.teams.fullTrust
@@ -77,7 +88,12 @@ export namespace legacy {
     }
 
     /**
+     * @hidden
+     * Hide from docs
+     * ------
      * Checks if teams.fullTrust capability is supported currently
+     * @returns true if the teams.fullTrust capability is enabled in runtime.supports.teams.fullTrust and
+     * false if it is disabled
      */
     export function isSupported(): boolean {
       return runtime.supports.teams ? (runtime.supports.teams.fullTrust ? true : false) : false;
@@ -85,7 +101,12 @@ export namespace legacy {
   }
 
   /**
+   * @hidden
+   * Hide from docs
+   * ------
    * Checks if teams capability is supported currently
+   * @returns true if the teams capability is enabled in runtime.supports.teams and
+   * false if it is disabled
    */
   export function isSupported(): boolean {
     return runtime.supports.teams ? true : false;

--- a/packages/teams-js/src/private/legacy.ts
+++ b/packages/teams-js/src/private/legacy.ts
@@ -53,7 +53,7 @@ export namespace legacy {
        * @hidden
        * Hide from docs
        * ------
-       * Checks if teams.fullTrust.joinedTeams capability is supported currently
+       * Checks if teams.fullTrust.joinedTeams capability is supported by the host
        * @returns true if the teams.fullTrust.joinedTeams capability is enabled in
        * runtime.supports.teams.fullTrust.joinedTeams and false if it is disabled
        */
@@ -91,7 +91,7 @@ export namespace legacy {
      * @hidden
      * Hide from docs
      * ------
-     * Checks if teams.fullTrust capability is supported currently
+     * Checks if teams.fullTrust capability is supported by the host
      * @returns true if the teams.fullTrust capability is enabled in runtime.supports.teams.fullTrust and
      * false if it is disabled
      */
@@ -104,7 +104,7 @@ export namespace legacy {
    * @hidden
    * Hide from docs
    * ------
-   * Checks if teams capability is supported currently
+   * Checks if teams capability is supported by the host
    * @returns true if the teams capability is enabled in runtime.supports.teams and
    * false if it is disabled
    */

--- a/packages/teams-js/src/private/privateAPIs.ts
+++ b/packages/teams-js/src/private/privateAPIs.ts
@@ -31,7 +31,7 @@ export function uploadCustomApp(manifestBlob: Blob, onComplete?: (status: boolea
 /**
  * @hidden
  * Internal use only
- * Sends a custom action MessageRequest to Teams or parent window
+ * Sends a custom action MessageRequest to host or parent window
  *
  * @param actionName - Specifies name of the custom action to be sent
  * @param args - Specifies additional arguments passed to the action

--- a/packages/teams-js/src/private/teams.ts
+++ b/packages/teams-js/src/private/teams.ts
@@ -79,6 +79,12 @@ export namespace teams {
     sendMessageToParent('teams.refreshSiteUrl', [threadId], callback);
   }
 
+  /**
+   * @hidden
+   * Checks if teams capability is supported currently
+   * @returns true if the teams capability is enabled in runtime.supports.teams and
+   * false if it is disabled
+   */
   export function isSupported(): boolean {
     return runtime.supports.teams ? true : false;
   }

--- a/packages/teams-js/src/private/teams.ts
+++ b/packages/teams-js/src/private/teams.ts
@@ -81,7 +81,7 @@ export namespace teams {
 
   /**
    * @hidden
-   * Checks if teams capability is supported currently
+   * Checks if teams capability is supported by the host
    * @returns true if the teams capability is enabled in runtime.supports.teams and
    * false if it is disabled
    */

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -20,7 +20,7 @@ import { runtime } from './runtime';
 export namespace pages {
   /**
    * Return focus to the host. Will move focus forward or backward based on where the application container falls in
-   * the F6/Tab accessiblity loop in the host.
+   * the F6/tab order in the host.
    * @param navigateForward - Determines the direction to focus in host.
    */
   export function returnFocus(navigateForward?: boolean): void {
@@ -67,7 +67,7 @@ export namespace pages {
    *
    * @param frameInfo - Frame information containing the URL used in the iframe on reload and the URL for when the
    *  user clicks 'Go To Website'
-   * @param callback - An optional user-set callback that is executed once the application has finished initialization.
+   * @param callback - An optional callback that is executed once the application has finished initialization.
    * @param validMessageOrigins - An optional list of cross-frame message origins. They must have
    * https: protocol otherwise they will be ignored. Example: https:www.example.com
    */
@@ -211,7 +211,7 @@ export namespace pages {
   }
 
   /**
-   * Checks if the current application host supports the pages capability
+   * Checks if the pages capability is supported by the host
    * @returns true if the pages capability is enabled in runtime.supports.pages and
    * false if it is disabled
    */
@@ -302,7 +302,7 @@ export namespace pages {
     }
 
     /**
-     * Checks if the current application host supports the pages.tab capability
+     * Checks if the pages.tab capability is supported by the host
      * @returns true if the pages.tabs capability is enabled in runtime.supports.pages.tabs and
      * false if it is disabled
      */
@@ -523,7 +523,7 @@ export namespace pages {
     }
 
     /**
-     * Checks if the current application host supports the pages.config capability
+     * Checks if the pages.config capability is supported by the host
      * @returns true if the pages.config capability is enabled in runtime.supports.pages.config and
      * false if it is disabled
      */
@@ -581,7 +581,7 @@ export namespace pages {
     }
 
     /**
-     * Checks if the current application host supports the pages.backStack capability
+     * Checks if the pages.backStack capability is supported by the host
      * @returns true if the pages.backStack capability is enabled in runtime.supports.pages.backStack and
      * false if it is disabled
      */
@@ -628,7 +628,7 @@ export namespace pages {
      * @hidden
      * Hide from docs
      * ------
-     * Checks if the current application host supports the pages.fullTrust capability
+     * Checks if the pages.fullTrust capability is supported by the host
      * @returns true if the pages.fullTrust capability is enabled in runtime.supports.pages.fullTrust and
      * false if it is disabled
      */
@@ -681,7 +681,7 @@ export namespace pages {
     }
 
     /**
-     * Checks if pages.appButton capability is supported currently
+     * Checks if pages.appButton capability is supported by the host
      * @returns true if the pages.appButton capability is enabled in runtime.supports.pages.appButton and
      * false if it is disabled
      */

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -19,7 +19,7 @@ import { runtime } from './runtime';
  */
 export namespace pages {
   /**
-   * Return focus to the host. Will move focus forward or backward based on where the app container falls in
+   * Return focus to the host. Will move focus forward or backward based on where the application container falls in
    * the F6/Tab accessiblity loop in the host.
    * @param navigateForward - Determines the direction to focus in host.
    */
@@ -34,9 +34,9 @@ export namespace pages {
   /**
    * @hidden
    *
-   * Registers a handler when focus needs to be passed from teams to the place of choice on app.
+   * Registers a handler when focus needs to be passed from the host to the place of choice on application.
    *
-   * @param handler - The handler to invoked by the app when they want the focus to be in the place of their choice.
+   * @param handler - The handler to invoked by the application when they want the focus to be in the place of their choice.
    *
    * @internal
    */
@@ -67,7 +67,7 @@ export namespace pages {
    *
    * @param frameInfo - Frame information containing the URL used in the iframe on reload and the URL for when the
    *  user clicks 'Go To Website'
-   * @param callback - An optional user-set callback that is executed once the app has finished initialization.
+   * @param callback - An optional user-set callback that is executed once the application has finished initialization.
    * @param validMessageOrigins - An optional list of cross-frame message origins. They must have
    * https: protocol otherwise they will be ignored. Example: https:www.example.com
    */
@@ -125,7 +125,7 @@ export namespace pages {
    * Navigates the frame to a new cross-domain URL. The domain of this URL must match at least one of the
    * valid domains specified in the validDomains block of the manifest; otherwise, an exception will be
    * thrown. This function needs to be used only when navigating the frame to a URL in a different domain
-   * than the current one in a way that keeps the app informed of the change and allows the SDK to
+   * than the current one in a way that keeps the application informed of the change and allows the SDK to
    * continue working.
    * @param url - The URL to navigate the frame to.
    * @returns Promise that resolves when the navigation has completed.
@@ -151,12 +151,12 @@ export namespace pages {
   }
 
   /**
-   * Navigate to the given App ID and Page ID, with optional parameters for a WebURL (if the app cannot
-   * be navigated to, such as if it is not installed), Channel ID (for apps installed as a channel tab), and
-   * Sub-page ID (for navigating to specific content within the page). This is equivalent to navigating to
-   * a deep link with the above data, but does not require the app to build a URL or worry about different
+   * Navigate to the given application ID and page ID, with optional parameters for a WebURL (if the application
+   * cannot be navigated to, such as if it is not installed), Channel ID (for applications installed as a channel tab),
+   * and sub-page ID (for navigating to specific content within the page). This is equivalent to navigating to
+   * a deep link with the above data, but does not require the application to build a URL or worry about different
    * deep link formats for different hosts.
-   * @param params Parameters for the navigation
+   * @param params - Parameters for the navigation
    * @returns a promise that will resolve if the navigation was successful
    */
   export function navigateToApp(params: NavigateToAppParams): Promise<void> {
@@ -224,12 +224,12 @@ export namespace pages {
    */
   export interface NavigateToAppParams {
     /**
-     * ID of the App to navigate to
+     * ID of the application to navigate to
      */
     appId: string;
 
     /**
-     * Developer-defined ID of the Page to navigate to within the app (Formerly EntityID)
+     * Developer-defined ID of the Page to navigate to within the application (Formerly EntityID)
      */
     pageId: string;
 
@@ -240,23 +240,24 @@ export namespace pages {
 
     /**
      * Optional developer-defined ID describing the content to navigate to within the Page. This will be passed
-     * back to the App via the Context object.
+     * back to the application via the Context object.
      */
     subPageId?: string;
 
     /**
-     * Optional ID of the Teams Channel where the app should be opened
+     * Optional ID of the Teams Channel where the application should be opened
      */
     channelId?: string;
   }
 
   /**
-   * Namespace to interact with the teams specific part of the SDK.
+   * Provides APIs for querying and navigating between an application's "tabs", which are pages associated
+   * with a specific context like a channel or a chat (as opposed to "personal tabs").
    */
   export namespace tabs {
     /**
-     * Navigates the hosted app to the specified tab instance.
-     * @param tabInstance The tab instance to navigate to.
+     * Navigates the hosted application to the specified tab instance.
+     * @param tabInstance - The tab instance to navigate to.
      * @returns Promise that resolves when the navigation has completed.
      */
     export function navigateToTab(tabInstance: TabInstance): Promise<void> {
@@ -270,9 +271,9 @@ export namespace pages {
       });
     }
     /**
-     * Allows an app to retrieve for this user tabs that are owned by this app.
-     * If no TabInstanceParameters are passed, the app defaults to favorite teams and favorite channels.
-     * @param tabInstanceParameters OPTIONAL Flags that specify whether to scope call to favorite teams or channels.
+     * Allows an application to retrieve for this user tabs that are owned by this application.
+     * If no TabInstanceParameters are passed, the application defaults to favorite teams and favorite channels.
+     * @param tabInstanceParameters - An optional set of flags that specify whether to scope call to favorite teams or channels.
      * @returns Promise that resolves with the {@link TabInformation}. Contains information for the user's tabs that are owned by this application {@link TabInstance}.
      */
     export function getTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise<TabInformation> {
@@ -286,8 +287,8 @@ export namespace pages {
     }
 
     /**
-     * Allows an app to retrieve the most recently used tabs for this user.
-     * @param tabInstanceParameters OPTIONAL Ignored, kept for future use.
+     * Allows an application to retrieve the most recently used tabs for this user.
+     * @param tabInstanceParameters - An optional set of flags. Note this is currently ignored and kept for future use.
      * @returns Promise that resolves with the {@link TabInformation}. Contains information for the users' most recently used tabs {@link TabInstance}.
      */
     export function getMruTabInstances(tabInstanceParameters?: TabInstanceParameters): Promise<TabInformation> {
@@ -310,7 +311,7 @@ export namespace pages {
     }
   }
   /**
-   * Namespace to interact with the config-specific part of the SDK.
+   * Provides APIs to interact with the config-specific part of the SDK.
    * This object is usable only on the config frame.
    */
   export namespace config {
@@ -332,7 +333,7 @@ export namespace pages {
     /**
      * Sets the validity state for the config.
      * The initial value is false, so the user cannot save the config until this is called with true.
-     * @param validityState Indicates whether the save or remove button is enabled for the user.
+     * @param validityState - Indicates whether the save or remove button is enabled for the user.
      */
     export function setValidityState(validityState: boolean): void {
       ensureInitialized(FrameContexts.settings, FrameContexts.remove);
@@ -345,7 +346,7 @@ export namespace pages {
     /**
      * Sets the config for the current instance.
      * This is an asynchronous operation; calls to getConfig are not guaranteed to reflect the changed state.
-     * @param instanceConfig The desired config for this instance.
+     * @param instanceConfig - The desired config for this instance.
      * @returns Promise that resolves when the operation has completed.
      */
     export function setConfig(instanceConfig: InstanceConfig): Promise<void> {
@@ -363,7 +364,7 @@ export namespace pages {
      * to create or update the underlying resource powering the content.
      * The object passed to the handler must be used to notify whether to proceed with the save.
      * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
-     * @param handler The handler to invoke when the user selects the save button.
+     * @param handler - The handler to invoke when the user selects the save button.
      */
     export function registerOnSaveHandler(handler: (evt: SaveEvent) => void): void {
       ensureInitialized(FrameContexts.settings);
@@ -379,7 +380,7 @@ export namespace pages {
      * to remove the underlying resource powering the content.
      * The object passed to the handler must be used to indicate whether to proceed with the removal.
      * Only one handler may be registered at a time. Subsequent registrations will override the first.
-     * @param handler The handler to invoke when the user selects the remove button.
+     * @param handler - The handler to invoke when the user selects the remove button.
      */
     export function registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void {
       ensureInitialized(FrameContexts.remove, FrameContexts.settings);
@@ -402,7 +403,7 @@ export namespace pages {
 
     /**
      * Registers a handler for when the tab configuration is changed by the user
-     * @param handler The handler to invoke when the user click on Settings.
+     * @param handler - The handler to invoke when the user click on Settings.
      */
     export function registerChangeConfigHandler(handler: () => void): void {
       ensureInitialized(FrameContexts.content);
@@ -427,7 +428,7 @@ export namespace pages {
       notifySuccess(): void;
       /**
        * Indicates that creation of the underlying resource failed and that the config cannot be saved.
-       * @param reason Specifies a reason for the failure. If provided, this string is displayed to the user; otherwise a generic error is displayed.
+       * @param reason - Specifies a reason for the failure. If provided, this string is displayed to the user; otherwise a generic error is displayed.
        */
       notifyFailure(reason?: string): void;
     }
@@ -443,7 +444,7 @@ export namespace pages {
       notifySuccess(): void;
       /**
        * Indicates that removal of the underlying resource failed and that the content cannot be removed.
-       * @param reason Specifies a reason for the failure. If provided, this string is displayed to the user; otherwise a generic error is displayed.
+       * @param reason - Specifies a reason for the failure. If provided, this string is displayed to the user; otherwise a generic error is displayed.
        */
       notifyFailure(reason?: string): void;
     }
@@ -532,7 +533,7 @@ export namespace pages {
   }
 
   /**
-   * Namespace to interact with the back-stack part of the SDK.
+   * Provides APIs to interact with the back-stack part of the SDK.
    */
   export namespace backStack {
     let backButtonPressHandler: () => boolean;
@@ -542,7 +543,7 @@ export namespace pages {
     }
 
     /**
-     * Navigates back in the hosted app. See registerBackButtonHandler for more information on when
+     * Navigates back in the hosted application. See registerBackButtonHandler for more information on when
      * it's appropriate to use this method.
      * @returns Promise that resolves when the navigation has completed.
      */
@@ -558,11 +559,11 @@ export namespace pages {
     }
 
     /**
-     * Registers a handler for user presses of the Team client's back button. Experiences that maintain an internal
-     * navigation stack should use this handler to navigate the user back within their frame. If an app finds
+     * Registers a handler for user presses of the host client's back button. Experiences that maintain an internal
+     * navigation stack should use this handler to navigate the user back within their frame. If an application finds
      * that after running its back button handler it cannot handle the event it should call the navigateBack
-     * method to ask the Teams client to handle it instead.
-     * @param handler The handler to invoke when the user presses their Team client's back button.
+     * method to ask the host client to handle it instead.
+     * @param handler - The handler to invoke when the user presses the host client's back button.
      */
     export function registerBackButtonHandler(handler: () => boolean): void {
       ensureInitialized();
@@ -593,7 +594,7 @@ export namespace pages {
    * @hidden
    * Hide from docs
    * ------
-   * Namespace to interact with the full-trust part of the SDK. Limited to 1P apps
+   * Provides APIs to interact with the full-trust part of the SDK. Limited to 1P applications
    */
   export namespace fullTrust {
     /**
@@ -637,7 +638,7 @@ export namespace pages {
   }
 
   /**
-   * Namespace to interact with the app button part of the SDK.
+   * Provides APIs to interact with the app button part of the SDK.
    */
   export namespace appButton {
     /**

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -34,9 +34,9 @@ export namespace pages {
   /**
    * @hidden
    *
-   * Registers a handler when focus needs to be passed from the host to the place of choice on application.
+   * Registers a handler when focus passes from the host to a specified part of the application.
    *
-   * @param handler - The handler to invoked by the application when they want the focus to be in the place of their choice.
+   * @param handler - The handler for placing focus within the application.
    *
    * @internal
    */
@@ -251,13 +251,13 @@ export namespace pages {
   }
 
   /**
-   * Provides APIs for querying and navigating between an application's "tabs", which are pages associated
-   * with a specific context like a channel or a chat (as opposed to "personal tabs").
+   * Provides APIs for querying and navigating between contextual tabs of an application. Unlike personal tabs,
+   * contextual tabs are pages associated with a specific context, such as channel or chat.
    */
   export namespace tabs {
     /**
      * Navigates the hosted application to the specified tab instance.
-     * @param tabInstance - The tab instance to navigate to.
+     * @param tabInstance - The destination tab instance.
      * @returns Promise that resolves when the navigation has completed.
      */
     export function navigateToTab(tabInstance: TabInstance): Promise<void> {
@@ -271,7 +271,7 @@ export namespace pages {
       });
     }
     /**
-     * Allows an application to retrieve for this user tabs that are owned by this application.
+     * Retrieves application tabs for the current user.
      * If no TabInstanceParameters are passed, the application defaults to favorite teams and favorite channels.
      * @param tabInstanceParameters - An optional set of flags that specify whether to scope call to favorite teams or channels.
      * @returns Promise that resolves with the {@link TabInformation}. Contains information for the user's tabs that are owned by this application {@link TabInstance}.
@@ -287,7 +287,7 @@ export namespace pages {
     }
 
     /**
-     * Allows an application to retrieve the most recently used tabs for this user.
+     * Retrieves the most recently used application tabs for the current user.
      * @param tabInstanceParameters - An optional set of flags. Note this is currently ignored and kept for future use.
      * @returns Promise that resolves with the {@link TabInformation}. Contains information for the users' most recently used tabs {@link TabInstance}.
      */
@@ -311,8 +311,8 @@ export namespace pages {
     }
   }
   /**
-   * Provides APIs to interact with the config-specific part of the SDK.
-   * This object is usable only on the config frame.
+   * Provides APIs to interact with the configuration-specific part of the SDK.
+   * This object is usable only on the configuration frame.
    */
   export namespace config {
     let saveHandler: (evt: SaveEvent) => void;
@@ -331,8 +331,8 @@ export namespace pages {
     }
 
     /**
-     * Sets the validity state for the config.
-     * The initial value is false, so the user cannot save the config until this is called with true.
+     * Sets the validity state for the configuration.
+     * The initial value is false, so the user cannot save the configuration until this is called with true.
      * @param validityState - Indicates whether the save or remove button is enabled for the user.
      */
     export function setValidityState(validityState: boolean): void {
@@ -344,9 +344,9 @@ export namespace pages {
     }
 
     /**
-     * Sets the config for the current instance.
+     * Sets the configuration for the current instance.
      * This is an asynchronous operation; calls to getConfig are not guaranteed to reflect the changed state.
-     * @param instanceConfig - The desired config for this instance.
+     * @param instanceConfig - The desired configuration for this instance.
      * @returns Promise that resolves when the operation has completed.
      */
     export function setConfig(instanceConfig: InstanceConfig): Promise<void> {
@@ -360,11 +360,11 @@ export namespace pages {
     }
 
     /**
-     * Registers a handler for when the user attempts to save the settings. This handler should be used
+     * Registers a handler for when the user attempts to save the configuration. This handler should be used
      * to create or update the underlying resource powering the content.
      * The object passed to the handler must be used to notify whether to proceed with the save.
      * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
-     * @param handler - The handler to invoke when the user selects the save button.
+     * @param handler - The handler to invoke when the user selects the Save button.
      */
     export function registerOnSaveHandler(handler: (evt: SaveEvent) => void): void {
       ensureInitialized(FrameContexts.settings);
@@ -380,7 +380,7 @@ export namespace pages {
      * to remove the underlying resource powering the content.
      * The object passed to the handler must be used to indicate whether to proceed with the removal.
      * Only one handler may be registered at a time. Subsequent registrations will override the first.
-     * @param handler - The handler to invoke when the user selects the remove button.
+     * @param handler - The handler to invoke when the user selects the Remove button.
      */
     export function registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void {
       ensureInitialized(FrameContexts.remove, FrameContexts.settings);
@@ -403,7 +403,7 @@ export namespace pages {
 
     /**
      * Registers a handler for when the tab configuration is changed by the user
-     * @param handler - The handler to invoke when the user click on Settings.
+     * @param handler - The handler to invoke when the user clicks on Settings.
      */
     export function registerChangeConfigHandler(handler: () => void): void {
       ensureInitialized(FrameContexts.content);
@@ -533,7 +533,7 @@ export namespace pages {
   }
 
   /**
-   * Provides APIs to interact with the back-stack part of the SDK.
+   * Provides APIs for handling the user's navigational history.
    */
   export namespace backStack {
     let backButtonPressHandler: () => boolean;
@@ -543,8 +543,7 @@ export namespace pages {
     }
 
     /**
-     * Navigates back in the hosted application. See registerBackButtonHandler for more information on when
-     * it's appropriate to use this method.
+     * Navigates back in the hosted application. See {@link pages.backStack.registerBackButtonHandler} for notes on usage.
      * @returns Promise that resolves when the navigation has completed.
      */
     export function navigateBack(): Promise<void> {

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -34,7 +34,7 @@ export namespace pages {
   /**
    * @hidden
    *
-   * Registers a handler when focus passes from the host to a specified part of the application.
+   * Registers a handler for specifying focus when it passes from the host to the application.
    *
    * @param handler - The handler for placing focus within the application.
    *

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -346,7 +346,9 @@ export function initializeWithFrameContext(
 }
 
 /**
- * Transforms the app.Context object received to TeamsJS Context
+ * Transforms the app.Context object received to the legacy global Context object
+ * @param appContext - The app.Context object to be transformed
+ * @returns The transformed legacy global Context object
  */
 function transformAppContextToLegacyContext(appContext: app.Context): Context {
   const context: Context = {

--- a/packages/teams-js/src/public/stageView.ts
+++ b/packages/teams-js/src/public/stageView.ts
@@ -49,7 +49,7 @@ export namespace stageView {
    *
    * Opens a stage view to display a Teams application
    * @param stageViewParams - The parameters to pass into the stage view.
-   * @returns Promise that resolves when open has completed.
+   * @returns Promise that resolves once the stage view is closed.
    */
   export function open(stageViewParams: StageViewParams): Promise<void>;
   /**

--- a/packages/teams-js/src/public/stageView.ts
+++ b/packages/teams-js/src/public/stageView.ts
@@ -13,7 +13,7 @@ export namespace stageView {
    */
   export interface StageViewParams {
     /**
-     * The application ID of the Teams application to be opened.
+     * The application ID of the hosted application to be opened.
      */
     appId: string;
 
@@ -33,12 +33,12 @@ export namespace stageView {
     title: string;
 
     /**
-     * The Teams app website URL.
+     * The hosted application website URL.
      */
     websiteUrl?: string;
 
     /**
-     * The entity ID of the Teams app content being opened.
+     * The entity ID of the hosted application content being opened.
      */
     entityId?: string;
   }
@@ -47,9 +47,9 @@ export namespace stageView {
    * @hidden
    * Feature is under development
    *
-   * Opens a stage view to display a Teams app
-   * @param stageViewParams The parameters to pass into the stage view.
-   *
+   * Opens a stage view to display a hosted application
+   * @param stageViewParams - The parameters to pass into the stage view.
+   * @returns Promise that resolves when open has completed.
    */
   export function open(stageViewParams: StageViewParams): Promise<void>;
   /**
@@ -59,9 +59,9 @@ export namespace stageView {
    * @deprecated
    * As of 2.0.0, please use {@link stageView.open stageView.open(): Promise\<void\>} instead.
    *
-   * Opens a stage view to display a Teams app
-   * @param stageViewParams The parameters to pass into the stage view.
-   * Optional; @param callback Callback that will be triggered once the stage view is closed.
+   * Opens a stage view to display a hosted application
+   * @param stageViewParams - The parameters to pass into the stage view.
+   * @param callback - Optional callback that will be triggered once the stage view is closed.
    *                 The callback takes as an argument an SdkError in case something happened (i.e.
    *                 no permissions to execute the API)
    */

--- a/packages/teams-js/src/public/stageView.ts
+++ b/packages/teams-js/src/public/stageView.ts
@@ -13,7 +13,7 @@ export namespace stageView {
    */
   export interface StageViewParams {
     /**
-     * The application ID of the hosted application to be opened.
+     * The ID of the Teams application to be opened.
      */
     appId: string;
 
@@ -33,12 +33,12 @@ export namespace stageView {
     title: string;
 
     /**
-     * The hosted application website URL.
+     * The Teams application website URL.
      */
     websiteUrl?: string;
 
     /**
-     * The entity ID of the hosted application content being opened.
+     * The entity ID of the Teams application content being opened.
      */
     entityId?: string;
   }
@@ -47,7 +47,7 @@ export namespace stageView {
    * @hidden
    * Feature is under development
    *
-   * Opens a stage view to display a hosted application
+   * Opens a stage view to display a Teams application
    * @param stageViewParams - The parameters to pass into the stage view.
    * @returns Promise that resolves when open has completed.
    */
@@ -59,7 +59,7 @@ export namespace stageView {
    * @deprecated
    * As of 2.0.0, please use {@link stageView.open stageView.open(): Promise\<void\>} instead.
    *
-   * Opens a stage view to display a hosted application
+   * Opens a stage view to display a Teams application
    * @param stageViewParams - The parameters to pass into the stage view.
    * @param callback - Optional callback that will be triggered once the stage view is closed.
    *                 The callback takes as an argument an SdkError in case something happened (i.e.

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -75,7 +75,7 @@ export namespace teamsCore {
   }
 
   /**
-   * Checks if teamsCore capability is supported currently
+   * Checks if teamsCore capability is supported by the host
    * @returns true if the teamsCore capability is enabled in runtime.supports.teamsCore and
    * false if it is disabled
    */

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -74,6 +74,11 @@ export namespace teamsCore {
     Handlers.registerBeforeUnloadHandler(handler);
   }
 
+  /**
+   * Checks if teamsCore capability is supported currently
+   * @returns true if the teamsCore capability is enabled in runtime.supports.teamsCore and
+   * false if it is disabled
+   */
   export function isSupported(): boolean {
     return runtime.supports.teamsCore ? true : false;
   }

--- a/packages/teams-js/src/public/video.ts
+++ b/packages/teams-js/src/public/video.ts
@@ -150,7 +150,7 @@ export namespace video {
   }
 
   /**
-   * Checks if video capability is supported currently
+   * Checks if video capability is supported by the host
    * @returns true if the video capability is enabled in runtime.supports.video and
    * false if it is disabled
    */

--- a/packages/teams-js/src/public/video.ts
+++ b/packages/teams-js/src/public/video.ts
@@ -46,7 +46,7 @@ export namespace video {
   }
 
   /**
-   * Video frame configuration supplied to Teams to customize the generated video frame parameters, like format
+   * Video frame configuration supplied to the host to customize the generated video frame parameters, like format
    */
   export interface VideoFrameConfig {
     /**
@@ -85,6 +85,8 @@ export namespace video {
 
   /**
    * Register to read the video frames in Permissions section
+   * @param frameCallback - The callback to invoke when registerForVideoFrame has completed
+   * @param config - VideoFrameConfig to customize generated video frame parameters
    */
   export function registerForVideoFrame(frameCallback: VideoFrameCallback, config: VideoFrameConfig): void {
     ensureInitialized(FrameContexts.sidePanel);
@@ -101,9 +103,9 @@ export namespace video {
   }
 
   /**
-   * video extension should call this to notify Teams Client current selected effect parameter changed.
-   * If it's pre-meeting, Teams client will call videoEffectCallback immediately then use the videoEffect.
-   * in-meeting scenario, we will call videoEffectCallback when apply button clicked.
+   * video extension should call this to notify host client that the current selected effect parameter changed.
+   * If it's pre-meeting, host client will call videoEffectCallback immediately then use the videoEffect.
+   * If it's the in-meeting scenario, we will call videoEffectCallback when apply button clicked.
    *
    * @param effectChangeType - the effect change type.
    * @param effectId - Newly selected effect id.
@@ -120,7 +122,8 @@ export namespace video {
   }
 
   /**
-   * Register the video effect callback, Teams client uses this to notify the video extension the new video effect will by applied
+   * Register the video effect callback, host client uses this to notify the video extension the new video effect will by applied
+   * @param callback - The VideoEffectCallback to invoke when registerForVideoEffect has completed
    */
   export function registerForVideoEffect(callback: VideoEffectCallBack): void {
     ensureInitialized(FrameContexts.sidePanel);
@@ -131,7 +134,7 @@ export namespace video {
   }
 
   /**
-   * Sending notification to Teams client finished the video frame processing, now Teams client can render this video frame
+   * Sending notification to host client finished the video frame processing, now host client can render this video frame
    * or pass the video frame to next one in video pipeline
    */
   function notifyVideoFrameProcessed(): void {
@@ -139,12 +142,18 @@ export namespace video {
   }
 
   /**
-   * Sending error notification to Teams client
+   * Sending error notification to host client
+   * @param errorMessage - The error message that will be sent to the host
    */
   function notifyError(errorMessage: string): void {
     sendMessageToParent('video.notifyError', [errorMessage]);
   }
 
+  /**
+   * Checks if video capability is supported currently
+   * @returns true if the video capability is enabled in runtime.supports.video and
+   * false if it is disabled
+   */
   export function isSupported(): boolean {
     return runtime.supports.video ? true : false;
   }


### PR DESCRIPTION
There were several places in the SDK where we still refer to "Teams", but since the SDK supports multiple hosts, these should be changed to "host". 

While I was editing these files, I made the additional updates:

- Cleaned up instances of app -> application
- Added doc comments for several isSupported functions
- Made other minor doc updates in edited files for consistency and completeness