### PR TITLE
Proposal for sdk update to add search capability

### DIFF
--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -33,6 +33,7 @@ export interface IRuntime {
     };
     readonly people?: {};
     readonly remoteCamera?: {};
+    readonly search?: {};
     readonly sharing?: {};
     readonly teams?: {
       readonly fullTrust?: {
@@ -72,6 +73,7 @@ export let runtime: IRuntime = {
     },
     people: undefined,
     remoteCamera: undefined,
+    search: undefined,
     sharing: undefined,
     teams: {
       fullTrust: {
@@ -109,6 +111,7 @@ export const teamsRuntimeConfig: IRuntime = {
       fullTrust: {},
     },
     remoteCamera: {},
+    search: undefined,
     sharing: {},
     teams: {
       fullTrust: {},

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -111,7 +111,6 @@ export const teamsRuntimeConfig: IRuntime = {
       fullTrust: {},
     },
     remoteCamera: {},
-    search: undefined,
     sharing: {},
     teams: {
       fullTrust: {},

--- a/packages/teams-js/src/public/search.ts
+++ b/packages/teams-js/src/public/search.ts
@@ -1,0 +1,87 @@
+import { sendMessageToParent } from '../internal/communication';
+import { registerHandler, removeHandler } from '../internal/handlers';
+import { runtime } from './runtime';
+
+/**
+ * Allows you to interact with the host search experience
+ *
+ * @beta
+ */
+export namespace search {
+  /**
+   * This interface contains information pertaining to the search term in the host search experience
+   */
+  export interface SearchQuery {
+    /** The current search term in the host search experience */
+    searchTerm: string;
+
+    // may need some sort of timestamp or sequence value to
+    // ensure messages are processed in correct order / combine them
+    // having any sort of logic around combining messages or sorting them
+    // would make sense to go into the teamsjs-sdk layer
+    // timestamp: number;
+  }
+
+  export type SearchQueryHandler = (query: SearchQuery) => void;
+
+  /**
+   * Allows the caller to register for various events fired by the host search experience.
+   * Calling this function will cause the host search experience to set its default scope to
+   * the name of your application.
+   *
+   * @param onChangeHandler - This handler will be called when the user begins searching and every
+   * time the user changes the contents of the query. The value of the query is the current term
+   * the user is searching for. Should be used to put your application into whatever state is used
+   * to handle searching. This handler will be called once with an empty {@link SearchQuery.searchTerm}
+   * when search is beginning. 
+   * @param onClosedHandler - This handler will be called when the user finishes searching. Should be
+   * used to return your application to its default, non-search state. The value of {@link SearchQuery.searchTerm}
+   * will be whatever the last query was before ending search.
+   * @param onExecuteHandler - This optional handler will be called whenever the user 'executes' the
+   * search (by pressing enter for example). The value of {@link SearchQuery.searchTerm} is the current 
+   * term the user is searching for. Should be used if your app wants to treat executing searches differently than responding
+   * to changes to the search query.
+   *
+   * @example
+   * ``` ts
+   * search.registerHandlers(
+      query => {
+        alert(`Update your application to render a change to the search query: ${query.searchTerm}`);
+      },
+      () => {
+        alert('Update your application to handle the search experience being closed');
+      },
+      query => {
+        alert(`Update your application to render an executed search result: ${query.searchTerm}`);
+      },
+     );
+   * ```
+   */
+  export function registerHandlers(
+    onChangeHandler: SearchQueryHandler,
+    onClosedHandler: () => SearchQueryHandler,
+    onExecuteHandler?: SearchQueryHandler,
+  ): void {
+    registerHandler('searchQueryChange', onChangeHandler);
+    registerHandler('searchQueryClosed', onClosedHandler);
+    if (onExecuteHandler) {
+      registerHandler('searchQueryExecute', onExecuteHandler);
+    }
+  }
+
+  /**
+   * Allows the caller to unregister for all events fired by the host search experience. Calling
+   * this function will cause your app to stop appearing in the set of search scopes in the host.s
+   */
+  export function unregisterHandlers(): void {
+    // This should let the host know to stop making the app scope show up in the search experience
+    sendMessageToParent('search.unregister');
+    removeHandler('searchQueryChange');
+    removeHandler('searchQueryClosed');
+    removeHandler('searchQueryExecute');
+  }
+
+  export function isSupported(): boolean {
+    return runtime.supports.search ? true : false;
+  }
+}

--- a/packages/teams-js/src/public/search.ts
+++ b/packages/teams-js/src/public/search.ts
@@ -41,7 +41,7 @@ export namespace search {
    * @param onChangeHandler - This handler will be called when the user begins searching and every
    * time the user changes the contents of the query. The value of the query is the current term
    * the user is searching for. Should be used to put your application into whatever state is used
-   * to handle searching. This handler will be called once with an empty {@link SearchQuery.searchTerm}
+   * to handle searching. This handler will be called with an empty {@link SearchQuery.searchTerm}
    * when search is beginning. 
    * @param onClosedHandler - This handler will be called when the user finishes searching. Should be
    * used to return your application to its default, non-search state. The value of {@link SearchQuery.searchTerm}
@@ -55,13 +55,13 @@ export namespace search {
    * ``` ts
    * search.registerHandlers(
       query => {
-        console.log(`Update your application to render a change to the search query: ${query.searchTerm}`);
+        console.log(`Update your application with the changed search query: ${query.searchTerm}`);
       },
       () => {
         console.log('Update your application to handle the search experience being closed');
       },
       query => {
-        console.log(`Update your application to render an executed search result: ${query.searchTerm}`);
+        console.log(`Update your application to handle an executed search result: ${query.searchTerm}`);
       },
      );
    * ```
@@ -95,7 +95,7 @@ export namespace search {
 
   /**
    * Allows the caller to unregister for all events fired by the host search experience. Calling
-   * this function will cause your app to stop appearing in the set of search scopes in the host.s
+   * this function will cause your app to stop appearing in the set of search scopes in the hosts
    */
   export function unregisterHandlers(): void {
     // TODO: figure out what frame contexts you want to support this in


### PR DESCRIPTION
This is a proposal for how apps could integrate with the host search experience.

Applications can register for 3 different events:
1) onChange: this will be called when search begins and every time the contents of the searchQuery change
2) onClosed: this will be called when search ends in the host
3) onExecute: <OPTIONAL> this will be called when search is executed by the user (pressing enter for example)
If an application registers for these events their application name will show up in the host as the default search scope *while their application is running*.

Applications can also unregister for search events, which will cause their application to stop showing up as a valid search scope in the host.