### PR TITLE
Add directory to repository info in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://office.visualstudio.com/ISS/_apis/build/status/Taos%20Platform/App%20SDK/OfficeDev.microsoft-teams-library-js)](https://office.visualstudio.com/ISS/_build/latest?definitionId=17483)
 [![Coverage Status](https://coveralls.io/repos/github/OfficeDev/microsoft-teams-library-js/badge.svg)](https://coveralls.io/github/OfficeDev/microsoft-teams-library-js)
 
-Welcome to the Teams client SDK monorepo! For breaking changes, please refer to our [changelog](./packages/teams-js/CHANGELOG.md) in the `<root>/packages/teams-js` directory of the `main` branch. This repository contains the core teams-js package as well as tools and applications for analyzing and testing.
+Welcome to the Teams client SDK monorepo! For breaking changes, please refer to our [changelog](./packages/teams-js/CHANGELOG.md) in the `<root>/packages/teams-js` directory. This repository contains the core teams-js package as well as tools and applications for analyzing and testing.
 
 ## Getting Started
 
@@ -14,6 +14,8 @@ Welcome to the Teams client SDK monorepo! For breaking changes, please refer to 
 4. To run Unit tests, run `yarn test`
 
 TIP: whenever building or testing the Teams client SDK, you can run `yarn build` or `yarn test` from the `packages/teams-js` directory.
+
+See also: [Contributing](#Contributing)
 
 This JavaScript library is part of the [Microsoft Teams developer platform](https://docs.microsoft.com/en-us/microsoftteams/platform/overview?view=msteams-client-js-beta). See full [SDK reference documentation](https://docs.microsoft.com/en-us/javascript/api/overview/msteams-client?view=msteams-client-js-beta).
 
@@ -45,7 +47,7 @@ Application used to test the functionality of the various SDK APIs.
 
 If you would like to locally generate reference documentation for TeamsJS v2, simply utilize the script `yarn docs` either from the monorepo root or inside the teams-js project root (`packages/teams-js`). This should output the generated documentation to `packages/teams-js/docs`.
 
-## Contributing
+# Contributing
 
 We strongly welcome and encourage contributions to this project. Please read the [contributor's guide](CONTRIBUTING.md) which contains important information.
 

--- a/change/@microsoft-teams-js-927f99f5-92fd-4a8b-979f-11b6a9e7a6e2.json
+++ b/change/@microsoft-teams-js-927f99f5-92fd-4a8b-979f-11b6a9e7a6e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add directory to repository info in package.json",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -1,6 +1,6 @@
 # Microsoft Teams JavaScript client SDK
 
-Welcome to the Teams JavaScript client SDK! For breaking changes, please refer to our [changelog](./CHANGELOG.md) in the current `<root>/packages/teams-js` directory of the `main` branch.
+Welcome to the Teams JavaScript client SDK! For breaking changes, please refer to our [changelog](./CHANGELOG.md) in the current `<root>/packages/teams-js` directory.
 
 This JavaScript library is part of the [Microsoft Teams developer platform](https://docs.microsoft.com/en-us/microsoftteams/platform/overview?view=msteams-client-js-beta). See full [SDK reference documentation](https://docs.microsoft.com/en-us/javascript/api/overview/msteams-client?view=msteams-client-js-beta).
 

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -5,7 +5,8 @@
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OfficeDev/microsoft-teams-library-js"
+    "url": "https://github.com/OfficeDev/microsoft-teams-library-js",
+    "directory": "packages/teams-js"
   },
   "main": "./dist/MicrosoftTeams.min.js",
   "typings": "./dist/MicrosoftTeams.d.ts",

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -4,9 +4,9 @@
   "version": "2.0.0-beta.6",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
+    "directory": "packages/teams-js",
     "type": "git",
-    "url": "https://github.com/OfficeDev/microsoft-teams-library-js",
-    "directory": "packages/teams-js"
+    "url": "https://github.com/OfficeDev/microsoft-teams-library-js"
   },
   "main": "./dist/MicrosoftTeams.min.js",
   "typings": "./dist/MicrosoftTeams.d.ts",


### PR DESCRIPTION
The [npm docs](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository) suggest that you can specify a github repo with a link to the specific directory when your repo is a monorepo using the `directory` field.

Also made two small tweaks to the README files to remove redundant references to the "main branch" and added a reference to the Contributing section from the Getting Started section to hopefully help distinguish between when you should clone and fork the repo.