### PR TITLE
Add displayCapture.getSources private API

### DIFF
--- a/change/@microsoft-teams-js-55496c42-df6c-43b1-8bb4-455b6113d224.json
+++ b/change/@microsoft-teams-js-55496c42-df6c-43b1-8bb4-455b6113d224.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add displayCapture.getSources private API",
+  "packageName": "@microsoft/teams-js",
+  "email": "yujin1@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/displayCapture.ts
+++ b/packages/teams-js/src/private/displayCapture.ts
@@ -1,0 +1,32 @@
+import { sendMessageToParentAsync } from '../internal/communication';
+import { ensureInitialized } from '../internal/internalAPIs';
+import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
+import { runtime } from '../public/runtime';
+
+export interface DisplaySource {
+  id: string;
+  name: string;
+  thumbnaiel: string;
+  icon: string;
+  deviceId: string;
+}
+
+export namespace displayCapture {
+  export function getDisplaySources(): Promise<DisplaySource[]> {
+    return new Promise<DisplaySource[]>(resolve => {
+      ensureInitialized(FrameContexts.content, FrameContexts.task);
+
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+
+      sendMessageToParentAsync('displayCapture.getSources').then((sources: DisplaySource[]) => {
+        resolve(sources);
+      });
+    });
+  }
+
+  export function isSupported(): boolean {
+    return runtime.supports.displayCapture ? true : false;
+  }
+}

--- a/packages/teams-js/src/private/displayCapture.ts
+++ b/packages/teams-js/src/private/displayCapture.ts
@@ -6,8 +6,8 @@ import { runtime } from '../public/runtime';
 export interface DisplaySource {
   id: string;
   name: string;
-  thumbnaiel: string;
-  icon: string;
+  thumbnail: string;
+  appIcon: string;
   deviceId: string;
 }
 

--- a/packages/teams-js/src/private/index.ts
+++ b/packages/teams-js/src/private/index.ts
@@ -25,3 +25,4 @@ export { notifications } from './notifications';
 export { remoteCamera } from './remoteCamera';
 export { appEntity } from './appEntity';
 export { teams } from './teams';
+export { displayCapture } from './displayCapture';

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -19,6 +19,7 @@ export interface IRuntime {
     };
     readonly files?: {};
     readonly location?: {};
+    readonly displayCapture?: {};
     readonly logs?: {};
     readonly mail?: {};
     readonly media?: {};
@@ -60,6 +61,7 @@ export let runtime: IRuntime = {
       update: undefined,
     },
     location: undefined,
+    displayCapture: undefined,
     logs: undefined,
     mail: undefined,
     media: undefined,
@@ -166,6 +168,13 @@ export const versionConstants: Record<string, Array<ICapabilityReqs>> = {
         HostClientType.teamsPhones,
         HostClientType.teamsDisplays,
       ],
+    },
+  ],
+  // TODO: Not sure which version it will go under, 2.0.4 is used as a placeholder here.
+  '2.0.4': [
+    {
+      capability: { displayCapture: {} },
+      hostClientTypes: [HostClientType.desktop, HostClientType.web],
     },
   ],
 };


### PR DESCRIPTION
This PR is to add a private API: displayCapture.getSources. 
This API will return the sources of Electron.desktopCapturer.getSources. The returned result can be used for screen/window sharing purpose.