### PR TITLE
Remove callback version of stageView.open

### DIFF
--- a/apps/teams-test-app/src/components/StageViewAPIs.tsx
+++ b/apps/teams-test-app/src/components/StageViewAPIs.tsx
@@ -33,7 +33,11 @@ const OpenStageView = (): ReactElement =>
               setResult(JSON.stringify(error));
             }
           };
-          stageView.open(input, callback);
+          // remove after updating e2e tests
+          stageView
+            .open(input)
+            .then()
+            .catch(error => callback(error));
         },
       },
     },

--- a/change/@microsoft-teams-js-a1117fe3-9c1f-4d89-8020-c75903495d39.json
+++ b/change/@microsoft-teams-js-a1117fe3-9c1f-4d89-8020-c75903495d39.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "`stageView.open` now returns a Promise instead of taking a callback",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/stageView.ts
+++ b/packages/teams-js/src/public/stageView.ts
@@ -1,7 +1,5 @@
 import { sendAndHandleSdkError } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
-import { callCallbackWithErrorOrResultFromPromiseAndReturnPromise } from '../internal/utils';
-import { SdkError } from '../public';
 import { FrameContexts } from './constants';
 
 /**
@@ -49,32 +47,17 @@ export namespace stageView {
    *
    * Opens a stage view to display a Teams application
    * @param stageViewParams - The parameters to pass into the stage view.
-   * @returns Promise that resolves once the stage view is closed.
+   * @returns Promise that resolves or rejects with an error once the stage view is closed.
    */
-  export function open(stageViewParams: StageViewParams): Promise<void>;
-  /**
-   * @hidden
-   * Feature is under development
-   *
-   * @deprecated
-   * As of 2.0.0, please use {@link stageView.open stageView.open(): Promise\<void\>} instead.
-   *
-   * Opens a stage view to display a Teams application
-   * @param stageViewParams - The parameters to pass into the stage view.
-   * @param callback - Optional callback that will be triggered once the stage view is closed.
-   *                 The callback takes as an argument an SdkError in case something happened (i.e.
-   *                 no permissions to execute the API)
-   */
-  export function open(stageViewParams: StageViewParams, callback?: (sdkError?: SdkError) => void): void;
-  export function open(stageViewParams: StageViewParams, callback?: (sdkError?: SdkError) => void): Promise<void> {
-    ensureInitialized(FrameContexts.content);
+  export function open(stageViewParams: StageViewParams): Promise<void> {
+    return new Promise(resolve => {
+      ensureInitialized(FrameContexts.content);
 
-    if (!stageViewParams) {
-      throw new Error('[stageView.open] Stage view params cannot be null');
-    }
-    const wrappedFunction = (): Promise<void> =>
-      new Promise(resolve => resolve(sendAndHandleSdkError('stageView.open', stageViewParams)));
+      if (!stageViewParams) {
+        throw new Error('[stageView.open] Stage view params cannot be null');
+      }
 
-    return callCallbackWithErrorOrResultFromPromiseAndReturnPromise(wrappedFunction, callback);
+      resolve(sendAndHandleSdkError('stageView.open', stageViewParams));
+    });
   }
 }


### PR DESCRIPTION
`stageView.open` is a relatively new API that is still under development. On the path to v2, we have converted APIs that take callbacks to instead return Promises. As such, the `open` function that takes a callback has already been deprecated, despite being under development still.

Would be a clearer message to developers if we just had the `open` function that returns a `Promise`.