### PR TITLE
shrshinde/authNotifySuccessFailure

### DIFF
--- a/change/@microsoft-teams-js-36a90bf1-c107-470b-b128-4291b1cdee38.json
+++ b/change/@microsoft-teams-js-36a90bf1-c107-470b-b128-4291b1cdee38.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updating authentication.notifySuccess/Failure logic to throw error in Frameless context",
+  "packageName": "@microsoft/teams-js",
+  "email": "98348000+shrshindeMSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -371,6 +371,9 @@ export namespace authentication {
   export function notifySuccess(result?: string, callbackUrl?: string): void {
     redirectIfWin32Outlook(callbackUrl, 'result', result);
     ensureInitialized(FrameContexts.authentication);
+    if (GlobalVars.isFramelessWindow) {
+      throw new Error('Not Allowed in Frameless Window');
+    }
     sendMessageToParent('authentication.authenticate.success', [result]);
     // Wait for the message to be sent before closing the window
     waitForMessageQueue(Communication.parentWindow, () => setTimeout(() => Communication.currentWindow.close(), 200));
@@ -389,6 +392,9 @@ export namespace authentication {
   export function notifyFailure(reason?: string, callbackUrl?: string): void {
     redirectIfWin32Outlook(callbackUrl, 'reason', reason);
     ensureInitialized(FrameContexts.authentication);
+    if (GlobalVars.isFramelessWindow) {
+      throw new Error('Not Allowed in Frameless Window');
+    }
     sendMessageToParent('authentication.authenticate.failure', [reason]);
     // Wait for the message to be sent before closing the window
     waitForMessageQueue(Communication.parentWindow, () => setTimeout(() => Communication.currentWindow.close(), 200));

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -1320,6 +1320,12 @@ describe('Testing authentication capability', () => {
               )}. Current context: "${context}".`,
             );
           });
+        } else {
+          it(`authentication.notifySuccess should successfully notify auth success from ${context} context`, async () => {
+            await framelessPostMock.initializeWithContext(context);
+
+            expect(() => authentication.notifySuccess(mockResult)).toThrowError('Not Allowed in Frameless Window');
+          });
         }
       });
     });
@@ -1339,6 +1345,11 @@ describe('Testing authentication capability', () => {
                 allowedContexts,
               )}. Current context: "${context}".`,
             );
+          });
+        } else {
+          it(`authentication.failure should successfully notify auth failure from ${context} context`, async () => {
+            await framelessPostMock.initializeWithContext(context);
+            expect(() => authentication.notifyFailure(mockResult)).toThrowError('Not Allowed in Frameless Window');
           });
         }
       });

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -1,7 +1,7 @@
-import { app } from '../src/public/app';
-import { GlobalVars } from '../src/internal/globalVars';
 import { defaultSDKVersionForCompatCheck } from '../src/internal/constants';
+import { GlobalVars } from '../src/internal/globalVars';
 import { DOMMessageEvent, ExtendedWindow } from '../src/internal/interfaces';
+import { app } from '../src/public/app';
 import { applyRuntimeConfig, IRuntime } from '../src/public/runtime';
 export interface MessageRequest {
   id: number;


### PR DESCRIPTION
Updating `authentication.notifySuccess/Failure` code to throw error when window initialized as `frameless`.