### PR TITLE
Merge release/2.0.0 into main

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.0.0-beta.7/js/MicrosoftTeams.min.js"
-      integrity="sha384-u9MstnkqBQI9EtqTMRCoqno88AbVbKQ/iEN3UJqBUaIBSW3wEYsWEOTp3Im6mCdn"
+      src="https://res.cdn.office.net/teams-js/2.0.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-QtTBFeFlfRDZBfwHJHYQp7MdLJ2C3sfAEB1Qpy+YblvjavBye+q87TELpTnvlXw4"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0",
   "scripts": {
     "build": "yarn build:bundle",
     "build:bundle": "yarn lint && webpack",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
         parameters:
           appHostGitPath: git://$(AppHostingSdkGitPath2)@$(AppHostingSdkGitRef)
 
-      - bash: 'node tools/cli/runAppsWithE2ETests.js'
+      - bash: 'node tools/cli/runAppsWithE2ETests.js --targetClientSdkCheckpoint=2.0.0'
         displayName: 'Run E2E integration tests'
         condition: succeeded()
         workingDirectory: '$(AppHostingSdkProjectDirectory)'
@@ -77,7 +77,7 @@ jobs:
           Arguments: 'build-test-app-local'
           ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
-      - bash: 'node tools/cli/runAppsWithE2ETests.js --reportFileName=e2e-tests-report-local-script-tag --envType=localScriptTag'
+      - bash: 'node tools/cli/runAppsWithE2ETests.js --reportFileName=e2e-tests-report-local-script-tag --envType=localScriptTag --targetClientSdkCheckpoint=2.0.0'
         displayName: 'Run E2E integration tests with local script tag'
         condition: succeeded()
         workingDirectory: '$(AppHostingSdkProjectDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
         parameters:
           appHostGitPath: git://$(AppHostingSdkGitPath2)@$(AppHostingSdkGitRef)
 
-      - bash: 'node tools/cli/runAppsWithE2ETests.js --targetClientSdkCheckpoint=2.0.0'
+      - bash: 'node tools/cli/runAppsWithE2ETests.js'
         displayName: 'Run E2E integration tests'
         condition: succeeded()
         workingDirectory: '$(AppHostingSdkProjectDirectory)'
@@ -77,7 +77,7 @@ jobs:
           Arguments: 'build-test-app-local'
           ProjectDirectory: '$(ClientSdkProjectDirectory)'
 
-      - bash: 'node tools/cli/runAppsWithE2ETests.js --reportFileName=e2e-tests-report-local-script-tag --envType=localScriptTag --targetClientSdkCheckpoint=2.0.0'
+      - bash: 'node tools/cli/runAppsWithE2ETests.js --reportFileName=e2e-tests-report-local-script-tag --envType=localScriptTag'
         displayName: 'Run E2E integration tests with local script tag'
         condition: succeeded()
         workingDirectory: '$(AppHostingSdkProjectDirectory)'

--- a/change/@microsoft-teams-js-b8534d5d-068f-4ccc-8f59-482a8f11e76c.json
+++ b/change/@microsoft-teams-js-b8534d5d-068f-4ccc-8f59-482a8f11e76c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Consolidated change log entries across beta versions",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/d.json
+++ b/change/d.json
@@ -1,7 +1,0 @@
-{
-  "type": "major",
-  "comment": "Promote 2.0.0 beta changes to stable. TeamsJS can be used to write applications with support in multiple Microsoft 365 hosts, including Teams, Outlook, and Office.",
-  "packageName": "@microsoft/teams-js",
-  "email": "erinha@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,219 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Thu, 12 May 2022 21:34:49 GMT and should not be manually modified.
+This log was last generated on Fri, 13 May 2022 22:32:13 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.0.0
+
+Fri, 13 May 2022 22:32:13 GMT
+
+The change log comments for v2.0.0 are a consolidated summary of the comments for each beta release to describe the changes made since v1. Detailed change log comments for each beta release follow after 2.0.0.
+
+### Major changes
+
+- Promote 2.0.0 beta changes to stable. TeamsJS can be used to write applications with support in multiple Microsoft 365 hosts, including Teams, Outlook, and Office.
+- The Teams JavaScript client SDK repo has been converted to a monorepo
+
+  - Utilized [Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/) to turn our repo into a monorepo.
+  - The files specific to the Teams client SDK have been moved to an inner directory with the name `teams-js`
+  - A new TeamsJS Test App for validating the Teams client SDK has been added in the <root>/apps/teams-test-app location.
+
+- Reverted `registerEnterSettingsHandler` back to its original name `registerChangeSettingsHandler`
+- Removed deprecated `stageView.open` function that took a callback as a parameter
+- Modified `enablePrintCapability` to correctly require the library be initialized before using it
+- Removed `bot` namespace and APIs
+- Added `hostName` property to `Context` interface which contains the name of the host in which the app is running.
+- The `Context` interface has been updated to group similar properties for better scalability in a multi-host environment.
+- The `FrameContext` interface has been renamed `FrameInfo`.
+
+- Capabilities organization introduced
+
+  - Each capability has an `isSupported` function that is used to determine if a capability is supported in the host in which the application is running. All APIs call this function and will throw an `SdkError` with `ErrorCode.NOT_SUPPORTED_ON_PLATFORM` if it returns false.
+  - Added App capability
+    - The following APIs have been moved from `publicAPIs` to new `app` namespace:
+      - `initialize`
+      - `getContext`
+      - `registerOnThemeChangeHandler`
+      - `executeDeepLink` has been renamed `openLink`
+    - The following APIs have been moved from `appInitialization` to `app` namespace:
+      - `notifyAppLoaded`
+      - `notifySuccess`
+      - `notifyFailure`
+      - `notifyExpectedFailure`
+    - The following APIs have been added to `app` namespace:
+      - `isInitialized`
+      - `getFrameContext`
+  - Added a Pages capability and reorganized several APIs under it:
+
+    - The following APIs have been moved to the new `pages` namespace:
+      - `registerFullScreenHandler` moved from `publicAPIs`
+      - `initializeWithFrameContext` moved from `publicAPIs`
+      - `navigateCrossDomain` moved from `navigation` namespace
+      - `returnFocus` moved from `navigation` namespace
+      - `registerFocusEnterHandler` moved from `publicAPIs`
+      - `shareDeepLink` moved from `publicAPIs`
+      - `DeepLinkParameters` has been renamed to `ShareDeepLinkParameters`
+      - `setFrameContext` has been moved from `publicAPIs` and renamed `pages.setCurrentFrame`
+      - `settings.getSettings` has been renamed `pages.getConfig`
+    - Added `pages.navigateToApp` that navigates to the given application ID and page ID, with optional parameters for a WebURL (if the application cannot be navigated to, such as if it is not installed), Channel ID (for applications installed as a channel tab), and sub-page ID (for navigating to specific content within the page).
+    - The following APIs have been been renamed and moved from `publicAPIs` to a new Pages.AppButton sub-capability in the new `pages.appButton` namespace:
+      - `registerAppButtonClickHandler` has renamed and moved to `pages.appButton.onClick`
+      - `registerAppButtonHoverEnterHandler` has renamed and moved to `pages.appButton.onHoverEnter`
+      - `regsiterAppButtonHoverLeaveHandler` has renamed and moved to `pages.appButton.onHoverLeave`
+    - The following APIs have been moved to a new Pages.BackStack sub-capability in the new `pages.backStack` namespace:
+      - `registerBackButtonHandler` moved from `publicAPIs`
+      - `navigateBack` moved from `navigation` namespace
+    - The following APIs have been renamed and moved into the Pages.Config sub-capability in the `pages.config` namespace (formerly the `settings` namespace):
+      - `registerEnterSettingsHandler` has renamed and moved to `pages.config.registerChangeConfigHandler`
+      - `registerOnSaveHandler`
+      - `registerOnRemoveHandler`
+      - `setSettings` has been renamed `pages.config.setConfig`
+      - `setValidityState`
+    - The following APIs have been been moved from `privateAPIs` to a new Pages.FullTrust sub-capability in the new `pages.fullTrust` namespace:
+      - `enterFullscreen`
+      - `exitFullscreen`
+    - The following APIs have been been moved to a new Pages.Tabs sub-capability in the new `pages.tabs` namespace:
+      - `getTabInstances` moved from `publicAPIs`
+      - `getMruTabInstances` moved from `publicAPIs`
+      - `navigateToTab` moved from `navigation` namespace
+
+  - Tasks APIs renamed and reorganized under new Dialog capability:
+
+    - Added `dialog` capability, which has support for HTML-based dialogs, and a `dialog.bot` sub-capability has been added for bot-based dialogs. At this time, `dialog` does not support adaptive card-based dialogs.
+      - The following APIs have been renamed:
+        - `startTask` has been renamed `dialog.open`. It takes
+          - a `UrlDialogInfo` parameter instead of `DialogInfo` to enforce only HTML based dialogs,
+          - an optional `DialogSubmitHandler` callback that takes a single object parameter containing both error and result,
+          - an optional `PostMessageChannel` parameter which is triggered if dialog sends a message to the app
+        - `dialog.bot.open` has the same function signature except it takes `BotUrlDialogInfo` instead of `UrlDialogInfo`
+        - `submitTasks` has been renamed `dialog.submit`
+        - `TaskInfo` interface has been renamed `DialogInfo`
+        - `TaskModuleDimension` enum has been renamed `DialogDimension`
+      - Added `sendMessageToDialog` function which can be used to send messages to the dialog.
+    - Added `dialog.update` sub-capability and renamed `updateTask` to `dialog.update.resize`, which now takes a `DialogSize` parameter.
+
+  - Added TeamsCore capability
+
+    - The following APIs have been moved from `publicAPIs` to new `teamsCore` namespace:
+      - `enablePrintCapability`
+      - `print`
+      - `registerOnLoadHandler`
+      - `registerBeforeUnloadHandler`
+
+  - Added AppInstallDialog capability
+    - `openAppInstallDialog` is added to new `appInstallDialog` namespace
+  - Added Calendar capability
+    - The following APIs have been added to new `calendar` namespace:
+      - `openCalendarItem` is added
+      - `composeMeeting` is added
+  - Added Call capability
+    - `startCall` is added to new `call` namespace
+  - Added Mail capability
+    - The following APIs have been added to the new `mail` namespace:
+      - `openMailItem` is added
+      - `composeMail` is added
+  - Added Chat capability to new `chat` namespace to represent public chat functionality
+    - Added `openChat` and `openGroupChat` to open Teams chats with one or more users
+  - Converted existing `conversations` namespace into the Conversations capability to represent private chat functionality
+
+    - `getChatMembers` has been moved from `privateAPIs` to `conversations` namespace
+
+  - Added `fullTrust` and `fullTrust.joinedTeams` sub-capabilities to existing `teams` namespace
+    - The following API has been moved from `privateAPIs` to a new `teams.fullTrust` namespace:
+      - `getConfigSetting`
+    - The following API has been moved from `privateAPIs` to a new `teams.fullTrust.joinedTeams` namespace:
+      - `getUserJoinedTeams`
+  - Added Notifications capability
+    - `showNotification` has moved from `privateAPIs` to `notifications` namespace
+  - Converted existing namespaces into the following new capabilites
+    - Location
+    - Menus
+    - Monetization
+    - People
+    - Sharing
+    - Video
+    - Logs
+    - MeetingRoom
+    - RemoteCamera
+    - Teams
+  - Added Runtime capability
+    - Added `applyRuntimeConfig`
+
+- Promises introduced
+
+  - The following APIs that took in a callback function as a parameter now instead return a `Promise`.
+    - app APIs:
+      - `app.initialize`
+      - `app.getContext`
+    - authentication APIs：
+      - `authentication.authenticate`
+      - `authentication.getAuthToken`
+      - `authentication.getUser`
+    - conversations APIs:
+      - `conversations.getChatMembers`
+      - `conversations.openConversation`
+    - location APIs:
+      - `location.getLocation`
+      - `location.showLocation`
+    - meetingRoom APIs:
+      - `meetingRoom.getPairedMeetingRoomInfo`
+      - `meetingRoom.sendCommandToPairedMeetingRoom`
+    - pages APIs：
+      - `pages.navigateCrossDomain`
+      - `pages.tabs.navigateToTab`
+      - `pages.tabs.getTabInstances`
+      - `pages.tabs.getMruTabInstances`
+      - `pages.getConfig`
+      - `pages.config.setConfig`
+      - `pages.backStack.navigateBack`
+    - people APIs:
+      - `people.selectPeople`
+    - teams APIs:
+      - `teams.fulltrust.getConfigSetting`
+      - `teams.fulltrust.getUserJoinedTeams`
+    - others:
+      - `ChildAppWindow.postMessage`
+      - `ParentAppWindow.postMessage`
+      - `appInstallDialog.openAppInstallDialog`
+
+- Changed TypeScript to output ES6 modules instead of CommonJS
+
+### Minor changes
+
+- Updated `app.initialize` to automatically listen for messages that an application is sending to a dialog. Modified `registerOnMessageFromParent` in DialogAPI.tsx for the Teams Test App to account for this new functionality.
+- Copied `ParentAppWindow` functionality into `dialog` capability. In `dialog`, `ParentAppWindow.postMessage` was renamed to `dialog.sendMessageToParent(message: any): void`. `ParentAppWindow.addEventListener` was renamed to `dialog.registerOnMessageFromParent`.
+- Added `runtime.isLegacy` handler for the following deep link capabilities:
+  - `appInstallDialog`
+  - `calendar`
+  - `call`
+- Changed topic parameter name to `topicName` for `executeDeepLink` call in chat.ts
+- When the application host will not understand standard chat requests, added logic to send them as deep links.
+
+### Patches
+
+- Added a link to information about the updated `Context` in the reference documentation comments
+- Updated all `@deprecated` tags to reference version 2.0.0
+- Added directory field to repository info in package.json
+- Added missing reference documentation comments to interfaces, functions, and enums in app.ts and appInitialization.ts
+- Added missing reference documentation comments to the `pages` capability
+- Added missing reference documentation comments to the `authentication` capability
+- Updated reference documentation comments to rationalize 'Teams' vs 'host' occurrences and other minor edits
+- Updated `dialog.open` and `dialog.bot.open` to send `DialogInfo` type over to the host instead of `UrlDialogInfo` or `BotUrlDialogInfo` types
+- Added `minRuntimeConfig` to `uninitialize` for various capabilities
+- Updated README.md to reflect branch rename
+- In adaptive card based task modules, if the height is not provided in `taskInfo`, it will not be set to a default small size. Instead the card content will be set to fit on a Task Module.
+- Added office365 Outlook to domain allowlist
+- Updated comment for `initializePrivateApis` explaining that this function needs to stay for backwards compatibility purposes
+- In appWindow.ts file, converted `ChildAppWindow` and `ParentAppWindow` back to synchronous calls because the promise was never being resolved.
+- Fixed `teamsRuntimeConfig` (default backwards compatible host client runtime config) to not contain `location` or `people` capabilities since those are not guaranteed to be supported. Added new function to dynamically generate backwards compatible host client runtime config during initialization.
+- Added `ensureInitialized` call to `registerOnMessageFromParent` function in dialog.ts and `addEventListener` function in appWindow.ts
+- Removed the duplicate property of `StageLayoutControls` type in `meetingRoom` capability
+- `null` runtimeConfig is no longer allowed during initialization. This will now throw a "Received runtime config is invalid" error.
+- Update TSDoc `@deprecated comments` to include links to replaced APIs.
+- Update webpack-dev-server types to match webpack 5 versions and stop generating module wrappers in MicrosoftTeams.d.ts.
+- Fix warnings produced during documentation generation, including exporting additional existing interfaces.
+- Update integrity hash to valid value in README file.
 
 ## 2.0.0-beta.7
 
@@ -115,6 +326,7 @@ Wed, 13 Apr 2022 21:40:51 GMT
   - `dialog.bot.open` has the same function signature except it takes `BotUrlDialogInfo` instead of `UrlDialogInfo`
 - Moved `chat.openConversation` and `chat.closeConversation` into `chat.conversation` sub-capability. Added new APIs `chat.openChat` and `chat.openGroupChat` as a replacement to open Teams chats with one or more user
 - Moved `dialog.resize()` function to a new `update` sub-capability and is now `dialog.update.resize()`. The parameter has been changed to `DialogSize` type
+- Removed `bot` namespace and APIs.
 
 ### Minor changes
 
@@ -165,6 +377,8 @@ Tue, 01 Mar 2022 19:50:49 GMT
 - Moved `registerFocusEnterHandler` from `teamsCore` namespace to `pages`
 - `core.shareDeepLink` has been moved to `pages.shareDeepLink`
 - `core.executeDeepLink` has been renamed and moved to `app.openLink`
+- `pages.config.getConfig` has been moved to `pages.getConfig`
+- Added `pages.navigateToApp` that navigates to the given application ID and page ID, with optional parameters for a WebURL (if the application cannot be navigated to, such as if it is not installed), Channel ID (for applications installed as a channel tab), and sub-page ID (for navigating to specific content within the page).
 
 ### Minor changes
 
@@ -215,10 +429,11 @@ Tue, 01 Mar 2022 19:50:49 GMT
   `meeting.requestStartLiveStreaming` and `meeting.requestStopLiveStreaming` no longer take in the parameter liveStreamState.
 
 - Context interface changes <br>
-  The Context interface has been updated to group similar properties for better scalability in a multi-host environment.
+
+  - The Context interface has been updated to group similar properties for better scalability in a multi-host environment.
+  - Context's `user.tenant.sku` has been renamed to `user.tenant.teamsSku` to reflect that it is used by Teams for a different purpose than from the Graph API's user.tenant.sku's.
 
 - FrameContext changes <br>
-  FrameContext's `user.tenant.sku` has been renamed to `user.tenant.teamsSku` to reflect that it is used by Teams for a different purpose than from the Graph API's user.tenant.sku's.
   The `FrameContext` interface has been renamed `FrameInfo`.
 
 - appEntity.selectAppEntity now takes in an additional parameter and the callback has reversed parameters with one one of them becoming optional.
@@ -337,7 +552,7 @@ Tue, 01 Mar 2022 19:50:49 GMT
       - `getConfigSetting`
   - Added Notifications capability
     - `showNotification` has moved from `privateAPIs` to `notifications` namespace
-  - Added the following new capabilites from existing namespaces
+  - Converted existing namespaces into the following new capabilites
     - Location
     - Media
     - Meeting
@@ -357,67 +572,67 @@ Tue, 01 Mar 2022 19:50:49 GMT
 
   - The following APIs that took in a callback function as a parameter now instead return a `Promise`.
     - app APIs:
-      - app.initialize
-      - app.getContext
+      - `app.initialize`
+      - `app.getContext`
     - authentication APIs：
-      - authentication.authenticate
-      - authentication.getAuthToken
-      - authentication.getUser
+      - `authentication.authenticate`
+      - `authentication.getAuthToken`
+      - `authentication.getUser`
     - calendar APIs:
-      - calendar.openCalendarItem
-      - calendar.composeMeeting
+      - `calendar.openCalendarItem`
+      - `calendar.composeMeeting`
     - chat APIs:
-      - chat.getChatMembers
-      - chat.openConversation
+      - `chat.getChatMembers`
+      - `chat.openConversation`
     - files APIs:
-      - files.addCloudStorageFolder
-      - files.deleteCloudStorageFolder
-      - files.getCloudStorageFolderContents
-      - files.getCloudStorageFolders
+      - `files.addCloudStorageFolder`
+      - `files.deleteCloudStorageFolder`
+      - `files.getCloudStorageFolderContents`
+      - `files.getCloudStorageFolders`
     - legacy APIs:
-      - legacy.fulltrust.getConfigSetting
-      - legacy.fulltrust.getUserJoinedTeams
+      - `legacy.fulltrust.getConfigSetting`
+      - `legacy.fulltrust.getUserJoinedTeams`
     - location APIs:
-      - location.getLocation
-      - location.showLocation
+      - `location.getLocation`
+      - `location.showLocation`
     - mail APIs:
-      - mail.openMailItem
-      - mail.composeMail
+      - `mail.openMailItem`
+      - `mail.composeMail`
     - media APIs:
-      - media.captureImage
-      - media.selectMedia
-      - media.viewImages
-      - media.scanBarCode
+      - `media.captureImage`
+      - `media.selectMedia`
+      - `media.viewImages`
+      - `media.scanBarCode`
     - meeting APIs:
-      - meeting.getAppContentStageSharingState
-      - meeting.getAppContentStageSharingCapabilities
-      - meeting.getAuthenticationTokenForAnonymousUser
-      - meeting.getIncomingClientAudioState
-      - meeting.getLiveStreamState
-      - meeting.getMeetingDetails
-      - meeting.requestStartLiveStreaming
-      - meeting.requestStopLiveStreaming
-      - meeting.shareAppContentToStage
-      - meeting.stopSharingAppContentToStage
-      - meeting.toggleIncomingClientAudio
+      - `meeting.getAppContentStageSharingState`
+      - `meeting.getAppContentStageSharingCapabilities`
+      - `meeting.getAuthenticationTokenForAnonymousUser`
+      - `meeting.getIncomingClientAudioState`
+      - `meeting.getLiveStreamState`
+      - `meeting.getMeetingDetails`
+      - `meeting.requestStartLiveStreaming`
+      - `meeting.requestStopLiveStreaming`
+      - `meeting.shareAppContentToStage`
+      - `meeting.stopSharingAppContentToStage`
+      - `meeting.toggleIncomingClientAudio`
     - meetingRoom APIs:
-      - meetingRoom.getPairedMeetingRoomInfo
-      - meetingRoom.sendCommandToPairedMeetingRoom
+      - `meetingRoom.getPairedMeetingRoomInfo`
+      - `meetingRoom.sendCommandToPairedMeetingRoom`
     - pages APIs：
-      - pages.navigateCrossDomain
-      - pages.tabs.navigateToTab
-      - pages.tabs.getTabInstances
-      - pages.tabs.getMruTabInstances
-      - pages.config.getConfig
-      - pages.config.setConfig
-      - pages.backStack.navigateBack
+      - `pages.navigateCrossDomain`
+      - `pages.tabs.navigateToTab`
+      - `pages.tabs.getTabInstances`
+      - `pages.tabs.getMruTabInstances`
+      - `pages.config.getConfig`
+      - `pages.config.setConfig`
+      - `pages.backStack.navigateBack`
     - people APIs:
-      - people.selectPeople
+      - `people.selectPeople`
     - others:
-      - ChildAppWindow.postMessage
-      - ParentAppWindow.postMessage
-      - core.executeDeepLink
-      - appInstallDialog.openAppInstallDialog
-      - call.startCall
+      - `ChildAppWindow.postMessage`
+      - `ParentAppWindow.postMessage`
+      - `core.executeDeepLink`
+      - `appInstallDialog.openAppInstallDialog`
+      - `call.startCall`
 
 - Changed TypeScript to output ES6 modules instead of CommonJS

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://docs.microsoft.com/javascript/api/overvi
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.0.0-beta.7/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.0.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the SDK inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.0.0-beta.7/js/MicrosoftTeams.min.js"
-  integrity="sha384-u9MstnkqBQI9EtqTMRCoqno88AbVbKQ/iEN3UJqBUaIBSW3wEYsWEOTp3Im6mCdn"
+  src="https://res.cdn.office.net/teams-js/2.0.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-QtTBFeFlfRDZBfwHJHYQp7MdLJ2C3sfAEB1Qpy+YblvjavBye+q87TELpTnvlXw4"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.0.0-beta.7/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.0.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",


### PR DESCRIPTION
Release 2.0.0 was done in PR #1184 

Merging through an intermediate branch because we don't want to merge the azure-pipelines.yml change in the release branch into main.

---
Releasing 2.0.0

Consolidate change log entries across all the beta releases (https://github.com/OfficeDev/microsoft-teams-library-js/pull/1180)

Consolidate change log entries across all the beta releases into major, minor, patch notes and keep per-beta comments for reference

Change files