### PR TITLE
Update test app with meeting API

### DIFF
--- a/apps/teams-test-app/src/components/MeetingAPIs.tsx
+++ b/apps/teams-test-app/src/components/MeetingAPIs.tsx
@@ -179,6 +179,21 @@ const RegisterRaiseHandStateChangedHandler = (): React.ReactElement =>
     },
   });
 
+const RegisterSpeakingStateChangedHandler = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'registerSpeakingStateChangedHandler',
+    title: 'Register SpeakingState Changed Handler',
+    onClick: async setResult => {
+      const handler = (speakingState: meeting.ISpeakingState): void => {
+        const res = `Speaking state changed to ${speakingState.isSpeakingDetected}`;
+        setResult(res);
+      };
+      meeting.registerSpeakingStateChangeHandler(handler);
+
+      return generateRegistrationMsg('the speaking state changes');
+    },
+  });
+
 const ShareAppContentToStage = (): React.ReactElement =>
   ApiWithTextInput<string>({
     name: 'shareAppContentToStage',
@@ -273,6 +288,7 @@ const MeetingAPIs = (): ReactElement => (
     <RequestStopLiveStreaming />
     <RegisterLiveStreamChangedHandler />
     <RegisterRaiseHandStateChangedHandler />
+    <RegisterSpeakingStateChangedHandler />
     <ShareAppContentToStage />
     <GetAppContentStageSharingCapabilities />
     <StopSharingAppContentToStage />


### PR DESCRIPTION
Adding a test for the `registerSpeakingStateChangedHandler` API to the MeetingAPIs.tsx component in test app.