### PR TITLE
Manually bump eventsource from 1.1.0 to 1.1.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,7 +1974,7 @@
     write-file-atomic "^2.3.0"
 
 "@microsoft/teams-js@file:packages/teams-js":
-  version "2.0.0-beta.6"
+  version "2.0.0"
   dependencies:
     debug "4.3.3"
 
@@ -5207,9 +5207,9 @@ events@^3.2.0:
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 eventsource@^1.0.7:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.1.0.tgz#00e8ca7c92109e94b0ddf32dac677d841028cfaf"
-  integrity sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.1.1.tgz#4544a35a57d7120fba4fa4c86cb4023b2c09df2f"
+  integrity sha512-qV5ZC0h7jYIAOhArFJgSfdyz6rALJyb270714o7ZtNnw2WSJ+eexhKtE0O8LYPRsHZHf2osHKZBxGPvm3kPkCA==
   dependencies:
     original "^1.0.0"
 


### PR DESCRIPTION
I noticed that the [PR from dependabot](https://github.com/OfficeDev/microsoft-teams-library-js/pull/1198) for updating the eventsource dependency including a lot of deleted lines from the yarn.lock file. This seemed strange to me and searching for what command dependabot uses yielded nothing useful to find out exactly how to repro the update process.

I found an issue that suggested that yarn doesn't have a great way of updating subdependencies (dependencies of dependencies that are in your package.json file) and tried the [step suggested by someone in the issue](https://github.com/yarnpkg/yarn/issues/4986#issuecomment-395036563).

This produced a yarn.lock file that makes much more sense to me for updating eventsource.