### PR TITLE
Changing toMatch to toEqual in appInstallDialog legacy test

### DIFF
--- a/packages/teams-js/test/public/appInstallDialog.spec.ts
+++ b/packages/teams-js/test/public/appInstallDialog.spec.ts
@@ -70,7 +70,7 @@ describe('appInstallDialog', () => {
     expect(executeDeepLinkMsg.args).toHaveLength(1);
 
     const appInstallDialogDeepLink: URL = new URL(executeDeepLinkMsg.args[0]);
-    expect(appInstallDialogDeepLink.pathname).toMatch(
+    expect(appInstallDialogDeepLink.pathname).toEqual(
       teamsDeepLinkUrlPathForAppInstall + mockOpenAppInstallDialogParams.appId,
     );
     utils.respondToMessage(executeDeepLinkMsg, true);


### PR DESCRIPTION
Currently `toMatch` does not test against regressions for the unnecessary `/`. Changing this to `toEqual` will ensure that regressions are found during the unit testing phase.