### PR TITLE
Add SDK reference documentation validation as part of build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ts-jest": "^27.0.5",
     "ts-loader": "^9.2.5",
     "ts-node": "^10.2.1",
-    "typedoc": "^0.22.10",
+    "typedoc": "^0.22.17",
     "typescript": "^4.1.2",
     "webpack": "^5.10.0",
     "webpack-assets-manifest": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "clean:full": "yarn clean && yarn clean:modules",
     "clean:modules": "lerna clean -y && rimraf node_modules",
     "docs": "yarn workspace @microsoft/teams-js docs",
+    "docs:validate": "yarn workspace @microsoft/teams-js docs:validate",
     "lint": "lerna run lint",
     "start-perf-app": "yarn workspace teams-perf-test-app start",
     "start-test-app": "yarn workspace teams-test-app start",

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "yarn lint && webpack",
     "clean": "rimraf ./dist",
-    "docs": "yarn typedoc --out docs src/index.ts",
+    "docs": "yarn typedoc --validation.invalidLink --out docs src/index.ts",
     "lint": "yarn eslint ./src --max-warnings 0 --fix --ext .ts",
     "prettier": "prettier --write '**/*.{ts,js,css,html}'",
     "test": "jest"

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -11,9 +11,10 @@
   "main": "./dist/MicrosoftTeams.min.js",
   "typings": "./dist/MicrosoftTeams.d.ts",
   "scripts": {
-    "build": "yarn lint && webpack",
+    "build": "yarn lint && webpack && yarn docs:validate",
     "clean": "rimraf ./dist",
-    "docs": "yarn typedoc --validation.invalidLink --out docs src/index.ts",
+    "docs": "yarn typedoc",
+    "docs:validate": "yarn typedoc --treatWarningsAsErrors --emit none",
     "lint": "yarn eslint ./src --max-warnings 0 --fix --ext .ts",
     "prettier": "prettier --write '**/*.{ts,js,css,html}'",
     "test": "jest"

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -619,6 +619,9 @@ export interface BotUrlDialogInfo extends UrlDialogInfo {
   completionBotId: string;
 }
 
+/**
+ * Data structure to describe dialog information
+ */
 export interface DialogInfo {
   /**
    * The url to be rendered in the webview/iframe.

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -474,7 +474,7 @@ export namespace meeting {
 
   /**
    * Registers a handler for changes to the selfParticipant's (current user's) raiseHandState. If the selfParticipant raises their hand, isHandRaised
-   * will be true. By default and if the selfParticipant hand is lowered, isHandRaised will be false. This API will return {@link RaiseHandStateChangedEvent}
+   * will be true. By default and if the selfParticipant hand is lowered, isHandRaised will be false. This API will return {@link RaiseHandStateChangedEventData}
    * that will have the raiseHandState or an error object. Only one handler can be registered at a time. A subsequent registration
    * replaces an existing registration.
    *

--- a/packages/teams-js/src/public/settings.ts
+++ b/packages/teams-js/src/public/settings.ts
@@ -59,7 +59,7 @@ export namespace settings {
 
   /**
    * @deprecated
-   * As of 2.0.0, please use {@link pages.config.getConfig pages.config.getConfig(): Promise\<Config\>} instead.
+   * As of 2.0.0, please use {@link pages.getConfig pages.getConfig(): Promise\<InstanceConfig\>} instead.
    *
    * Gets the settings for the current instance.
    *

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -18,9 +18,8 @@ import { BotUrlDialogInfo, DialogInfo, DialogSize, TaskInfo, UrlDialogInfo } fro
 export namespace tasks {
   /**
    * @deprecated
-   * As of 2.0.0, please use {@link dialog.open(urlDialogInfo: UrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): PostMessageChannel} for url based dialogs
-   * and {@link dialog.bot.open(botUrlDialogInfo: BotUrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): PostMessageChannel} for bot based dialogs.
-   *
+   * As of 2.0.0, please use {@link dialog.open dialog.open(urlDialogInfo: UrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): void} for url based dialogs
+   * and {@link dialog.bot.open dialog.bot.open(botUrlDialogInfo: BotUrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): void} for bot based dialogs.
    * Allows an app to open the task module.
    *
    * @param taskInfo - An object containing the parameters of the task module

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -65,7 +65,7 @@ export namespace tasks {
 
   /**
    * @deprecated
-   * As of 2.0.0, please use {@link dialog.submit dialog.submit(result?: string | object, appIds?: string | string[]): void} instead.
+   * As of 2.0.0, please use {@link dialog.submit} instead.
    *
    * Submit the task module.
    *
@@ -76,6 +76,11 @@ export namespace tasks {
     dialog.submit(result, appIds);
   }
 
+  /**
+   * Converts TaskInfo to UrlDialogInfo
+   * @param taskInfo - TaskInfo object to convert
+   * @returns - Converted UrlDialogInfo object
+   */
   export function getUrlDialogInfoFromTaskInfo(taskInfo: TaskInfo): UrlDialogInfo {
     const urldialogInfo: UrlDialogInfo = {
       url: taskInfo.url,
@@ -89,6 +94,11 @@ export namespace tasks {
     return urldialogInfo;
   }
 
+  /**
+   * Converts TaskInfo to BotUrlDialogInfo
+   * @param taskInfo - TaskInfo object to convert
+   * @returns - converted BotUrlDialogInfo object
+   */
   export function getBotUrlDialogInfoFromTaskInfo(taskInfo: TaskInfo): BotUrlDialogInfo {
     const botUrldialogInfo: BotUrlDialogInfo = {
       url: taskInfo.url,
@@ -102,6 +112,13 @@ export namespace tasks {
     };
     return botUrldialogInfo;
   }
+
+  /**
+   * Sets the height and width of the TaskInfo object to the original height and width, if initially specified,
+   * otherwise uses the height and width values corresponding to TaskModuleDimension.Small
+   * @param taskInfo TaskInfo object from which to extract size info, if specified
+   * @returns TaskInfo with height and width specified
+   */
   export function getDefaultSizeIfNotProvided(taskInfo: TaskInfo): TaskInfo {
     taskInfo.height = taskInfo.height ? taskInfo.height : TaskModuleDimension.Small;
     taskInfo.width = taskInfo.width ? taskInfo.width : TaskModuleDimension.Small;

--- a/packages/teams-js/typedoc.json
+++ b/packages/teams-js/typedoc.json
@@ -5,7 +5,7 @@
   "validation": {
     "notExported": true,
     "invalidLink": true,
-    "notDocumented": true
+    "notDocumented": false
   },
   "intentionallyNotExported": [
     "src/public/chat.ts:OpenGroupChatRequest",

--- a/packages/teams-js/typedoc.json
+++ b/packages/teams-js/typedoc.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["./src/index.ts"],
+  "out": "docs",
+  "validation": {
+    "notExported": true,
+    "invalidLink": true,
+    "notDocumented": true
+  },
+  "intentionallyNotExported": [
+    "src/public/chat.ts:OpenGroupChatRequest",
+    "src/public/chat.ts:OpenSingleChatRequest",
+    "src/public/interfaces.ts:BotUrlDialogInfo",
+    "src/public/interfaces.ts:DialogSize",
+    "src/public/interfaces.ts:TaskInfo",
+    "src/public/interfaces.ts:UrlDialogInfo",
+    "src/public/media.ts:MediaControllerEvent"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3538,6 +3538,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
@@ -5929,7 +5936,7 @@ glob@^6.0.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -5940,6 +5947,17 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, gl
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -8077,10 +8095,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-3.0.8.tgz#2785f0dc79cbdc6034be4bb4f0f0a396bd3f8aeb"
-  integrity sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==
+marked@^4.0.16:
+  version "4.0.17"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.17.tgz#1186193d85bb7882159cdcfc57d1dfccaffb3fe9"
+  integrity sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==
 
 md5.js@1.3.4:
   version "1.3.4"
@@ -8275,6 +8293,13 @@ minimatch@^3.0.4:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1, minimatch@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
+  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist-options@4.1.0:
   version "4.1.0"
@@ -10416,10 +10441,10 @@ shelljs@^0.8.4:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shiki@^0.9.12:
-  version "0.9.15"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.15.tgz#2481b46155364f236651319d2c18e329ead6fa44"
-  integrity sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==
+shiki@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.10.1.tgz#6f9a16205a823b56c072d0f1a0bcd0f2646bef14"
+  integrity sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==
   dependencies:
     jsonc-parser "^3.0.0"
     vscode-oniguruma "^1.6.1"
@@ -11429,16 +11454,16 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc@^0.22.10:
-  version "0.22.10"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.10.tgz#221e1a2b17bcb71817ef027dc4c4969d572e7620"
-  integrity sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==
+typedoc@^0.22.17:
+  version "0.22.17"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.17.tgz#bc51cc95f569040112504300831cdac4f8089b7b"
+  integrity sha512-h6+uXHVVCPDaANzjwzdsj9aePBjZiBTpiMpBBeyh1zcN2odVsDCNajz8zyKnixF93HJeGpl34j/70yoEE5BfNg==
   dependencies:
-    glob "^7.2.0"
+    glob "^8.0.3"
     lunr "^2.3.9"
-    marked "^3.0.8"
-    minimatch "^3.0.4"
-    shiki "^0.9.12"
+    marked "^4.0.16"
+    minimatch "^5.1.0"
+    shiki "^0.10.1"
 
 typescript@^4.1.2:
   version "4.4.3"


### PR DESCRIPTION
This PR adds SDK reference validation as part of the teams-js build step.

It also adds validation of symbolic links and treats warnings as errors. Essentially if you add an {@link ...} to a reference doc comment that fails, this will fail the build.

I fixed several broken symbolic links as part of this change.

I also upgraded to the latest version of typedoc to be able to specify the `notDocumented` validation option (even though it's not enabled yet).

There are a couple of things to call out here.
1. I haven't turned on the `notDocumented` validation option in typedoc.json yet. I've opened a work item to track fixing the warnings that are produced if this is enabled. There are 246 and it is not obvious how to fix about 70 of them (e.g., some refer to API parameters defined as inline functions).
2. I had to explicitly add 7 entries to "intentionallyNotExported" in typedoc.json. I thought this was better than turning off the `notExported` validation option. This is a complicated setting and I don't fully understand how we would otherwise satisfy this warning. Here are two (closed) GitHub issues that talk about it:
https://github.com/TypeStrong/typedoc/issues/1687
https://github.com/TypeStrong/typedoc/issues/1739

If I didn't add those 7 entries, these warnings are produced (even with the changes I made in tasks.ts):
```
Warning: BotUrlDialogInfo, defined at src/public/interfaces.ts:613, is referenced by tasks.getBotUrlDialogInfoFromTaskInfo.getBotUrlDialogInfoFromTaskInfo but not included in the documentation.
Warning: TaskInfo, defined at src/public/interfaces.ts:672, is referenced by tasks.getDefaultSizeIfNotProvided.getDefaultSizeIfNotProvided but not included in the documentation.
Warning: UrlDialogInfo, defined at src/public/interfaces.ts:584, is referenced by tasks.getUrlDialogInfoFromTaskInfo.getUrlDialogInfoFromTaskInfo but not included in the documentation.
Warning: OpenSingleChatRequest, defined at src/public/chat.ts:26, is referenced by chat.openChat.openChat.openChatRequest but not included in the documentation.
Warning: OpenGroupChatRequest, defined at src/public/chat.ts:40, is referenced by chat.openGroupChat.openGroupChat.openChatRequest but not included in the documentation.
Warning: DialogSize, defined at src/public/interfaces.ts:569, is referenced by dialog.update.resize.resize.dimensions but not included in the documentation.
Warning: MediaControllerEvent, defined at src/public/media.ts:462, is referenced by media.VideoController.notifyEventToApp.notifyEventToApp.mediaEvent but not included in the documentation.
error Command failed with exit code 4.
```

Note that even though it is flagged in a warning, the documentation generated for `dialog.update.resize` (as an example) does produce a link to `DialogSize` that resolves in our public docs.

I believe this addition even with the caveats is better than what we currently have (relying on intrepid developers to check themselves that the docs are in good shape as part of their PRs).