### PR TITLE
Upload logs to blob container directly when SAS is provided

### DIFF
--- a/change/@microsoft-teams-js-0e666cf5-5708-4bd7-ba38-3eda8934b434.json
+++ b/change/@microsoft-teams-js-0e666cf5-5708-4bd7-ba38-3eda8934b434.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "upload logs to blob container directly when SAS is provided",
+  "packageName": "@microsoft/teams-js",
+  "email": "Xukai.Wu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -338,3 +338,26 @@ export function createTeamsAppLink(params: pages.NavigateToAppParams): string {
   }
   return url.toString();
 }
+
+/**
+ * Upload logs to the azure blob container with a SAS
+ * @param logs logs of the app
+ * @param fileName name of the file to be updated in the blob container
+ * @param azureSas The Shared Access Signature token
+ * @internal
+ */
+export function uploadLogsWithAzureSas(logs: string, fileName: string, azureSas: string): Promise<Response> {
+  const [endpoint, rest] = azureSas.split('?');
+  const url = `${endpoint}/${fileName}?${rest}`;
+
+  return fetch(url, {
+    method: 'PUT',
+    headers: {
+      'x-ms-date': Date.now().toLocaleString(),
+      'x-ms-version': '2015-02-21',
+      'x-ms-blob-type': 'BlockBlob',
+      'x-ms-blob-content-disposition': `attachment; filename=${fileName}`,
+    },
+    body: logs,
+  });
+}

--- a/packages/teams-js/src/private/logs.ts
+++ b/packages/teams-js/src/private/logs.ts
@@ -21,6 +21,7 @@ export namespace logs {
    */
   interface ILogRequestOptions {
     appId: string;
+    appSessionId?: string;
     azureSas: string;
   }
 
@@ -39,10 +40,10 @@ export namespace logs {
     }
 
     if (handler) {
-      registerHandler('log.request', ({ appId, azureSas }: ILogRequestOptions) => {
+      registerHandler('log.request', ({ appId, appSessionId, azureSas }: ILogRequestOptions) => {
         Promise.resolve(handler()).then(log => {
           appId && azureSas
-            ? uploadLogsWithAzureSas(log, `${appId}.txt`, azureSas)
+            ? uploadLogsWithAzureSas(log, `${appId}_${appSessionId}.txt`, azureSas)
             : sendMessageToParent('log.receive', [log]);
         });
       });


### PR DESCRIPTION
Update the private logging API to support uploading app logs to the blob container directly when the SAS token is given instead of sending the logs back to the host. 