### PR TITLE
Test app: Fix the validation of getExternalProviders API

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/FilesAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/FilesAPIs.tsx
@@ -133,13 +133,13 @@ const GetExternalProviders = (): React.ReactElement =>
     name: 'getExternalProviders',
     title: 'Get External Providers',
     label: 'excludeAddedProviders',
-    onClick: async (excludeAddedProviders: boolean) => {
+    onClick: async (excludeAddedProviders: boolean, setResult: (result: string) => void) => {
       let result;
       const callback = (error: SdkError, providers: files.IExternalProvider[]): void => {
         if (error) {
-          result = JSON.stringify(error);
+          setResult(JSON.stringify(error));
         } else {
-          result = JSON.stringify(providers);
+          setResult(JSON.stringify(providers));
         }
       };
       await files.getExternalProviders(excludeAddedProviders, callback);

--- a/apps/teams-test-app/src/components/privateApis/FilesAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/FilesAPIs.tsx
@@ -134,7 +134,6 @@ const GetExternalProviders = (): React.ReactElement =>
     title: 'Get External Providers',
     label: 'excludeAddedProviders',
     onClick: async (excludeAddedProviders: boolean, setResult: (result: string) => void) => {
-      let result;
       const callback = (error: SdkError, providers: files.IExternalProvider[]): void => {
         if (error) {
           setResult(JSON.stringify(error));
@@ -142,8 +141,8 @@ const GetExternalProviders = (): React.ReactElement =>
           setResult(JSON.stringify(providers));
         }
       };
-      await files.getExternalProviders(excludeAddedProviders, callback);
-      return result;
+      files.getExternalProviders(excludeAddedProviders, callback);
+      return '';
     },
   });
 

--- a/apps/teams-test-app/src/components/utils/ApiWithCheckboxInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithCheckboxInput.tsx
@@ -9,10 +9,10 @@ export interface ApiWithCheckboxInputProps {
   name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
   label: string;
   onClick:
-    | ((input: boolean) => Promise<string>)
+    | ((input: boolean, setResult: (result: string) => void) => Promise<string>)
     | {
-        withPromise: (input: boolean) => Promise<string>;
-        withCallback: (input: boolean) => string;
+        withPromise: (input: boolean, setResult: (result: string) => void) => Promise<string>;
+        withCallback: (input: boolean, setResult: (result: string) => void) => string;
       };
   defaultCheckboxState?: boolean;
 }
@@ -27,14 +27,14 @@ export const ApiWithCheckboxInput = (props: ApiWithCheckboxInputProps): React.Re
 
     try {
       if (typeof onClick === 'function') {
-        const result = await onClick(value);
+        const result = await onClick(value, setResult);
         setResult(result);
       } else {
         if (isTestBackCompat()) {
-          const result = onClick.withCallback(value);
+          const result = onClick.withCallback(value, setResult);
           setResult(result);
         } else {
-          const result = await onClick.withPromise(value);
+          const result = await onClick.withPromise(value, setResult);
           setResult(result);
         }
       }


### PR DESCRIPTION
- Fix the validation of getExternalProviders API
- Extend the ApiWithCheckBoxInput to ingest setResult callback which allows callback based APIs to set the result of the text box.