### PR TITLE
Unhide sdk docs for Tab Conversations

### DIFF
--- a/packages/teams-js/src/private/conversations.ts
+++ b/packages/teams-js/src/private/conversations.ts
@@ -10,7 +10,11 @@ import { runtime } from '../public/runtime';
 import { ChatMembersInformation } from './interfaces';
 
 /**
- * Represents information about the conversation being opened
+ * @hidden
+ * Hide from docs.
+ * ------
+ *
+ * @internal
  */
 export interface OpenConversationRequest {
   /**
@@ -50,7 +54,11 @@ export interface OpenConversationRequest {
 }
 
 /**
- * Represents information about the conversation that has been started or closed
+ * @hidden
+ * Hide from docs.
+ * ------
+ *
+ * @internal
  */
 export interface ConversationResponse {
   /**

--- a/packages/teams-js/src/private/conversations.ts
+++ b/packages/teams-js/src/private/conversations.ts
@@ -10,99 +10,76 @@ import { runtime } from '../public/runtime';
 import { ChatMembersInformation } from './interfaces';
 
 /**
- * @hidden
- * Hide from docs.
- * ------
- *
- * @internal
+ * Represents the information about the conversation being opened
  */
 export interface OpenConversationRequest {
   /**
-   * @hidden
    * The Id of the subEntity where the conversation is taking place
    */
   subEntityId: string;
 
   /**
-   * @hidden
    * The title of the conversation
    */
   title: string;
 
   /**
-   * @hidden
    * The Id of the conversation. This is optional and should be specified whenever a previous conversation about a specific sub-entity has already been started before
    */
   conversationId?: string;
 
   /**
-   * @hidden
    * The Id of the channel. This is optional and should be specified whenever a conversation is started or opened in a personal app scope
    */
   channelId?: string;
 
   /**
-   * @hidden
    * The entity Id of the tab
    */
   entityId: string;
 
   /**
-   * @hidden
    * A function that is called once the conversation Id has been created
    */
   onStartConversation?: (conversationResponse: ConversationResponse) => void;
 
   /**
-   * @hidden
    * A function that is called if the pane is closed
    */
   onCloseConversation?: (conversationResponse: ConversationResponse) => void;
 }
 
 /**
- * @hidden
- * Hide from docs.
- * ------
- *
- * @internal
+ * Represents information about the conversation that has been started or closed
  */
 export interface ConversationResponse {
   /**
-   * @hidden
    * The Id of the subEntity where the conversation is taking place
    */
   subEntityId: string;
 
   /**
-   * @hidden
    * The Id of the conversation. This is optional and should be specified whenever a previous conversation about a specific sub-entity has already been started before
    */
   conversationId?: string;
 
   /**
-   * @hidden
    * The Id of the channel. This is optional and should be specified whenever a conversation is started or opened in a personal app scope
    */
   channelId?: string;
 
   /**
-   * @hidden
    * The entity Id of the tab
    */
   entityId?: string;
 }
 
 /**
- * @hidden
  * Namespace to interact with the conversational subEntities inside the tab
  */
 export namespace conversations {
   /**
-   * @hidden
-   * Hide from docs
-   * --------------
-   * Allows the user to start or continue a conversation with each subentity inside the tab
+   * Allows the user to start or continue a conversation with each sub-entity inside the tab
    *
    * @returns Promise resolved upon completion
    */
@@ -148,9 +125,6 @@ export namespace conversations {
   }
 
   /**
-   * @hidden
-   * Hide from docs
-   * --------------
    * Allows the user to close the conversation in the right pane
    */
   export function closeConversation(): void {

--- a/packages/teams-js/src/private/conversations.ts
+++ b/packages/teams-js/src/private/conversations.ts
@@ -10,7 +10,7 @@ import { runtime } from '../public/runtime';
 import { ChatMembersInformation } from './interfaces';
 
 /**
- * Represents the information about the conversation being opened
+ * Represents information about the conversation being opened
  */
 export interface OpenConversationRequest {
   /**
@@ -81,6 +81,7 @@ export namespace conversations {
   /**
    * Allows the user to start or continue a conversation with each sub-entity inside the tab
    *
+   * @param openConversationRequest the conversation that is being opened or started
    * @returns Promise resolved upon completion
    */
   export function openConversation(openConversationRequest: OpenConversationRequest): Promise<void> {

--- a/packages/teams-js/typedoc.json
+++ b/packages/teams-js/typedoc.json
@@ -8,6 +8,7 @@
     "notDocumented": false
   },
   "intentionallyNotExported": [
+    "src/private/conversations.ts:OpenConversationRequest",
     "src/public/chat.ts:OpenGroupChatRequest",
     "src/public/chat.ts:OpenSingleChatRequest",
     "src/public/interfaces.ts:BotUrlDialogInfo",


### PR DESCRIPTION
Tab Conversations is a released feature, but the SDK docs are not public.
This PR unhides some of those docs.

I've had to exclude OpenConversationRequest in the typedoc. We should expose both OpenConversationRequest and ConversationResponse but I think any changes to do that might require actual code changes so I would prefer the feature team to schedule time to ensure the docs are complete.

There are two things that I am uncertain about:
1. Do I need to bump the package version for a docs change?
2. Does this file need to move from `/private` to `/public`. The code is already in use and being used but I am not sure of the correct folder structure. 

This was originally discussed in https://github.com/MicrosoftDocs/msteams-docs/pull/6233 based on https://github.com/MicrosoftDocs/msteams-docs/issues/6103