### PR TITLE
Modified npmrc file to read the more secure secret for NPM-TOKEN

### DIFF
--- a/.npmrc_publish
+++ b/.npmrc_publish
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=${NPM-TOKEN}
+//registry.npmjs.org/:_authToken=$(NPM-TOKEN)


### PR DESCRIPTION
We can't dereference the old value with Lockbox requests without manually setting an environment variable with the value. Testing if dereferencing the generated secret variable instead.