### PR TITLE
video extensibility: assign string value to EffectChangeType values

### DIFF
--- a/packages/teams-js/src/public/video.ts
+++ b/packages/teams-js/src/public/video.ts
@@ -67,11 +67,11 @@ export namespace video {
     /**
      * current video effect changed
      */
-    EffectChanged,
+    EffectChanged = 'EffectChanged',
     /**
      * disable the video effect
      */
-    EffectDisabled,
+    EffectDisabled = 'EffectDisabled',
   }
 
   /**


### PR DESCRIPTION
To make enum more stable for 3rd party when using JS directly.