### PR TITLE
3p cloud storage provider action API improvements

### DIFF
--- a/change/@microsoft-teams-js-d548f18c-2998-4465-94f5-1d4edfde9668.json
+++ b/change/@microsoft-teams-js-d548f18c-2998-4465-94f5-1d4edfde9668.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Split single action API into 3 action APIs",
+  "packageName": "@microsoft/teams-js",
+  "email": "jainharsh@microsof.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/files.ts
+++ b/packages/teams-js/src/private/files.ts
@@ -339,6 +339,7 @@ export namespace files {
   export interface CloudStorageProviderNewFileContent extends CloudStorageProviderContent {
     newFileName: string;
     newFileExtension: string;
+    destinationFolder: CloudStorageFolderItem | ISharePointFile;
   }
 
   /**
@@ -356,11 +357,31 @@ export namespace files {
    * @hidden
    * Hide from docs
    *
-   * Interface representing 3P cloud storage provider actions like Upload / Download / Delete file(s)
+   * Interface representing 3P cloud storage provider delete existing file(s) action
    */
-  export interface CloudStorageProviderActionContent extends CloudStorageProviderContent {
-    action: CloudStorageProviderFileAction;
+  export interface CloudStorageProviderDeleteFileContent extends CloudStorageProviderContent {
     itemList: CloudStorageFolderItem[] | ISharePointFile[];
+  }
+
+  /**
+   * @hidden
+   * Hide from docs
+   *
+   * Interface representing 3P cloud storage provider download existing file(s) action
+   */
+  export interface CloudStorageProviderDownloadFileContent extends CloudStorageProviderContent {
+    itemList: CloudStorageFolderItem[] | ISharePointFile[];
+  }
+
+  /**
+   * @hidden
+   * Hide from docs
+   *
+   * Interface representing 3P cloud storage provider upload existing file(s) action
+   */
+  export interface CloudStorageProviderUploadFileContent extends CloudStorageProviderContent {
+    itemList: CloudStorageFolderItem[] | ISharePointFile[];
+    destinationFolder: CloudStorageFolderItem | ISharePointFile;
   }
 
   /**
@@ -710,17 +731,42 @@ export namespace files {
    * @hidden
    * Hide from docs
    *
-   * Initiates the 3P cloud storage provider file action (Upload / Download / Delete) flow
+   * Initiates the delete 3P cloud storage file(s) flow, which will delete existing file(s) from the given 3P provider
    *
-   * Upload Action : Allows uploading file(s) to the given 3P cloud storage provider
-   * Download Action : Allows downloading file(s) from the given 3P cloud storage provider
-   * Delete Action : Allows deleting file(s) from the given 3P cloud storage provider
-   *
-   * @param cloudStorageProviderFileActionRequest 3P cloud storage provider file action (Upload / Download / Delete) request content
-   * @param callback Callback that will be triggered post 3P cloud storage action
+   * @param deleteFileRequest 3P cloud storage provider delete action request content
+   * @param callback Callback that will be triggered post deleting existing file(s) flow is finished
    */
-  export function performCloudStorageProviderFileAction(
-    cloudStorageProviderFileActionRequest: CloudStorageProviderRequest<CloudStorageProviderActionContent>,
+  export function deleteCloudStorageProviderFile(
+    deleteFileRequest: CloudStorageProviderRequest<CloudStorageProviderDeleteFileContent>,
+    callback: (error?: SdkError) => void,
+  ): void {
+    ensureInitialized(FrameContexts.content);
+
+    if (!callback) {
+      throw getSdkError(ErrorCode.INVALID_ARGUMENTS, '[files.deleteCloudStorageProviderFile] callback cannot be null');
+    }
+
+    if (!(deleteFileRequest && deleteFileRequest.content)) {
+      throw getSdkError(
+        ErrorCode.INVALID_ARGUMENTS,
+        '[files.deleteCloudStorageProviderFile] 3P cloud storage provider request content is missing',
+      );
+    }
+
+    sendMessageToParent('files.deleteCloudStorageProviderFile', [deleteFileRequest], callback);
+  }
+
+  /**
+   * @hidden
+   * Hide from docs
+   *
+   * Initiates the download 3P cloud storage file(s) flow, which will download existing file(s) from the given 3P provider
+   *
+   * @param downloadFileRequest 3P cloud storage provider download file(s) action request content
+   * @param callback Callback that will be triggered post downloading existing file(s) flow is finished
+   */
+  export function downloadCloudStorageProviderFile(
+    downloadFileRequest: CloudStorageProviderRequest<CloudStorageProviderDownloadFileContent>,
     callback: (error?: SdkError) => void,
   ): void {
     ensureInitialized(FrameContexts.content);
@@ -728,22 +774,47 @@ export namespace files {
     if (!callback) {
       throw getSdkError(
         ErrorCode.INVALID_ARGUMENTS,
-        '[files.performCloudStorageProviderFileAction] callback cannot be null',
+        '[files.downloadCloudStorageProviderFile] callback cannot be null',
       );
     }
 
-    if (!(cloudStorageProviderFileActionRequest && cloudStorageProviderFileActionRequest.content)) {
+    if (!(downloadFileRequest && downloadFileRequest.content)) {
       throw getSdkError(
         ErrorCode.INVALID_ARGUMENTS,
-        '[files.performCloudStorageProviderFileAction] 3P cloud storage provider request content is missing',
+        '[files.downloadCloudStorageProviderFile] 3P cloud storage provider request content is missing',
       );
     }
 
-    sendMessageToParent(
-      'files.performCloudStorageProviderFileAction',
-      [cloudStorageProviderFileActionRequest],
-      callback,
-    );
+    sendMessageToParent('files.downloadCloudStorageProviderFile', [downloadFileRequest], callback);
+  }
+
+  /**
+   * @hidden
+   * Hide from docs
+   *
+   * Initiates the upload 3P cloud storage file(s) flow, which will upload file(s) to the given 3P provider
+   *
+   * @param uploadFileRequest 3P cloud storage provider upload file(s) action request content
+   * @param callback Callback that will be triggered post uploading file(s) flow is finished
+   */
+  export function uploadCloudStorageProviderFile(
+    uploadFileRequest: CloudStorageProviderRequest<CloudStorageProviderUploadFileContent>,
+    callback: (error?: SdkError) => void,
+  ): void {
+    ensureInitialized(FrameContexts.content);
+
+    if (!callback) {
+      throw getSdkError(ErrorCode.INVALID_ARGUMENTS, '[files.uploadCloudStorageProviderFile] callback cannot be null');
+    }
+
+    if (!(uploadFileRequest && uploadFileRequest.content)) {
+      throw getSdkError(
+        ErrorCode.INVALID_ARGUMENTS,
+        '[files.uploadCloudStorageProviderFile] 3P cloud storage provider request content is missing',
+      );
+    }
+
+    sendMessageToParent('files.uploadCloudStorageProviderFile', [uploadFileRequest], callback);
   }
 
   /**
@@ -763,7 +834,7 @@ export namespace files {
       throw new Error('[registerCloudStorageProviderListChangeHandler] Handler cannot be null');
     }
 
-    registerHandler('files.cloudStorageProviderList', handler);
+    registerHandler('files.cloudStorageProviderListChange', handler);
   }
 
   /**
@@ -783,7 +854,7 @@ export namespace files {
       throw new Error('[registerCloudStorageProviderContentChangeHandler] Handler cannot be null');
     }
 
-    registerHandler('files.cloudStorageProviderContent', handler);
+    registerHandler('files.cloudStorageProviderContentChange', handler);
   }
 
   function getSdkError(errorCode: ErrorCode, message: string): SdkError {

--- a/packages/teams-js/test/private/files.spec.ts
+++ b/packages/teams-js/test/private/files.spec.ts
@@ -631,11 +631,21 @@ describe('files', () => {
   });
 
   describe('addCloudStorageProviderFile', () => {
+    const mockDestinationFolder: files.CloudStorageFolderItem = {
+      id: '111',
+      lastModifiedTime: '2021-04-14T15:08:35Z',
+      size: 0,
+      objectUrl: 'folder1',
+      title: 'folder1',
+      isSubdirectory: true,
+      type: 'folder',
+    };
     const addNewFileRequest: files.CloudStorageProviderRequest<files.CloudStorageProviderNewFileContent> = {
       content: {
         providerCode: files.CloudStorageProvider.Box,
         newFileName: 'testFile',
         newFileExtension: 'docx',
+        destinationFolder: mockDestinationFolder,
       },
     };
 
@@ -734,43 +744,39 @@ describe('files', () => {
     });
   });
 
-  describe('performCloudStorageProviderFileAction', () => {
-    const mockItem: files.CloudStorageFolderItem = {
+  describe('deleteCloudStorageProviderFile', () => {
+    const mockDeleteFile: files.CloudStorageFolderItem = {
       id: '111',
       lastModifiedTime: '2021-04-14T15:08:35Z',
       size: 32,
-      objectUrl: 'abc.com',
+      objectUrl: 'file1.com',
       title: 'file1',
       isSubdirectory: false,
       type: 'pdf',
     };
-
-    const cloudStorageProviderFileActionRequest: files.CloudStorageProviderRequest<files.CloudStorageProviderActionContent> = {
+    const deleteFileRequest: files.CloudStorageProviderRequest<files.CloudStorageProviderDeleteFileContent> = {
       content: {
-        action: files.CloudStorageProviderFileAction.Upload,
         providerCode: files.CloudStorageProvider.Box,
-        itemList: [mockItem],
+        itemList: [mockDeleteFile],
       },
     };
 
     it('should not allow calls before initialization', () => {
-      expect(() =>
-        files.performCloudStorageProviderFileAction(cloudStorageProviderFileActionRequest, emptyCallback),
-      ).toThrowError('The library has not yet been initialized');
+      expect(() => files.deleteCloudStorageProviderFile(deleteFileRequest, emptyCallback)).toThrowError(
+        'The library has not yet been initialized',
+      );
     });
 
     it('should not allow calls with empty callback', async () => {
       await utils.initializeWithContext('content');
-      expect(() =>
-        files.performCloudStorageProviderFileAction(cloudStorageProviderFileActionRequest, null),
-      ).toThrowError();
+      expect(() => files.deleteCloudStorageProviderFile(deleteFileRequest, null)).toThrowError();
     });
 
     it('should not allow calls without frame context initialization', async () => {
       await utils.initializeWithContext('settings');
-      expect(() =>
-        files.performCloudStorageProviderFileAction(cloudStorageProviderFileActionRequest, emptyCallback),
-      ).toThrowError('This call is only allowed in following contexts: ["content"]. Current context: "settings"');
+      expect(() => files.deleteCloudStorageProviderFile(deleteFileRequest, emptyCallback)).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings"',
+      );
     });
 
     it('should send the message to parent correctly', () => {
@@ -780,13 +786,123 @@ describe('files', () => {
         expect(err).toBeFalsy();
       });
 
-      files.performCloudStorageProviderFileAction(cloudStorageProviderFileActionRequest, callback);
+      files.deleteCloudStorageProviderFile(deleteFileRequest, callback);
 
-      const performCloudStorageProviderFileActionMessage = utils.findMessageByFunc(
-        'files.performCloudStorageProviderFileAction',
+      const deleteCloudStorageProviderFileMessage = utils.findMessageByFunc('files.deleteCloudStorageProviderFile');
+      expect(deleteCloudStorageProviderFileMessage).not.toBeNull();
+      utils.respondToMessage(deleteCloudStorageProviderFileMessage, false);
+      expect(callback).toHaveBeenCalled();
+    });
+  });
+
+  describe('downloadCloudStorageProviderFile', () => {
+    const mockDownloadFile: files.CloudStorageFolderItem = {
+      id: '111',
+      lastModifiedTime: '2021-04-14T15:08:35Z',
+      size: 32,
+      objectUrl: 'file1.com',
+      title: 'file1',
+      isSubdirectory: false,
+      type: 'pdf',
+    };
+    const downloadFileRequest: files.CloudStorageProviderRequest<files.CloudStorageProviderDownloadFileContent> = {
+      content: {
+        providerCode: files.CloudStorageProvider.Box,
+        itemList: [mockDownloadFile],
+      },
+    };
+
+    it('should not allow calls before initialization', () => {
+      expect(() => files.downloadCloudStorageProviderFile(downloadFileRequest, emptyCallback)).toThrowError(
+        'The library has not yet been initialized',
       );
-      expect(performCloudStorageProviderFileActionMessage).not.toBeNull();
-      utils.respondToMessage(performCloudStorageProviderFileActionMessage, false);
+    });
+
+    it('should not allow calls with empty callback', async () => {
+      await utils.initializeWithContext('content');
+      expect(() => files.downloadCloudStorageProviderFile(downloadFileRequest, null)).toThrowError();
+    });
+
+    it('should not allow calls without frame context initialization', async () => {
+      await utils.initializeWithContext('settings');
+      expect(() => files.downloadCloudStorageProviderFile(downloadFileRequest, emptyCallback)).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings"',
+      );
+    });
+
+    it('should send the message to parent correctly', () => {
+      utils.initializeWithContext('content');
+
+      const callback = jest.fn(err => {
+        expect(err).toBeFalsy();
+      });
+
+      files.downloadCloudStorageProviderFile(downloadFileRequest, callback);
+
+      const downloadCloudStorageProviderFileMessage = utils.findMessageByFunc('files.downloadCloudStorageProviderFile');
+      expect(downloadCloudStorageProviderFileMessage).not.toBeNull();
+      utils.respondToMessage(downloadCloudStorageProviderFileMessage, false);
+      expect(callback).toHaveBeenCalled();
+    });
+  });
+
+  describe('uploadCloudStorageProviderFile', () => {
+    const mockUploadFile: files.CloudStorageFolderItem = {
+      id: '111',
+      lastModifiedTime: '2021-04-14T15:08:35Z',
+      size: 32,
+      objectUrl: 'file1.com',
+      title: 'file1',
+      isSubdirectory: false,
+      type: 'pdf',
+    };
+    const mockDestinationFolder: files.CloudStorageFolderItem = {
+      id: '112',
+      lastModifiedTime: '2021-03-14T15:08:35Z',
+      size: 0,
+      objectUrl: 'folder1',
+      title: 'folder1',
+      isSubdirectory: true,
+      type: 'folder',
+    };
+    const uploadFileRequest: files.CloudStorageProviderRequest<files.CloudStorageProviderUploadFileContent> = {
+      content: {
+        providerCode: files.CloudStorageProvider.Dropbox,
+        itemList: [mockUploadFile],
+        destinationFolder: mockDestinationFolder,
+      },
+    };
+
+    it('should not allow calls before initialization', () => {
+      expect(() => files.uploadCloudStorageProviderFile(uploadFileRequest, emptyCallback)).toThrowError(
+        'The library has not yet been initialized',
+      );
+    });
+
+    it('should not allow calls with empty callback', async () => {
+      await utils.initializeWithContext('content');
+      expect(() => files.uploadCloudStorageProviderFile(uploadFileRequest, null)).toThrowError();
+    });
+
+    it('should not allow calls without frame context initialization', async () => {
+      await utils.initializeWithContext('settings');
+      expect(() => files.uploadCloudStorageProviderFile(uploadFileRequest, emptyCallback)).toThrowError(
+        'This call is only allowed in following contexts: ["content"]. Current context: "settings"',
+      );
+    });
+
+    it('should send the message to parent correctly', () => {
+      utils.initializeWithContext('content');
+
+      const callback = jest.fn(err => {
+        expect(err).toBeFalsy();
+      });
+
+      files.uploadCloudStorageProviderFile(uploadFileRequest, callback);
+
+      const uploadCloudStorageProviderFileMessage = utils.findMessageByFunc('files.uploadCloudStorageProviderFile');
+      expect(uploadCloudStorageProviderFileMessage).not.toBeNull();
+      utils.respondToMessage(uploadCloudStorageProviderFileMessage, false);
       expect(callback).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
3p cloud storage provider action API improvements

An improvement over changes of [This PR](https://github.com/OfficeDev/microsoft-teams-library-js/pull/1152). 
Split a single a single action API into following 3 APIs:
1. Delete 2. Download 3. Upload

Corresponding Task : [Task Link](https://domoreexp.visualstudio.com/MSTeams/_workitems/edit/2519496)