### PR TITLE
In progress proposal for Adaptive Card Dialog support

### DIFF
--- a/apps/teams-test-app/src/components/DialogAPIs.tsx
+++ b/apps/teams-test-app/src/components/DialogAPIs.tsx
@@ -112,7 +112,7 @@ const DialogAPIs = (): ReactElement => {
             return '';
           } else {
             setResult('Message sent to child');
-            dialog.sendMessageToDialog(message);
+            dialog.url.sendMessageToDialog(message);
             return '';
           }
         },
@@ -147,7 +147,7 @@ const DialogAPIs = (): ReactElement => {
             }
           } else {
             setResult('Message sent to parent');
-            dialog.sendMessageToParentFromDialog(message);
+            dialog.url.sendMessageToParentFromDialog(message);
           }
           return '';
         },
@@ -170,7 +170,7 @@ const DialogAPIs = (): ReactElement => {
             msg = message;
             setResult(message);
           };
-          dialog.registerOnMessageFromParent(callback);
+          dialog.url.registerOnMessageFromParent(callback);
         }
         return msg;
       },

--- a/apps/teams-test-app/src/components/DialogAPIs.tsx
+++ b/apps/teams-test-app/src/components/DialogAPIs.tsx
@@ -42,7 +42,7 @@ const DialogAPIs = (): ReactElement => {
             // Message from parent
             setResult(message);
           };
-          dialog.open(urlDialogInfo as UrlDialogInfo, onComplete, messageFromChildHandler);
+          dialog.url.open(urlDialogInfo as UrlDialogInfo, onComplete, messageFromChildHandler);
           return '';
         },
       },

--- a/apps/teams-test-app/src/components/DialogAPIs.tsx
+++ b/apps/teams-test-app/src/components/DialogAPIs.tsx
@@ -188,7 +188,7 @@ const DialogAPIs = (): ReactElement => {
         },
         submit: {
           withPromise: async submitInput => {
-            dialog.submit(submitInput.result, submitInput.appIds);
+            dialog.url.submit(submitInput.result, submitInput.appIds);
             return '';
           },
           withCallback: submitInput => {

--- a/packages/teams-js/src/public/adaptiveCards.ts
+++ b/packages/teams-js/src/public/adaptiveCards.ts
@@ -1,0 +1,10 @@
+import { AdaptiveCardVersion } from './interfaces';
+import { runtime } from './runtime';
+
+/**
+ * @returns The {@linkcode: AdaptiveCardVersion} representing the adaptive card schema
+ * version supported by the host, or undefined if the host does not support adaptive cards
+ */
+export function getAdaptiveCardSchemaVersion(): AdaptiveCardVersion | undefined {
+  return runtime.adaptiveCardVersion;
+}

--- a/packages/teams-js/src/public/adaptiveCards.ts
+++ b/packages/teams-js/src/public/adaptiveCards.ts
@@ -6,5 +6,9 @@ import { runtime } from './runtime';
  * version supported by the host, or undefined if the host does not support adaptive cards
  */
 export function getAdaptiveCardSchemaVersion(): AdaptiveCardVersion | undefined {
-  return runtime.adaptiveCardVersion;
+  if (!runtime.hostVersionsInfo) {
+    return undefined;
+  } else {
+    return runtime.hostVersionsInfo.adaptiveCardSchemaVersion;
+  }
 }

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -65,7 +65,7 @@ export enum DialogDimension {
   Small = 'small',
 }
 
-import { ErrorCode, SdkError } from './interfaces';
+import { AdaptiveCardVersion, ErrorCode, SdkError } from './interfaces';
 /**
  * @deprecated
  * As of 2.0.0, please use {@link DialogDimension} instead.
@@ -83,3 +83,5 @@ export enum ChannelType {
 }
 
 export const errorNotSupportedOnPlatform: SdkError = { errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM };
+
+export const minAdaptiveCardVersion: AdaptiveCardVersion = { majorVersion: 1, minorVersion: 15 };

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -1,3 +1,5 @@
+import { AdaptiveCardVersion, ErrorCode, SdkError } from './interfaces';
+
 export enum HostClientType {
   desktop = 'desktop',
   web = 'web',
@@ -65,7 +67,6 @@ export enum DialogDimension {
   Small = 'small',
 }
 
-import { AdaptiveCardVersion, ErrorCode, SdkError } from './interfaces';
 /**
  * @deprecated
  * As of 2.0.0, please use {@link DialogDimension} instead.

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -194,7 +194,8 @@ export namespace dialog {
      * This function cannot be called from inside of a dialog
      *
      * @param adaptiveCardDialogInfo - An object containing the parameters of the dialog module.
-     * @param submitHandler - Handler that triggers when the adaptive card dialog executes the Action.Submit action from the adaptive card or when the user closes the dialog.
+     * @param submitHandler - Handler that triggers when the adaptive card dialog executes the Action.Submit action
+     * from the adaptive card or when the user closes the dialog.
      */
     export function open(adaptiveCardDialogInfo: AdaptiveCardDialogInfo, submitHandler?: DialogSubmitHandler): void {
       ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -230,6 +230,10 @@ export namespace dialog {
     }
 
     export function getVersion(): Promise<AdaptiveCardVersion> {
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+
       return sendAndHandleSdkError('adaptiveCard.version');
     }
 

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -9,12 +9,10 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts, minAdaptiveCardVersion } from './constants';
 import {
   AdaptiveCardDialogInfo,
-  AdaptiveCardVersion,
   BotAdaptiveCardDialogInfo,
   BotUrlDialogInfo,
   DialogInfo,
   DialogSize,
-  ErrorCode,
   UrlDialogInfo,
 } from './interfaces';
 import { runtime } from './runtime';
@@ -204,41 +202,10 @@ export namespace dialog {
         throw errorNotSupportedOnPlatform;
       }
 
-      getVersion().then(hostVersion => {
-        validateMinimumAdaptiveCardVersion(hostVersion);
-
-        const dialogInfo: DialogInfo = getDialogInfoFromAdaptiveCardDialogInfo(adaptiveCardDialogInfo);
-        sendMessageToParent('tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
-          submitHandler?.({ err, result });
-        });
+      const dialogInfo: DialogInfo = getDialogInfoFromAdaptiveCardDialogInfo(adaptiveCardDialogInfo);
+      sendMessageToParent('tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
+        submitHandler?.({ err, result });
       });
-    }
-
-    /**
-     * Query the host to see what version of the AdaptiveCard schema they support
-     *
-     * @returns a Promise containing the {@linkcode AdaptiveCardVersion}, describing what version of the AdaptiveCard
-     * schema the host supports
-     */
-    export function getVersion(): Promise<AdaptiveCardVersion> {
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
-      }
-
-      return sendAndHandleSdkError('adaptiveCard.version');
-    }
-
-    function validateMinimumAdaptiveCardVersion(hostVersion: AdaptiveCardVersion): void {
-      if (
-        hostVersion.majorVersion < minAdaptiveCardVersion.majorVersion ||
-        (hostVersion.majorVersion === minAdaptiveCardVersion.majorVersion &&
-          hostVersion.minorVersion < minAdaptiveCardVersion.minorVersion)
-      ) {
-        throw {
-          errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM,
-          message: `Can not open adaptive card dialog because host adaptive card version is ${hostVersion.majorVersion}.${hostVersion.minorVersion}, but the minimum acceptable adaptive card version is ${minAdaptiveCardVersion.majorVersion}.${minAdaptiveCardVersion.minorVersion}`,
-        };
-      }
     }
 
     /**
@@ -247,9 +214,7 @@ export namespace dialog {
      * @returns boolean to represent whether dialog.adaptiveCard module is supported
      */
     export function isSupported(): boolean {
-      return runtime.supports.dialog && runtime.supports.dialog.adaptiveCard && runtime.supports.adaptiveCard
-        ? true
-        : false;
+      return runtime.supports.dialog && runtime.supports.dialog.adaptiveCard ? true : false;
     }
 
     /**
@@ -273,14 +238,10 @@ export namespace dialog {
           throw errorNotSupportedOnPlatform;
         }
 
-        getVersion().then(hostVersion => {
-          validateMinimumAdaptiveCardVersion(hostVersion);
+        const dialogInfo: DialogInfo = getDialogInfoFromBotAdaptiveCardDialogInfo(botAdaptiveCardDialogInfo);
 
-          const dialogInfo: DialogInfo = getDialogInfoFromBotAdaptiveCardDialogInfo(botAdaptiveCardDialogInfo);
-
-          sendMessageToParent('tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
-            submitHandler?.({ err, result });
-          });
+        sendMessageToParent('tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
+          submitHandler?.({ err, result });
         });
       }
 
@@ -292,8 +253,7 @@ export namespace dialog {
       export function isSupported(): boolean {
         return runtime.supports.dialog &&
           runtime.supports.dialog.adaptiveCard &&
-          runtime.supports.dialog.adaptiveCard.bot &&
-          runtime.supports.adaptiveCard
+          runtime.supports.dialog.adaptiveCard.bot
           ? true
           : false;
       }

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -63,38 +63,6 @@ export namespace dialog {
   }
 
   /**
-   * Allows app to open a url based dialog.
-   *
-   * @remarks
-   * This function cannot be called from inside of a dialog
-   *
-   * @param urlDialogInfo - An object containing the parameters of the dialog module.
-   * @param submitHandler - Handler that triggers when a dialog calls the {@linkcode submit} function or when the user closes the dialog.
-   * @param messageFromChildHandler - Handler that triggers if dialog sends a message to the app.
-   *
-   * @returns a function that can be used to send messages to the dialog.
-   */
-  export function open(
-    urlDialogInfo: UrlDialogInfo,
-    submitHandler?: DialogSubmitHandler,
-    messageFromChildHandler?: PostMessageChannel,
-  ): void {
-    ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
-    if (!isSupported()) {
-      throw errorNotSupportedOnPlatform;
-    }
-
-    if (messageFromChildHandler) {
-      registerHandler('messageForParent', messageFromChildHandler);
-    }
-    const dialogInfo: DialogInfo = getDialogInfoFromUrlDialogInfo(urlDialogInfo);
-    sendMessageToParent('tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
-      submitHandler?.({ err, result });
-      removeHandler('messageForParent');
-    });
-  }
-
-  /**
    * Submit the dialog module.
    *
    * @param result - The result to be sent to the bot or the app. Typically a JSON object or a serialized version of it
@@ -210,53 +178,10 @@ export namespace dialog {
   }
 
   /**
-   * Namespace to open a dialog that sends results to the bot framework
-   */
-  export namespace bot {
-    /**
-     * Allows an app to open the dialog module using bot.
-     *
-     * @param botUrlDialogInfo - An object containing the parameters of the dialog module including completionBotId.
-     * @param submitHandler - Handler that triggers when the dialog has been submitted or closed.
-     * @param messageFromChildHandler - Handler that triggers if dialog sends a message to the app.
-     *
-     * @returns a function that can be used to send messages to the dialog.
-     */
-    export function open(
-      botUrlDialogInfo: BotUrlDialogInfo,
-      submitHandler?: DialogSubmitHandler,
-      messageFromChildHandler?: PostMessageChannel,
-    ): void {
-      ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
-      }
-      if (messageFromChildHandler) {
-        registerHandler('messageForParent', messageFromChildHandler);
-      }
-      const dialogInfo: DialogInfo = getDialogInfoFromBotUrlDialogInfo(botUrlDialogInfo);
-
-      sendMessageToParent('tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
-        submitHandler?.({ err, result });
-        removeHandler('messageForParent');
-      });
-    }
-
-    /**
-     * Checks if dialog.bot capability is supported by the host
-     *
-     * @returns boolean to represent whether dialog.bot is supported
-     */
-    export function isSupported(): boolean {
-      return runtime.supports.dialog ? (runtime.supports.dialog.bot ? true : false) : false;
-    }
-  }
-
-  /**
    * @hidden
    * Hide from docs
    * --------
-   * Convert UrlDialogInfo to DialogInfo to send the information to host in {@linkcode open} API.
+   * Convert UrlDialogInfo to DialogInfo to send the information to host in {@linkcode url.open} API.
    *
    * @internal
    */
@@ -275,7 +200,7 @@ export namespace dialog {
    * @hidden
    * Hide from docs
    * --------
-   * Convert BotUrlDialogInfo to DialogInfo to send the information to host in {@linkcode bot.open} API.
+   * Convert BotUrlDialogInfo to DialogInfo to send the information to host in {@linkcode url.bot.open} API.
    *
    * @internal
    */
@@ -289,5 +214,91 @@ export namespace dialog {
       completionBotId: botUrlDialogInfo.completionBotId,
     };
     return dialogInfo;
+  }
+
+  export namespace url {
+    /**
+     * Allows app to open a url based dialog.
+     *
+     * @remarks
+     * This function cannot be called from inside of a dialog
+     *
+     * @param urlDialogInfo - An object containing the parameters of the dialog module.
+     * @param submitHandler - Handler that triggers when a dialog calls the {@linkcode submit} function or when the user closes the dialog.
+     * @param messageFromChildHandler - Handler that triggers if dialog sends a message to the app.
+     *
+     * @returns a function that can be used to send messages to the dialog.
+     */
+    export function open(
+      urlDialogInfo: UrlDialogInfo,
+      submitHandler?: DialogSubmitHandler,
+      messageFromChildHandler?: PostMessageChannel,
+    ): void {
+      ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+
+      if (messageFromChildHandler) {
+        registerHandler('messageForParent', messageFromChildHandler);
+      }
+      const dialogInfo: DialogInfo = getDialogInfoFromUrlDialogInfo(urlDialogInfo);
+      sendMessageToParent('tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
+        submitHandler?.({ err, result });
+        removeHandler('messageForParent');
+      });
+    }
+
+    /**
+     * Checks if dialog.url module is supported by the host
+     *
+     * @returns boolean to represent whether dialog.url module is supported
+     */
+    export function isSupported(): boolean {
+      return runtime.supports.dialog.url ? true : false;
+    }
+
+    /**
+     * Namespace to open a dialog that sends results to the bot framework
+     */
+    export namespace bot {
+      /**
+       * Allows an app to open a url-based dialog module using bot.
+       *
+       * @param botUrlDialogInfo - An object containing the parameters of the dialog module including completionBotId.
+       * @param submitHandler - Handler that triggers when the dialog has been submitted or closed.
+       * @param messageFromChildHandler - Handler that triggers if dialog sends a message to the app.
+       *
+       * @returns a function that can be used to send messages to the dialog.
+       */
+      export function open(
+        botUrlDialogInfo: BotUrlDialogInfo,
+        submitHandler?: DialogSubmitHandler,
+        messageFromChildHandler?: PostMessageChannel,
+      ): void {
+        ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
+        if (!isSupported()) {
+          throw errorNotSupportedOnPlatform;
+        }
+        if (messageFromChildHandler) {
+          registerHandler('messageForParent', messageFromChildHandler);
+        }
+        const dialogInfo: DialogInfo = getDialogInfoFromBotUrlDialogInfo(botUrlDialogInfo);
+
+        sendMessageToParent('tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
+          submitHandler?.({ err, result });
+          removeHandler('messageForParent');
+        });
+      }
+
+      /**
+       * Checks if dialog.bot capability is supported by the host
+       *
+       * @returns boolean to represent whether dialog.bot is supported
+       */
+      export function isSupported(): boolean {
+        return runtime.supports.dialog && runtime.supports.dialog.url && runtime.supports.dialog.url.bot ? true : false;
+      }
+    }
   }
 }

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -224,7 +224,7 @@ export namespace dialog {
 
         const dialogInfo: DialogInfo = getDialogInfoFromAdaptiveCardDialogInfo(adaptiveCardDialogInfo);
         sendMessageToParent('tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
-          removeHandler('messageForParent');
+          submitHandler?.({ err, result });
         });
       });
     }

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -7,7 +7,14 @@ import { GlobalVars } from '../internal/globalVars';
 import { registerHandler, removeHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from './constants';
-import { BotUrlDialogInfo, DialogInfo, DialogSize, UrlDialogInfo } from './interfaces';
+import {
+  AdaptiveCardDialogInfo,
+  BotAdaptiveCardDialogInfo,
+  BotUrlDialogInfo,
+  DialogInfo,
+  DialogSize,
+  UrlDialogInfo,
+} from './interfaces';
 import { runtime } from './runtime';
 
 /**
@@ -200,6 +207,24 @@ export namespace dialog {
    * @hidden
    * Hide from docs
    * --------
+   * Convert AdaptiveCardDialogInfo to DialogInfo to send the information to host in {@linkcode adaptiveCard.open} API.
+   *
+   * @internal
+   */
+  export function getDialogInfoFromAdaptiveCardDialogInfo(adaptiveCardDialogInfo: AdaptiveCardDialogInfo): DialogInfo {
+    const dialogInfo: DialogInfo = {
+      card: adaptiveCardDialogInfo.card,
+      height: adaptiveCardDialogInfo.size ? adaptiveCardDialogInfo.size.height : DialogDimension.Small,
+      width: adaptiveCardDialogInfo.size ? adaptiveCardDialogInfo.size.width : DialogDimension.Small,
+      title: adaptiveCardDialogInfo.title,
+    };
+    return dialogInfo;
+  }
+
+  /**
+   * @hidden
+   * Hide from docs
+   * --------
    * Convert BotUrlDialogInfo to DialogInfo to send the information to host in {@linkcode url.bot.open} API.
    *
    * @internal
@@ -214,6 +239,114 @@ export namespace dialog {
       completionBotId: botUrlDialogInfo.completionBotId,
     };
     return dialogInfo;
+  }
+
+  /**
+   * @hidden
+   * Hide from docs
+   * --------
+   * Convert AdaptiveCardDialogInfo to DialogInfo to send the information to host in {@linkcode adaptiveCard.open} API.
+   *
+   * @internal
+   */
+  export function getDialogInfoFromBotAdaptiveCardDialogInfo(
+    botAdaptiveCardDialogInfo: BotAdaptiveCardDialogInfo,
+  ): DialogInfo {
+    const dialogInfo: DialogInfo = {
+      card: botAdaptiveCardDialogInfo.card,
+      height: botAdaptiveCardDialogInfo.size ? botAdaptiveCardDialogInfo.size.height : DialogDimension.Small,
+      width: botAdaptiveCardDialogInfo.size ? botAdaptiveCardDialogInfo.size.width : DialogDimension.Small,
+      title: botAdaptiveCardDialogInfo.title,
+      completionBotId: botAdaptiveCardDialogInfo.completionBotId,
+    };
+    return dialogInfo;
+  }
+
+  export namespace adaptiveCard {
+    /**
+     * Allows app to open an adaptive card based dialog.
+     *
+     * @remarks
+     * This function cannot be called from inside of a dialog
+     *
+     * @param adaptiveCardDialogInfo - An object containing the parameters of the dialog module.
+     * @param submitHandler - Handler that triggers when a dialog calls the {@linkcode submit} function or when the user closes the dialog.
+     * @param messageFromChildHandler - Handler that triggers if dialog sends a message to the app.
+     *
+     * @returns a function that can be used to send messages to the dialog.
+     */
+    export function open(
+      adaptiveCardDialogInfo: AdaptiveCardDialogInfo,
+      submitHandler?: DialogSubmitHandler,
+      messageFromChildHandler?: PostMessageChannel,
+    ): void {
+      ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+
+      if (messageFromChildHandler) {
+        registerHandler('messageForParent', messageFromChildHandler);
+      }
+      const dialogInfo: DialogInfo = getDialogInfoFromAdaptiveCardDialogInfo(adaptiveCardDialogInfo);
+      sendMessageToParent('tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
+        submitHandler?.({ err, result });
+        removeHandler('messageForParent');
+      });
+    }
+
+    /**
+     * Checks if dialog.adaptiveCard module is supported by the host
+     *
+     * @returns boolean to represent whether dialog.adaptiveCard module is supported
+     */
+    export function isSupported(): boolean {
+      return runtime.supports.dialog && runtime.supports.dialog.adaptiveCard ? true : false;
+    }
+
+    export namespace bot {
+      /**
+       * Allows an app to open a adaptive card-based dialog module using bot.
+       *
+       * @param botAdaptiveCardDialogInfo - An object containing the parameters of the dialog module including completionBotId.
+       * @param submitHandler - Handler that triggers when the dialog has been submitted or closed.
+       * @param messageFromChildHandler - Handler that triggers if dialog sends a message to the app.
+       *
+       * @returns a function that can be used to send messages to the dialog.
+       */
+      export function open(
+        botAdaptiveCardDialogInfo: BotAdaptiveCardDialogInfo,
+        submitHandler?: DialogSubmitHandler,
+        messageFromChildHandler?: PostMessageChannel,
+      ): void {
+        ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
+        if (!isSupported()) {
+          throw errorNotSupportedOnPlatform;
+        }
+        if (messageFromChildHandler) {
+          registerHandler('messageForParent', messageFromChildHandler);
+        }
+        const dialogInfo: DialogInfo = getDialogInfoFromBotAdaptiveCardDialogInfo(botAdaptiveCardDialogInfo);
+
+        sendMessageToParent('tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
+          submitHandler?.({ err, result });
+          removeHandler('messageForParent');
+        });
+      }
+
+      /**
+       * Checks if dialog.adaptiveCard.bot capability is supported by the host
+       *
+       * @returns boolean to represent whether dialog.adaptiveCard.bot is supported
+       */
+      export function isSupported(): boolean {
+        return runtime.supports.dialog &&
+          runtime.supports.dialog.adaptiveCard &&
+          runtime.supports.dialog.adaptiveCard.bot
+          ? true
+          : false;
+      }
+    }
   }
 
   export namespace url {
@@ -255,7 +388,7 @@ export namespace dialog {
      * @returns boolean to represent whether dialog.url module is supported
      */
     export function isSupported(): boolean {
-      return runtime.supports.dialog.url ? true : false;
+      return runtime.supports.dialog && runtime.supports.dialog.url ? true : false;
     }
 
     /**

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -72,22 +72,6 @@ export namespace dialog {
   }
 
   /**
-   * Submit the dialog module.
-   *
-   * @param result - The result to be sent to the bot or the app. Typically a JSON object or a serialized version of it
-   * @param appIds - Helps to validate that the call originates from the same appId as the one that invoked the task module
-   */
-  export function submit(result?: string | object, appIds?: string | string[]): void {
-    ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.task, FrameContexts.meetingStage);
-    if (!isSupported()) {
-      throw errorNotSupportedOnPlatform;
-    }
-
-    // Send tasks.completeTask instead of tasks.submitTask message for backward compatibility with Mobile clients
-    sendMessageToParent('tasks.completeTask', [result, appIds ? (Array.isArray(appIds) ? appIds : [appIds]) : []]);
-  }
-
-  /**
    * Checks if dialog module is supported by the host
    *
    * @returns boolean to represent whether dialog module is supported
@@ -212,7 +196,7 @@ export namespace dialog {
      * This function cannot be called from inside of a dialog
      *
      * @param adaptiveCardDialogInfo - An object containing the parameters of the dialog module.
-     * @param submitHandler - Handler that triggers when a dialog calls the {@linkcode submit} function or when the user closes the dialog.
+     * @param submitHandler - Handler that triggers when the adaptive card dialog executes the Action.Submit action from the adaptive card or when the user closes the dialog.
      */
     export function open(adaptiveCardDialogInfo: AdaptiveCardDialogInfo, submitHandler?: DialogSubmitHandler): void {
       ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
@@ -413,6 +397,22 @@ export namespace dialog {
         const message = storedMessages.pop();
         listener(message);
       }
+    }
+
+    /**
+     * Submit the dialog module.
+     *
+     * @param result - The result to be sent to the bot or the app. Typically a JSON object or a serialized version of it
+     * @param appIds - Helps to validate that the call originates from the same appId as the one that invoked the task module
+     */
+    export function submit(result?: string | object, appIds?: string | string[]): void {
+      ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.task, FrameContexts.meetingStage);
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+
+      // Send tasks.completeTask instead of tasks.submitTask message for backward compatibility with Mobile clients
+      sendMessageToParent('tasks.completeTask', [result, appIds ? (Array.isArray(appIds) ? appIds : [appIds]) : []]);
     }
 
     /**

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -201,6 +201,9 @@ export namespace dialog {
     return dialogInfo;
   }
 
+  /**
+   * Subcapability for interacting with adaptive card dialogs
+   */
   export namespace adaptiveCard {
     /**
      * Allows app to open an adaptive card based dialog.
@@ -210,8 +213,6 @@ export namespace dialog {
      *
      * @param adaptiveCardDialogInfo - An object containing the parameters of the dialog module.
      * @param submitHandler - Handler that triggers when a dialog calls the {@linkcode submit} function or when the user closes the dialog.
-     *
-     * @returns a function that can be used to send messages to the dialog.
      */
     export function open(adaptiveCardDialogInfo: AdaptiveCardDialogInfo, submitHandler?: DialogSubmitHandler): void {
       ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
@@ -229,6 +230,12 @@ export namespace dialog {
       });
     }
 
+    /**
+     * Query the host to see what version of the AdaptiveCard schema they support
+     *
+     * @returns a Promise containing the {@linkcode AdaptiveCardVersion}, describing what version of the AdaptiveCard
+     * schema the host supports
+     */
     export function getVersion(): Promise<AdaptiveCardVersion> {
       if (!isSupported()) {
         throw errorNotSupportedOnPlatform;
@@ -261,6 +268,9 @@ export namespace dialog {
         : false;
     }
 
+    /**
+     * Namespace for interaction with adaptive card dialogs that need to communicate with the bot framework
+     */
     export namespace bot {
       /**
        * Allows an app to open a adaptive card-based dialog module using bot.
@@ -306,6 +316,9 @@ export namespace dialog {
     }
   }
 
+  /**
+   * Namespace for interacting with url based dialogs
+   */
   export namespace url {
     /**
      * Allows app to open a url based dialog.

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -25,6 +25,9 @@ export {
   LocaleInfo,
   FrameInfo,
   ShareDeepLinkParameters,
+  AdaptiveCardVersion,
+  AdaptiveCardDialogInfo,
+  BotAdaptiveCardDialogInfo,
 } from './interfaces';
 export { app } from './app';
 export { appInstallDialog } from './appInstallDialog';

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -29,6 +29,7 @@ export {
   AdaptiveCardDialogInfo,
   BotAdaptiveCardDialogInfo,
 } from './interfaces';
+export { getAdaptiveCardSchemaVersion } from './adaptiveCards';
 export { app } from './app';
 export { appInstallDialog } from './appInstallDialog';
 export { barCode } from './barCode';

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -681,19 +681,7 @@ export interface DialogSize {
   width: DialogDimension | number;
 }
 
-/**
- * Data structure to describe dialog information needed to open a url based dialog.
- */
-export interface UrlDialogInfo {
-  /**
-   * The url to be rendered in the webview/iframe.
-   *
-   * @remarks
-   * The domain of the url must match at least one of the
-   * valid domains specified in the validDomains block of the manifest
-   */
-  url: string;
-
+interface BaseDialogInfo {
   /*
    * The requested size of the dialog
    */
@@ -703,6 +691,42 @@ export interface UrlDialogInfo {
    * Title of the task module.
    */
   title?: string;
+}
+
+/**
+ * Data structure to describe dialog information needed to open an adaptive card based dialog.
+ */
+export interface AdaptiveCardDialogInfo extends BaseDialogInfo {
+  /**
+   * JSON defining an adaptive card.
+   */
+  card?: string;
+}
+
+/**
+ * Data structure to describe dialog information needed to open a bot based adaptive card dialog.
+ */
+export interface BotAdaptiveCardDialogInfo extends AdaptiveCardDialogInfo {
+  /**
+   * Specifies a bot ID to send the result of the user's interaction with the task module.
+   * The bot will receive a task/complete invoke event with a JSON object
+   * in the event payload.
+   */
+  completionBotId: string;
+}
+
+/**
+ * Data structure to describe dialog information needed to open a url based dialog.
+ */
+export interface UrlDialogInfo extends BaseDialogInfo {
+  /**
+   * The url to be rendered in the webview/iframe.
+   *
+   * @remarks
+   * The domain of the url must match at least one of the
+   * valid domains specified in the validDomains block of the manifest
+   */
+  url: string;
 
   /**
    * If client doesnt support the URL, the URL that needs to be opened in the browser.
@@ -711,7 +735,7 @@ export interface UrlDialogInfo {
 }
 
 /**
- * Data structure to describe dialog information needed to open a bot based dialog.
+ * Data structure to describe dialog information needed to open a bot based url dialog.
  */
 export interface BotUrlDialogInfo extends UrlDialogInfo {
   /**

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -925,6 +925,11 @@ export enum DevicePermission {
   Media = 'media',
 }
 
+/** @hidden */
+export interface HostVersionsInfo {
+  adaptiveCardSchemaVersion?: AdaptiveCardVersion;
+}
+
 /**
  * Represents the major and minor versions of the AdaptiveCard schema
  */

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -681,7 +681,10 @@ export interface DialogSize {
   width: DialogDimension | number;
 }
 
-interface BaseDialogInfo {
+/**
+ * Shared Dialog Properties
+ */
+export interface BaseDialogInfo {
   /*
    * The requested size of the dialog
    */
@@ -920,4 +923,9 @@ export enum ErrorCode {
 export enum DevicePermission {
   GeoLocation = 'geolocation',
   Media = 'media',
+}
+
+export interface AdaptiveCardVersion {
+  majorVersion: number;
+  minorVersion: number;
 }

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -925,6 +925,9 @@ export enum DevicePermission {
   Media = 'media',
 }
 
+/**
+ * Represents the major and minor versions of the AdaptiveCard schema
+ */
 export interface AdaptiveCardVersion {
   majorVersion: number;
   minorVersion: number;

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -121,6 +121,9 @@ export const teamsRuntimeConfig: IRuntime = {
     chat: {},
     conversations: {},
     dialog: {
+      adaptiveCard: {
+        bot: {},
+      },
       update: {},
       url: {
         bot: {},

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -7,6 +7,7 @@ export interface IRuntime {
   readonly apiVersion: number;
   readonly isLegacyTeams?: boolean;
   readonly supports: {
+    readonly adaptiveCard?: {};
     readonly appInstallDialog?: {};
     readonly appEntity?: {};
     readonly barCode?: {};
@@ -60,6 +61,7 @@ export interface IRuntime {
 export let runtime: IRuntime = {
   apiVersion: 1,
   supports: {
+    adaptiveCard: undefined,
     appInstallDialog: undefined,
     barCode: undefined,
     calendar: undefined,

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -3,10 +3,10 @@
 import { GlobalVars } from '../internal/globalVars';
 import { compareSDKVersions, deepFreeze } from '../internal/utils';
 import { HostClientType } from './constants';
-import { AdaptiveCardVersion } from './interfaces';
+import { HostVersionsInfo } from './interfaces';
 export interface IRuntime {
-  readonly adaptiveCardVersion?: AdaptiveCardVersion;
   readonly apiVersion: number;
+  readonly hostVersionsInfo?: HostVersionsInfo;
   readonly isLegacyTeams?: boolean;
   readonly supports: {
     readonly appInstallDialog?: {};

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -3,11 +3,12 @@
 import { GlobalVars } from '../internal/globalVars';
 import { compareSDKVersions, deepFreeze } from '../internal/utils';
 import { HostClientType } from './constants';
+import { AdaptiveCardVersion } from './interfaces';
 export interface IRuntime {
+  readonly adaptiveCardVersion?: AdaptiveCardVersion;
   readonly apiVersion: number;
   readonly isLegacyTeams?: boolean;
   readonly supports: {
-    readonly adaptiveCard?: {};
     readonly appInstallDialog?: {};
     readonly appEntity?: {};
     readonly barCode?: {};
@@ -61,7 +62,6 @@ export interface IRuntime {
 export let runtime: IRuntime = {
   apiVersion: 1,
   supports: {
-    adaptiveCard: undefined,
     appInstallDialog: undefined,
     barCode: undefined,
     calendar: undefined,

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -16,15 +16,6 @@ export interface IRuntime {
     readonly webStorage?: {};
     readonly conversations?: {};
     readonly dialog?: {
-      readonly update?: {};
-      readonly url?: {
-        readonly bot?: {};
-      };
-    };
-    readonly geoLocation?: {
-      readonly map?: {};
-    };
-    readonly dialog2?: {
       readonly adaptiveCard?: {
         readonly bot?: {};
       };
@@ -32,6 +23,9 @@ export interface IRuntime {
       readonly url?: {
         readonly bot?: {};
       };
+    };
+    readonly geoLocation?: {
+      readonly map?: {};
     };
     readonly location?: {};
     readonly logs?: {};
@@ -74,12 +68,6 @@ export let runtime: IRuntime = {
     webStorage: undefined,
     conversations: undefined,
     dialog: {
-      update: undefined,
-      url: {
-        bot: undefined,
-      },
-    },
-    dialog2: {
       adaptiveCard: {
         bot: undefined,
       },
@@ -131,18 +119,6 @@ export const teamsRuntimeConfig: IRuntime = {
     chat: {},
     conversations: {},
     dialog: {
-      update: {},
-      url: {
-        bot: {},
-      },
-    },
-    dialog2: {
-      // I think this should be omitted: creating adaptive cards in teams would still work from tasks
-      // but we make no promises about how their adaptive cards work since they have an old version of adaptive
-      // cards
-      adaptiveCard: {
-        bot: {},
-      },
       update: {},
       url: {
         bot: {},

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -16,11 +16,22 @@ export interface IRuntime {
     readonly webStorage?: {};
     readonly conversations?: {};
     readonly dialog?: {
-      readonly bot?: {};
       readonly update?: {};
+      readonly url?: {
+        readonly bot?: {};
+      };
     };
     readonly geoLocation?: {
       readonly map?: {};
+    };
+    readonly dialog2?: {
+      readonly adaptiveCard?: {
+        readonly bot?: {};
+      };
+      readonly update?: {};
+      readonly url?: {
+        readonly bot?: {};
+      };
     };
     readonly location?: {};
     readonly logs?: {};
@@ -63,8 +74,19 @@ export let runtime: IRuntime = {
     webStorage: undefined,
     conversations: undefined,
     dialog: {
-      bot: undefined,
       update: undefined,
+      url: {
+        bot: undefined,
+      },
+    },
+    dialog2: {
+      adaptiveCard: {
+        bot: undefined,
+      },
+      update: undefined,
+      url: {
+        bot: undefined,
+      },
     },
     geoLocation: {
       map: undefined,
@@ -109,8 +131,22 @@ export const teamsRuntimeConfig: IRuntime = {
     chat: {},
     conversations: {},
     dialog: {
-      bot: {},
       update: {},
+      url: {
+        bot: {},
+      },
+    },
+    dialog2: {
+      // I think this should be omitted: creating adaptive cards in teams would still work from tasks
+      // but we make no promises about how their adaptive cards work since they have an old version of adaptive
+      // cards
+      adaptiveCard: {
+        bot: {},
+      },
+      update: {},
+      url: {
+        bot: {},
+      },
     },
     logs: {},
     meetingRoom: {},

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -22,9 +22,12 @@ import {
 export namespace tasks {
   /**
    * @deprecated
-   * As of 2.0.0, please use {@link dialog.url.open dialog.open(urlDialogInfo: UrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): void} for url based dialogs
+   * As of 2.0.0, please use {@link dialog.url.open dialog.url.open(urlDialogInfo: UrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): void} for url based dialogs
    * and {@link dialog.url.bot.open dialog.bot.open(botUrlDialogInfo: BotUrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): void}
-   * for bot based dialogs. In Teams *only* this function can be used for adaptive card based dialogs.
+   * for url dialogs that send their result to a bot.
+   * Please use {@link dialog.adaptiveCard.open dialog.adaptiveCard.open(adaptiveCardDialogInfo: AdaptiveCardDialogInfo, submitHandler?: DialogSubmitHandler): void}
+   * for adaptive card based dialogs and {@link dialog.adaptiveCard.bot.open dialog.adaptiveCard.bot.open(botAdaptiveCardDialogInfo: BotAdaptiveCardDialogInfo, submitHandler?: DialogSubmitHandler): void}
+   * for adaptive card based dialogs that send their results to a bot
    *
    * Allows an app to open the task module.
    *

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -1,11 +1,15 @@
 /* eslint-disable @typescript-eslint/ban-types */
-
-import { sendMessageToParent } from '../internal/communication';
-import { ensureInitialized } from '../internal/internalAPIs';
 import { ChildAppWindow, IAppWindow } from './appWindow';
-import { FrameContexts, TaskModuleDimension } from './constants';
+import { TaskModuleDimension } from './constants';
 import { dialog } from './dialog';
-import { BotUrlDialogInfo, DialogInfo, DialogSize, TaskInfo, UrlDialogInfo } from './interfaces';
+import {
+  AdaptiveCardDialogInfo,
+  BotAdaptiveCardDialogInfo,
+  BotUrlDialogInfo,
+  DialogSize,
+  TaskInfo,
+  UrlDialogInfo,
+} from './interfaces';
 
 /**
  * @deprecated
@@ -35,8 +39,13 @@ export namespace tasks {
       ? (sdkResponse: dialog.ISdkResponse) => submitHandler(sdkResponse.err, sdkResponse.result)
       : undefined;
     if (taskInfo.card !== undefined || taskInfo.url === undefined) {
-      ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
-      sendMessageToParent('tasks.startTask', [taskInfo as DialogInfo], submitHandler);
+      if (taskInfo.completionBotId) {
+        dialog.adaptiveCard.bot.open(getBotAdaptiveCardDialogInfoFromTaskInfo(taskInfo), dialogSubmitHandler);
+      } else {
+        dialog.adaptiveCard.open(getAdaptiveCardDialogInfoFromTaskInfo(taskInfo), dialogSubmitHandler);
+      }
+      // ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
+      // sendMessageToParent('tasks.startTask', [taskInfo as DialogInfo], submitHandler);
     } else if (taskInfo.completionBotId !== undefined) {
       dialog.url.bot.open(getBotUrlDialogInfoFromTaskInfo(taskInfo), dialogSubmitHandler);
     } else {
@@ -112,6 +121,45 @@ export namespace tasks {
       completionBotId: taskInfo.completionBotId,
     };
     return botUrldialogInfo;
+  }
+
+  /**
+   * @hidden
+   * Converts {@link TaskInfo} to {@link AdaptiveCardDialogInfo}
+   * @param taskInfo - TaskInfo object to convert
+   * @returns - converted AdaptiveCardDialogInfo
+   */
+  function getAdaptiveCardDialogInfoFromTaskInfo(taskInfo: TaskInfo): AdaptiveCardDialogInfo {
+    const adaptiveCardDialogInfo: AdaptiveCardDialogInfo = {
+      card: taskInfo.card,
+      size: {
+        height: taskInfo.height ? taskInfo.height : TaskModuleDimension.Small,
+        width: taskInfo.width ? taskInfo.width : TaskModuleDimension.Small,
+      },
+      title: taskInfo.title,
+    };
+
+    return adaptiveCardDialogInfo;
+  }
+
+  /**
+   * @hidden
+   * Converts {@link TaskInfo} to {@link BotAdaptiveCardDialogInfo}
+   * @param taskInfo - TaskInfo object to convert
+   * @returns - converted BotAdaptiveCardDialogInfo
+   */
+  function getBotAdaptiveCardDialogInfoFromTaskInfo(taskInfo: TaskInfo): BotAdaptiveCardDialogInfo {
+    const botAdaptiveCardDialogInfo: BotAdaptiveCardDialogInfo = {
+      card: taskInfo.card,
+      size: {
+        height: taskInfo.height ? taskInfo.height : TaskModuleDimension.Small,
+        width: taskInfo.width ? taskInfo.width : TaskModuleDimension.Small,
+      },
+      title: taskInfo.title,
+      completionBotId: taskInfo.completionBotId,
+    };
+
+    return botAdaptiveCardDialogInfo;
   }
 
   /**

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -66,7 +66,7 @@ export namespace tasks {
 
   /**
    * @deprecated
-   * As of 2.0.0, please use {@link dialog.submit} instead.
+   * As of 2.0.0, please use {@link dialog.url.submit} instead.
    *
    * Submit the task module.
    *
@@ -74,7 +74,7 @@ export namespace tasks {
    * @param appIds - Helps to validate that the call originates from the same appId as the one that invoked the task module
    */
   export function submitTask(result?: string | object, appIds?: string | string[]): void {
-    dialog.submit(result, appIds);
+    dialog.url.submit(result, appIds);
   }
 
   /**

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -18,8 +18,8 @@ import { BotUrlDialogInfo, DialogInfo, DialogSize, TaskInfo, UrlDialogInfo } fro
 export namespace tasks {
   /**
    * @deprecated
-   * As of 2.0.0, please use {@link dialog.open dialog.open(urlDialogInfo: UrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): void} for url based dialogs
-   * and {@link dialog.bot.open dialog.bot.open(botUrlDialogInfo: BotUrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): void} for bot based dialogs. In Teams,
+   * As of 2.0.0, please use {@link dialog.url.open dialog.open(urlDialogInfo: UrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): void} for url based dialogs
+   * and {@link dialog.url.bot.open dialog.bot.open(botUrlDialogInfo: BotUrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): void} for bot based dialogs. In Teams,
    * this function can be used for adaptive card based dialogs. Support for adaptive card based dialogs is coming to other hosts in the future.
    *
    * Allows an app to open the task module.
@@ -38,9 +38,9 @@ export namespace tasks {
       ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
       sendMessageToParent('tasks.startTask', [taskInfo as DialogInfo], submitHandler);
     } else if (taskInfo.completionBotId !== undefined) {
-      dialog.bot.open(getBotUrlDialogInfoFromTaskInfo(taskInfo), dialogSubmitHandler);
+      dialog.url.bot.open(getBotUrlDialogInfoFromTaskInfo(taskInfo), dialogSubmitHandler);
     } else {
-      dialog.open(getUrlDialogInfoFromTaskInfo(taskInfo), dialogSubmitHandler);
+      dialog.url.open(getUrlDialogInfoFromTaskInfo(taskInfo), dialogSubmitHandler);
     }
     return new ChildAppWindow();
   }

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -19,8 +19,8 @@ export namespace tasks {
   /**
    * @deprecated
    * As of 2.0.0, please use {@link dialog.url.open dialog.open(urlDialogInfo: UrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): void} for url based dialogs
-   * and {@link dialog.url.bot.open dialog.bot.open(botUrlDialogInfo: BotUrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): void} for bot based dialogs. In Teams,
-   * this function can be used for adaptive card based dialogs. Support for adaptive card based dialogs is coming to other hosts in the future.
+   * and {@link dialog.url.bot.open dialog.bot.open(botUrlDialogInfo: BotUrlDialogInfo, submitHandler?: DialogSubmitHandler, messageFromChildHandler?: PostMessageChannel): void}
+   * for bot based dialogs. In Teams *only* this function can be used for adaptive card based dialogs.
    *
    * Allows an app to open the task module.
    *


### PR DESCRIPTION
I'm not sure this is ready for review yet which is why it is marked as draft.

A few points:

1. The Dialog capability has been restructured to better support both url and adaptive card-based dialogs. I feel ok doing this since the capability is still marked as @beta. You can now use dialog and its subcapabilities as follows:
     _dialog.url.open_ will open a url based dialog that does not interact with the bot framework
     _dialog.url.bot.open_ will open a url based dialog that **does** interact with the bot framework
     _dialog.adaptiveCard.open_ will open an adaptive card based dialog that does not interact with the bot framework
     _dialog.adaptiveCard.bot.open_ will open an adaptive card based dialog that **does** interact with the bot framework
2. dialog.adaptiveCard.getVersion() will return the current version (MAJOR.MINOR) of adaptive cards that the host supports for dialogs. Hosts will need to attest to the version of adaptive cards they are providing to app developers
3. The 2 open functions in the adaptiveCard subcapability will also verify that the version of adaptiveCards the host claims to provide meets a minimum version requirement. I have this set to 1.15 in this PR because that's the version the most recent JS adaptive card package supports.