### PR TITLE
Arocc/register speaking state changed add error

### DIFF
--- a/apps/teams-test-app/src/components/MeetingAPIs.tsx
+++ b/apps/teams-test-app/src/components/MeetingAPIs.tsx
@@ -204,7 +204,7 @@ const RegisterSpeakingStateChangedHandler = (): React.ReactElement =>
     name: 'registerSpeakingStateChangedHandler',
     title: 'Register SpeakingState Changed Handler',
     onClick: async setResult => {
-      const handler = (eventData: meeting.SpeakingStateChangedEventData): void => {
+      const handler = (eventData: meeting.ISpeakingState): void => {
         let res;
         if (eventData.error) {
           res = `Receieved error ${JSON.stringify(eventData.error)}`;

--- a/apps/teams-test-app/src/components/MeetingAPIs.tsx
+++ b/apps/teams-test-app/src/components/MeetingAPIs.tsx
@@ -204,8 +204,13 @@ const RegisterSpeakingStateChangedHandler = (): React.ReactElement =>
     name: 'registerSpeakingStateChangedHandler',
     title: 'Register SpeakingState Changed Handler',
     onClick: async setResult => {
-      const handler = (speakingState: meeting.ISpeakingState): void => {
-        const res = `Speaking state changed to ${speakingState.isSpeakingDetected}`;
+      const handler = (eventData: meeting.SpeakingStateChangedEventData): void => {
+        let res;
+        if (eventData.error) {
+          res = `Receieved error ${JSON.stringify(eventData.error)}`;
+        } else {
+          res = `Received ${JSON.stringify(eventData.isSpeakingDetected)}`;
+        }
         setResult(res);
       };
       meeting.registerSpeakingStateChangeHandler(handler);

--- a/apps/teams-test-app/src/components/MeetingAPIs.tsx
+++ b/apps/teams-test-app/src/components/MeetingAPIs.tsx
@@ -209,7 +209,7 @@ const RegisterSpeakingStateChangedHandler = (): React.ReactElement =>
         if (eventData.error) {
           res = `Receieved error ${JSON.stringify(eventData.error)}`;
         } else {
-          res = `Received ${JSON.stringify(eventData.isSpeakingDetected)}`;
+          res = `Speaking state changed to ${JSON.stringify(eventData.isSpeakingDetected)}`;
         }
         setResult(res);
       };

--- a/change/@microsoft-teams-js-20f1c31d-4466-4278-b140-f9454214c18b.json
+++ b/change/@microsoft-teams-js-20f1c31d-4466-4278-b140-f9454214c18b.json
@@ -1,8 +1,8 @@
 {
   "type": "minor",
   "comment": {
-    "title": "",
-    "value": ""
+    "title": "`registerSpeakingStateChangeHandler` API updates",
+    "value": "Updated interface for `registerSpeakingStateChangeHandler` API. Changed name to `SpeakingStateChangedEventData` and added an error object to align with other API error handling."
   },
   "packageName": "@microsoft/teams-js",
   "email": "ashleyrocha16@gmail.com",

--- a/change/@microsoft-teams-js-20f1c31d-4466-4278-b140-f9454214c18b.json
+++ b/change/@microsoft-teams-js-20f1c31d-4466-4278-b140-f9454214c18b.json
@@ -2,7 +2,7 @@
   "type": "minor",
   "comment": {
     "title": "`registerSpeakingStateChangeHandler` API updates",
-    "value": "Updated interface for `registerSpeakingStateChangeHandler` API. Changed name to `SpeakingStateChangedEventData` and added an error object to align with other API error handling."
+    "value": "Updated interface for `registerSpeakingStateChangeHandler` API (add an optional error object) to align with other API error handling."
   },
   "packageName": "@microsoft/teams-js",
   "email": "ashleyrocha16@gmail.com",

--- a/change/@microsoft-teams-js-20f1c31d-4466-4278-b140-f9454214c18b.json
+++ b/change/@microsoft-teams-js-20f1c31d-4466-4278-b140-f9454214c18b.json
@@ -1,0 +1,10 @@
+{
+  "type": "minor",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "@microsoft/teams-js",
+  "email": "ashleyrocha16@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -149,12 +149,22 @@ export namespace meeting {
     isAppSharing: boolean;
   }
 
-  export interface ISpeakingState {
+  /**
+   * Property bag for the speakingState changed event
+   *
+   * @beta
+   */
+  export interface SpeakingStateChangedEventData {
     /**
      * Indicates whether one or more participants in a meeting are speaking, or
      * if no participants are speaking
      */
-    isSpeakingDetected: boolean;
+    isSpeakingDetected?: boolean;
+
+    /**
+     * error object in case there is a failure
+     */
+    error?: SdkError;
   }
 
   /**
@@ -458,13 +468,15 @@ export namespace meeting {
   }
 
   /**
-   * Registers a handler for changes to paticipant speaking states. If any participant is speaking, isSpeakingDetected
-   * will be true. If no participants are speaking, isSpeakingDetected will be false. Only one handler can be registered
-   * at a time. A subsequent registration replaces an existing registration.
+   * Registers a handler for changes to paticipant speaking states. This API returns {@link SpeakingStateChangedEventData}, which will have isSpeakingDetected
+   * or an error object. If any participant is speaking, isSpeakingDetected will be true. If no participants are speaking, isSpeakingDetected
+   * will be false. Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *
    * @param handler The handler to invoke when the speaking state of any participant changes (start/stop speaking).
    */
-  export function registerSpeakingStateChangeHandler(handler: (speakingState: ISpeakingState) => void): void {
+  export function registerSpeakingStateChangeHandler(
+    handler: (eventData: SpeakingStateChangedEventData) => void,
+  ): void {
     if (!handler) {
       throw new Error('[registerSpeakingStateChangeHandler] Handler cannot be null');
     }

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -152,7 +152,6 @@ export namespace meeting {
   /**
    * Property bag for the speakingState changed event
    *
-   * @beta
    */
   export interface SpeakingStateChangedEventData {
     /**

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -468,12 +468,12 @@ export namespace meeting {
 
   /**
    * Registers a handler for changes to paticipant speaking states. This API returns {@link ISpeakingState}, which will have isSpeakingDetected
-   * or an error object. If any participant is speaking, isSpeakingDetected will be true. If no participants are speaking, isSpeakingDetected
-   * will be false. Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
+   * and/or an error object. If any participant is speaking, isSpeakingDetected will be true. If no participants are speaking, isSpeakingDetected
+   * will be false. Default value is false. Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *
    * @param handler The handler to invoke when the speaking state of any participant changes (start/stop speaking).
    */
-  export function registerSpeakingStateChangeHandler(handler: (eventData: ISpeakingState) => void): void {
+  export function registerSpeakingStateChangeHandler(handler: (speakingState: ISpeakingState) => void): void {
     if (!handler) {
       throw new Error('[registerSpeakingStateChangeHandler] Handler cannot be null');
     }

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -153,12 +153,12 @@ export namespace meeting {
    * Property bag for the speakingState changed event
    *
    */
-  export interface SpeakingStateChangedEventData {
+  export interface ISpeakingState {
     /**
      * Indicates whether one or more participants in a meeting are speaking, or
      * if no participants are speaking
      */
-    isSpeakingDetected?: boolean;
+    isSpeakingDetected: boolean;
 
     /**
      * error object in case there is a failure
@@ -467,15 +467,13 @@ export namespace meeting {
   }
 
   /**
-   * Registers a handler for changes to paticipant speaking states. This API returns {@link SpeakingStateChangedEventData}, which will have isSpeakingDetected
+   * Registers a handler for changes to paticipant speaking states. This API returns {@link ISpeakingState}, which will have isSpeakingDetected
    * or an error object. If any participant is speaking, isSpeakingDetected will be true. If no participants are speaking, isSpeakingDetected
    * will be false. Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *
    * @param handler The handler to invoke when the speaking state of any participant changes (start/stop speaking).
    */
-  export function registerSpeakingStateChangeHandler(
-    handler: (eventData: SpeakingStateChangedEventData) => void,
-  ): void {
+  export function registerSpeakingStateChangeHandler(handler: (eventData: ISpeakingState) => void): void {
     if (!handler) {
       throw new Error('[registerSpeakingStateChangeHandler] Handler cannot be null');
     }

--- a/packages/teams-js/test/public/meeting.spec.ts
+++ b/packages/teams-js/test/public/meeting.spec.ts
@@ -1071,16 +1071,16 @@ describe('meeting', () => {
       ).toThrowError('The library has not yet been initialized');
     });
 
-    it('should successfully register a handler for when the array of participants speaking changes', () => {
-      framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel, FrameContexts.meetingStage);
-      const speakingState: meeting.ISpeakingState = { isSpeakingDetected: true };
+    it('should successfully register a handler for when the array of participants speaking changes and frameContext=sidePanel', () => {
+      framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
+      const speakingState: meeting.SpeakingStateChangedEventData = { isSpeakingDetected: true };
 
       let handlerCalled = false;
-      let returnedSpeakingState: meeting.ISpeakingState | null;
+      let returnedSpeakingState: meeting.SpeakingStateChangedEventData | null;
 
-      meeting.registerSpeakingStateChangeHandler((isSpeakingDetected: meeting.ISpeakingState) => {
+      meeting.registerSpeakingStateChangeHandler((eventData: meeting.SpeakingStateChangedEventData) => {
         handlerCalled = true;
-        returnedSpeakingState = isSpeakingDetected;
+        returnedSpeakingState = eventData;
       });
 
       const registerHandlerMessage = framelessPlatformMock.findMessageByFunc('registerHandler');
@@ -1096,7 +1096,35 @@ describe('meeting', () => {
       } as DOMMessageEvent);
 
       expect(handlerCalled).toBeTruthy();
-      expect(returnedSpeakingState.isSpeakingDetected).toBe(speakingState.isSpeakingDetected);
+      expect(returnedSpeakingState).toBe(speakingState);
+    });
+
+    it('should successfully register a handler for when the array of participants speaking changes and frameContext=meetingStage', () => {
+      framelessPlatformMock.initializeWithContext(FrameContexts.meetingStage);
+      const speakingState: meeting.SpeakingStateChangedEventData = { isSpeakingDetected: true };
+
+      let handlerCalled = false;
+      let returnedSpeakingState: meeting.SpeakingStateChangedEventData | null;
+
+      meeting.registerSpeakingStateChangeHandler((eventData: meeting.SpeakingStateChangedEventData) => {
+        handlerCalled = true;
+        returnedSpeakingState = eventData;
+      });
+
+      const registerHandlerMessage = framelessPlatformMock.findMessageByFunc('registerHandler');
+      expect(registerHandlerMessage).not.toBeNull();
+      expect(registerHandlerMessage.args.length).toBe(1);
+      expect(registerHandlerMessage.args[0]).toBe('meeting.speakingStateChanged');
+
+      framelessPlatformMock.respondToMessage({
+        data: {
+          func: 'meeting.speakingStateChanged',
+          args: [speakingState],
+        },
+      } as DOMMessageEvent);
+
+      expect(handlerCalled).toBeTruthy();
+      expect(returnedSpeakingState).toBe(speakingState);
     });
   });
 

--- a/packages/teams-js/test/public/meeting.spec.ts
+++ b/packages/teams-js/test/public/meeting.spec.ts
@@ -1073,12 +1073,12 @@ describe('meeting', () => {
 
     it('should successfully register a handler for when the array of participants speaking changes and frameContext=sidePanel', () => {
       framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      const speakingState: meeting.SpeakingStateChangedEventData = { isSpeakingDetected: true };
+      const speakingState: meeting.ISpeakingState = { isSpeakingDetected: true };
 
       let handlerCalled = false;
-      let returnedSpeakingState: meeting.SpeakingStateChangedEventData | null;
+      let returnedSpeakingState: meeting.ISpeakingState | null;
 
-      meeting.registerSpeakingStateChangeHandler((eventData: meeting.SpeakingStateChangedEventData) => {
+      meeting.registerSpeakingStateChangeHandler((eventData: meeting.ISpeakingState) => {
         handlerCalled = true;
         returnedSpeakingState = eventData;
       });
@@ -1101,12 +1101,12 @@ describe('meeting', () => {
 
     it('should successfully register a handler for when the array of participants speaking changes and frameContext=meetingStage', () => {
       framelessPlatformMock.initializeWithContext(FrameContexts.meetingStage);
-      const speakingState: meeting.SpeakingStateChangedEventData = { isSpeakingDetected: true };
+      const speakingState: meeting.ISpeakingState = { isSpeakingDetected: true };
 
       let handlerCalled = false;
-      let returnedSpeakingState: meeting.SpeakingStateChangedEventData | null;
+      let returnedSpeakingState: meeting.ISpeakingState | null;
 
-      meeting.registerSpeakingStateChangeHandler((eventData: meeting.SpeakingStateChangedEventData) => {
+      meeting.registerSpeakingStateChangeHandler((eventData: meeting.ISpeakingState) => {
         handlerCalled = true;
         returnedSpeakingState = eventData;
       });

--- a/packages/teams-js/test/public/meeting.spec.ts
+++ b/packages/teams-js/test/public/meeting.spec.ts
@@ -1078,9 +1078,9 @@ describe('meeting', () => {
       let handlerCalled = false;
       let returnedSpeakingState: meeting.ISpeakingState | null;
 
-      meeting.registerSpeakingStateChangeHandler((eventData: meeting.ISpeakingState) => {
+      meeting.registerSpeakingStateChangeHandler((speakingState: meeting.ISpeakingState) => {
         handlerCalled = true;
-        returnedSpeakingState = eventData;
+        returnedSpeakingState = speakingState;
       });
 
       const registerHandlerMessage = framelessPlatformMock.findMessageByFunc('registerHandler');


### PR DESCRIPTION
Updating registerSpeakingStateChangeHandler API to align with other meeting APIs that register a handler:

- Add optional error object in case any failure