### PR TITLE
Adding test flow for External Authentication

### DIFF
--- a/apps/teams-test-app/src/components/AuthenticationAPIs.tsx
+++ b/apps/teams-test-app/src/components/AuthenticationAPIs.tsx
@@ -3,6 +3,8 @@ import React, { ReactElement } from 'react';
 
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
 
+type authAuthenticateParams = authentication.AuthenticatePopUpParameters & { mockOAuth?: boolean };
+
 const Initialize = (): React.ReactElement =>
   ApiWithoutInput({
     name: 'initialize',
@@ -96,7 +98,7 @@ const NotifySuccess = (): React.ReactElement =>
   });
 
 const Authenticate = (): React.ReactElement =>
-  ApiWithTextInput<authentication.AuthenticatePopUpParameters>({
+  ApiWithTextInput<authAuthenticateParams>({
     name: 'authentication.authenticate2',
     title: 'authentication.authenticate',
     onClick: {
@@ -107,7 +109,7 @@ const Authenticate = (): React.ReactElement =>
       },
       submit: {
         withPromise: async authParams => {
-          const token = await authentication.authenticate(authParams);
+          const token = await authentication.authenticate(getAuthParams(authParams));
           return 'Success: ' + token;
         },
         withCallback: (authParams, setResult) => {
@@ -122,11 +124,25 @@ const Authenticate = (): React.ReactElement =>
             failureCallback: failureCallback,
             ...authParams,
           };
-          authentication.authenticate(authRequest);
+          authentication.authenticate(getAuthParams(authRequest));
         },
       },
     },
   });
+
+const getAuthParams = (authParam: authAuthenticateParams): authentication.AuthenticatePopUpParameters => {
+  let authUrl = authParam.url;
+
+  // Append mockOAuth flag at the end of URL
+  if (authParam.mockOAuth) {
+    authUrl = authParam.url + 'mockOAuth=true';
+  }
+
+  return {
+    ...authParam,
+    url: authUrl,
+  };
+};
 
 const AuthenticationAPIs = (): ReactElement => (
   <>

--- a/apps/teams-test-app/src/components/AuthenticationAPIs.tsx
+++ b/apps/teams-test-app/src/components/AuthenticationAPIs.tsx
@@ -135,7 +135,7 @@ const getAuthParams = (authParam: authAuthenticateParams): authentication.Authen
 
   // Append mockOAuth flag at the end of URL
   if (authParam.mockOAuth) {
-    authUrl = authParam.url + 'mockOAuth=true';
+    authUrl = authParam.url + '&mockOAuth=true';
   }
 
   return {

--- a/apps/teams-test-app/src/public/auth_end.html
+++ b/apps/teams-test-app/src/public/auth_end.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    Ending auth
+  </head>
+  <body>
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      const result = params.get('code');
+      const { authId, method, hostName } = JSON.parse(params.get('state'));
+
+      // Redirect back to Orange host
+      if (method === 'deeplink' && hostName == 'Orange') {
+        window.location.href = `msorange://testapp.com?auth_callback?authId=${authId}&result=${result}`;
+      }
+    </script>
+  </body>
+</html>

--- a/apps/teams-test-app/src/public/auth_end.html
+++ b/apps/teams-test-app/src/public/auth_end.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    Ending auth
+    <h2 style="font-size: 40px;">Ending auth</h2>
+    <div id="errorMessage" style="font-size: 30px;"></div>
   </head>
   <body>
     <script>
@@ -12,6 +13,8 @@
       // Redirect back to Orange host
       if (method === 'deeplink' && hostName === 'Orange') {
         window.location.href = `msorange://testapp.com/auth_callback?authId=${authId}&result=${result}`;
+      } else {
+        document.getElementById('errorMessage').textContent = 'Unable to redirect back to the App';
       }
     </script>
   </body>

--- a/apps/teams-test-app/src/public/auth_end.html
+++ b/apps/teams-test-app/src/public/auth_end.html
@@ -10,8 +10,8 @@
       const { authId, method, hostName } = JSON.parse(params.get('state'));
 
       // Redirect back to Orange host
-      if (method === 'deeplink' && hostName == 'Orange') {
-        window.location.href = `msorange://testapp.com?auth_callback?authId=${authId}&result=${result}`;
+      if (method === 'deeplink' && hostName === 'Orange') {
+        window.location.href = `msorange://testapp.com/auth_callback?authId=${authId}&result=${result}`;
       }
     </script>
   </body>

--- a/apps/teams-test-app/src/public/auth_start.html
+++ b/apps/teams-test-app/src/public/auth_start.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    Starting auth
+  </head>
+
+  <body>
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      const mockOAuth = params.get('mockOAuth');
+      const authId = params.get('authId');
+      const method = params.get('oauthRedirectMethod');
+      const hostName = params.get('hostName');
+      const state = `{"authId":"${authId}","method":"${method}", "hostName":"${hostName}"}`;
+
+      const getRedirectUri = () => {
+        const idx = window.location.href.lastIndexOf('/');
+        return `${window.location.href.slice(0, idx)}/auth_end.html`;
+      };
+
+      // Redirect to auth_end page if its mockOauth for testing
+      if (mockOAuth === 'true') {
+        window.location.href = getRedirectUri() + `?state=${state}&code=test_auth_code_1234`;
+      } else {
+        // Do actual google login
+        const queryObj = {
+          state,
+          client_id: '1073583513214-oplf5k63msf7at9rcj68vbrh265803vo.apps.googleusercontent.com',
+          response_type: 'code',
+          access_type: 'offline',
+          scope: 'email%20profile',
+        };
+        const query = Object.entries(queryObj)
+          .map(([k, v]) => `&${k}=${v}`)
+          .join('');
+
+        window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?redirect_uri=${getRedirectUri()}${query}`;
+      }
+    </script>
+  </body>
+</html>

--- a/apps/teams-test-app/src/public/auth_start.html
+++ b/apps/teams-test-app/src/public/auth_start.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    Starting auth
+    <h2 style="font-size: 40px;">Starting auth</h2>
   </head>
 
   <body>

--- a/apps/teams-test-app/webpack.config.js
+++ b/apps/teams-test-app/webpack.config.js
@@ -4,11 +4,15 @@ const path = require('path');
 const commonConfig = require('./webpack.common.js');
 const { merge } = require('webpack-merge');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = merge(commonConfig, {
   output: {
     path: path.resolve(__dirname, 'build'),
     filename: 'indexBundle.js',
   },
-  plugins: [new HtmlWebPackPlugin({ template: './index_bundle.html', filename: 'index.html' })],
+  plugins: [
+    new HtmlWebPackPlugin({ template: './index_bundle.html', filename: 'index.html' }),
+    new CopyWebpackPlugin({ patterns: [{ from: './src/public' }] }),
+  ],
 });

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "azure-keyvault": "^3.0.4",
     "babel-loader": "^8.2.2",
     "beachball": "^2.21.0",
+    "copy-webpack-plugin": "9.1.0",
     "cross-env": "*",
     "css-loader": "^5.0.1",
     "del": "2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2868,7 +2868,7 @@
   integrity sha512-iKc5L036hc/wu13DX5kGf//3/WqTAErAPTyYKG6zT3vG070xXaaP7PInODznfyZduhiOvavmrRlQb34ajeDTUA==
 
 "@microsoft/teams-js@file:packages/teams-js":
-  version "2.0.0"
+  version "2.1.0"
   dependencies:
     debug "4.3.3"
 
@@ -5170,6 +5170,18 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-webpack-plugin@9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-9.1.0.tgz#2d2c460c4c4695ec0a58afb2801a1205256c4e6b"
+  integrity sha512-rxnR7PaGigJzhqETHGmAcxKnLZSR5u1Y3/bcIv/1FnqXedcL/E2ewK7ZCNrArJKCiSv8yVXhTqetJh8inDvfsA==
+  dependencies:
+    fast-glob "^3.2.7"
+    glob-parent "^6.0.1"
+    globby "^11.0.3"
+    normalize-path "^3.0.0"
+    schema-utils "^3.1.1"
+    serialize-javascript "^6.0.0"
+
 core-js-compat@^3.16.0, core-js-compat@^3.16.2:
   version "3.18.0"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.18.0.tgz#fb360652201e8ac8da812718c008cd0482ed9b42"
@@ -6389,7 +6401,7 @@ fast-glob@^3.1.1:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-glob@^3.2.9:
+fast-glob@^3.2.7, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -6971,7 +6983,7 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^3.1.0, glob-parent@^5.0.0, glob-parent@^5.1.2, glob-parent@^6.0.1, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==


### PR DESCRIPTION
> Added the test flow for 3rd party auth via auth_start.html and auth_end.html static html files.

> Added `mockOAuth` in auth params to recognise the test flow and redirect to auth_end.html directly with appropriate expected params.

> Modified the type of `Authentication.Authenticate` API in test app to take `mockOAuth` into account and change the url accordingly 