### PR TITLE
Remove intentionallyNotExported exceptions from documentation validation

### DIFF
--- a/change/@microsoft-teams-js-cd1a5a1d-7289-4987-bd29-944865d42a6a.json
+++ b/change/@microsoft-teams-js-cd1a5a1d-7289-4987-bd29-944865d42a6a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Exported publicly documented global interfaces to enable use outside the SDK.",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -1,35 +1,39 @@
 export { authentication } from './authentication';
 export {
+  ChannelType,
+  DialogDimension,
   FrameContexts,
   HostClientType,
-  DialogDimension,
+  HostName,
   TaskModuleDimension,
   TeamType,
   UserTeamRole,
-  ChannelType,
-  HostName,
 } from './constants';
 export {
+  BotUrlDialogInfo,
   Context,
   DeepLinkParameters,
+  DialogInfo,
+  DialogSize,
   ErrorCode,
+  FileOpenPreference,
   FrameContext,
+  FrameInfo,
   LoadContext,
+  LocaleInfo,
   SdkError,
+  ShareDeepLinkParameters,
   TabInformation,
   TabInstance,
   TabInstanceParameters,
-  DialogInfo,
+  TaskInfo,
   TeamInformation,
-  FileOpenPreference,
-  LocaleInfo,
-  FrameInfo,
-  ShareDeepLinkParameters,
+  UrlDialogInfo,
 } from './interfaces';
 export { app } from './app';
 export { appInstallDialog } from './appInstallDialog';
 export { barCode } from './barCode';
-export { chat } from './chat';
+export { chat, OpenGroupChatRequest, OpenSingleChatRequest } from './chat';
 export { dialog } from './dialog';
 export { geoLocation } from './geoLocation';
 export { pages } from './pages';

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -454,9 +454,7 @@ export namespace media {
   }
 
   /**
-   * @hidden
-   * Hide from docs
-   * --------
+   * @beta
    * Events which are used to communicate between the app and the host client during the media recording flow
    */
   export enum MediaControllerEvent {

--- a/packages/teams-js/typedoc.json
+++ b/packages/teams-js/typedoc.json
@@ -6,14 +6,5 @@
     "notExported": true,
     "invalidLink": true,
     "notDocumented": false
-  },
-  "intentionallyNotExported": [
-    "src/public/chat.ts:OpenGroupChatRequest",
-    "src/public/chat.ts:OpenSingleChatRequest",
-    "src/public/interfaces.ts:BotUrlDialogInfo",
-    "src/public/interfaces.ts:DialogSize",
-    "src/public/interfaces.ts:TaskInfo",
-    "src/public/interfaces.ts:UrlDialogInfo",
-    "src/public/media.ts:MediaControllerEvent"
-  ]
+  }
 }


### PR DESCRIPTION
I finally figured out how to resolve errors that were previously worked around in the typedoc.json file. We need to explicitly export interfaces (and types, etc.) defined in the global namespace in order to have the referring documentation show up correctly.

Note my change in the media.ts file in order to make sure that `MediaControllerEvent` appears in the docs, since it's already referenced by other public documentation. The alternative would be to hide the documentation that refers to it.