### PR TITLE
Trharris/internalcommentfixes

### DIFF
--- a/change/@microsoft-teams-js-8f021e4d-e427-4bb6-8811-25e6f8a2f811.json
+++ b/change/@microsoft-teams-js-8f021e4d-e427-4bb6-8811-25e6f8a2f811.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Updated comments on items marked with the `@internal` tag to make it clear they are intended for Microsoft use only. Removed app.initializePrivateApis, an unexported no-op function.",
+  "comment": "Updated comments on items marked with the `@internal` tag to make it clear they are intended for Microsoft use only and removed some `@internal` items from dev documentation. Removed `app.initializePrivateApis`, an unexported and hidden no-op function.",
   "packageName": "@microsoft/teams-js",
   "email": "trharris@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-8f021e4d-e427-4bb6-8811-25e6f8a2f811.json
+++ b/change/@microsoft-teams-js-8f021e4d-e427-4bb6-8811-25e6f8a2f811.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated comments on items marked with the `@internal` tag to make it clear they are intended for Microsoft use only. Removed app.initializePrivateApis, an unexported no-op function.",
+  "packageName": "@microsoft/teams-js",
+  "email": "trharris@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-8f021e4d-e427-4bb6-8811-25e6f8a2f811.json
+++ b/change/@microsoft-teams-js-8f021e4d-e427-4bb6-8811-25e6f8a2f811.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Updated comments on items marked with the `@internal` tag to make it clear they are intended for Microsoft use only and removed some `@internal` items from dev documentation. Removed `app.initializePrivateApis`, an unexported and hidden no-op function.",
+  "comment": "Updated comments on items marked with the `@internal` tag to make it clear they are intended for Microsoft use only and removed some `@internal` items from dev documentation. Removed `initializePrivateApis` from the privateAPIs file, an unexported and hidden no-op function.",
   "packageName": "@microsoft/teams-js",
   "email": "trharris@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -12,7 +12,10 @@ import { validateOrigin } from './utils';
 
 const communicationLogger = getLogger('communication');
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export class Communication {
   public static currentWindow: Window | any;
   public static parentOrigin: string;
@@ -21,7 +24,10 @@ export class Communication {
   public static childOrigin: string;
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 class CommunicationPrivate {
   public static parentMessageQueue: MessageRequest[] = [];
   public static childMessageQueue: MessageRequest[] = [];
@@ -35,7 +41,10 @@ class CommunicationPrivate {
   public static messageListener: Function;
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 interface InitializeResponse {
   context: FrameContexts;
   clientType: string;
@@ -43,7 +52,10 @@ interface InitializeResponse {
   clientSupportedSDKVersion: string;
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function initializeCommunication(validMessageOrigins: string[] | undefined): Promise<InitializeResponse> {
   // Listen for messages post to our window
   CommunicationPrivate.messageListener = (evt: DOMMessageEvent): void => processMessage(evt);
@@ -87,7 +99,10 @@ export function initializeCommunication(validMessageOrigins: string[] | undefine
   }
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function uninitializeCommunication(): void {
   Communication.currentWindow.removeEventListener('message', CommunicationPrivate.messageListener, false);
 
@@ -101,7 +116,10 @@ export function uninitializeCommunication(): void {
   CommunicationPrivate.callbacks = {};
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function sendAndUnwrap<T>(actionName: string, ...args: any[]): Promise<T> {
   return sendMessageToParentAsync(actionName, args).then(([result]: [T]) => result);
 }
@@ -114,7 +132,10 @@ export function sendAndHandleStatusAndReason(actionName: string, ...args: any[])
   });
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function sendAndHandleStatusAndReasonWithDefaultError(
   actionName: string,
   defaultError: string,
@@ -127,7 +148,10 @@ export function sendAndHandleStatusAndReasonWithDefaultError(
   });
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function sendAndHandleSdkError<T>(actionName: string, ...args: any[]): Promise<T> {
   return sendMessageToParentAsync(actionName, args).then(([error, result]: [SdkError, T]) => {
     if (error) {
@@ -142,6 +166,7 @@ export function sendAndHandleSdkError<T>(actionName: string, ...args: any[]): Pr
  * Send a message to parent. Uses nativeInterface on mobile to communicate with parent context
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function sendMessageToParentAsync<T>(actionName: string, args: any[] = undefined): Promise<T> {
   return new Promise(resolve => {
@@ -150,14 +175,20 @@ export function sendMessageToParentAsync<T>(actionName: string, args: any[] = un
   });
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 function waitForResponse<T>(requestId: number): Promise<T> {
   return new Promise<T>(resolve => {
     CommunicationPrivate.promiseCallbacks[requestId] = resolve;
   });
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function sendMessageToParent(actionName: string, callback?: Function): void;
 
 /**
@@ -165,10 +196,14 @@ export function sendMessageToParent(actionName: string, callback?: Function): vo
  * Send a message to parent. Uses nativeInterface on mobile to communicate with parent context
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function sendMessageToParent(actionName: string, args: any[], callback?: Function): void;
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function sendMessageToParent(actionName: string, argsOrCallback?: any[] | Function, callback?: Function): void {
   let args: any[] | undefined;
   if (argsOrCallback instanceof Function) {
@@ -185,7 +220,10 @@ export function sendMessageToParent(actionName: string, argsOrCallback?: any[] |
 
 const sendMessageToParentHelperLogger = communicationLogger.extend('sendMessageToParentHelper');
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 function sendMessageToParentHelper(actionName: string, args: any[]): MessageRequest {
   const logger = sendMessageToParentHelperLogger;
 
@@ -215,7 +253,10 @@ function sendMessageToParentHelper(actionName: string, args: any[]): MessageRequ
   return request;
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function processMessage(evt: DOMMessageEvent): void {
   // Process only if we received a valid message
   if (!evt || !evt.data || typeof evt.data !== 'object') {
@@ -246,6 +287,7 @@ export function processMessage(evt: DOMMessageEvent): void {
  * Validates the message source and origin, if it should be processed
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function shouldProcessMessage(messageSource: Window, messageOrigin: string): boolean {
   // Process if message source is a different window and if origin is either in
@@ -264,7 +306,10 @@ export function shouldProcessMessage(messageSource: Window, messageOrigin: strin
   }
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 function updateRelationships(messageSource: Window, messageOrigin: string): void {
   // Determine whether the source of the message is our parent or child and update our
   // window and origin pointer accordingly
@@ -301,7 +346,10 @@ function updateRelationships(messageSource: Window, messageOrigin: string): void
 
 const handleParentMessageLogger = communicationLogger.extend('handleParentMessage');
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 function handleParentMessage(evt: DOMMessageEvent): void {
   const logger = handleParentMessageLogger;
 
@@ -338,12 +386,18 @@ function handleParentMessage(evt: DOMMessageEvent): void {
   }
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 function isPartialResponse(evt: DOMMessageEvent): boolean {
   return evt.data.isPartialResponse === true;
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 function handleChildMessage(evt: DOMMessageEvent): void {
   if ('id' in evt.data && 'func' in evt.data) {
     // Try to delegate the request to the proper handler, if defined
@@ -364,7 +418,10 @@ function handleChildMessage(evt: DOMMessageEvent): void {
   }
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 function getTargetMessageQueue(targetWindow: Window): MessageRequest[] {
   return targetWindow === Communication.parentWindow
     ? CommunicationPrivate.parentMessageQueue
@@ -373,7 +430,10 @@ function getTargetMessageQueue(targetWindow: Window): MessageRequest[] {
     : [];
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 function getTargetOrigin(targetWindow: Window): string {
   return targetWindow === Communication.parentWindow
     ? Communication.parentOrigin
@@ -383,7 +443,10 @@ function getTargetOrigin(targetWindow: Window): string {
 }
 
 const flushMessageQueueLogger = communicationLogger.extend('flushMessageQueue');
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 function flushMessageQueue(targetWindow: Window | any): void {
   const targetOrigin = getTargetOrigin(targetWindow);
   const targetMessageQueue = getTargetMessageQueue(targetWindow);
@@ -395,7 +458,10 @@ function flushMessageQueue(targetWindow: Window | any): void {
   }
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function waitForMessageQueue(targetWindow: Window, callback: () => void): void {
   const messageQueueMonitor = Communication.currentWindow.setInterval(() => {
     if (getTargetMessageQueue(targetWindow).length === 0) {
@@ -410,6 +476,7 @@ export function waitForMessageQueue(targetWindow: Window, callback: () => void):
  * Send a response to child for a message request that was from child
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 function sendMessageResponseToChild(
   id: number,
@@ -431,6 +498,7 @@ function sendMessageResponseToChild(
  * instead of a response message to a child
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function sendMessageEventToChild(
   actionName: string,
@@ -450,7 +518,10 @@ export function sendMessageEventToChild(
   }
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 // tslint:disable-next-line:no-any
 function createMessageRequest(func: string, args: any[]): MessageRequest {
   return {
@@ -461,7 +532,10 @@ function createMessageRequest(func: string, args: any[]): MessageRequest {
   };
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 // tslint:disable-next-line:no-any
 function createMessageResponse(id: number, args: any[], isPartialResponse: boolean): MessageResponse {
   return {
@@ -476,6 +550,7 @@ function createMessageResponse(id: number, args: any[], isPartialResponse: boole
  * Creates a message object without any id, used for custom actions being sent to child frame/window
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 // tslint:disable-next-line:no-any
 function createMessageEvent(func: string, args: any[]): MessageRequest {

--- a/packages/teams-js/src/internal/constants.ts
+++ b/packages/teams-js/src/internal/constants.ts
@@ -8,6 +8,7 @@ export const version = PACKAGE_VERSION;
  * Mobile clients are passing versions, hence will be applicable to web and desktop clients only.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const defaultSDKVersionForCompatCheck = '2.0.1';
 
@@ -16,16 +17,25 @@ export const defaultSDKVersionForCompatCheck = '2.0.1';
  * This is the client version when selectMedia API - VideoAndImage is supported on mobile.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const videoAndImageMediaAPISupportVersion = '2.0.2';
 
 /**
+ * @hidden
  * This is the client version when selectMedia API - Video with non-full screen mode is supported on mobile.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export const nonFullScreenVideoModeAPISupportVersion = '2.0.3';
 
 /**
+ * @hidden
  * This is the client version when selectMedia API - ImageOutputFormats is supported on mobile.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export const imageOutputFormatsAPISupportVersion = '2.0.4';
 
@@ -34,6 +44,7 @@ export const imageOutputFormatsAPISupportVersion = '2.0.4';
  * Minimum required client supported version for {@link getUserJoinedTeams} to be supported on {@link HostClientType.android}
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const getUserJoinedTeamsSupportedAndroidClientVersion = '2.0.1';
 
@@ -42,6 +53,7 @@ export const getUserJoinedTeamsSupportedAndroidClientVersion = '2.0.1';
  * This is the client version when location APIs (getLocation and showLocation) are supported.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const locationAPIsRequiredVersion = '1.9.0';
 
@@ -50,6 +62,7 @@ export const locationAPIsRequiredVersion = '1.9.0';
  * This is the client version when permisisons are supported
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const permissionsAPIsRequiredVersion = '2.0.1';
 
@@ -58,6 +71,7 @@ export const permissionsAPIsRequiredVersion = '2.0.1';
  * This is the client version when people picker API is supported on mobile.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const peoplePickerRequiredVersion = '2.0.0';
 
@@ -66,6 +80,7 @@ export const peoplePickerRequiredVersion = '2.0.0';
  * This is the client version when captureImage API is supported on mobile.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const captureImageMobileSupportVersion = '1.7.0';
 
@@ -74,6 +89,7 @@ export const captureImageMobileSupportVersion = '1.7.0';
  * This is the client version when media APIs are supported on all three platforms ios, android and web.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const mediaAPISupportVersion = '1.8.0';
 
@@ -82,6 +98,7 @@ export const mediaAPISupportVersion = '1.8.0';
  * This is the client version when getMedia API is supported via Callbacks on all three platforms ios, android and web.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const getMediaCallbackSupportVersion = '2.0.0';
 
@@ -90,6 +107,7 @@ export const getMediaCallbackSupportVersion = '2.0.0';
  * This is the client version when scanBarCode API is supported on mobile.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const scanBarCodeAPIMobileSupportVersion = '1.9.0';
 
@@ -98,6 +116,7 @@ export const scanBarCodeAPIMobileSupportVersion = '1.9.0';
  * List of supported Host origins
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const validOrigins = [
   'teams.microsoft.com',
@@ -134,6 +153,7 @@ export const validOrigins = [
  * USer specified message origins should satisfy this test
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const userOriginUrlValidationRegExp = /^https:\/\//;
 
@@ -142,6 +162,7 @@ export const userOriginUrlValidationRegExp = /^https:\/\//;
  * The protocol used for deep links into Teams
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const teamsDeepLinkProtocol = 'https';
 
@@ -150,5 +171,6 @@ export const teamsDeepLinkProtocol = 'https';
  * The host used for deep links into Teams
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const teamsDeepLinkHost = 'teams.microsoft.com';

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -7,7 +7,10 @@ import { getLogger } from './telemetry';
 
 const handlersLogger = getLogger('handlers');
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 class HandlersPrivate {
   public static handlers: {
     [func: string]: Function;
@@ -17,7 +20,10 @@ class HandlersPrivate {
   public static beforeUnloadHandler: (readyToUnload: () => void) => boolean;
 }
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function initializeHandlers(): void {
   // ::::::::::::::::::::MicrosoftTeams SDK Internal :::::::::::::::::
   HandlersPrivate.handlers['themeChange'] = handleThemeChange;
@@ -27,7 +33,10 @@ export function initializeHandlers(): void {
 }
 
 const callHandlerLogger = handlersLogger.extend('callHandler');
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function callHandler(name: string, args?: unknown[]): [true, unknown] | [false, undefined] {
   const handler = HandlersPrivate.handlers[name];
   if (handler) {
@@ -40,7 +49,10 @@ export function callHandler(name: string, args?: unknown[]): [true, unknown] | [
   }
 }
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function registerHandler(name: string, handler: Function, sendMessage = true, args: unknown[] = []): void {
   if (handler) {
     HandlersPrivate.handlers[name] = handler;
@@ -50,7 +62,10 @@ export function registerHandler(name: string, handler: Function, sendMessage = t
   }
 }
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function removeHandler(name: string): void {
   delete HandlersPrivate.handlers[name];
 }
@@ -60,13 +75,19 @@ export function doesHandlerExist(name: string): boolean {
   return HandlersPrivate.handlers[name] != null;
 }
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function registerOnThemeChangeHandler(handler: (theme: string) => void): void {
   HandlersPrivate.themeChangeHandler = handler;
   handler && sendMessageToParent('registerHandler', ['themeChange']);
 }
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function handleThemeChange(theme: string): void {
   if (HandlersPrivate.themeChangeHandler) {
     HandlersPrivate.themeChangeHandler(theme);
@@ -77,13 +98,19 @@ export function handleThemeChange(theme: string): void {
   }
 }
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function registerOnLoadHandler(handler: (context: LoadContext) => void): void {
   HandlersPrivate.loadHandler = handler;
   handler && sendMessageToParent('registerHandler', ['load']);
 }
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 function handleLoad(context: LoadContext): void {
   if (HandlersPrivate.loadHandler) {
     HandlersPrivate.loadHandler(context);
@@ -94,13 +121,19 @@ function handleLoad(context: LoadContext): void {
   }
 }
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void {
   HandlersPrivate.beforeUnloadHandler = handler;
   handler && sendMessageToParent('registerHandler', ['beforeUnload']);
 }
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 function handleBeforeUnload(): void {
   const readyToUnload = (): void => {
     sendMessageToParent('readyToUnload', []);

--- a/packages/teams-js/src/internal/interfaces.ts
+++ b/packages/teams-js/src/internal/interfaces.ts
@@ -4,6 +4,7 @@
  * Shim in definitions used for browser-compat
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface DOMMessageEvent {
@@ -19,6 +20,7 @@ export interface DOMMessageEvent {
  * Hide from docs
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export interface TeamsNativeClient {
   framelessPostMessage(msg: string): void;
@@ -29,13 +31,17 @@ export interface TeamsNativeClient {
  * Hide from docs
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export interface ExtendedWindow extends Window {
   nativeInterface: TeamsNativeClient;
   onNativeMessage(evt: DOMMessageEvent): void;
 }
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export interface MessageRequest {
   id?: number;
   func: string;
@@ -43,7 +49,10 @@ export interface MessageRequest {
   args?: any[]; // tslint:disable-line:no-any The args here are a passthrough to postMessage where we do allow any[]
 }
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export interface MessageResponse {
   id: number;
   args?: any[]; // tslint:disable-line:no-any The args here are a passthrough from OnMessage where we do receive any[]
@@ -55,6 +64,7 @@ export interface MessageResponse {
  * Meant for Message objects that are sent to children without id
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export interface DOMMessageEvent {
   func: string;

--- a/packages/teams-js/src/internal/internalAPIs.ts
+++ b/packages/teams-js/src/internal/internalAPIs.ts
@@ -4,7 +4,10 @@ import { defaultSDKVersionForCompatCheck, userOriginUrlValidationRegExp } from '
 import { GlobalVars } from './globalVars';
 import { compareSDKVersions } from './utils';
 
-/** @internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function ensureInitialized(...expectedFrameContexts: string[]): void {
   if (!GlobalVars.initializeCalled) {
     throw new Error('The library has not yet been initialized');
@@ -36,6 +39,7 @@ export function ensureInitialized(...expectedFrameContexts: string[]): void {
  * @param requiredVersion - SDK version required by the API
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function isCurrentSDKVersionAtLeast(requiredVersion: string = defaultSDKVersionForCompatCheck): boolean {
   const value = compareSDKVersions(GlobalVars.clientSupportedSDKVersion, requiredVersion);
@@ -50,6 +54,7 @@ export function isCurrentSDKVersionAtLeast(requiredVersion: string = defaultSDKV
  * Helper function to identify if host client is either android or ios
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function isHostClientMobile(): boolean {
   return GlobalVars.hostClientType == HostClientType.android || GlobalVars.hostClientType == HostClientType.ios;
@@ -62,6 +67,7 @@ export function isHostClientMobile(): boolean {
  *          supported by platform or not. Null is returned in case of success.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function throwExceptionIfMobileApiIsNotSupported(
   requiredVersion: string = defaultSDKVersionForCompatCheck,
@@ -81,6 +87,7 @@ export function throwExceptionIfMobileApiIsNotSupported(
  * which is used later for message source/origin validation
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function processAdditionalValidOrigins(validMessageOrigins: string[]): void {
   let combinedOriginUrls = GlobalVars.additionalValidOrigins.concat(

--- a/packages/teams-js/src/internal/mediaUtil.ts
+++ b/packages/teams-js/src/internal/mediaUtil.ts
@@ -12,6 +12,7 @@ import { throwExceptionIfMobileApiIsNotSupported } from './internalAPIs';
  * Helper function to create a blob from media chunks based on their sequence
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function createFile(assembleAttachment: media.AssembleAttachment[], mimeType: string): Blob {
   if (assembleAttachment == null || mimeType == null || assembleAttachment.length <= 0) {
@@ -39,6 +40,7 @@ export function createFile(assembleAttachment: media.AssembleAttachment[], mimeT
  * Converts base 64 encoded string to byte array and then into an array of blobs
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function decodeAttachment(attachment: media.MediaChunk, mimeType: string): media.AssembleAttachment {
   if (attachment == null || mimeType == null) {
@@ -61,8 +63,11 @@ export function decodeAttachment(attachment: media.MediaChunk, mimeType: string)
 /**
  * @hidden
  * Function throws an SdkError if the media call is not supported on current mobile version, else undefined.
+ *
  * @throws an SdkError if the media call is not supported
+ *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function throwExceptionIfMediaCallIsNotSupportedOnMobile(mediaInputs: media.MediaInputs): void {
   if (isMediaCallForVideoAndImageInputs(mediaInputs)) {
@@ -79,6 +84,7 @@ export function throwExceptionIfMediaCallIsNotSupportedOnMobile(mediaInputs: med
  * Function returns true if the app has registered to listen to video controller events, else false.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function isVideoControllerRegistered(mediaInputs: media.MediaInputs): boolean {
   if (
@@ -96,6 +102,7 @@ export function isVideoControllerRegistered(mediaInputs: media.MediaInputs): boo
  * Returns true if the mediaInput params are valid and false otherwise
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function validateSelectMediaInputs(mediaInputs: media.MediaInputs): boolean {
   if (mediaInputs == null || mediaInputs.maxMediaCount > 10) {
@@ -105,7 +112,11 @@ export function validateSelectMediaInputs(mediaInputs: media.MediaInputs): boole
 }
 
 /**
+ * @hidden
  * Returns true if the mediaInput params are called for mediatype Image and contains Image outputs formats, false otherwise
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export function isMediaCallForImageOutputFormats(mediaInputs: media.MediaInputs): boolean {
   if (mediaInputs?.mediaType == media.MediaType.Image && mediaInputs?.imageProps?.imageOutputFormats) {

--- a/packages/teams-js/src/internal/profileUtil.ts
+++ b/packages/teams-js/src/internal/profileUtil.ts
@@ -7,6 +7,7 @@ import { profile } from '../public/profile';
  * @returns true if the parameters are valid, false otherwise
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function validateShowProfileRequest(
   showProfileRequest: profile.ShowProfileRequest,
@@ -43,6 +44,7 @@ export function validateShowProfileRequest(
  * @returns true if the persona is valid, false otherwise
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 function validatePersona(persona: profile.Persona): [boolean, string | undefined] {
   if (!persona) {

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -4,6 +4,7 @@ const topLevelLogger = registerLogger('teamsJs');
 
 /**
  * @internal
+ * Limited to Microsoft-internal use
  *
  * Returns a logger for a given namespace, within the pre-defined top-level teamsJs namespace
  */

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -17,6 +17,7 @@ import { validOrigins } from './constants';
  *    validateHostAgainstPattern('teams.microsoft.com', 'team.microsoft.com') returns false
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 function validateHostAgainstPattern(pattern: string, host: string): boolean {
   if (pattern.substring(0, 2) === '*.') {
@@ -34,7 +35,10 @@ function validateHostAgainstPattern(pattern: string, host: string): boolean {
   return false;
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function validateOrigin(messageOrigin: URL): boolean {
   // Check whether the url is in the pre-known allowlist or supplied by user
   if (messageOrigin.protocol !== 'https:') {
@@ -56,7 +60,10 @@ export function validateOrigin(messageOrigin: URL): boolean {
   return false;
 }
 
-/**@internal */
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function getGenericOnCompleteHandler(errorMessage?: string): (success: boolean, reason?: string) => void {
   return (success: boolean, reason: string): void => {
     if (!success) {
@@ -83,6 +90,7 @@ export function getGenericOnCompleteHandler(errorMessage?: string): (success: bo
  *    compareSDKVersions('2.0', 2.0) returns NaN
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function compareSDKVersions(v1: string, v2: string): number {
   if (typeof v1 !== 'string' || typeof v2 !== 'string') {
@@ -127,11 +135,16 @@ export function compareSDKVersions(v1: string, v2: string): number {
  * Generates a GUID
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function generateGUID(): string {
   return uuid.v4();
 }
 
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function deepFreeze<T extends object>(obj: T): T {
   Object.keys(obj).forEach(prop => {
     if (typeof obj[prop] === 'object') {
@@ -148,6 +161,7 @@ export function deepFreeze<T extends object>(obj: T): T {
  * promises to support callbacks for backward compatibility
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export type ErrorResultCallback<T> = (err?: SdkError, result?: T) => void;
 export type ErrorResultNullCallback<T> = (err: SdkError | null, result: T | null) => void;
@@ -165,6 +179,7 @@ export type SdkErrorCallback = ResultCallback<SdkError | null>;
  * @returns
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function callCallbackWithErrorOrResultFromPromiseAndReturnPromise<T>(
   funcHelper: InputFunction<T>,
@@ -193,6 +208,7 @@ export function callCallbackWithErrorOrResultFromPromiseAndReturnPromise<T>(
  * @param args
  * @returns
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function callCallbackWithErrorOrBooleanFromPromiseAndReturnPromise<T>(
   funcHelper: InputFunction<T>,
@@ -219,7 +235,9 @@ export function callCallbackWithErrorOrBooleanFromPromiseAndReturnPromise<T>(
  * @param callback
  * @param args
  * @returns
+ *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function callCallbackWithSdkErrorFromPromiseAndReturnPromise<T>(
   funcHelper: InputFunction<T>,
@@ -248,6 +266,7 @@ export function callCallbackWithSdkErrorFromPromiseAndReturnPromise<T>(
  * @returns
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function callCallbackWithErrorOrResultOrNullFromPromiseAndReturnPromise<T>(
   funcHelper: InputFunction<T>,
@@ -278,6 +297,7 @@ export function callCallbackWithErrorOrResultOrNullFromPromiseAndReturnPromise<T
  * if the initial action didn't complete within provided timeout.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function runWithTimeout<TResult, TError>(
   action: () => Promise<TResult>,
@@ -298,6 +318,10 @@ export function runWithTimeout<TResult, TError>(
   });
 }
 
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function createTeamsAppLink(params: pages.NavigateToAppParams): string {
   const url = new URL(
     'https://teams.microsoft.com/l/entity/' +

--- a/packages/teams-js/src/private/appEntity.ts
+++ b/packages/teams-js/src/private/appEntity.ts
@@ -6,42 +6,62 @@ import { runtime } from '../public/runtime';
 /**
  * @hidden
  * Namespace to interact with the application entities specific part of the SDK.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export namespace appEntity {
   /**
    * @hidden
-   * Hide from docs
-   * --------
+   *
    * Information on an app entity
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface AppEntity {
     /**
      * @hidden
      * ID of the application
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     appId: string;
 
     /**
      * @hidden
      * URL for the application's icon
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     appIconUrl: string;
 
     /**
      * @hidden
      * Content URL for the app entity
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     contentUrl: string;
 
     /**
      * @hidden
      * The display name for the app entity
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     displayName: string;
 
     /**
      * @hidden
      * Website URL for the app entity. It is meant to be opened by the user in a browser.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     websiteUrl: string;
   }
@@ -58,6 +78,9 @@ export namespace appEntity {
    * @param callback Callback that will be triggered once the app entity information is available.
    *                 The callback takes two arguments: an SdkError in case something happened (i.e.
    *                 no permissions to execute the API) and the app entity configuration, if available
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function selectAppEntity(
     threadId: string,
@@ -83,9 +106,14 @@ export namespace appEntity {
   }
 
   /**
+   * @hidden
+   *
    * Checks if appEntity capability is supported by the host
    * @returns true if the appEntity capability is enabled in runtime.supports.appEntity and
    * false if it is disabled
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function isSupported(): boolean {
     return runtime.supports.appEntity ? true : false;

--- a/packages/teams-js/src/private/conversations.ts
+++ b/packages/teams-js/src/private/conversations.ts
@@ -11,65 +11,86 @@ import { ChatMembersInformation } from './interfaces';
 
 /**
  * @hidden
- * Hide from docs.
- * ------
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export interface OpenConversationRequest {
   /**
    * @hidden
    * The Id of the subEntity where the conversation is taking place
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   subEntityId: string;
 
   /**
    * @hidden
    * The title of the conversation
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   title: string;
 
   /**
    * @hidden
    * The Id of the conversation. This is optional and should be specified whenever a previous conversation about a specific sub-entity has already been started before
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   conversationId?: string;
 
   /**
    * @hidden
    * The Id of the channel. This is optional and should be specified whenever a conversation is started or opened in a personal app scope
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   channelId?: string;
 
   /**
    * @hidden
    * The entity Id of the tab
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   entityId: string;
 
   /**
    * @hidden
    * A function that is called once the conversation Id has been created
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   onStartConversation?: (conversationResponse: ConversationResponse) => void;
 
   /**
    * @hidden
    * A function that is called if the pane is closed
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   onCloseConversation?: (conversationResponse: ConversationResponse) => void;
 }
 
 /**
  * @hidden
- * Hide from docs.
- * ------
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export interface ConversationResponse {
   /**
    * @hidden
+   *
+   * Limited to Microsoft-internal use
    * The Id of the subEntity where the conversation is taking place
    */
   subEntityId: string;
@@ -77,18 +98,27 @@ export interface ConversationResponse {
   /**
    * @hidden
    * The Id of the conversation. This is optional and should be specified whenever a previous conversation about a specific sub-entity has already been started before
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   conversationId?: string;
 
   /**
    * @hidden
    * The Id of the channel. This is optional and should be specified whenever a conversation is started or opened in a personal app scope
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   channelId?: string;
 
   /**
    * @hidden
    * The entity Id of the tab
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   entityId?: string;
 }
@@ -96,6 +126,9 @@ export interface ConversationResponse {
 /**
  * @hidden
  * Namespace to interact with the conversational subEntities inside the tab
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export namespace conversations {
   /**
@@ -105,6 +138,9 @@ export namespace conversations {
    * Allows the user to start or continue a conversation with each subentity inside the tab
    *
    * @returns Promise resolved upon completion
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function openConversation(openConversationRequest: OpenConversationRequest): Promise<void> {
     return new Promise<void>(resolve => {
@@ -149,9 +185,11 @@ export namespace conversations {
 
   /**
    * @hidden
-   * Hide from docs
-   * --------------
+   *
    * Allows the user to close the conversation in the right pane
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function closeConversation(): void {
     ensureInitialized(FrameContexts.content);
@@ -174,6 +212,7 @@ export namespace conversations {
    * @returns Promise resolved with information on all chat members
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function getChatMembers(): Promise<ChatMembersInformation> {
     return new Promise<ChatMembersInformation>(resolve => {
@@ -185,6 +224,12 @@ export namespace conversations {
     });
   }
 
+  /**
+   * @returns boolean to represent whether conversations capability is supported
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
   export function isSupported(): boolean {
     return runtime.supports.conversations ? true : false;
   }

--- a/packages/teams-js/src/private/files.ts
+++ b/packages/teams-js/src/private/files.ts
@@ -5,16 +5,20 @@ import { ErrorCode, FileOpenPreference, FrameContexts, SdkError } from '../publi
 
 /**
  * @hidden
- * Hide from docs
- * ------
+ *
  * Namespace to interact with the files specific part of the SDK.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export namespace files {
   /**
    * @hidden
-   * Hide from docs
-   * ------
+   *
    * Cloud storage providers registered with Microsoft Teams
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export enum CloudStorageProvider {
     Dropbox = 'DROPBOX',
@@ -37,10 +41,11 @@ export namespace files {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    *
    * External third-party cloud storages providers interface
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface IExternalProvider extends IWopiService {
     providerType: CloudStorageProviderType;
@@ -49,9 +54,11 @@ export namespace files {
 
   /**
    * @hidden
-   * Hide from docs
    *
    * Cloud storage provider type enums
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export enum CloudStorageProviderType {
     Sharepoint = 0,
@@ -68,141 +75,213 @@ export namespace files {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    *
    * Cloud storage folder interface
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface CloudStorageFolder {
     /**
      * @hidden
      * ID of the cloud storage folder
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     id: string;
     /**
      * @hidden
      * Display Name/Title of the cloud storage folder
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     title: string;
     /**
      * @hidden
      * ID of the cloud storage folder in the provider
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     folderId: string;
     /**
      * @hidden
      * Type of the cloud storage folder provider integration
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     providerType: CloudStorageProviderType;
     /**
      * @hidden
      * Code of the supported cloud storage folder provider
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     providerCode: CloudStorageProvider;
     /**
      * @hidden
      * Display name of the owner of the cloud storage folder provider
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     ownerDisplayName: string;
     /**
      * @hidden
      * Sharepoint specific siteURL of the folder
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     siteUrl?: string;
     /**
      * @hidden
      * Sharepoint specific serverRelativeUrl of the folder
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     serverRelativeUrl?: string;
     /**
      * @hidden
      * Sharepoint specific libraryType of the folder
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     libraryType?: string;
     /**
      * @hidden
      * Sharepoint specific accessType of the folder
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     accessType?: string;
   }
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    *
    * Cloud storage item interface
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface CloudStorageFolderItem {
     /**
      * @hidden
      * ID of the item in the provider
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     id: string;
     /**
      * @hidden
      * Display name/title
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     title: string;
     /**
      * @hidden
      * Key to differentiate files and subdirectory
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     isSubdirectory: boolean;
     /**
      * @hidden
      * File extension
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     type: string;
     /**
      * @hidden
      * Last modifed time of the item
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     lastModifiedTime: string;
     /**
      * @hidden
      * Display size of the items in bytes
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     size: number;
     /**
      * @hidden
      * URL of the file
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     objectUrl: string;
     /**
      * @hidden
      * Temporary access token for the item
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     accessToken?: string;
   }
 
   /**
    * @hidden
-   * Hide from docs
    *
    * Files entity user interface
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface IFilesEntityUser {
     /**
+     * @hidden
      * User name.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     displayName: string;
     /**
+     * @hidden
      * User email.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     email: string;
 
     /**
+     * @hidden
      * User MRI.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     mri: string;
   }
 
   /**
    * @hidden
-   * Hide from docs
    *
    * Special Document Library enum
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export enum SpecialDocumentLibraryType {
     ClassMaterials = 'classMaterials',
@@ -210,9 +289,11 @@ export namespace files {
 
   /**
    * @hidden
-   * Hide from docs
    *
    * Document Library Access enum
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export enum DocumentLibraryAccessType {
     Readonly = 'readonly',
@@ -220,9 +301,11 @@ export namespace files {
 
   /**
    * @hidden
-   * Hide from docs
    *
    * SharePoint file interface
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface ISharePointFile {
     siteId?: string;
@@ -250,9 +333,11 @@ export namespace files {
 
   /**
    * @hidden
-   * Hide from docs
    *
    * Download status enum
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export enum FileDownloadStatus {
     Downloaded = 'Downloaded',
@@ -262,43 +347,77 @@ export namespace files {
 
   /**
    * @hidden
-   * Hide from docs
    *
    * Download Files interface
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface IFileItem {
     /**
+     * @hidden
      * ID of the file metadata
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     objectId?: string;
     /**
+     * @hidden
      * Path of the file
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     path?: string;
     /**
+     * @hidden
      * Size of the file in bytes
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     sizeInBytes?: number;
     /**
+     * @hidden
      * Download status
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     status?: FileDownloadStatus;
     /**
+     * @hidden
      * Download timestamp
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     timestamp: Date;
     /**
+     * @hidden
      * File name
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     title: string;
     /**
+     * @hidden
      * Type of file i.e. the file extension.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     extension: string;
   }
 
   /**
+   * @hidden
    * Object used to represent a file
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface File extends Blob {
     /**
@@ -320,6 +439,9 @@ export namespace files {
    * Hide from docs
    *
    * Actions specific to 3P cloud storage provider file and / or account
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export enum CloudStorageProviderFileAction {
     Download = 'DOWNLOAD',
@@ -332,6 +454,9 @@ export namespace files {
    * Hide from docs
    *
    * Interface for 3P cloud storage provider request content type
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface CloudStorageProviderRequest<T> {
     content: T;
@@ -342,6 +467,9 @@ export namespace files {
    * Hide from docs
    *
    * Base interface for 3P cloud storage provider action request content
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface CloudStorageProviderContent {
     providerCode: CloudStorageProvider;
@@ -353,6 +481,9 @@ export namespace files {
    *
    * Interface representing 3P cloud storage provider add new file action.
    * The file extension represents type of file e.g. docx, pptx etc. and need not be prefixed with dot(.)
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface CloudStorageProviderNewFileContent extends CloudStorageProviderContent {
     newFileName: string;
@@ -365,6 +496,9 @@ export namespace files {
    * Hide from docs
    *
    * Interface representing 3P cloud storage provider rename existing file action
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface CloudStorageProviderRenameFileContent extends CloudStorageProviderContent {
     existingFile: CloudStorageFolderItem | ISharePointFile;
@@ -376,6 +510,9 @@ export namespace files {
    * Hide from docs
    *
    * Interface representing 3P cloud storage provider delete existing file(s) action
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface CloudStorageProviderDeleteFileContent extends CloudStorageProviderContent {
     itemList: CloudStorageFolderItem[] | ISharePointFile[];
@@ -386,6 +523,9 @@ export namespace files {
    * Hide from docs
    *
    * Interface representing 3P cloud storage provider download existing file(s) action
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface CloudStorageProviderDownloadFileContent extends CloudStorageProviderContent {
     itemList: CloudStorageFolderItem[] | ISharePointFile[];
@@ -396,6 +536,9 @@ export namespace files {
    * Hide from docs
    *
    * Interface representing 3P cloud storage provider upload existing file(s) action
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface CloudStorageProviderUploadFileContent extends CloudStorageProviderContent {
     itemList: File[];
@@ -409,6 +552,9 @@ export namespace files {
    * Gets a list of cloud storage folders added to the channel
    * @param channelId - ID of the channel whose cloud storage folders should be retrieved
    * @param callback - Callback that will be triggered post folders load
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function getCloudStorageFolders(
     channelId: string,
@@ -434,6 +580,9 @@ export namespace files {
    *
    * @param channelId - ID of the channel to add cloud storage folder
    * @param callback - Callback that will be triggered post add folder flow is compelete
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function addCloudStorageFolder(
     channelId: string,
@@ -461,6 +610,9 @@ export namespace files {
    * @param channelId - ID of the channel where folder is to be deleted
    * @param folderToDelete - cloud storage folder to be deleted
    * @param callback - Callback that will be triggered post delete
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function deleteCloudStorageFolder(
     channelId: string,
@@ -492,6 +644,9 @@ export namespace files {
    * @param folder - Cloud storage folder (CloudStorageFolder) / sub directory (CloudStorageFolderItem)
    * @param providerCode - Code of the cloud storage folder provider
    * @param callback - Callback that will be triggered post contents are loaded
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function getCloudStorageFolderContents(
     folder: CloudStorageFolder | CloudStorageFolderItem,
@@ -525,6 +680,9 @@ export namespace files {
    * @param file - cloud storage file that should be opened
    * @param providerCode - Code of the cloud storage folder provider
    * @param fileOpenPreference - Whether file should be opened in web/inline
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function openCloudStorageFile(
     file: CloudStorageFolderItem,
@@ -550,6 +708,9 @@ export namespace files {
    * third party cloud storage accounts that the tenant supports
    * @param excludeAddedProviders: return a list of support third party
    * cloud storages that hasn't been added yet.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function getExternalProviders(
     excludeAddedProviders = false,
@@ -568,6 +729,9 @@ export namespace files {
    * @hidden
    * Allow 1st party apps to call this function to move files
    * among SharePoint and third party cloud storages.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function copyMoveFiles(
     selectedFiles: CloudStorageFolderItem[] | ISharePointFile[],
@@ -607,6 +771,9 @@ export namespace files {
    *
    * Gets list of downloads for current user
    * @param callback Callback that will be triggered post downloads load
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function getFileDownloads(callback: (error?: SdkError, files?: IFileItem[]) => void): void {
     ensureInitialized(FrameContexts.content);
@@ -625,6 +792,9 @@ export namespace files {
    * Open download preference folder if fileObjectId value is undefined else open folder containing the file with id fileObjectId
    * @param fileObjectId - Id of the file whose containing folder should be opened
    * @param callback Callback that will be triggered post open download folder/path
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function openDownloadFolder(fileObjectId: string = undefined, callback: (error?: SdkError) => void): void {
     ensureInitialized(FrameContexts.content);
@@ -645,6 +815,9 @@ export namespace files {
    * for selected 3P provider is performed on success of which the selected 3P provider support is added for user
    *
    * @param callback Callback that will be triggered post add 3P cloud storage provider action
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function addCloudStorageProvider(callback: (error?: SdkError) => void): void {
     ensureInitialized(FrameContexts.content);
@@ -666,6 +839,9 @@ export namespace files {
    *
    * @param logoutRequest 3P cloud storage provider remove action request content
    * @param callback Callback that will be triggered post signout of 3P cloud storage provider action
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function removeCloudStorageProvider(
     logoutRequest: CloudStorageProviderRequest<CloudStorageProviderContent>,
@@ -695,6 +871,9 @@ export namespace files {
    *
    * @param addNewFileRequest 3P cloud storage provider add action request content
    * @param callback Callback that will be triggered post adding a new file flow is finished
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function addCloudStorageProviderFile(
     addNewFileRequest: CloudStorageProviderRequest<CloudStorageProviderNewFileContent>,
@@ -724,6 +903,9 @@ export namespace files {
    *
    * @param renameFileRequest 3P cloud storage provider rename action request content
    * @param callback Callback that will be triggered post renaming an existing file flow is finished
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function renameCloudStorageProviderFile(
     renameFileRequest: CloudStorageProviderRequest<CloudStorageProviderRenameFileContent>,
@@ -754,6 +936,9 @@ export namespace files {
    *
    * @param deleteFileRequest 3P cloud storage provider delete action request content
    * @param callback Callback that will be triggered post deleting existing file(s) flow is finished
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function deleteCloudStorageProviderFile(
     deleteFileRequest: CloudStorageProviderRequest<CloudStorageProviderDeleteFileContent>,
@@ -791,6 +976,9 @@ export namespace files {
    *
    * @param downloadFileRequest 3P cloud storage provider download file(s) action request content
    * @param callback Callback that will be triggered post downloading existing file(s) flow is finished
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function downloadCloudStorageProviderFile(
     downloadFileRequest: CloudStorageProviderRequest<CloudStorageProviderDownloadFileContent>,
@@ -830,6 +1018,9 @@ export namespace files {
    *
    * @param uploadFileRequest 3P cloud storage provider upload file(s) action request content
    * @param callback Callback that will be triggered post uploading file(s) flow is finished
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function uploadCloudStorageProviderFile(
     uploadFileRequest: CloudStorageProviderRequest<CloudStorageProviderUploadFileContent>,
@@ -882,6 +1073,7 @@ export namespace files {
    *
    * @param handler - When 3P cloud storage provider list is updated this handler is called
    *
+   * @internal Limited to Microsoft-internal use
    */
   export function registerCloudStorageProviderListChangeHandler(handler: () => void): void {
     ensureInitialized();
@@ -902,6 +1094,8 @@ export namespace files {
    *
    * @param handler - When 3P cloud storage provider content is updated this handler is called
    *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function registerCloudStorageProviderContentChangeHandler(handler: () => void): void {
     ensureInitialized();

--- a/packages/teams-js/src/private/interfaces.ts
+++ b/packages/teams-js/src/private/interfaces.ts
@@ -2,9 +2,11 @@ import { FileOpenPreference, TeamInformation } from '../public/interfaces';
 
 /**
  * @hidden
- * Hide from docs
- * --------
+ *
  * Information about all members in a chat
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface ChatMembersInformation {
   members: ThreadMember[];
@@ -12,23 +14,40 @@ export interface ChatMembersInformation {
 
 /**
  * @hidden
- * Hide from docs
- * --------
+ *
  * Information about a chat member
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface ThreadMember {
   /**
    * @hidden
    * The member's user principal name in the current tenant.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   upn: string;
 }
 
+/**
+ * @hidden
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export enum NotificationTypes {
   fileDownloadStart = 'fileDownloadStart',
   fileDownloadComplete = 'fileDownloadComplete',
 }
 
+/**
+ * @hidden
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export interface ShowNotificationParameters {
   message: string;
   notificationType: NotificationTypes;
@@ -36,7 +55,9 @@ export interface ShowNotificationParameters {
 
 /**
  * @hidden
- * Hide from docs.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export enum ViewerActionTypes {
   view = 'view',
@@ -46,86 +67,123 @@ export enum ViewerActionTypes {
 
 /**
  * @hidden
- * Hide from docs.
- * ------
+ *
  * User setting changes that can be subscribed to
  */
 export enum UserSettingTypes {
   /**
    * @hidden
    * Use this key to subscribe to changes in user's file open preference
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   fileOpenPreference = 'fileOpenPreference',
   /**
    * @hidden
    * Use this key to subscribe to theme changes
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   theme = 'theme',
 }
 
 /**
  * @hidden
- * Hide from docs.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface FilePreviewParameters {
   /**
    * @hidden
    * The developer-defined unique ID for the file.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   entityId: string;
 
   /**
    * @hidden
    * The display name of the file.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   title: string;
 
   /**
    * @hidden
    * An optional description of the file.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   description?: string;
 
   /**
    * @hidden
    * The file extension; e.g. pptx, docx, etc.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   type: string;
 
   /**
    * @hidden
    * A url to the source of the file, used to open the content in the user's default browser
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   objectUrl: string;
 
   /**
    * @hidden
    * Optional; an alternate self-authenticating url used to preview the file in Mobile clients and offer it for download by the user
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   downloadUrl?: string;
 
   /**
    * @hidden
    * Optional; an alternate url optimized for previewing the file in web and desktop clients
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   webPreviewUrl?: string;
 
   /**
    * @hidden
    * Optional; an alternate url that allows editing of the file in web and desktop clients
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   webEditUrl?: string;
 
   /**
    * @hidden
    * Optional; the base url of the site where the file is hosted
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   baseUrl?: string;
 
   /**
    * @hidden
-   * Deprecated; prefer using viewerAction instead
+   * Deprecated; prefer using {@linkcode viewerAction} instead
    * Optional; indicates whether the file should be opened in edit mode
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   editFile?: boolean;
 
@@ -133,51 +191,74 @@ export interface FilePreviewParameters {
    * @hidden
    * Optional; the developer-defined unique ID for the sub-entity to return to when the file stage closes.
    * This field should be used to restore to a specific state within an entity, such as scrolling to or activating a specific piece of content.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   subEntityId?: string;
 
   /**
    * @hidden
    * Optional; indicates the mode in which file should be opened. Takes precedence over edit mode.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   viewerAction?: ViewerActionTypes;
 
   /**
    * @hidden
    * Optional; indicates how user prefers to open the file
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   fileOpenPreference?: FileOpenPreference;
 
   /**
+   * @hidden
    * Optional; id required to enable conversation button in files. Will be channel id in case file is shared in a channel or the chat id in p2p chat case.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   conversationId?: string;
 }
 
 /**
  * @hidden
- * Hide from docs
- * --------
+ *
  * Query parameters used when fetching team information
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface TeamInstanceParameters {
   /**
    * @hidden
    * Flag allowing to select favorite teams only
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   favoriteTeamsOnly?: boolean;
 }
 
 /**
  * @hidden
- * Hide from docs
- * --------
+ *
  * Information on userJoined Teams
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface UserJoinedTeamsInformation {
   /**
    * @hidden
    * List of team information
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   userJoinedTeams: TeamInformation[];
 }

--- a/packages/teams-js/src/private/logs.ts
+++ b/packages/teams-js/src/private/logs.ts
@@ -9,18 +9,19 @@ import { runtime } from '../public/runtime';
  * Namespace to interact with the logging part of the SDK.
  * This object is used to send the app logs on demand to the host client
  *
- * Hide from docs
- *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export namespace logs {
   /**
    * @hidden
-   * Hide from docs
-   * ------
+   *
    * Registers a handler for getting app log
    *
    * @param handler - The handler to invoke to get the app log
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function registerGetLogHandler(handler: () => string): void {
     ensureInitialized();
@@ -38,6 +39,14 @@ export namespace logs {
     }
   }
 
+  /**
+   * @hidden
+   *
+   * @returns boolean to represent whether the logs capability is supported
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
   export function isSupported(): boolean {
     return runtime.supports.logs ? true : false;
   }

--- a/packages/teams-js/src/private/meetingRoom.ts
+++ b/packages/teams-js/src/private/meetingRoom.ts
@@ -4,48 +4,64 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { errorNotSupportedOnPlatform } from '../public/constants';
 import { runtime } from '../public/runtime';
 
+/**
+ * @hidden
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export namespace meetingRoom {
   /**
    * @hidden
-   * Hide from docs
-   * ------
+   *
    * Data structure to represent a meeting room.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface MeetingRoomInfo {
     /**
      * @hidden
      * Endpoint id of the meeting room.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     endpointId: string;
     /**
      * @hidden
      * Device name of the meeting room.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     deviceName: string;
     /**
      * @hidden
      * Client type of the meeting room.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     clientType: string;
     /**
      * @hidden
      * Client version of the meeting room.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     clientVersion: string;
   }
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Type of Media control capabilities of a meeting room.
    */
   type MediaControls = 'toggleMute' | 'toggleCamera' | 'toggleCaptions' | 'volume';
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Types of Stage Layout control capabilities of a meeting room.
    */
 
@@ -58,8 +74,6 @@ export namespace meetingRoom {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Types of Meeting Control capabilities of a meeting room.
    */
 
@@ -67,8 +81,6 @@ export namespace meetingRoom {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Types of Stage Layout State of a meeting room.
    */
 
@@ -76,69 +88,96 @@ export namespace meetingRoom {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Data structure to represent capabilities of a meeting room.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface MeetingRoomCapability {
     /**
      * @hidden
      * Media control capabilities, value can be "toggleMute", "toggleCamera", "toggleCaptions", "volume".
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     mediaControls: MediaControls[];
     /**
      * @hidden
      * Main stage layout control capabilities, value can be "showVideoGallery", "showContent", "showVideoGalleryAndContent", "showLargeGallery", "showTogether".
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     stageLayoutControls: StageLayoutControls[];
     /**
      * @hidden
      * Meeting control capabilities, value can be "leaveMeeting".
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     meetingControls: MeetingControls[];
   }
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Data structure to represent states of a meeting room.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface MeetingRoomState {
     /**
      * @hidden
      * Current mute state, true: mute, false: unmute.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     toggleMute: boolean;
     /**
      * @hidden
      * Current camera state, true: camera on, false: camera off.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     toggleCamera: boolean;
     /**
      * @hidden
      * Current captions state, true: captions on, false: captions off.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     toggleCaptions: boolean;
     /**
      * @hidden
      * Current main stage layout state, value can be one of "Gallery", "Content + gallery", "Content", "Large gallery" and "Together mode".
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     stageLayout: StageLayoutStates;
     /**
      * @hidden
      * Current leaveMeeting state, true: leave, false: no-op.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     leaveMeeting: boolean;
   }
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Fetch the meeting room info that paired with current client.
    *
    * @returns Promise resolved with meeting room info or rejected with SdkError value
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function getPairedMeetingRoomInfo(): Promise<MeetingRoomInfo> {
     return new Promise<MeetingRoomInfo>(resolve => {
@@ -152,12 +191,13 @@ export namespace meetingRoom {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Send a command to paired meeting room.
    *
    * @param commandName The command name.
    * @returns Promise resolved upon completion or rejected with SdkError value
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function sendCommandToPairedMeetingRoom(commandName: string): Promise<void> {
     return new Promise<void>(resolve => {
@@ -174,12 +214,13 @@ export namespace meetingRoom {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Registers a handler for meeting room capabilities update.
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *
    * @param handler The handler to invoke when the capabilities of meeting room update.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function registerMeetingRoomCapabilitiesUpdateHandler(
     handler: (capabilities: MeetingRoomCapability) => void,
@@ -204,6 +245,9 @@ export namespace meetingRoom {
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *
    * @param handler The handler to invoke when the states of meeting room update.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function registerMeetingRoomStatesUpdateHandler(handler: (states: MeetingRoomState) => void): void {
     if (!handler) {
@@ -219,6 +263,14 @@ export namespace meetingRoom {
     });
   }
 
+  /**
+   * @hidden
+   *
+   * @returns boolean to represent whether the meetingRoom capability is supported
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
   export function isSupported(): boolean {
     return runtime.supports.meetingRoom ? true : false;
   }

--- a/packages/teams-js/src/private/notifications.ts
+++ b/packages/teams-js/src/private/notifications.ts
@@ -7,14 +7,13 @@ import { ShowNotificationParameters } from './interfaces';
 export namespace notifications {
   /**
    * @hidden
-   * Hide from docs.
-   * ------
    * display notification API.
    *
    * @param message - Notification message.
    * @param notificationType - Notification type
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function showNotification(showNotificationParameters: ShowNotificationParameters): void {
     ensureInitialized(FrameContexts.content);
@@ -24,6 +23,14 @@ export namespace notifications {
 
     sendMessageToParent('notifications.showNotification', [showNotificationParameters]);
   }
+
+  /**
+   * @hidden
+   * @returns boolean to represent whether the notifications capability is supported
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
   export function isSupported(): boolean {
     return runtime.supports.notifications ? true : false;
   }

--- a/packages/teams-js/src/private/privateAPIs.ts
+++ b/packages/teams-js/src/private/privateAPIs.ts
@@ -8,19 +8,12 @@ import { FrameContexts } from '../public/constants';
 import { FilePreviewParameters, UserSettingTypes } from './interfaces';
 
 /**
- * @internal
- */
-export function initializePrivateApis(): void {
-  // To maintain backwards compatability, this function cannot be deleted as it is callable
-}
-/**
  * @hidden
- * Hide from docs.
- * ------
  * Upload a custom App manifest directly to both team and personal scopes.
  * This method works just for the first party Apps.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function uploadCustomApp(manifestBlob: Blob, onComplete?: (status: boolean, reason?: string) => void): void {
   ensureInitialized();
@@ -30,7 +23,6 @@ export function uploadCustomApp(manifestBlob: Blob, onComplete?: (status: boolea
 
 /**
  * @hidden
- * Internal use only
  * Sends a custom action MessageRequest to host or parent window
  *
  * @param actionName - Specifies name of the custom action to be sent
@@ -39,6 +31,7 @@ export function uploadCustomApp(manifestBlob: Blob, onComplete?: (status: boolea
  * @returns id of sent message
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function sendCustomMessage(
   actionName: string,
@@ -54,7 +47,6 @@ export function sendCustomMessage(
 
 /**
  * @hidden
- * Internal use only
  * Sends a custom action MessageEvent to a child iframe/window, only if you are not using auth popup.
  * Otherwise it will go to the auth popup (which becomes the child)
  *
@@ -63,6 +55,7 @@ export function sendCustomMessage(
  * @returns id of sent message
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function sendCustomEvent(
   actionName: string,
@@ -80,13 +73,13 @@ export function sendCustomEvent(
 
 /**
  * @hidden
- * Internal use only
  * Adds a handler for an action sent by a child window or parent window
  *
  * @param actionName - Specifies name of the action message to handle
  * @param customHandler - The callback to invoke when the action message is received. The return value is sent to the child
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function registerCustomHandler(
   actionName: string,
@@ -109,6 +102,7 @@ export function registerCustomHandler(
  * @param handler - When a subscribed setting is updated this handler is called
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function registerUserSettingsChangeHandler(
   settingTypes: UserSettingTypes[],
@@ -121,11 +115,12 @@ export function registerUserSettingsChangeHandler(
 
 /**
  * @hidden
- * Hide from docs.
- * ------
  * Opens a client-friendly preview of the specified file.
  *
  * @param file - The file to preview.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export function openFilePreview(filePreviewParameters: FilePreviewParameters): void {
   ensureInitialized(FrameContexts.content, FrameContexts.task);

--- a/packages/teams-js/src/private/remoteCamera.ts
+++ b/packages/teams-js/src/private/remoteCamera.ts
@@ -5,36 +5,53 @@ import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants'
 import { SdkError } from '../public/interfaces';
 import { runtime } from '../public/runtime';
 
+/**
+ * @hidden
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export namespace remoteCamera {
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Data structure to represent patricipant details needed to request control of camera.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface Participant {
     /**
      * @hidden
      * Id of participant.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     id: string;
     /**
      * @hidden
      * Display name of participant.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     displayName?: string;
     /**
      * @hidden
      * Active indicates whether the participant's device is actively being controlled.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     active?: boolean;
   }
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Enum used to indicate possible camera control commands.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export enum ControlCommand {
     Reset = 'Reset',
@@ -48,63 +65,91 @@ export namespace remoteCamera {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Data structure to indicate the current state of the device.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface DeviceState {
     /**
      * @hidden
      * All operation are available to apply.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     available: boolean;
     /**
      * @hidden
      * Either camera doesnt support to get state or It unable to apply command.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     error: boolean;
     /**
      * @hidden
      * Reset max out or already applied. Client Disable Reset.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     reset: boolean;
     /**
      * @hidden
      * ZoomIn maxed out.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     zoomIn: boolean;
     /**
      * @hidden
      * ZoomOut maxed out.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     zoomOut: boolean;
     /**
      * @hidden
      * PanLeft reached max left.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     panLeft: boolean;
     /**
      * @hidden
      * PanRight reached max right.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     panRight: boolean;
     /**
      * @hidden
      * TiltUp reached top.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     tiltUp: boolean;
     /**
      * @hidden
      * TiltDown reached bottom.
+     *
+     * @internal Limited to Microsoft-internal use
      */
     tiltDown: boolean;
   }
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Enum used to indicate the reason for the error.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export enum ErrorReason {
     CommandResetError,
@@ -119,28 +164,36 @@ export namespace remoteCamera {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Data structure to indicate the status of the current session.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface SessionStatus {
     /**
      * @hidden
      * Whether the far-end user is controlling a  device.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     inControl: boolean;
     /**
      * @hidden
      * Reason the  control session was terminated.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     terminatedReason?: SessionTerminatedReason;
   }
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Enum used to indicate the reason the session was terminated.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export enum SessionTerminatedReason {
     None,
@@ -158,14 +211,15 @@ export namespace remoteCamera {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Fetch a list of the participants with controllable-cameras in a meeting.
    *
    * @param callback - Callback contains 2 parameters, error and participants.
    * error can either contain an error of type SdkError, incase of an error, or null when fetch is successful
    * participants can either contain an array of Participant objects, incase of a successful fetch or null when it fails
    * participants: object that contains an array of participants with controllable-cameras
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function getCapableParticipants(
     callback: (error: SdkError | null, participants: Participant[] | null) => void,
@@ -182,8 +236,6 @@ export namespace remoteCamera {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Request control of a participant's camera.
    *
    * @param participant - Participant specifies the participant to send the request for camera control.
@@ -191,6 +243,9 @@ export namespace remoteCamera {
    * error can either contain an error of type SdkError, incase of an error, or null when fetch is successful
    * requestResponse can either contain the true/false value, incase of a successful request or null when it fails
    * requestResponse: True means request was accepted and false means request was denied
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function requestControl(
     participant: Participant,
@@ -211,12 +266,13 @@ export namespace remoteCamera {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Send control command to the participant's camera.
    *
    * @param ControlCommand - ControlCommand specifies the command for controling the camera.
    * @param callback - Callback to invoke when the command response returns.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function sendControlCommand(ControlCommand: ControlCommand, callback: (error: SdkError | null) => void): void {
     if (!ControlCommand) {
@@ -234,11 +290,12 @@ export namespace remoteCamera {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Terminate the remote  session
    *
    * @param callback - Callback to invoke when the command response returns.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function terminateSession(callback: (error: SdkError | null) => void): void {
     if (!callback) {
@@ -257,6 +314,9 @@ export namespace remoteCamera {
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *
    * @param handler - The handler to invoke when the list of participants with controllable-cameras changes.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function registerOnCapableParticipantsChangeHandler(
     handler: (participantChange: Participant[]) => void,
@@ -277,6 +337,9 @@ export namespace remoteCamera {
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *
    * @param handler - The handler to invoke when there is an error from the camera handler.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function registerOnErrorHandler(handler: (error: ErrorReason) => void): void {
     if (!handler) {
@@ -295,6 +358,9 @@ export namespace remoteCamera {
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *
    * @param handler - The handler to invoke when the controlled device changes state.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function registerOnDeviceStateChangeHandler(handler: (deviceStateChange: DeviceState) => void): void {
     if (!handler) {
@@ -313,6 +379,9 @@ export namespace remoteCamera {
    * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
    *
    * @param handler - The handler to invoke when the current session status changes.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function registerOnSessionStatusChangeHandler(handler: (sessionStatusChange: SessionStatus) => void): void {
     if (!handler) {
@@ -325,6 +394,13 @@ export namespace remoteCamera {
     registerHandler('remoteCamera.sessionStatusChange', handler);
   }
 
+  /**
+   * @hidden
+   * @returns boolean to represent whether the remoteCamera capability is supported
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
   export function isSupported(): boolean {
     return runtime.supports.remoteCamera ? true : false;
   }

--- a/packages/teams-js/src/private/teams.ts
+++ b/packages/teams-js/src/private/teams.ts
@@ -10,10 +10,9 @@ import { TeamInstanceParameters, UserJoinedTeamsInformation } from './interfaces
 /**
  * @hidden
  * Namespace to interact with the `teams` specific part of the SDK.
- * ------
- * Hide from docs
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export namespace teams {
   export enum ChannelType {
@@ -22,6 +21,12 @@ export namespace teams {
     Shared = 2,
   }
 
+  /**
+   * @hidden
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
   export interface ChannelInfo {
     siteUrl: string;
     objectId: string;
@@ -32,11 +37,12 @@ export namespace teams {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
    * Get a list of channels belong to a Team
    *
    * @param groupId - a team's objectId
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function getTeamChannels(groupId: string, callback: (error: SdkError, channels: ChannelInfo[]) => void): void {
     ensureInitialized(FrameContexts.content);
@@ -63,6 +69,9 @@ export namespace teams {
    *
    * @param threadId - ID of the thread where the app entity will be created; if threadId is not
    * provided, the threadId from route params will be used.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function refreshSiteUrl(threadId: string, callback: (error: SdkError) => void): void {
     ensureInitialized();
@@ -88,6 +97,9 @@ export namespace teams {
    *
    * @returns true if the teams capability is enabled in runtime.supports.teams and
    * false if it is disabled
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export function isSupported(): boolean {
     return runtime.supports.teams ? true : false;
@@ -95,21 +107,25 @@ export namespace teams {
 
   /**
    * @hidden
-   * Hide from docs
-   * ------
-   *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export namespace fullTrust {
+    /**
+     * @hidden
+     * @internal
+     * Limited to Microsoft-internal use
+     */
     export namespace joinedTeams {
       /**
        * @hidden
-       * Hide from docs
-       * ------
        * Allows an app to retrieve information of all user joined teams
        *
        * @param teamInstanceParameters - Optional flags that specify whether to scope call to favorite teams
        * @returns Promise that resolves with information about the user joined teams or rejects with an error when the operation has completed
+       *
+       * @internal
+       * Limited to Microsoft-internal use
        */
       export function getUserJoinedTeams(
         teamInstanceParameters?: TeamInstanceParameters,
@@ -136,12 +152,13 @@ export namespace teams {
       }
       /**
        * @hidden
-       * Hide from docs
-       * ------
        * Checks if teams.fullTrust.joinedTeams capability is supported by the host
        *
        * @returns true if the teams.fullTrust.joinedTeams capability is enabled in
        * runtime.supports.teams.fullTrust.joinedTeams and false if it is disabled
+       *
+       * @internal
+       * Limited to Microsoft-internal use
        */
       export function isSupported(): boolean {
         return runtime.supports.teams
@@ -156,12 +173,13 @@ export namespace teams {
 
     /**
      * @hidden
-     * Hide from docs
-     * ------
      * Allows an app to get the configuration setting value
      *
      * @param key - The key for the config setting
      * @returns Promise that resolves with the value for the provided configuration setting or rejects with an error when the operation has completed
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     export function getConfigSetting(key: string): Promise<string> {
       return new Promise<string>(resolve => {
@@ -175,11 +193,12 @@ export namespace teams {
 
     /**
      * @hidden
-     * Hide from docs
-     * ------
      * Checks if teams.fullTrust capability is supported by the host
      * @returns true if the teams.fullTrust capability is enabled in runtime.supports.teams.fullTrust and
      * false if it is disabled
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     export function isSupported(): boolean {
       return runtime.supports.teams ? (runtime.supports.teams.fullTrust ? true : false) : false;

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -16,7 +16,6 @@ import * as Handlers from '../internal/handlers'; // Conflict with some names
 import { ensureInitialized, processAdditionalValidOrigins } from '../internal/internalAPIs';
 import { compareSDKVersions, runWithTimeout } from '../internal/utils';
 import { logs } from '../private/logs';
-import { initializePrivateApis } from '../private/privateAPIs';
 import { authentication } from './authentication';
 import { ChannelType, FrameContexts, HostClientType, HostName, TeamType, UserTeamRole } from './constants';
 import { dialog } from './dialog';
@@ -604,7 +603,6 @@ export namespace app {
         menus.initialize();
         pages.config.initialize();
         dialog.initialize();
-        initializePrivateApis();
       }
 
       // Handle additional valid message origins if specified

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -616,11 +616,10 @@ export namespace app {
 
   /**
    * @hidden
-   * Hide from docs.
-   * ------
    * Undocumented function used to set a mock window for unit tests
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function _initialize(hostWindow: any): void {
     Communication.currentWindow = hostWindow;
@@ -628,11 +627,10 @@ export namespace app {
 
   /**
    * @hidden
-   * Hide from docs.
-   * ------
    * Undocumented function used to clear state between unit tests
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function _uninitialize(): void {
     if (!GlobalVars.initializeCalled) {
@@ -758,6 +756,7 @@ export namespace app {
  * Transforms the Legacy Context object received from Messages to the structured app.Context object
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 function transformLegacyContextToAppContext(legacyContext: LegacyContext): app.Context {
   const context: app.Context = {

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -203,13 +203,12 @@ export namespace authentication {
 
   /**
    * @hidden
-   * Hide from docs.
-   * ------
    * Requests the decoded Azure AD user identity on behalf of the app.
    *
    * @returns Promise that resolves with the {@link UserProfile}.
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function getUser(): Promise<UserProfile>;
   /**
@@ -217,12 +216,11 @@ export namespace authentication {
    * As of 2.0.0, please use {@link authentication.getUser authentication.getUser(): Promise\<UserProfile\>} instead.
    *
    * @hidden
-   * Hide from docs.
-   * ------
    * Requests the decoded Azure AD user identity on behalf of the app.
    *
    * @param userRequest - It passes success/failure callbacks in the userRequest object(deprecated)
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function getUser(userRequest: UserRequest): void;
   export function getUser(userRequest?: UserRequest): Promise<UserProfile> {
@@ -537,26 +535,34 @@ export namespace authentication {
 
   /**
    * @hidden
-   * Hide from docs.
-   * ------
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export interface UserProfile {
     /**
      * @hidden
      * The intended recipient of the token. The application that receives the token must verify that the audience
      * value is correct and reject any tokens intended for a different audience.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     aud: string;
     /**
      * @hidden
      * Identifies how the subject of the token was authenticated.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     amr: string[];
     /**
      * @hidden
      * Stores the time at which the token was issued. It is often used to measure token freshness.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     iat: number;
     /**
@@ -564,28 +570,43 @@ export namespace authentication {
      * Identifies the security token service (STS) that constructs and returns the token. In the tokens that Azure AD
      * returns, the issuer is sts.windows.net. The GUID in the issuer claim value is the tenant ID of the Azure AD
      * directory. The tenant ID is an immutable and reliable identifier of the directory.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     iss: string;
     /**
      * @hidden
      * Provides the last name, surname, or family name of the user as defined in the Azure AD user object.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     family_name: string;
     /**
      * @hidden
      * Provides the first or "given" name of the user, as set on the Azure AD user object.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     given_name: string;
     /**
      * @hidden
      * Provides a human-readable value that identifies the subject of the token. This value is not guaranteed to
      * be unique within a tenant and is designed to be used only for display purposes.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     unique_name: string;
     /**
      * @hidden
      * Contains a unique identifier of an object in Azure AD. This value is immutable and cannot be reassigned or
      * reused. Use the object ID to identify an object in queries to Azure AD.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     oid: string;
     /**
@@ -594,6 +615,9 @@ export namespace authentication {
      * This value is immutable and cannot be reassigned or reused, so it can be used to perform authorization
      * checks safely. Because the subject is always present in the tokens the Azure AD issues, we recommended
      * using this value in a general-purpose authorization system.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     sub: string;
     /**
@@ -601,6 +625,9 @@ export namespace authentication {
      * An immutable, non-reusable identifier that identifies the directory tenant that issued the token. You can
      * use this value to access tenant-specific directory resources in a multitenant application. For example,
      * you can use this value to identify the tenant in a call to the Graph API.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     tid: string;
     /**
@@ -609,6 +636,9 @@ export namespace authentication {
      * should verify that the current date is within the token lifetime; otherwise it should reject the token. The
      * service might allow for up to five minutes beyond the token lifetime to account for any differences in clock
      * time ("time skew") between Azure AD and the service.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     exp: number;
     /**
@@ -617,16 +647,25 @@ export namespace authentication {
      * should verify that the current date is within the token lifetime; otherwise it should reject the token. The
      * service might allow for up to five minutes beyond the token lifetime to account for any differences in clock
      * time ("time skew") between Azure AD and the service.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     nbf: number;
     /**
      * @hidden
      * Stores the user name of the user principal.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     upn: string;
     /**
      * @hidden
      * Stores the version number of the token.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     ver: string;
   }
@@ -635,11 +674,10 @@ export namespace authentication {
    * @deprecated
    * As of 2.0.0, this interface has been deprecated in favor of a Promise-based pattern.
    * @hidden
-   * Hide from docs.
-   * ------
    * Describes the UserRequest. Success callback describes how a successful request is handled.
    * Failure callback describes how a failed request is handled.
    * @internal
+   * Limited to Microsoft-internal use
    */
   export interface UserRequest {
     /**

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -39,10 +39,11 @@ export namespace dialog {
   /**
    * @hidden
    * Hide from docs because this function is only used during initialization
-   * ------------------
+   *
    * Adds register handlers for messageForChild upon initialization and only in the tasks FrameContext. {@link FrameContexts.task}
    * Function is called during app initialization
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function initialize(): void {
     registerHandler('messageForChild', handleDialogMessage, false);
@@ -254,11 +255,11 @@ export namespace dialog {
 
   /**
    * @hidden
-   * Hide from docs
-   * --------
+   *
    * Convert UrlDialogInfo to DialogInfo to send the information to host in {@linkcode open} API.
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function getDialogInfoFromUrlDialogInfo(urlDialogInfo: UrlDialogInfo): DialogInfo {
     const dialogInfo: DialogInfo = {
@@ -273,11 +274,11 @@ export namespace dialog {
 
   /**
    * @hidden
-   * Hide from docs
-   * --------
+   *
    * Convert BotUrlDialogInfo to DialogInfo to send the information to host in {@linkcode bot.open} API.
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function getDialogInfoFromBotUrlDialogInfo(botUrlDialogInfo: BotUrlDialogInfo): DialogInfo {
     const dialogInfo: DialogInfo = {

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -21,6 +21,7 @@ export interface TabInstance {
 
   /**
    * @internal
+   * Limited to Microsoft-internal use
    * @protected
    */
   internalTabInstanceId?: string;
@@ -862,9 +863,9 @@ export interface DialogSize {
 }
 /**
  * @hidden
- * Hide from docs.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export interface LoadContext {
   /**

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -7,10 +7,10 @@ import { SdkError } from './interfaces';
 export namespace meeting {
   /**
    * @hidden
-   * Hide from docs
-   * Data structure to represent a meeting details
+   * Data structure to represent meeting details
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export interface IMeetingDetailsResponse {
     /**
@@ -85,10 +85,10 @@ export namespace meeting {
 
   /**
    * @hidden
-   * Hide from docs
    * Data structure to represent a conversation object.
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export interface IConversation {
     /**
@@ -100,10 +100,10 @@ export namespace meeting {
 
   /**
    * @hidden
-   * Hide from docs
    * Data structure to represent an organizer object.
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export interface IOrganizer {
     /**
@@ -273,8 +273,6 @@ export namespace meeting {
 
   /**
    * @hidden
-   * Hide from docs
-   *
    * Allows an app to get the meeting details for the meeting
    *
    * @param callback - Callback contains 2 parameters, error and meetingDetailsResponse.
@@ -282,6 +280,7 @@ export namespace meeting {
    * result can either contain a IMeetingDetailsResponse value, in case of a successful get or null when the get fails
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function getMeetingDetails(
     callback: (error: SdkError | null, meetingDetails: IMeetingDetailsResponse | null) => void,
@@ -307,6 +306,7 @@ export namespace meeting {
    * authenticationTokenOfAnonymousUser can either contain a string value, incase of a successful get or null when the get fails
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function getAuthenticationTokenForAnonymousUser(
     callback: (error: SdkError | null, authenticationTokenOfAnonymousUser: string | null) => void,

--- a/packages/teams-js/src/public/menus.ts
+++ b/packages/teams-js/src/public/menus.ts
@@ -12,21 +12,33 @@ export namespace menus {
   /**
    * @hidden
    * Represents information about item in View Configuration.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export interface ViewConfiguration {
     /**
      * @hidden
      * Unique identifier of view.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     id: string;
     /**
      * @hidden
      * Display title of the view.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     title: string;
     /**
      * @hidden
      * Additional information for accessibility.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
      */
     contentDescription?: string;
   }

--- a/packages/teams-js/src/public/monetization.ts
+++ b/packages/teams-js/src/public/monetization.ts
@@ -8,10 +8,10 @@ import { runtime } from './runtime';
 export namespace monetization {
   /**
    * @hidden
-   * Hide from docs
    * Data structure to represent a subscription plan.
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export interface PlanInfo {
     /**
@@ -28,7 +28,6 @@ export namespace monetization {
 
   /**
    * @hidden
-   * Hide from docs
    * Open dialog to start user's purchase experience
    *
    * @param planInfo optional parameter. It contains info of the subscription plan pushed to users.
@@ -36,6 +35,7 @@ export namespace monetization {
    * @returns Promise that will be resolved when the operation has completed or rejected with SdkError value
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function openPurchaseExperience(planInfo?: PlanInfo): Promise<void>;
   /**
@@ -43,7 +43,6 @@ export namespace monetization {
    * As of 2.0.0, please use {@link monetization.openPurchaseExperience monetization.openPurchaseExperience(planInfo?: PlanInfo): Promise\<void\>} instead.
    *
    * @hidden
-   * Hide from docs
    * Open dialog to start user's purchase experience
    *
    * @param callback Callback contains 1 parameters, error.
@@ -51,6 +50,7 @@ export namespace monetization {
    * error can either contain an error of type SdkError, incase of an error, or null when get is successful
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function openPurchaseExperience(callback: (error: SdkError | null) => void, planInfo?: PlanInfo): void;
   /**

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -39,6 +39,7 @@ export namespace pages {
    * @param handler - The handler for placing focus within the application.
    *
    * @internal
+   * Limited to Microsoft-internal use
    */
   export function registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void {
     ensureInitialized();
@@ -321,9 +322,10 @@ export namespace pages {
     /**
      * @hidden
      * Hide from docs because this function is only used during initialization
-     * ------------------
+     *
      * Adds register handlers for settings.save and settings.remove upon initialization. Function is called in {@link app.initializeHelper}
      * @internal
+     * Limited to Microsoft-internal use
      */
     export function initialize(): void {
       registerHandler('settings.save', handleSave, false);

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -36,11 +36,10 @@ export function initialize(callback?: () => void, validMessageOrigins?: string[]
  * As of 2.0.0, please use {@link app._initialize app._initialize(hostWindow: any): void} instead.
  *
  * @hidden
- * Hide from docs.
- * ------
  * Undocumented function used to set a mock window for unit tests
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 // eslint-disable-next-line
 export function _initialize(hostWindow: any): void {
@@ -52,11 +51,10 @@ export function _initialize(hostWindow: any): void {
  * As of 2.0.0, please use {@link app._uninitialize app._uninitialize(): void} instead.
  *
  * @hidden
- * Hide from docs.
- * ------
  * Undocumented function used to clear state between unit tests
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export function _uninitialize(): void {
   app._uninitialize();

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -187,6 +187,7 @@ export const versionConstants: Record<string, Array<ICapabilityReqs>> = {
 
 /**
  * @internal
+ * Limited to Microsoft-internal use
  *
  * Generates and returns a runtime configuration for host clients which are not on the latest host SDK version
  * and do not provide their own runtime config. Their supported capabilities are based on the highest
@@ -225,12 +226,11 @@ export function applyRuntimeConfig(runtimeConfig: IRuntime): void {
 
 /**
  * @hidden
- * Hide from docs.
- * ------
  * Constant used to set minimum runtime configuration
  * while un-initializing an app in unit test case.
  *
  * @internal
+ * Limited to Microsoft-internal use
  */
 export const _minRuntimeConfigToUninitialize = {
   apiVersion: 1,

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -300,17 +300,6 @@ describe('Testing app capability', () => {
         expect(spy).toHaveBeenCalled();
       });
 
-      it('app.initialize should call initializePrivateApis', async () => {
-        const spy = jest.spyOn(privateAPIs, 'initializePrivateApis');
-
-        const initPromise = app.initialize();
-        const initMessage = utils.findMessageByFunc('initialize');
-        utils.respondToMessage(initMessage, FrameContexts.content);
-        await initPromise;
-
-        expect(spy).toHaveBeenCalled();
-      });
-
       it('app.initialize should assign additionalValidOrigins when supplied', async () => {
         const validOrigin = 'https://www.mydomain.com';
         const initPromise = app.initialize([validOrigin]);
@@ -1047,22 +1036,6 @@ describe('Testing app capability', () => {
 
       it('app.initialize should call dialog.initialize', async () => {
         const spy = jest.spyOn(dialog, 'initialize');
-
-        const initPromise = app.initialize();
-        const initMessage = framelessPostMock.findMessageByFunc('initialize');
-        framelessPostMock.respondToMessage({
-          data: {
-            id: initMessage.id,
-            args: [],
-          },
-        } as DOMMessageEvent);
-        await initPromise;
-
-        expect(spy).toHaveBeenCalled();
-      });
-
-      it('app.initialize should call initializePrivateApis', async () => {
-        const spy = jest.spyOn(privateAPIs, 'initializePrivateApis');
 
         const initPromise = app.initialize();
         const initMessage = framelessPostMock.findMessageByFunc('initialize');


### PR DESCRIPTION
Functions marked with the @internal tag in comments are intended for Microsoft use only, and in general were being hidden from dev documentation. Unfortunately, the @internal and @hidden tags don't prevent exported functions from showing up in intellisense for developers. To help make it clear that @internal functions are only for internal use I have added the phrase "Limited to Microsoft-internal use" to *all* @internal functions in teamsjs-sdk.

As I went through, I also fixed a few other small problems:

- Some exported items in the private folder weren't marked as hidden, which made them show up in the dev documentation. @hidden tag has been added to all of these that I found
- the `initalizePrivateApis` function has been removed from privateAPIs.ts. It was not being exported in the index file and was a no-op, so there's no need to keep it in the package. Also removed associated calls to it and unit tests validating it was being called.