### PR TITLE
Change the number of retries on the Android E2E pipeline

### DIFF
--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -41,7 +41,7 @@ steps:
   - bash: 'chmod u+x ./gradlew && chmod u+x e2eTest.sh && ./e2eTest.sh'
     displayName: 'Run Android E2E Tests'
     workingDirectory: '$(Agent.BuildDirectory)/androidHost/apps/orangeandroid'
-    retryCountOnTaskFailure: 2
+    retryCountOnTaskFailure: 1
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Android E2E test task will timeout if it runs more than twice. When the task times out the tests results are not published and we cannot see which tests failed. Reducing retry number to 1 to avoid timeout.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
