### PR TITLE
Register handler fix

### DIFF
--- a/apps/sample-app/src/components/PeopleAvatars.tsx
+++ b/apps/sample-app/src/components/PeopleAvatars.tsx
@@ -66,8 +66,7 @@ export const PeopleAvatarList: React.FC<AvatarProps> = (props: AvatarProps) => {
           People to Meet Today
         </Title3>
         <div>
-
-          {AvatarItemList.map(avatar => (
+          {AvatarItemList.map((avatar) => (
             <>
               <Popover trapFocus openOnHover={true} size="medium">
                 <PopoverTrigger>

--- a/change/@microsoft-teams-js-0f43576d-6006-404f-a65b-a8328c022626.json
+++ b/change/@microsoft-teams-js-0f43576d-6006-404f-a65b-a8328c022626.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed an issue with the v1 versions of `register*Handler` functions. Previously if the v2 version of the API's capability was not supported, attempts to call the v1 version would throw an exception, breaking backwards compatibility.",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -50,6 +50,27 @@ export namespace pages {
   }
 
   /**
+   * @hidden
+   * Undocumented helper function with shared code between deprecated version and current version of the registerFocusEnterHandler API.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
+   * @param handler - The handler for placing focus within the application.
+   * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
+   */
+  export function registerFocusEnterHandlerHelper(
+    handler: (navigateForward: boolean) => void,
+    versionSpecificHelper?: () => void,
+  ): void {
+    ensureInitialized();
+    if (versionSpecificHelper) {
+      versionSpecificHelper();
+    }
+    registerHandler('focusEnter', handler);
+  }
+
+  /**
    * Sets/Updates the current frame with new information
    *
    * @param frameInfo - Frame information containing the URL used in the iframe on reload and the URL for when the
@@ -212,6 +233,27 @@ export namespace pages {
   }
 
   /**
+   * @hidden
+   * Undocumented helper function with shared code between deprecated version and current version of the registerFullScreenHandler API.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
+   * @param handler - The handler to invoke when the user toggles full-screen view for a tab.
+   * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
+   */
+  export function registerFullScreenHandlerHelper(
+    handler: (isFullScreen: boolean) => void,
+    versionSpecificHelper?: () => void,
+  ): void {
+    ensureInitialized();
+    if (versionSpecificHelper) {
+      versionSpecificHelper();
+    }
+    registerHandler('fullScreenChange', handler);
+  }
+
+  /**
    * Checks if the pages capability is supported by the host
    * @returns true if the pages capability is enabled in runtime.supports.pages and
    * false if it is disabled
@@ -369,9 +411,30 @@ export namespace pages {
      * @param handler - The handler to invoke when the user selects the Save button.
      */
     export function registerOnSaveHandler(handler: (evt: SaveEvent) => void): void {
+      registerOnSaveHandlerHelper(handler, () => {
+        if (!isSupported()) {
+          throw errorNotSupportedOnPlatform;
+        }
+      });
+    }
+
+    /**
+     * @hidden
+     * Undocumented helper function with shared code between deprecated version and current version of the registerOnSaveHandler API.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
+     *
+     * @param handler - The handler to invoke when the user selects the Save button.
+     * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
+     */
+    export function registerOnSaveHandlerHelper(
+      handler: (evt: SaveEvent) => void,
+      versionSpecificHelper?: () => void,
+    ): void {
       ensureInitialized(FrameContexts.settings);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
+      if (versionSpecificHelper) {
+        versionSpecificHelper();
       }
       saveHandler = handler;
       handler && sendMessageToParent('registerHandler', ['save']);
@@ -385,9 +448,30 @@ export namespace pages {
      * @param handler - The handler to invoke when the user selects the Remove button.
      */
     export function registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void {
+      registerOnRemoveHandlerHelper(handler, () => {
+        if (!isSupported()) {
+          throw errorNotSupportedOnPlatform;
+        }
+      });
+    }
+
+    /**
+     * @hidden
+     * Undocumented helper function with shared code between deprecated version and current version of the registerOnRemoveHandler API.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
+     *
+     * @param handler - The handler to invoke when the user selects the Remove button.
+     * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
+     */
+    export function registerOnRemoveHandlerHelper(
+      handler: (evt: RemoveEvent) => void,
+      versionSpecificHelper?: () => void,
+    ): void {
       ensureInitialized(FrameContexts.remove, FrameContexts.settings);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
+      if (versionSpecificHelper) {
+        versionSpecificHelper();
       }
       removeHandler = handler;
       handler && sendMessageToParent('registerHandler', ['remove']);
@@ -408,10 +492,30 @@ export namespace pages {
      * @param handler - The handler to invoke when the user clicks on Settings.
      */
     export function registerChangeConfigHandler(handler: () => void): void {
+      registerChangeConfigHandlerHelper(handler, () => {
+        if (!isSupported()) {
+          throw errorNotSupportedOnPlatform;
+        }
+      });
+    }
+
+    /**
+     * @hidden
+     * Undocumented helper function with shared code between deprecated version and current version of the registerConfigChangeHandler API.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
+     *
+     * @param handler - The handler to invoke when the user clicks on Settings.
+     * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
+     */
+    export function registerChangeConfigHandlerHelper(handler: () => void, versionSpecificHelper?: () => void): void {
       ensureInitialized(FrameContexts.content);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
+
+      if (versionSpecificHelper) {
+        versionSpecificHelper();
       }
+
       registerHandler('changeSettings', handler);
     }
 
@@ -567,9 +671,27 @@ export namespace pages {
      * @param handler - The handler to invoke when the user presses the host client's back button.
      */
     export function registerBackButtonHandler(handler: () => boolean): void {
+      registerBackButtonHandlerHelper(handler, () => {
+        if (!isSupported()) {
+          throw errorNotSupportedOnPlatform;
+        }
+      });
+    }
+
+    /**
+     * @hidden
+     * Undocumented helper function with shared code between deprecated version and current version of the registerBackButtonHandler API.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
+     *
+     * @param handler - The handler to invoke when the user presses the host client's back button.
+     * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
+     */
+    export function registerBackButtonHandlerHelper(handler: () => boolean, versionSpecificHelper?: () => void): void {
       ensureInitialized();
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
+      if (versionSpecificHelper) {
+        versionSpecificHelper();
       }
       backButtonPressHandler = handler;
       handler && sendMessageToParent('registerHandler', ['backButton']);
@@ -648,9 +770,27 @@ export namespace pages {
      * @param handler - The handler to invoke when the personal app button is clicked in the app bar.
      */
     export function onClick(handler: () => void): void {
+      onClickHelper(handler, () => {
+        if (!isSupported()) {
+          throw errorNotSupportedOnPlatform;
+        }
+      });
+    }
+
+    /**
+     * @hidden
+     * Undocumented helper function with shared code between deprecated version and current version of the onClick API.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
+     *
+     * @param handler - The handler to invoke when the personal app button is clicked in the app bar.
+     * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
+     */
+    export function onClickHelper(handler: () => void, versionSpecificHelper?: () => void): void {
       ensureInitialized(FrameContexts.content);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
+      if (versionSpecificHelper) {
+        versionSpecificHelper();
       }
       registerHandler('appButtonClick', handler);
     }
@@ -661,9 +801,27 @@ export namespace pages {
      * @param handler - The handler to invoke when entering hover of the personal app button in the app bar.
      */
     export function onHoverEnter(handler: () => void): void {
+      onHoverEnterHelper(handler, () => {
+        if (!isSupported()) {
+          throw errorNotSupportedOnPlatform;
+        }
+      });
+    }
+
+    /**
+     * @hidden
+     * Undocumented helper function with shared code between deprecated version and current version of the onHoverEnter API.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
+     *
+     * @param handler - The handler to invoke when entering hover of the personal app button in the app bar.
+     * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
+     */
+    export function onHoverEnterHelper(handler: () => void, versionSpecificHelper?: () => void): void {
       ensureInitialized(FrameContexts.content);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
+      if (versionSpecificHelper) {
+        versionSpecificHelper();
       }
       registerHandler('appButtonHoverEnter', handler);
     }
@@ -674,9 +832,27 @@ export namespace pages {
      * @param handler - The handler to invoke when exiting hover of the personal app button in the app bar.
      */
     export function onHoverLeave(handler: () => void): void {
+      onHoverLeaveHelper(handler, () => {
+        if (!isSupported()) {
+          throw errorNotSupportedOnPlatform;
+        }
+      });
+    }
+
+    /**
+     * @hidden
+     * Undocumented helper function with shared code between deprecated version and current version of the onHoverLeave API.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
+     *
+     * @param handler - The handler to invoke when existing hover of the personal app button in the app bar.
+     * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
+     */
+    export function onHoverLeaveHelper(handler: () => void, versionSpecificHelper?: () => void): void {
       ensureInitialized(FrameContexts.content);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
+      if (versionSpecificHelper) {
+        versionSpecificHelper();
       }
       registerHandler('appButtonHoverLeave', handler);
     }

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -120,7 +120,7 @@ export function registerOnThemeChangeHandler(handler: (theme: string) => void): 
  * @param handler - The handler to invoke when the user toggles full-screen view for a tab.
  */
 export function registerFullScreenHandler(handler: (isFullScreen: boolean) => void): void {
-  pages.registerFullScreenHandler(handler);
+  pages.registerFullScreenHandlerHelper(handler);
 }
 
 /**
@@ -133,7 +133,7 @@ export function registerFullScreenHandler(handler: (isFullScreen: boolean) => vo
  * @param handler - The handler to invoke when the personal app button is clicked in the app bar.
  */
 export function registerAppButtonClickHandler(handler: () => void): void {
-  pages.appButton.onClick(handler);
+  pages.appButton.onClickHelper(handler);
 }
 
 /**
@@ -146,7 +146,7 @@ export function registerAppButtonClickHandler(handler: () => void): void {
  * @param handler - The handler to invoke when entering hover of the personal app button in the app bar.
  */
 export function registerAppButtonHoverEnterHandler(handler: () => void): void {
-  pages.appButton.onHoverEnter(handler);
+  pages.appButton.onHoverEnterHelper(handler);
 }
 
 /**
@@ -159,7 +159,7 @@ export function registerAppButtonHoverEnterHandler(handler: () => void): void {
  *
  */
 export function registerAppButtonHoverLeaveHandler(handler: () => void): void {
-  pages.appButton.onHoverLeave(handler);
+  pages.appButton.onHoverLeaveHelper(handler);
 }
 
 /**
@@ -174,7 +174,7 @@ export function registerAppButtonHoverLeaveHandler(handler: () => void): void {
  * @param handler - The handler to invoke when the user presses their Team client's back button.
  */
 export function registerBackButtonHandler(handler: () => boolean): void {
-  pages.backStack.registerBackButtonHandler(handler);
+  pages.backStack.registerBackButtonHandlerHelper(handler);
 }
 
 /**
@@ -187,7 +187,7 @@ export function registerBackButtonHandler(handler: () => boolean): void {
  * @param handler - The handler to invoke when the page is loaded.
  */
 export function registerOnLoadHandler(handler: (context: LoadContext) => void): void {
-  teamsCore.registerOnLoadHandler(handler);
+  teamsCore.registerOnLoadHandlerHelper(handler);
 }
 
 /**
@@ -201,7 +201,7 @@ export function registerOnLoadHandler(handler: (context: LoadContext) => void): 
  * invoke the readyToUnload function provided to it once it's ready to be unloaded.
  */
 export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void {
-  teamsCore.registerBeforeUnloadHandler(handler);
+  teamsCore.registerBeforeUnloadHandlerHelper(handler);
 }
 
 /**
@@ -214,7 +214,7 @@ export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void)
  * @param handler - The handler to invoked by the app when they want the focus to be in the place of their choice.
  */
 export function registerFocusEnterHandler(handler: (navigateForward: boolean) => boolean): void {
-  pages.registerFocusEnterHandler(handler);
+  pages.registerFocusEnterHandlerHelper(handler);
 }
 
 /**
@@ -226,7 +226,7 @@ export function registerFocusEnterHandler(handler: (navigateForward: boolean) =>
  * @param handler - The handler to invoke when the user click on Settings.
  */
 export function registerChangeSettingsHandler(handler: () => void): void {
-  pages.config.registerChangeConfigHandler(handler);
+  pages.config.registerChangeConfigHandlerHelper(handler);
 }
 
 /**

--- a/packages/teams-js/src/public/settings.ts
+++ b/packages/teams-js/src/public/settings.ts
@@ -109,7 +109,7 @@ export namespace settings {
    * @param handler - The handler to invoke when the user selects the save button.
    */
   export function registerOnSaveHandler(handler: (evt: SaveEvent) => void): void {
-    pages.config.registerOnSaveHandler(handler);
+    pages.config.registerOnSaveHandlerHelper(handler);
   }
 
   /**
@@ -124,6 +124,6 @@ export namespace settings {
    * @param handler - The handler to invoke when the user selects the remove button.
    */
   export function registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void {
-    pages.config.registerOnRemoveHandler(handler);
+    pages.config.registerOnRemoveHandlerHelper(handler);
   }
 }

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -48,10 +48,31 @@ export namespace teamsCore {
    * @internal
    */
   export function registerOnLoadHandler(handler: (context: LoadContext) => void): void {
+    registerOnLoadHandlerHelper(handler, () => {
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+    });
+  }
+
+  /**
+   * @hidden
+   * Undocumented helper function with shared code between deprecated version and current version of the registerOnLoadHandler API.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
+   * @param handler - The handler to invoke when the page is loaded.
+   * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
+   */
+  export function registerOnLoadHandlerHelper(
+    handler: (context: LoadContext) => void,
+    versionSpecificHelper?: () => void,
+  ): void {
     ensureInitialized();
 
-    if (!isSupported()) {
-      throw errorNotSupportedOnPlatform;
+    if (versionSpecificHelper) {
+      versionSpecificHelper();
     }
 
     Handlers.registerOnLoadHandler(handler);
@@ -67,9 +88,31 @@ export namespace teamsCore {
    * @internal
    */
   export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void {
+    registerBeforeUnloadHandlerHelper(handler, () => {
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+    });
+  }
+
+  /**
+   * @hidden
+   * Undocumented helper function with shared code between deprecated version and current version of the registerBeforeUnloadHandler API.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
+   * @param handler - - The handler to invoke before the page is unloaded. If this handler returns true the page should
+   * invoke the readyToUnload function provided to it once it's ready to be unloaded.
+   * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
+   */
+  export function registerBeforeUnloadHandlerHelper(
+    handler: (readyToUnload: () => void) => boolean,
+    versionSpecificHelper?: () => void,
+  ): void {
     ensureInitialized();
-    if (!isSupported()) {
-      throw errorNotSupportedOnPlatform;
+    if (versionSpecificHelper) {
+      versionSpecificHelper();
     }
     Handlers.registerBeforeUnloadHandler(handler);
   }

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -26,6 +26,7 @@ import {
   setFrameContext,
   shareDeepLink,
 } from '../../src/public/publicAPIs';
+import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';
 
 describe('MicrosoftTeams-publicAPIs', () => {
@@ -46,6 +47,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
   afterEach(() => {
     // Reset the object since it's a singleton
     if (_uninitialize) {
+      utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
       _uninitialize();
     }
   });
@@ -141,6 +143,14 @@ describe('MicrosoftTeams-publicAPIs', () => {
     expect(handlerCalled).toBeTruthy();
   });
 
+  it('registerChangeSettingsHandler should not throw if pages.config is not supported', async () => {
+    await utils.initializeWithContext(FrameContexts.content);
+    utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: {} } });
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    expect(() => registerChangeSettingsHandler(() => {})).not.toThrowError();
+  });
+
   it('should successfully register a app button click handler', async () => {
     await utils.initializeWithContext(FrameContexts.content);
     let handlerCalled = false;
@@ -151,6 +161,14 @@ describe('MicrosoftTeams-publicAPIs', () => {
 
     utils.sendMessage('appButtonClick', '');
     expect(handlerCalled).toBeTruthy();
+  });
+
+  it('registerAppButtonHandler should not throw if pages.appButton is not supported', async () => {
+    await utils.initializeWithContext(FrameContexts.content);
+    utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: {} } });
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    expect(() => registerAppButtonClickHandler(() => {})).not.toThrowError();
   });
 
   it('should successfully register a app button hover enter handler', async () => {
@@ -166,6 +184,14 @@ describe('MicrosoftTeams-publicAPIs', () => {
     expect(handlerCalled).toBeTruthy();
   });
 
+  it('registerAppButtonHoverEnterHandler should not throw if pages.appButton is not supported', async () => {
+    await utils.initializeWithContext(FrameContexts.content);
+    utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: {} } });
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    expect(() => registerAppButtonHoverEnterHandler(() => {})).not.toThrowError();
+  });
+
   it('should successfully register a app button hover leave handler', async () => {
     await utils.initializeWithContext(FrameContexts.content);
     let handlerCalled = false;
@@ -177,6 +203,14 @@ describe('MicrosoftTeams-publicAPIs', () => {
     utils.sendMessage('appButtonHoverLeave', '');
 
     expect(handlerCalled).toBeTruthy();
+  });
+
+  it('registerAppButtonHoverLeaveHandler should not throw if pages.appButton is not supported', async () => {
+    await utils.initializeWithContext(FrameContexts.content);
+    utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: {} } });
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    expect(() => registerAppButtonHoverLeaveHandler(() => {})).not.toThrowError();
   });
 
   it('should successfully register a theme change handler', async () => {
@@ -216,17 +250,61 @@ describe('MicrosoftTeams-publicAPIs', () => {
     expect(handlerInvoked).toBe(true);
   });
 
+  it('registerBackButtonHandler should not throw if pages.backStack is not supported', async () => {
+    await utils.initializeWithContext(FrameContexts.content);
+    utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: {} } });
+
+    expect(() =>
+      registerBackButtonHandler(() => {
+        return true;
+      }),
+    ).not.toThrowError();
+  });
+
   it('should successfully register a focus enter handler and return true', async () => {
     await utils.initializeWithContext(FrameContexts.content);
 
     let handlerInvoked = false;
-    registerFocusEnterHandler((x: boolean) => {
+    registerFocusEnterHandler((_x: boolean) => {
       handlerInvoked = true;
       return true;
     });
 
     utils.sendMessage('focusEnter');
     expect(handlerInvoked).toBe(true);
+  });
+
+  it('registerFocusEnterHandler should not throw if pages is not supported', async () => {
+    await utils.initializeWithContext(FrameContexts.content);
+    utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const emptyHandler = (x: boolean): boolean => {
+      return true;
+    };
+    expect(() => microsoftTeams.registerFocusEnterHandler(emptyHandler)).not.toThrowError();
+  });
+
+  it('should successfully register a full screen handler', async () => {
+    await utils.initializeWithContext(FrameContexts.content); // this can be used in any context
+
+    let handlerInvoked = false;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    microsoftTeams.registerFullScreenHandler((_x: boolean) => {
+      handlerInvoked = true;
+    });
+
+    utils.sendMessage('fullScreenChange');
+    expect(handlerInvoked).toBe(true);
+  });
+
+  it('registerFullScreenHandler should not throw if pages is not supported', async () => {
+    await utils.initializeWithContext(FrameContexts.content); // this can be used in any context
+    utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
+    const emptyHandler = (x: boolean): void => {};
+    expect(() => microsoftTeams.registerFullScreenHandler(emptyHandler)).not.toThrowError();
   });
 
   it('should successfully get context', (done) => {
@@ -676,7 +754,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
     });
   });
 
-  it("Ctrl+P shouldn't call print handler if printCapabilty is disabled", () => {
+  it("Ctrl+P shouldn't call print handler if printCapability is disabled", () => {
     let handlerCalled = false;
     initialize();
     jest.spyOn(microsoftTeams, 'print').mockImplementation((): void => {
@@ -692,7 +770,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
     expect(handlerCalled).toBeFalsy();
   });
 
-  it("Cmd+P shouldn't call print handler if printCapabilty is disabled", () => {
+  it("Cmd+P shouldn't call print handler if printCapability is disabled", () => {
     let handlerCalled = false;
     initialize();
     jest.spyOn(microsoftTeams, 'print').mockImplementation((): void => {
@@ -776,6 +854,13 @@ describe('MicrosoftTeams-publicAPIs', () => {
 
       expect(handlerInvoked).toBe(true);
     });
+    it('registerOnLoadHandler should not throw if teamsCore is not supported', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      expect(() => registerOnLoadHandler(() => {})).not.toThrowError();
+    });
   });
 
   describe('should not allow authentication and remove context', () => {
@@ -824,6 +909,17 @@ describe('MicrosoftTeams-publicAPIs', () => {
       utils.sendMessage('beforeUnload');
 
       expect(handlerInvoked).toBe(true);
+    });
+
+    it('registerBeforeUnloadHandler should not throw if teamsCore is not supported', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+
+      expect(() =>
+        registerBeforeUnloadHandler(() => {
+          return true;
+        }),
+      ).not.toThrowError();
     });
 
     it('should call readyToUnload automatically when no before unload handler is registered', async () => {

--- a/packages/teams-js/test/public/settings.spec.ts
+++ b/packages/teams-js/test/public/settings.spec.ts
@@ -1,5 +1,6 @@
 import { FrameContexts } from '../../src/public';
 import { _uninitialize } from '../../src/public/publicAPIs';
+import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { settings } from '../../src/public/settings';
 import { Utils } from '../utils';
 
@@ -21,6 +22,7 @@ describe('settings', () => {
   afterEach(() => {
     // Reset the object since it's a singleton
     if (_uninitialize) {
+      utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
       _uninitialize();
     }
   });
@@ -210,6 +212,14 @@ describe('settings', () => {
       expect(handlerCalled).toBe(true);
     });
 
+    it('settings.registerOnSaveHandler should not throw if pages.config is not supported', async () => {
+      await utils.initializeWithContext(FrameContexts.settings);
+      utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: {} } });
+
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      expect(() => settings.registerOnSaveHandler(() => {})).not.toThrowError();
+    });
+
     it('settings.registerOnSaveHandler should successfully register a save handler', async () => {
       await utils.initializeWithContext(FrameContexts.settings);
 
@@ -344,6 +354,14 @@ describe('settings', () => {
       const message = utils.findMessageByFunc('settings.remove.success');
       expect(message).not.toBeNull();
       expect(message.args.length).toBe(0);
+    });
+
+    it('settings.registerOnRemoveHandler should not throw if pages.config is not supported', async () => {
+      await utils.initializeWithContext(FrameContexts.settings);
+      utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: {} } });
+
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      expect(() => settings.registerOnRemoveHandler(() => {})).not.toThrowError();
     });
 
     it('settings.registerOnRemoveHandler should successfully notify success from the registered remove handler', async () => {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Previously, the v1 versions of the `register*Handler` functions would throw if the v2 version of the API's capability was not supported, breaking backwards compatibility.

E.g.,:
If `pages.config` was not supported, calling `registerChangeSettingsHandler` would throw `ErrorCode.NOT_SUPPORTED_ON_PLATFORM`. 

This changes ensures that the v1 versions do not throw if the v2 capability is not supported, while keeping the v2 version's `isSupported` check present.

Fixes #1331 

### Main changes in the PR:

1. Added a register*HandlerHelper function in the v2 version of the API's capability. This helper takes an additional optional closure parameter that represents the v2-specific functionality that should still be executed. 
2. Updated the v2 register*Handler function to call the helper and pass in the `isSupported` check as the additional parameter.
3. Updated the v1 register*Handler function to call the helper without passing any additional parameter.
4. Note that I had to export these helper functions in order to call them in the v1 versions, but I added documentation comments to mark them hidden and internal and effectively hide them from the public docs.

## Validation

### Validation performed:

1. Added unit tests prior to implementing the fix to ensure existing (incorrect) behavior was correctly failing the tests (yay TDD!).

### Unit Tests added:

Yes

### End-to-end tests added:

Will add separately. Don't want to block this PR as it needs to get into the next release.

## Additional Requirements

### Change file added:

Yes

### Next/remaining steps:

- [ ] Add e2e tests
