### PR TITLE
Add OutlookWin32 to HostName enum

### DIFF
--- a/change/@microsoft-teams-js-8b731aef-816c-49f6-9435-5b79bc5b99ca.json
+++ b/change/@microsoft-teams-js-8b731aef-816c-49f6-9435-5b79bc5b99ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added OutlookWin32 to HostName enum",
+  "packageName": "@microsoft/teams-js",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-8b731aef-816c-49f6-9435-5b79bc5b99ca.json
+++ b/change/@microsoft-teams-js-8b731aef-816c-49f6-9435-5b79bc5b99ca.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Added OutlookWin32 to HostName enum",
+  "comment": "Added `OutlookWin32` to `HostName` enum",
   "packageName": "@microsoft/teams-js",
   "email": "email not defined",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -17,10 +17,30 @@ export enum HostClientType {
 }
 
 export enum HostName {
+  /**
+   * Office.com and Office Windows App
+   */
   office = 'Office',
+
+  /**
+   * For "desktop" specifically, this refers to the new, pre-release version of Outlook for Windows.
+   * Also used on other platforms that map to a single Outlook client.
+   */
   outlook = 'Outlook',
+
+  /**
+   * Outlook for Windows: the classic, native, desktop client
+   */
   outlookWin32 = 'OutlookWin32',
+
+  /**
+   * Microsoft-internal test Host
+   */
   orange = 'Orange',
+
+  /**
+   * Teams
+   */
   teams = 'Teams',
 }
 

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -19,6 +19,7 @@ export enum HostClientType {
 export enum HostName {
   office = 'Office',
   outlook = 'Outlook',
+  outlookWin32 = 'OutlookWin32',
   orange = 'Orange',
   teams = 'Teams',
 }


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Add a new value (`OutlookWin32`) to `HostName` enum.

### Main changes in the PR:

1. Add a new value (`OutlookWin32`) to `HostName` enum.

## Validation

### Validation performed:

N/A

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes
