### PR TITLE
Refactor register*Handler APIs calls to use a common helper function where possible

### DIFF
--- a/change/@microsoft-teams-js-ea1fbc8a-654d-4410-8191-321b66d8f2d8.json
+++ b/change/@microsoft-teams-js-ea1fbc8a-654d-4410-8191-321b66d8f2d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added one common `registerHandlerHelper` function to replace several helpers.",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -212,27 +212,6 @@ export namespace pages {
   }
 
   /**
-   * @hidden
-   * Undocumented helper function with shared code between deprecated version and current version of the registerFullScreenHandler API.
-   *
-   * @internal
-   * Limited to Microsoft-internal use
-   *
-   * @param handler - The handler to invoke when the user toggles full-screen view for a tab.
-   * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
-   */
-  export function registerFullScreenHandlerHelper(
-    handler: (isFullScreen: boolean) => void,
-    versionSpecificHelper?: () => void,
-  ): void {
-    ensureInitialized();
-    if (versionSpecificHelper) {
-      versionSpecificHelper();
-    }
-    registerHandler('fullScreenChange', handler);
-  }
-
-  /**
    * Checks if the pages capability is supported by the host
    * @returns true if the pages capability is enabled in runtime.supports.pages and
    * false if it is disabled
@@ -729,29 +708,11 @@ export namespace pages {
      * @param handler - The handler to invoke when the personal app button is clicked in the app bar.
      */
     export function onClick(handler: () => void): void {
-      onClickHelper(handler, () => {
+      registerHandlerHelper('appButtonClick', handler, [FrameContexts.content], () => {
         if (!isSupported()) {
           throw errorNotSupportedOnPlatform;
         }
       });
-    }
-
-    /**
-     * @hidden
-     * Undocumented helper function with shared code between deprecated version and current version of the onClick API.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     *
-     * @param handler - The handler to invoke when the personal app button is clicked in the app bar.
-     * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
-     */
-    export function onClickHelper(handler: () => void, versionSpecificHelper?: () => void): void {
-      ensureInitialized(FrameContexts.content);
-      if (versionSpecificHelper) {
-        versionSpecificHelper();
-      }
-      registerHandler('appButtonClick', handler);
     }
 
     /**
@@ -760,29 +721,11 @@ export namespace pages {
      * @param handler - The handler to invoke when entering hover of the personal app button in the app bar.
      */
     export function onHoverEnter(handler: () => void): void {
-      onHoverEnterHelper(handler, () => {
+      registerHandlerHelper('appButtonHoverEnter', handler, [FrameContexts.content], () => {
         if (!isSupported()) {
           throw errorNotSupportedOnPlatform;
         }
       });
-    }
-
-    /**
-     * @hidden
-     * Undocumented helper function with shared code between deprecated version and current version of the onHoverEnter API.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     *
-     * @param handler - The handler to invoke when entering hover of the personal app button in the app bar.
-     * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
-     */
-    export function onHoverEnterHelper(handler: () => void, versionSpecificHelper?: () => void): void {
-      ensureInitialized(FrameContexts.content);
-      if (versionSpecificHelper) {
-        versionSpecificHelper();
-      }
-      registerHandler('appButtonHoverEnter', handler);
     }
 
     /**
@@ -791,29 +734,11 @@ export namespace pages {
      * @param handler - The handler to invoke when exiting hover of the personal app button in the app bar.
      */
     export function onHoverLeave(handler: () => void): void {
-      onHoverLeaveHelper(handler, () => {
+      registerHandlerHelper('appButtonHoverLeave', handler, [FrameContexts.content], () => {
         if (!isSupported()) {
           throw errorNotSupportedOnPlatform;
         }
       });
-    }
-
-    /**
-     * @hidden
-     * Undocumented helper function with shared code between deprecated version and current version of the onHoverLeave API.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     *
-     * @param handler - The handler to invoke when existing hover of the personal app button in the app bar.
-     * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
-     */
-    export function onHoverLeaveHelper(handler: () => void, versionSpecificHelper?: () => void): void {
-      ensureInitialized(FrameContexts.content);
-      if (versionSpecificHelper) {
-        versionSpecificHelper();
-      }
-      registerHandler('appButtonHoverLeave', handler);
     }
 
     /**

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -4,7 +4,7 @@ import {
   sendAndUnwrap,
   sendMessageToParent,
 } from '../internal/communication';
-import { registerHandler } from '../internal/handlers';
+import { registerHandler, registerHandlerHelper } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { createTeamsAppLink } from '../internal/utils';
 import { app } from './app';
@@ -42,32 +42,11 @@ export namespace pages {
    * Limited to Microsoft-internal use
    */
   export function registerFocusEnterHandler(handler: (navigateForward: boolean) => void): void {
-    ensureInitialized();
-    if (!isSupported()) {
-      throw errorNotSupportedOnPlatform;
-    }
-    registerHandler('focusEnter', handler);
-  }
-
-  /**
-   * @hidden
-   * Undocumented helper function with shared code between deprecated version and current version of the registerFocusEnterHandler API.
-   *
-   * @internal
-   * Limited to Microsoft-internal use
-   *
-   * @param handler - The handler for placing focus within the application.
-   * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
-   */
-  export function registerFocusEnterHandlerHelper(
-    handler: (navigateForward: boolean) => void,
-    versionSpecificHelper?: () => void,
-  ): void {
-    ensureInitialized();
-    if (versionSpecificHelper) {
-      versionSpecificHelper();
-    }
-    registerHandler('focusEnter', handler);
+    registerHandlerHelper('focusEnter', handler, [], () => {
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+    });
   }
 
   /**
@@ -225,11 +204,11 @@ export namespace pages {
    * @param handler - The handler to invoke when the user toggles full-screen view for a tab.
    */
   export function registerFullScreenHandler(handler: (isFullScreen: boolean) => void): void {
-    ensureInitialized();
-    if (!isSupported()) {
-      throw errorNotSupportedOnPlatform;
-    }
-    registerHandler('fullScreenChange', handler);
+    registerHandlerHelper('fullScreenChange', handler, [], () => {
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+    });
   }
 
   /**
@@ -492,31 +471,11 @@ export namespace pages {
      * @param handler - The handler to invoke when the user clicks on Settings.
      */
     export function registerChangeConfigHandler(handler: () => void): void {
-      registerChangeConfigHandlerHelper(handler, () => {
+      registerHandlerHelper('changeSettings', handler, [FrameContexts.content], () => {
         if (!isSupported()) {
           throw errorNotSupportedOnPlatform;
         }
       });
-    }
-
-    /**
-     * @hidden
-     * Undocumented helper function with shared code between deprecated version and current version of the registerConfigChangeHandler API.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     *
-     * @param handler - The handler to invoke when the user clicks on Settings.
-     * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
-     */
-    export function registerChangeConfigHandlerHelper(handler: () => void, versionSpecificHelper?: () => void): void {
-      ensureInitialized(FrameContexts.content);
-
-      if (versionSpecificHelper) {
-        versionSpecificHelper();
-      }
-
-      registerHandler('changeSettings', handler);
     }
 
     /**

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -1,3 +1,4 @@
+import { registerHandlerHelper } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { getGenericOnCompleteHandler } from '../internal/utils';
 import { app } from './app';
@@ -214,7 +215,7 @@ export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void)
  * @param handler - The handler to invoked by the app when they want the focus to be in the place of their choice.
  */
 export function registerFocusEnterHandler(handler: (navigateForward: boolean) => boolean): void {
-  pages.registerFocusEnterHandlerHelper(handler);
+  registerHandlerHelper('focusEnter', handler, []);
 }
 
 /**
@@ -226,7 +227,7 @@ export function registerFocusEnterHandler(handler: (navigateForward: boolean) =>
  * @param handler - The handler to invoke when the user click on Settings.
  */
 export function registerChangeSettingsHandler(handler: () => void): void {
-  pages.config.registerChangeConfigHandlerHelper(handler);
+  registerHandlerHelper('changeSettings', handler, [FrameContexts.content]);
 }
 
 /**

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -121,7 +121,7 @@ export function registerOnThemeChangeHandler(handler: (theme: string) => void): 
  * @param handler - The handler to invoke when the user toggles full-screen view for a tab.
  */
 export function registerFullScreenHandler(handler: (isFullScreen: boolean) => void): void {
-  pages.registerFullScreenHandlerHelper(handler);
+  registerHandlerHelper('fullScreenChange', handler, []);
 }
 
 /**
@@ -134,7 +134,7 @@ export function registerFullScreenHandler(handler: (isFullScreen: boolean) => vo
  * @param handler - The handler to invoke when the personal app button is clicked in the app bar.
  */
 export function registerAppButtonClickHandler(handler: () => void): void {
-  pages.appButton.onClickHelper(handler);
+  registerHandlerHelper('appButtonClick', handler, [FrameContexts.content]);
 }
 
 /**
@@ -147,7 +147,7 @@ export function registerAppButtonClickHandler(handler: () => void): void {
  * @param handler - The handler to invoke when entering hover of the personal app button in the app bar.
  */
 export function registerAppButtonHoverEnterHandler(handler: () => void): void {
-  pages.appButton.onHoverEnterHelper(handler);
+  registerHandlerHelper('appButtonHoverEnter', handler, [FrameContexts.content]);
 }
 
 /**
@@ -160,7 +160,7 @@ export function registerAppButtonHoverEnterHandler(handler: () => void): void {
  *
  */
 export function registerAppButtonHoverLeaveHandler(handler: () => void): void {
-  pages.appButton.onHoverLeaveHelper(handler);
+  registerHandlerHelper('appButtonHoverLeave', handler, [FrameContexts.content]);
 }
 
 /**


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Based on the PR feedback from #1335, this change removes several register\*HandlerHelper functions in favor of using a common `registerHandlerHelper` function. I chose to keep several of the specific register\*HandlerHelper functions (`pages.config.registerOnSaveHandlerHelper`, `pages.config.registerOnRemoveHandlerHelper`, `pages.backStack.registerBackButtonHandlerHelper`, `teamsCore.registerOnLoadHandlerHelper`, and `teamsCore.registerBeforeUnloadHandlerHelper` due to the unique code patterns they each have). I think this approach is cleaner overall.

### Main changes in the PR:

1. Added `registerHandlerHelper` function to src/internal/handlers.ts. Included reference documentation indicating it should not be used outside of the SDK.
2. Removed several register\*HandlerHelper functions and call `registerHandlerHelper` from the respective register\*Handler APIs instead.

## Validation

### Validation performed:

1. Unit tests pass.

### Unit Tests added:

No additional unit tests needed as this was refactoring.

### End-to-end tests added:

No, still pending as per the previous PR.

## Additional Requirements

### Change file added:

Yes

