### PR TITLE
Update dialog.submit and dialog.sendMessageToParentFromDialog

### DIFF
--- a/change/@microsoft-teams-js-87e67164-063e-4f04-81b1-03d17d698b48.json
+++ b/change/@microsoft-teams-js-87e67164-063e-4f04-81b1-03d17d698b48.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update dialog.submit and dialog.sendMessageToParentFromDialog to handle situation when called and contentActions are present and arguments are passed to functions",
+  "packageName": "@microsoft/teams-js",
+  "email": "jekoch@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-87e67164-063e-4f04-81b1-03d17d698b48.json
+++ b/change/@microsoft-teams-js-87e67164-063e-4f04-81b1-03d17d698b48.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "update dialog.submit and dialog.sendMessageToParentFromDialog to handle situation when called and contentActions are present and arguments are passed to functions",
+  "comment": "updated dialog.submit and dialog.sendMessageToParentFromDialog to handle situation when called and contentActions are present and arguments are passed to functions",
   "packageName": "@microsoft/teams-js",
   "email": "jekoch@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -83,3 +83,5 @@ export enum ChannelType {
 }
 
 export const errorNotSupportedOnPlatform: SdkError = { errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM };
+
+export const errorInvalidArguments: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -85,3 +85,5 @@ export enum ChannelType {
 export const errorNotSupportedOnPlatform: SdkError = { errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM };
 
 export const errorInvalidArguments: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
+
+export const errorNotSupportedInCurrentContext: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -108,32 +108,24 @@ export namespace dialog {
    * @param result - The result to be sent to the bot or the app. Typically a JSON object or a serialized version of it
    * @param appIds - Helps to validate that the call originates from the same appId as the one that invoked the task module
    */
-  export function submit(result?: string | object, appIds?: string | string[]): void {
+  export function submit(result?: string | object, appIds?: string | string[]): Promise<void> {
     ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.task, FrameContexts.meetingStage);
 
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
 
-    app
-      .getContext()
-      .then((appContext) => {
-        // if actionInfo exists in appContext, the dialog was loaded from a 3rd party app,
-        // and if submit was called with a result, throw an error because the result cannot be
-        // passed along to the desired recipient
-        if (result && appContext.actionInfo) {
-          throw errorInvalidArguments;
-        } else {
-          // Send tasks.completeTask instead of tasks.submitTask message for backward compatibility with Mobile clients
-          sendMessageToParent('tasks.completeTask', [
-            result,
-            appIds ? (Array.isArray(appIds) ? appIds : [appIds]) : [],
-          ]);
-        }
-      })
-      .catch((error) => {
-        throw error;
-      });
+    return app.getContext().then((appContext) => {
+      // if actionInfo exists in appContext, the dialog was loaded from a 3rd party app,
+      // and if submit was called with a result, throw an error because the result cannot be
+      // passed along to the desired recipient
+      if (result && appContext.actionInfo) {
+        throw errorInvalidArguments;
+      } else {
+        // Send tasks.completeTask instead of tasks.submitTask message for backward compatibility with Mobile clients
+        sendMessageToParent('tasks.completeTask', [result, appIds ? (Array.isArray(appIds) ? appIds : [appIds]) : []]);
+      }
+    });
   }
 
   /**
@@ -147,7 +139,7 @@ export namespace dialog {
   export function sendMessageToParentFromDialog(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     message: any,
-  ): void {
+  ): Promise<void> {
     ensureInitialized(FrameContexts.task);
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
@@ -156,18 +148,13 @@ export namespace dialog {
     // if actionInfo exists in appContext, the dialog was loaded from a 3rd party app,
     // and if sendMessageToParentFromDialog was called with a message,
     // throw an error because the message cannot be passed along to the desired recipient
-    app
-      .getContext()
-      .then((appContext) => {
-        if (appContext.actionInfo) {
-          throw errorNotSupportedInCurrentContext;
-        } else {
-          sendMessageToParent('messageForParent', [message]);
-        }
-      })
-      .catch((error) => {
-        throw error;
-      });
+    app.getContext().then((appContext) => {
+      if (appContext.actionInfo) {
+        throw errorNotSupportedInCurrentContext;
+      } else {
+        sendMessageToParent('messageForParent', [message]);
+      }
+    });
   }
 
   /**

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -148,7 +148,7 @@ export namespace dialog {
     // if actionInfo exists in appContext, the dialog was loaded from a 3rd party app,
     // and if sendMessageToParentFromDialog was called with a message,
     // throw an error because the message cannot be passed along to the desired recipient
-    app.getContext().then((appContext) => {
+    return app.getContext().then((appContext) => {
       if (appContext.actionInfo) {
         throw errorNotSupportedInCurrentContext;
       } else {

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -6,7 +6,8 @@ import { sendMessageToParent } from '../internal/communication';
 import { GlobalVars } from '../internal/globalVars';
 import { registerHandler, removeHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
-import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from './constants';
+import { app } from '.';
+import { DialogDimension, errorInvalidArguments, errorNotSupportedOnPlatform, FrameContexts } from './constants';
 import { BotUrlDialogInfo, DialogInfo, DialogSize, UrlDialogInfo } from './interfaces';
 import { runtime } from './runtime';
 
@@ -107,8 +108,14 @@ export namespace dialog {
       throw errorNotSupportedOnPlatform;
     }
 
-    // Send tasks.completeTask instead of tasks.submitTask message for backward compatibility with Mobile clients
-    sendMessageToParent('tasks.completeTask', [result, appIds ? (Array.isArray(appIds) ? appIds : [appIds]) : []]);
+    app.getContext().then((appContext) => {
+      if (result && appContext.actionInfo) {
+        throw errorInvalidArguments;
+      } else {
+        // Send tasks.completeTask instead of tasks.submitTask message for backward compatibility with Mobile clients
+        sendMessageToParent('tasks.completeTask', [result, appIds ? (Array.isArray(appIds) ? appIds : [appIds]) : []]);
+      }
+    });
   }
 
   /**

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -415,106 +415,130 @@ describe('Dialog', () => {
     });
   });
   describe('submit', () => {
-    it('should not allow calls before initialization', () => {
-      expect(() => dialog.submit()).toThrowError('The library has not yet been initialized');
-    });
+    // it('should not allow calls before initialization', () => {
+    //   expect(() => dialog.submit()).toThrowError('The library has not yet been initialized');
+    // });
     const allowedContexts = [
       FrameContexts.content,
       FrameContexts.sidePanel,
       FrameContexts.task,
       FrameContexts.meetingStage,
     ];
-    Object.values(FrameContexts).forEach((context) => {
-      if (allowedContexts.some((allowedContexts) => allowedContexts === context)) {
-        it(`FRAMED: should throw error when dialog is not supported in ${context} context`, async () => {
-          await framedMock.initializeWithContext(context);
-          framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-          expect.assertions(1);
-          try {
-            dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
-          } catch (e) {
-            expect(e).toEqual(errorNotSupportedOnPlatform);
-          }
-        });
+    // Object.values(FrameContexts).forEach((context) => {
+    //   if (allowedContexts.some((allowedContexts) => allowedContexts === context)) {
 
-        it(`FRAMED: should successfully pass result and appIds parameters when called from ${JSON.stringify(
-          context,
-        )}`, async () => {
-          await framedMock.initializeWithContext(context);
-          dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
-          const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
-          expect(submitMessage).not.toBeNull();
-          expect(submitMessage.args).toEqual(['someResult', ['someAppId', 'someOtherAppId']]);
-        });
+    // it(`FRAMED: should throw error when dialog is not supported in ${context} context`, async () => {
+    //   await framedMock.initializeWithContext(context);
+    //   framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
+    //   expect.assertions(1);
+    //   try {
+    //     dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+    //   } catch (e) {
+    //     expect(e).toEqual(errorNotSupportedOnPlatform);
+    //   }
+    // });
 
-        it(`FRAMELESS: should throw error when dialog is not supported in ${context} context`, async () => {
-          await framelessMock.initializeWithContext(context);
-          framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-          expect.assertions(4);
-          try {
-            dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
-          } catch (e) {
-            expect(e).toEqual(errorNotSupportedOnPlatform);
-          }
-        });
+    // it(`FRAMED: should successfully pass result and appIds parameters when called from ${JSON.stringify(
+    //   context,
+    // )}`, async () => {
+    //   await framedMock.initializeWithContext(context);
+    //   dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+    //   const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
+    //   expect(submitMessage).not.toBeNull();
+    //   expect(submitMessage.args).toEqual(['someResult', ['someAppId', 'someOtherAppId']]);
+    // });
 
-        it(`FRAMELESS: should successfully pass result and appIds parameters when called from ${JSON.stringify(
-          context,
-        )}`, async () => {
-          await framelessMock.initializeWithContext(context);
-          dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
-          const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
-          expect(submitMessage).not.toBeNull();
-          expect(submitMessage.args).toEqual(['someResult', ['someAppId', 'someOtherAppId']]);
-        });
+    // it(`FRAMELESS: should throw error when dialog is not supported in ${context} context`, async () => {
+    //   await framelessMock.initializeWithContext(context);
+    //   framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
+    //   expect.assertions(4);
+    //   try {
+    //     dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+    //   } catch (e) {
+    //     expect(e).toEqual(errorNotSupportedOnPlatform);
+    //   }
+    // });
+    const context = allowedContexts[0];
+    it('FRAMED: should throw an error if action info is present and submit is called with arguments', async () => {
+      await framedMock.initializeWithContext(context);
 
-        it(`FRAMED: should handle a single string passed as appIds parameter ${JSON.stringify(context)}`, async () => {
-          await framedMock.initializeWithContext(context);
-          dialog.submit('someResult', 'someAppId');
-          const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
-          expect(submitMessage).not.toBeNull();
-          expect(submitMessage.args).toEqual(['someResult', ['someAppId']]);
-        });
-
-        it(`FRAMELESS: should handle a single string passed as appIds parameter ${JSON.stringify(
-          context,
-        )}`, async () => {
-          await framelessMock.initializeWithContext(context);
-          dialog.submit('someResult', 'someAppId');
-          const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
-          expect(submitMessage).not.toBeNull();
-          expect(submitMessage.args).toEqual(['someResult', ['someAppId']]);
-        });
-        it(`FRAMED: should successfully pass results when no appIds parameters are provided ${JSON.stringify(
-          context,
-        )}`, async () => {
-          await framedMock.initializeWithContext(context);
-          dialog.submit('someResult');
-          const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
-          expect(submitMessage).not.toBeNull();
-          expect(submitMessage.args).toEqual(['someResult', []]);
-        });
-
-        it(`FRAMELESS: should successfully pass results when no appIds parameters are provided ${JSON.stringify(
-          context,
-        )}`, async () => {
-          await framelessMock.initializeWithContext(context);
-          dialog.submit('someResult');
-          const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
-          expect(submitMessage).not.toBeNull();
-          expect(submitMessage.args).toEqual(['someResult', []]);
-        });
-      } else {
-        it(`FRAMED: should not allow calls from context context: ${JSON.stringify(context)}`, async () => {
-          await framedMock.initializeWithContext(context);
-          expect(() => dialog.submit()).toThrowError(
-            `This call is only allowed in following contexts: ${JSON.stringify(
-              allowedContexts,
-            )}. Current context: ${JSON.stringify(context)}.`,
-          );
-        });
+      framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
+      expect.assertions(4);
+      try {
+        dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+      } catch (e) {
+        expect(e).toEqual(errorNotSupportedOnPlatform);
       }
     });
+
+    it('FRAMELESS: should throw an error if action info is present and submit is called with arguments', async () => {
+      await framelessMock.initializeWithContext(context);
+      framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
+      expect.assertions(4);
+      try {
+        dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+      } catch (e) {
+        expect(e).toEqual(errorNotSupportedOnPlatform);
+      }
+    });
+
+    //   it(`FRAMELESS: should successfully pass result and appIds parameters when called from ${JSON.stringify(
+    //     context,
+    //   )}`, async () => {
+    //     await framelessMock.initializeWithContext(context);
+    //     dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+    //     const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
+    //     expect(submitMessage).not.toBeNull();
+    //     expect(submitMessage.args).toEqual(['someResult', ['someAppId', 'someOtherAppId']]);
+    //   });
+
+    //   it(`FRAMED: should handle a single string passed as appIds parameter ${JSON.stringify(context)}`, async () => {
+    //     await framedMock.initializeWithContext(context);
+    //     dialog.submit('someResult', 'someAppId');
+    //     const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
+    //     expect(submitMessage).not.toBeNull();
+    //     expect(submitMessage.args).toEqual(['someResult', ['someAppId']]);
+    //   });
+
+    //   it(`FRAMELESS: should handle a single string passed as appIds parameter ${JSON.stringify(
+    //     context,
+    //   )}`, async () => {
+    //     await framelessMock.initializeWithContext(context);
+    //     dialog.submit('someResult', 'someAppId');
+    //     const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
+    //     expect(submitMessage).not.toBeNull();
+    //     expect(submitMessage.args).toEqual(['someResult', ['someAppId']]);
+    //   });
+    //   it(`FRAMED: should successfully pass results when no appIds parameters are provided ${JSON.stringify(
+    //     context,
+    //   )}`, async () => {
+    //     await framedMock.initializeWithContext(context);
+    //     dialog.submit('someResult');
+    //     const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
+    //     expect(submitMessage).not.toBeNull();
+    //     expect(submitMessage.args).toEqual(['someResult', []]);
+    //   });
+
+    //   it(`FRAMELESS: should successfully pass results when no appIds parameters are provided ${JSON.stringify(
+    //     context,
+    //   )}`, async () => {
+    //     await framelessMock.initializeWithContext(context);
+    //     dialog.submit('someResult');
+    //     const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
+    //     expect(submitMessage).not.toBeNull();
+    //     expect(submitMessage.args).toEqual(['someResult', []]);
+    //   });
+    // } else {
+    //   it(`FRAMED: should not allow calls from context context: ${JSON.stringify(context)}`, async () => {
+    //     await framedMock.initializeWithContext(context);
+    //     expect(() => dialog.submit()).toThrowError(
+    //       `This call is only allowed in following contexts: ${JSON.stringify(
+    //         allowedContexts,
+    //       )}. Current context: ${JSON.stringify(context)}.`,
+    //     );
+    //   });
+    // }
+    // });
   });
   describe('dialog.isSupported function', () => {
     it('dialog.isSupported should return false if the runtime says dialog is not supported', () => {

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -1,7 +1,12 @@
 import { doesHandlerExist } from '../../src/internal/handlers';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { app } from '../../src/public/app';
-import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
+import {
+  DialogDimension,
+  errorInvalidArguments,
+  errorNotSupportedOnPlatform,
+  FrameContexts,
+} from '../../src/public/constants';
 import { dialog } from '../../src/public/dialog';
 import { DialogSize } from '../../src/public/interfaces';
 import { BotUrlDialogInfo, UrlDialogInfo } from '../../src/public/interfaces';
@@ -415,130 +420,132 @@ describe('Dialog', () => {
     });
   });
   describe('submit', () => {
-    // it('should not allow calls before initialization', () => {
-    //   expect(() => dialog.submit()).toThrowError('The library has not yet been initialized');
-    // });
+    it('should not allow calls before initialization', () => {
+      expect(() => dialog.submit()).toThrowError('The library has not yet been initialized');
+    });
     const allowedContexts = [
       FrameContexts.content,
       FrameContexts.sidePanel,
       FrameContexts.task,
       FrameContexts.meetingStage,
     ];
-    // Object.values(FrameContexts).forEach((context) => {
-    //   if (allowedContexts.some((allowedContexts) => allowedContexts === context)) {
+    Object.values(FrameContexts).forEach((context) => {
+      if (allowedContexts.some((allowedContexts) => allowedContexts === context)) {
+        it(`FRAMED: should throw error when dialog is not supported in ${context} context`, async () => {
+          await framedMock.initializeWithContext(context);
+          framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
+          expect.assertions(1);
+          try {
+            dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+          } catch (e) {
+            expect(e).toEqual(errorNotSupportedOnPlatform);
+          }
+        });
 
-    // it(`FRAMED: should throw error when dialog is not supported in ${context} context`, async () => {
-    //   await framedMock.initializeWithContext(context);
-    //   framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-    //   expect.assertions(1);
-    //   try {
-    //     dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
-    //   } catch (e) {
-    //     expect(e).toEqual(errorNotSupportedOnPlatform);
-    //   }
-    // });
+        it(`FRAMED: should successfully pass result and appIds parameters when called from ${JSON.stringify(
+          context,
+        )}`, async () => {
+          await framedMock.initializeWithContext(context);
+          dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+          const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
+          expect(submitMessage).not.toBeNull();
+          expect(submitMessage.args).toEqual(['someResult', ['someAppId', 'someOtherAppId']]);
+        });
 
-    // it(`FRAMED: should successfully pass result and appIds parameters when called from ${JSON.stringify(
-    //   context,
-    // )}`, async () => {
-    //   await framedMock.initializeWithContext(context);
-    //   dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
-    //   const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
-    //   expect(submitMessage).not.toBeNull();
-    //   expect(submitMessage.args).toEqual(['someResult', ['someAppId', 'someOtherAppId']]);
-    // });
+        it(`FRAMELESS: should throw error when dialog is not supported in ${context} context`, async () => {
+          await framelessMock.initializeWithContext(context);
+          framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
+          expect.assertions(4);
+          try {
+            dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+          } catch (e) {
+            expect(e).toEqual(errorNotSupportedOnPlatform);
+          }
+        });
 
-    // it(`FRAMELESS: should throw error when dialog is not supported in ${context} context`, async () => {
-    //   await framelessMock.initializeWithContext(context);
-    //   framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-    //   expect.assertions(4);
-    //   try {
-    //     dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
-    //   } catch (e) {
-    //     expect(e).toEqual(errorNotSupportedOnPlatform);
-    //   }
-    // });
-    const context = allowedContexts[0];
-    it('FRAMED: should throw an error if action info is present and submit is called with arguments', async () => {
-      await framedMock.initializeWithContext(context);
+        it('FRAMED: should throw an error if actionInfo is present in appContext and submit is called with arguments', async () => {
+          app.getContext = jest.fn().mockResolvedValueOnce(framedMock.setAppContext(context));
+          await framedMock.initializeWithContext(context);
+          framedMock.setRuntimeConfig({ apiVersion: 1, supports: { dialog: {} } });
 
-      framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-      expect.assertions(4);
-      try {
-        dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
-      } catch (e) {
-        expect(e).toEqual(errorNotSupportedOnPlatform);
+          expect.assertions(1);
+          try {
+            await dialog.submit('someResult');
+          } catch (e) {
+            expect(e).toEqual(errorInvalidArguments);
+          }
+        });
+
+        it('FRAMELESS: should throw an error if actionInfo is present in appContext and submit is called with arguments', async () => {
+          app.getContext = jest.fn().mockResolvedValueOnce(framedMock.setAppContext(context));
+          await framelessMock.initializeWithContext(context);
+          framedMock.setRuntimeConfig({ apiVersion: 1, supports: { dialog: {} } });
+
+          expect.assertions(4);
+          try {
+            await dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+          } catch (e) {
+            expect(e).toEqual(errorInvalidArguments);
+          }
+        });
+
+        it(`FRAMELESS: should successfully pass result and appIds parameters when called from ${JSON.stringify(
+          context,
+        )}`, async () => {
+          await framelessMock.initializeWithContext(context);
+          dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+          const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
+          expect(submitMessage).not.toBeNull();
+          expect(submitMessage.args).toEqual(['someResult', ['someAppId', 'someOtherAppId']]);
+        });
+
+        it(`FRAMED: should handle a single string passed as appIds parameter ${JSON.stringify(context)}`, async () => {
+          await framedMock.initializeWithContext(context);
+          dialog.submit('someResult', 'someAppId');
+          const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
+          expect(submitMessage).not.toBeNull();
+          expect(submitMessage.args).toEqual(['someResult', ['someAppId']]);
+        });
+
+        it(`FRAMELESS: should handle a single string passed as appIds parameter ${JSON.stringify(
+          context,
+        )}`, async () => {
+          await framelessMock.initializeWithContext(context);
+          dialog.submit('someResult', 'someAppId');
+          const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
+          expect(submitMessage).not.toBeNull();
+          expect(submitMessage.args).toEqual(['someResult', ['someAppId']]);
+        });
+        it(`FRAMED: should successfully pass results when no appIds parameters are provided ${JSON.stringify(
+          context,
+        )}`, async () => {
+          await framedMock.initializeWithContext(context);
+          dialog.submit('someResult');
+          const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
+          expect(submitMessage).not.toBeNull();
+          expect(submitMessage.args).toEqual(['someResult', []]);
+        });
+
+        it(`FRAMELESS: should successfully pass results when no appIds parameters are provided ${JSON.stringify(
+          context,
+        )}`, async () => {
+          await framelessMock.initializeWithContext(context);
+          dialog.submit('someResult');
+          const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
+          expect(submitMessage).not.toBeNull();
+          expect(submitMessage.args).toEqual(['someResult', []]);
+        });
+      } else {
+        it(`FRAMED: should not allow calls from context context: ${JSON.stringify(context)}`, async () => {
+          await framedMock.initializeWithContext(context);
+          expect(() => dialog.submit()).toThrowError(
+            `This call is only allowed in following contexts: ${JSON.stringify(
+              allowedContexts,
+            )}. Current context: ${JSON.stringify(context)}.`,
+          );
+        });
       }
     });
-
-    it('FRAMELESS: should throw an error if action info is present and submit is called with arguments', async () => {
-      await framelessMock.initializeWithContext(context);
-      framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-      expect.assertions(4);
-      try {
-        dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
-      } catch (e) {
-        expect(e).toEqual(errorNotSupportedOnPlatform);
-      }
-    });
-
-    //   it(`FRAMELESS: should successfully pass result and appIds parameters when called from ${JSON.stringify(
-    //     context,
-    //   )}`, async () => {
-    //     await framelessMock.initializeWithContext(context);
-    //     dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
-    //     const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
-    //     expect(submitMessage).not.toBeNull();
-    //     expect(submitMessage.args).toEqual(['someResult', ['someAppId', 'someOtherAppId']]);
-    //   });
-
-    //   it(`FRAMED: should handle a single string passed as appIds parameter ${JSON.stringify(context)}`, async () => {
-    //     await framedMock.initializeWithContext(context);
-    //     dialog.submit('someResult', 'someAppId');
-    //     const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
-    //     expect(submitMessage).not.toBeNull();
-    //     expect(submitMessage.args).toEqual(['someResult', ['someAppId']]);
-    //   });
-
-    //   it(`FRAMELESS: should handle a single string passed as appIds parameter ${JSON.stringify(
-    //     context,
-    //   )}`, async () => {
-    //     await framelessMock.initializeWithContext(context);
-    //     dialog.submit('someResult', 'someAppId');
-    //     const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
-    //     expect(submitMessage).not.toBeNull();
-    //     expect(submitMessage.args).toEqual(['someResult', ['someAppId']]);
-    //   });
-    //   it(`FRAMED: should successfully pass results when no appIds parameters are provided ${JSON.stringify(
-    //     context,
-    //   )}`, async () => {
-    //     await framedMock.initializeWithContext(context);
-    //     dialog.submit('someResult');
-    //     const submitMessage = framedMock.findMessageByFunc('tasks.completeTask');
-    //     expect(submitMessage).not.toBeNull();
-    //     expect(submitMessage.args).toEqual(['someResult', []]);
-    //   });
-
-    //   it(`FRAMELESS: should successfully pass results when no appIds parameters are provided ${JSON.stringify(
-    //     context,
-    //   )}`, async () => {
-    //     await framelessMock.initializeWithContext(context);
-    //     dialog.submit('someResult');
-    //     const submitMessage = framelessMock.findMessageByFunc('tasks.completeTask');
-    //     expect(submitMessage).not.toBeNull();
-    //     expect(submitMessage.args).toEqual(['someResult', []]);
-    //   });
-    // } else {
-    //   it(`FRAMED: should not allow calls from context context: ${JSON.stringify(context)}`, async () => {
-    //     await framedMock.initializeWithContext(context);
-    //     expect(() => dialog.submit()).toThrowError(
-    //       `This call is only allowed in following contexts: ${JSON.stringify(
-    //         allowedContexts,
-    //       )}. Current context: ${JSON.stringify(context)}.`,
-    //     );
-    //   });
-    // }
-    // });
   });
   describe('dialog.isSupported function', () => {
     it('dialog.isSupported should return false if the runtime says dialog is not supported', () => {
@@ -928,6 +935,31 @@ describe('Dialog', () => {
             const message = framelessMock.findMessageByFunc('messageForParent');
             expect(message).not.toBeUndefined();
             expect(message.args).toStrictEqual(['exampleMessage']);
+          });
+          it('FRAMED: should throw an error if actionInfo is present in appContext and sendMessageToParentFromDialog is called with arguments', async () => {
+            app.getContext = jest.fn().mockResolvedValueOnce(framedMock.setAppContext(frameContext));
+            await framedMock.initializeWithContext(frameContext);
+            framedMock.setRuntimeConfig({ apiVersion: 1, supports: { dialog: {} } });
+
+            expect.assertions(1);
+            try {
+              await dialog.sendMessageToParentFromDialog('someMessage');
+            } catch (e) {
+              expect(e).toEqual(errorInvalidArguments);
+            }
+          });
+
+          it('FRAMELESS: should throw an error if actionInfo is present in appContext and sendMessageToParentFromDialog is called with arguments', async () => {
+            app.getContext = jest.fn().mockResolvedValueOnce(framedMock.setAppContext(frameContext));
+            await framelessMock.initializeWithContext(frameContext);
+            framedMock.setRuntimeConfig({ apiVersion: 1, supports: { dialog: {} } });
+
+            expect.assertions(4);
+            try {
+              await dialog.sendMessageToParentFromDialog('someMessage');
+            } catch (e) {
+              expect(e).toEqual(errorInvalidArguments);
+            }
           });
         } else {
           it(`FRAMED: should not allow calls from ${frameContext} context`, async () => {

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -458,7 +458,7 @@ describe('Dialog', () => {
           framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
           expect.assertions(4);
           try {
-            await dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+            dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
           } catch (e) {
             expect(e).toEqual(errorNotSupportedOnPlatform);
           }
@@ -478,8 +478,10 @@ describe('Dialog', () => {
         });
 
         it(`FRAMELESS: should throw an error if actionInfo is present in appContext and submit is called with arguments in ${context} context`, async () => {
+          app.getContext = jest.fn().mockResolvedValueOnce(framedMock.setAppContext(context));
           await framelessMock.initializeWithContext(context);
-          framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
+          framedMock.setRuntimeConfig({ apiVersion: 1, supports: { dialog: {} } });
+
           expect.assertions(4);
           try {
             dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
@@ -922,7 +924,7 @@ describe('Dialog', () => {
             framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
             expect.assertions(4);
             try {
-              dialog.sendMessageToParentFromDialog('exampleMessage');
+              await dialog.sendMessageToParentFromDialog('exampleMessage');
             } catch (e) {
               expect(e).toEqual(errorNotSupportedOnPlatform);
             }

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -458,7 +458,7 @@ describe('Dialog', () => {
           framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
           expect.assertions(4);
           try {
-            return await dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+            await dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
           } catch (e) {
             expect(e).toEqual(errorNotSupportedOnPlatform);
           }
@@ -471,22 +471,20 @@ describe('Dialog', () => {
 
           expect.assertions(1);
           try {
-            dialog.submit('someResult');
+            await dialog.submit('someResult');
           } catch (e) {
             expect(e).toEqual(errorInvalidArguments);
           }
         });
 
         it(`FRAMELESS: should throw an error if actionInfo is present in appContext and submit is called with arguments in ${context} context`, async () => {
-          app.getContext = jest.fn().mockResolvedValueOnce(framedMock.setAppContext(context));
           await framelessMock.initializeWithContext(context);
-          framedMock.setRuntimeConfig({ apiVersion: 1, supports: { dialog: {} } });
-
+          framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
           expect.assertions(4);
           try {
             dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
           } catch (e) {
-            expect(e).toEqual(errorInvalidArguments);
+            expect(e).toEqual(errorNotSupportedOnPlatform);
           }
         });
 

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -4,6 +4,7 @@ import { app } from '../../src/public/app';
 import {
   DialogDimension,
   errorInvalidArguments,
+  errorNotSupportedInCurrentContext,
   errorNotSupportedOnPlatform,
   FrameContexts,
 } from '../../src/public/constants';
@@ -457,33 +458,33 @@ describe('Dialog', () => {
           framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
           expect.assertions(4);
           try {
-            dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+            return await dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
           } catch (e) {
             expect(e).toEqual(errorNotSupportedOnPlatform);
           }
         });
 
-        it('FRAMED: should throw an error if actionInfo is present in appContext and submit is called with arguments', async () => {
+        it(`FRAMED: should throw an error if actionInfo is present in appContext and submit is called with arguments in ${context} context`, async () => {
           app.getContext = jest.fn().mockResolvedValueOnce(framedMock.setAppContext(context));
           await framedMock.initializeWithContext(context);
           framedMock.setRuntimeConfig({ apiVersion: 1, supports: { dialog: {} } });
 
           expect.assertions(1);
           try {
-            await dialog.submit('someResult');
+            dialog.submit('someResult');
           } catch (e) {
             expect(e).toEqual(errorInvalidArguments);
           }
         });
 
-        it('FRAMELESS: should throw an error if actionInfo is present in appContext and submit is called with arguments', async () => {
+        it(`FRAMELESS: should throw an error if actionInfo is present in appContext and submit is called with arguments in ${context} context`, async () => {
           app.getContext = jest.fn().mockResolvedValueOnce(framedMock.setAppContext(context));
           await framelessMock.initializeWithContext(context);
           framedMock.setRuntimeConfig({ apiVersion: 1, supports: { dialog: {} } });
 
           expect.assertions(4);
           try {
-            await dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
+            dialog.submit('someResult', ['someAppId', 'someOtherAppId']);
           } catch (e) {
             expect(e).toEqual(errorInvalidArguments);
           }
@@ -945,7 +946,7 @@ describe('Dialog', () => {
             try {
               await dialog.sendMessageToParentFromDialog('someMessage');
             } catch (e) {
-              expect(e).toEqual(errorInvalidArguments);
+              expect(e).toEqual(errorNotSupportedInCurrentContext);
             }
           });
 
@@ -958,7 +959,7 @@ describe('Dialog', () => {
             try {
               await dialog.sendMessageToParentFromDialog('someMessage');
             } catch (e) {
-              expect(e).toEqual(errorInvalidArguments);
+              expect(e).toEqual(errorNotSupportedInCurrentContext);
             }
           });
         } else {

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -1,6 +1,16 @@
 import { defaultSDKVersionForCompatCheck } from '../src/internal/constants';
 import { GlobalVars } from '../src/internal/globalVars';
 import { DOMMessageEvent, ExtendedWindow } from '../src/internal/interfaces';
+import {
+  ActionObjectType,
+  ChannelType,
+  FileOpenPreference,
+  HostClientType,
+  HostName,
+  SecondaryM365ContentIdName,
+  TeamType,
+  UserTeamRole,
+} from '../src/public';
 import { app } from '../src/public/app';
 import { applyRuntimeConfig, IRuntime } from '../src/public/runtime';
 export interface MessageRequest {
@@ -33,7 +43,7 @@ export class Utils {
   public parentWindow: Window;
 
   public constructor() {
-    let that = this;
+    const that = this;
     this.messages = [];
     this.childMessages = [];
 
@@ -200,4 +210,115 @@ export class Utils {
    * @returns A Promise that will be fulfilled when all other Promises have cleared from the microtask queue.
    */
   public flushPromises = () => new Promise((resolve) => setTimeout(resolve));
+
+  public setAppContext = (frameContext) => ({
+    actionInfo: {
+      actionId: 'actionId',
+      actionObjects: [
+        {
+          itemId: '1',
+          secondaryId: {
+            name: SecondaryM365ContentIdName.DriveId,
+            value: 'secondaryDriveValue',
+          },
+          type: ActionObjectType.M365Content,
+        },
+        { itemId: '2', type: ActionObjectType.M365Content },
+        {
+          itemId: '3',
+          secondaryId: {
+            name: SecondaryM365ContentIdName.GroupId,
+            value: 'secondaryGroupId',
+          },
+          type: ActionObjectType.M365Content,
+        },
+        {
+          itemId: '4',
+          secondaryId: {
+            name: SecondaryM365ContentIdName.SiteId,
+            value: 'secondarySiteId',
+          },
+          type: ActionObjectType.M365Content,
+        },
+        {
+          itemId: '5',
+          secondaryId: {
+            name: SecondaryM365ContentIdName.UserId,
+            value: 'secondarySiteId',
+          },
+          type: ActionObjectType.M365Content,
+        },
+      ],
+    },
+    app: {
+      iconPositionVertical: 5,
+      locale: 'someLocale',
+      parentMessageId: 'someParentMessageId',
+      sessionId: 'appSessionId',
+      theme: 'someTheme',
+      userClickTime: 2222,
+      userFileOpenPreference: FileOpenPreference.Inline,
+      appLaunchId: 'appLaunchId',
+      host: {
+        name: HostName.orange,
+        clientType: HostClientType.web,
+
+        ringId: 'someRingId',
+        sessionId: 'someSessionId',
+      },
+    },
+    page: {
+      id: 'someEntityId',
+      subPageId: 'someSubEntityId',
+      isFullScreen: true,
+      sourceOrigin: 'www.origin.com',
+      frameContext: frameContext,
+      isMultiWindow: true,
+    },
+    user: {
+      id: 'someUserObjectId',
+      displayName: 'someTestUser',
+      isCallingAllowed: true,
+      licenseType: 'someUserLicenseType',
+      loginHint: 'someLoginHint',
+      userPrincipalName: 'someUserPrincipalName',
+      tenant: {
+        id: 'someTid',
+        teamsSku: 'someTenantSKU',
+      },
+    },
+    channel: {
+      id: 'someChannelId',
+      displayName: 'someChannelName',
+      relativeUrl: 'someChannelRelativeUrl',
+      membershipType: ChannelType.Shared,
+      defaultOneNoteSectionId: 'someDefaultOneNoteSectionId',
+      ownerTenantId: 'someHostTenantId',
+      ownerGroupId: 'someHostGroupId',
+    },
+    chat: {
+      id: 'someChatId',
+    },
+    meeting: {
+      id: 'dummyMeetingId',
+    },
+    sharepoint: {},
+    team: {
+      internalId: 'someTeamId',
+      displayName: 'someTeamName',
+      type: TeamType.Staff,
+      groupId: 'someGroupId',
+      templateId: 'someTeamTemplateId',
+      isArchived: false,
+      userRole: UserTeamRole.Admin,
+    },
+    sharePointSite: {
+      teamSiteUrl: 'someSiteUrl',
+      teamSiteDomain: 'someTeamSiteDomain',
+      teamSitePath: 'someTeamSitePath',
+      teamSiteId: 'someSiteId',
+      mySitePath: 'mySitePath',
+      mySiteDomain: 'myDomain',
+    },
+  });
 }


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Dialog.submit now throws an error if it is called when contentActions within appContext is defined and arguments are passed to the submit function since they will not do what is expected in this context. 


**NEED INPUT**
Since content actions are new, there are no built in sdk errors that truly explain what is going on in these cases, is there a new SDK error I can add to the constants file that would fit better?  Or is there an existing one someone is partial to? 

### Main changes in the PR:

1. change dialog.submit to throw error 
2. change sendMessageToParentFromDialog to throw error 

## Validation

### Validation performed:

1. ran unit tests

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

yes
### End-to-end tests added:

no
## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Next/remaining steps:

- [ ] add e2e tests
