### PR TITLE
Theme docs

### DIFF
--- a/change/@microsoft-teams-js-ced9c7db-ddda-4b9e-806f-1bf25773315f.json
+++ b/change/@microsoft-teams-js-ced9c7db-ddda-4b9e-806f-1bf25773315f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Clarified possible values for `theme` property on `AppInfo` object in docs",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -124,7 +124,7 @@ export namespace app {
     locale: string;
 
     /**
-     * The current UI theme.
+     * The current UI theme of the host. Possible values: "default", "dark", or "contrast".
      */
     theme: string;
 


### PR DESCRIPTION
## Description

The documentation for the `theme` property on the `AppInfo` object was too terse and did not provide possible values.

### Main changes in the PR:

Update TSDocs for `theme` property to enumerate possible values.

## Validation

### Validation performed:

Ran unit tests; E2E tests will be run as part of publishing this PR.

### Unit Tests added:

No additional unit tests are necessary since there are no tests that validate our documentation is "complete."

### End-to-end tests added:

No.

## Additional Requirements

### Change file added:

Yes

### Next/remaining steps:

None, although documentation could always be improved.

### Screenshots:

Before:
<img width="665" alt="image" src="https://user-images.githubusercontent.com/36546967/189762393-5fa0536b-5b78-40cd-a3bf-f23c05d482b8.png">

After:
<img width="608" alt="image" src="https://user-images.githubusercontent.com/36546967/189762728-f98cf524-26bb-4a4c-8b41-b9b8afdccc6a.png">
