### PR TITLE
Deleting unnecessary export keywords from tasks.ts helper functions

### DIFF
--- a/change/@microsoft-teams-js-68e20fff-dd6d-40c6-9246-1e859e1f6c84.json
+++ b/change/@microsoft-teams-js-68e20fff-dd6d-40c6-9246-1e859e1f6c84.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Removed unnecessary export keyword from supporting functions `getUrlDialogInfoFromTaskInfo` and `getBotUrlDialogInfoFromTaskInfo` in `tasks.ts`",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -82,7 +82,7 @@ export namespace tasks {
    * @param taskInfo - TaskInfo object to convert
    * @returns - Converted UrlDialogInfo object
    */
-  export function getUrlDialogInfoFromTaskInfo(taskInfo: TaskInfo): UrlDialogInfo {
+  function getUrlDialogInfoFromTaskInfo(taskInfo: TaskInfo): UrlDialogInfo {
     const urldialogInfo: UrlDialogInfo = {
       url: taskInfo.url,
       size: {
@@ -100,7 +100,7 @@ export namespace tasks {
    * @param taskInfo - TaskInfo object to convert
    * @returns - converted BotUrlDialogInfo object
    */
-  export function getBotUrlDialogInfoFromTaskInfo(taskInfo: TaskInfo): BotUrlDialogInfo {
+  function getBotUrlDialogInfoFromTaskInfo(taskInfo: TaskInfo): BotUrlDialogInfo {
     const botUrldialogInfo: BotUrlDialogInfo = {
       url: taskInfo.url,
       size: {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Since the functions `getBotUrlDialogInfoFromTaskInfo` and `getUrlDialogInfoFromTaskInfo` functions are not used by developers and don't need to be exported. 

### Unit Tests added:

> No unit test has been added because there are no API changes.

### End-to-end tests added:

> NO e2e test has been added because there are no API changes.

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes
