### PR TITLE
Fixes Search Api initialization in tests

### DIFF
--- a/apps/teams-test-app/src/components/SearchAPIs.tsx
+++ b/apps/teams-test-app/src/components/SearchAPIs.tsx
@@ -27,7 +27,7 @@ const RegisterHandlers = (): React.ReactElement =>
       };
       setResult('register handlers');
 
-      search.registerHandlers(onChange, onClosed, onExecute);
+      search.registerHandlers(onClosed, onExecute, onChange);
       return 'recieved';
     },
   });


### PR DESCRIPTION
## Description

> Fixes search tests in Teams tests app. The Search Service's parameters function is being called with the wrong order of parameters

