### PR TITLE
Enable strictNullChecks as an eslint rule (not a compiler setting) and disable violations

### DIFF
--- a/change/@microsoft-teams-js-2cfa7e83-7b34-4723-8d88-4e9a4e2f9b77.json
+++ b/change/@microsoft-teams-js-2cfa7e83-7b34-4723-8d88-4e9a4e2f9b77.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Enabled `strict-null-checks` as lint rule",
+  "comment": "Enabled `strictNullChecks` as lint rule",
   "packageName": "@microsoft/teams-js",
   "email": "36546967+AE-MS@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-2cfa7e83-7b34-4723-8d88-4e9a4e2f9b77.json
+++ b/change/@microsoft-teams-js-2cfa7e83-7b34-4723-8d88-4e9a4e2f9b77.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Enabled `strict-null-checks` as lint rule",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
+    "eslint-plugin-strict-null-checks": "^0.0.19",
     "fs-extra": "^9.1.0",
     "fs-jetpack": "^2.2.2",
     "html-webpack-plugin": "^5.5.0",

--- a/packages/teams-js/.eslintrc.js
+++ b/packages/teams-js/.eslintrc.js
@@ -1,8 +1,14 @@
 module.exports = {
+  ignorePatterns: ['.eslintrc.js'],
+  parserOptions: {
+    project: './tsconfig.strictNullChecks.json',
+  },
+  plugins: ['strict-null-checks'],
   rules: {
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
-    'no-inner-declarations': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
+    'no-inner-declarations': 'off',
+    'strict-null-checks/all': 'warn',
   },
 };

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -171,6 +171,7 @@ export function sendAndHandleSdkError<T>(actionName: string, ...args: any[]): Pr
 export function sendMessageToParentAsync<T>(actionName: string, args: any[] = undefined): Promise<T> {
   return new Promise((resolve) => {
     const request = sendMessageToParentHelper(actionName, args);
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     resolve(waitForResponse<T>(request.id));
   });
 }
@@ -212,6 +213,7 @@ export function sendMessageToParent(actionName: string, argsOrCallback?: any[] |
     args = argsOrCallback;
   }
 
+  /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
   const request = sendMessageToParentHelper(actionName, args);
   if (callback) {
     CommunicationPrivate.callbacks[request.id] = callback;
@@ -230,10 +232,12 @@ function sendMessageToParentHelper(actionName: string, args: any[]): MessageRequ
   const targetWindow = Communication.parentWindow;
   const request = createMessageRequest(actionName, args);
 
+  /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
   logger('Message %i information: %o', request.id, { actionName, args });
 
   if (GlobalVars.isFramelessWindow) {
     if (Communication.currentWindow && Communication.currentWindow.nativeInterface) {
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       logger('Sending message %i to parent via framelessPostMessage interface', request.id);
       (Communication.currentWindow as ExtendedWindow).nativeInterface.framelessPostMessage(JSON.stringify(request));
     }
@@ -243,9 +247,11 @@ function sendMessageToParentHelper(actionName: string, args: any[]): MessageRequ
     // If the target window isn't closed and we already know its origin, send the message right away; otherwise,
     // queue the message and send it after the origin is established
     if (targetWindow && targetOrigin) {
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       logger('Sending message %i to parent via postMessage', request.id);
       targetWindow.postMessage(request, targetOrigin);
     } else {
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       logger('Adding message %i to parent message queue', request.id);
       getTargetMessageQueue(targetWindow).push(request);
     }
@@ -404,6 +410,7 @@ function handleChildMessage(evt: DOMMessageEvent): void {
     const message = evt.data as MessageRequest;
     const [called, result] = callHandler(message.func, message.args);
     if (called && typeof result !== 'undefined') {
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       sendMessageResponseToChild(message.id, Array.isArray(result) ? result : [result]);
     } else {
       // No handler, proxy to parent
@@ -411,6 +418,7 @@ function handleChildMessage(evt: DOMMessageEvent): void {
       sendMessageToParent(message.func, message.args, (...args: any[]): void => {
         if (Communication.childWindow) {
           const isPartialResponse = args.pop();
+          /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
           sendMessageResponseToChild(message.id, args, isPartialResponse);
         }
       });
@@ -453,6 +461,7 @@ function flushMessageQueue(targetWindow: Window | any): void {
   const target = targetWindow == Communication.parentWindow ? 'parent' : 'child';
   while (targetWindow && targetOrigin && targetMessageQueue.length > 0) {
     const request = targetMessageQueue.shift();
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     flushMessageQueueLogger('Flushing message %i from ' + target + ' message queue via postMessage.', request.id);
     targetWindow.postMessage(request, targetOrigin);
   }
@@ -485,6 +494,7 @@ function sendMessageResponseToChild(
   isPartialResponse?: boolean,
 ): void {
   const targetWindow = Communication.childWindow;
+  /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
   const response = createMessageResponse(id, args, isPartialResponse);
   const targetOrigin = getTargetOrigin(targetWindow);
   if (targetWindow && targetOrigin) {
@@ -506,6 +516,7 @@ export function sendMessageEventToChild(
   args?: any[],
 ): void {
   const targetWindow = Communication.childWindow;
+  /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
   const customEvent = createMessageEvent(actionName, args);
   const targetOrigin = getTargetOrigin(targetWindow);
 

--- a/packages/teams-js/src/internal/constants.ts
+++ b/packages/teams-js/src/internal/constants.ts
@@ -1,3 +1,4 @@
+/* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
 declare const PACKAGE_VERSION: string;
 export const version = PACKAGE_VERSION;
 

--- a/packages/teams-js/src/internal/mediaUtil.ts
+++ b/packages/teams-js/src/internal/mediaUtil.ts
@@ -18,6 +18,7 @@ export function createFile(assembleAttachment: media.AssembleAttachment[], mimeT
   if (assembleAttachment == null || mimeType == null || assembleAttachment.length <= 0) {
     return null;
   }
+  /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
   let file: Blob;
   let sequence = 1;
   assembleAttachment.sort((a, b) => (a.sequence > b.sequence ? 1 : -1));

--- a/packages/teams-js/src/private/teams.ts
+++ b/packages/teams-js/src/private/teams.ts
@@ -147,6 +147,7 @@ export namespace teams {
             throw new Error(JSON.stringify(oldPlatformError));
           }
 
+          /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
           resolve(sendAndUnwrap('getUserJoinedTeams', teamInstanceParameters));
         });
       }

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -564,6 +564,7 @@ export namespace app {
             // so we assume that if we don't have it, we must be running in Teams.
             // After Teams updates its client code, we can remove this default code.
             try {
+              /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
               const givenRuntimeConfig: IRuntime = JSON.parse(runtimeConfig);
               // Check that givenRuntimeConfig is a valid instance of IRuntimeConfig
               if (!givenRuntimeConfig || !givenRuntimeConfig.apiVersion) {
@@ -580,6 +581,7 @@ export namespace app {
                   if (!isNaN(compareSDKVersions(runtimeConfig, defaultSDKVersionForCompatCheck))) {
                     GlobalVars.clientSupportedSDKVersion = runtimeConfig;
                   }
+                  /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
                   const givenRuntimeConfig: IRuntime = JSON.parse(clientSupportedSDKVersion);
                   clientSupportedSDKVersion && applyRuntimeConfig(givenRuntimeConfig);
                 } catch (e) {
@@ -638,19 +640,23 @@ export namespace app {
     }
 
     if (GlobalVars.frameContext) {
+      /* eslint-disable strict-null-checks/all */ /* Fix tracked by 5730662 */
       registerOnThemeChangeHandler(null);
       pages.backStack.registerBackButtonHandler(null);
       pages.registerFullScreenHandler(null);
       teamsCore.registerBeforeUnloadHandler(null);
       teamsCore.registerOnLoadHandler(null);
-      logs.registerGetLogHandler(null);
+      logs.registerGetLogHandler(null); /* Fix tracked by 5730662 */
+      /* eslint-enable strict-null-checks/all */
     }
 
     if (GlobalVars.frameContext === FrameContexts.settings) {
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       pages.config.registerOnSaveHandler(null);
     }
 
     if (GlobalVars.frameContext === FrameContexts.remove) {
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       pages.config.registerOnRemoveHandler(null);
     }
 

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -18,7 +18,9 @@ import { FrameContexts, HostClientType } from './constants';
  * @beta
  */
 export namespace authentication {
+  /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
   let authHandlers: { success: (string) => void; fail: (string) => void };
+  /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
   let authWindowMonitor: number;
 
   export function initialize(): void {
@@ -26,6 +28,7 @@ export namespace authentication {
     registerHandler('authentication.authenticate.failure', handleFailure, false);
   }
 
+  /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
   let authParams: AuthenticateParameters;
   /**
    * @deprecated
@@ -61,6 +64,7 @@ export namespace authentication {
   export function authenticate(authenticateParameters?: AuthenticateParameters): void;
   export function authenticate(authenticateParameters?: AuthenticateParameters): Promise<string> {
     const isDifferentParamsInCall: boolean = authenticateParameters !== undefined;
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     const authenticateParams: AuthenticateParameters = isDifferentParamsInCall ? authenticateParameters : authParams;
     if (!authenticateParams) {
       throw new Error('No parameters are provided for authentication');

--- a/packages/teams-js/src/public/geoLocation.ts
+++ b/packages/teams-js/src/public/geoLocation.ts
@@ -64,7 +64,7 @@ export namespace geoLocation {
     }
     const permissions: DevicePermission = DevicePermission.GeoLocation;
 
-    return new Promise<boolean>(resolve => {
+    return new Promise<boolean>((resolve) => {
       resolve(sendAndHandleError('permissions.has', permissions));
     });
   }
@@ -85,7 +85,7 @@ export namespace geoLocation {
     }
     const permissions: DevicePermission = DevicePermission.GeoLocation;
 
-    return new Promise<boolean>(resolve => {
+    return new Promise<boolean>((resolve) => {
       resolve(sendAndHandleError('permissions.request', permissions));
     });
   }

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -88,12 +88,14 @@ export namespace media {
 
     if (!GlobalVars.isFramelessWindow) {
       const notSupportedError: SdkError = { errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM };
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       callback(notSupportedError, undefined);
       return;
     }
 
     if (!isCurrentSDKVersionAtLeast(captureImageMobileSupportVersion)) {
       const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       callback(oldPlatformError, undefined);
       return;
     }
@@ -135,11 +137,13 @@ export namespace media {
       ensureInitialized(FrameContexts.content, FrameContexts.task);
       if (!isCurrentSDKVersionAtLeast(mediaAPISupportVersion)) {
         const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
+        /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
         callback(oldPlatformError, null);
         return;
       }
       if (!validateGetMediaInputs(this.mimeType, this.format, this.content)) {
         const invalidInput: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
+        /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
         callback(invalidInput, null);
         return;
       }
@@ -160,6 +164,7 @@ export namespace media {
       function handleGetMediaCallbackRequest(mediaResult: MediaResult): void {
         if (callback) {
           if (mediaResult && mediaResult.error) {
+            /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
             callback(mediaResult.error, null);
           } else {
             if (mediaResult && mediaResult.mediaChunk) {
@@ -174,6 +179,7 @@ export namespace media {
                 helper.assembleAttachment.push(assemble);
               }
             } else {
+              /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
               callback({ errorCode: ErrorCode.INTERNAL_ERROR, message: 'data received is null' }, null);
             }
           }
@@ -192,8 +198,10 @@ export namespace media {
       this.content && callback && sendMessageToParent('getMedia', params);
       function handleGetMediaRequest(response: string): void {
         if (callback) {
+          /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
           const mediaResult: MediaResult = JSON.parse(response);
           if (mediaResult.error) {
+            /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
             callback(mediaResult.error, null);
             removeHandler('getMedia' + actionName);
           } else {
@@ -210,6 +218,7 @@ export namespace media {
                 helper.assembleAttachment.push(assemble);
               }
             } else {
+              /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
               callback({ errorCode: ErrorCode.INTERNAL_ERROR, message: 'data received is null' }, null);
               removeHandler('getMedia' + actionName);
             }
@@ -595,6 +604,7 @@ export namespace media {
     ensureInitialized(FrameContexts.content, FrameContexts.task);
     if (!isCurrentSDKVersionAtLeast(mediaAPISupportVersion)) {
       const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       callback(oldPlatformError, null);
       return;
     }
@@ -602,12 +612,14 @@ export namespace media {
     try {
       throwExceptionIfMediaCallIsNotSupportedOnMobile(mediaInputs);
     } catch (err) {
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       callback(err, null);
       return;
     }
 
     if (!validateSelectMediaInputs(mediaInputs)) {
       const invalidInput: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       callback(invalidInput, null);
       return;
     }
@@ -621,6 +633,7 @@ export namespace media {
         // MediaControllerEvent response is used to notify the app about events and is a partial response to selectMedia
         if (mediaEvent) {
           if (isVideoControllerRegistered(mediaInputs)) {
+            /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
             mediaInputs.videoProps.videoController.notifyEventToApp(mediaEvent);
           }
           return;
@@ -628,6 +641,7 @@ export namespace media {
 
         // Media Attachments are final response to selectMedia
         if (!localAttachments) {
+          /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
           callback(err, null);
           return;
         }
@@ -708,18 +722,22 @@ export namespace media {
       GlobalVars.hostClientType === HostClientType.teamsDisplays
     ) {
       const notSupportedError: SdkError = { errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM };
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       callback(notSupportedError, null);
       return;
     }
 
     if (!isCurrentSDKVersionAtLeast(scanBarCodeAPIMobileSupportVersion)) {
       const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       callback(oldPlatformError, null);
       return;
     }
 
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     if (!validateScanBarCodeInput(config)) {
       const invalidInput: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       callback(invalidInput, null);
       return;
     }

--- a/packages/teams-js/src/public/menus.ts
+++ b/packages/teams-js/src/public/menus.ts
@@ -142,9 +142,11 @@ export namespace menus {
     dropDown = 'dropDown',
     popOver = 'popOver',
   }
+  /* eslint-disable strict-null-checks/all */ /* Fix tracked by 5730662 */
   let navBarMenuItemPressHandler: (id: string) => boolean;
   let actionMenuItemPressHandler: (id: string) => boolean;
   let viewConfigItemPressHandler: (id: string) => boolean;
+  /* eslint-enable strict-null-checks/all */ /* Fix tracked by 5730662 */
 
   export function initialize(): void {
     registerHandler('navBarMenuItemPress', handleNavBarMenuItemPress, false);

--- a/packages/teams-js/src/public/monetization.ts
+++ b/packages/teams-js/src/public/monetization.ts
@@ -66,7 +66,9 @@ export namespace monetization {
     param1: ((error: SdkError | null) => void) | PlanInfo | undefined,
     param2?: PlanInfo,
   ): Promise<void> {
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     let callback: (error: SdkError | null) => void;
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     let planInfo: PlanInfo;
     if (typeof param1 === 'function') {
       callback = param1;

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -325,6 +325,7 @@ export namespace pages {
         if (!isSupported()) {
           throw errorNotSupportedOnPlatform;
         }
+        /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
         resolve(sendAndUnwrap('getTabInstances', tabInstanceParameters));
       });
     }
@@ -340,6 +341,7 @@ export namespace pages {
         if (!isSupported()) {
           throw errorNotSupportedOnPlatform;
         }
+        /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
         resolve(sendAndUnwrap('getMruTabInstances', tabInstanceParameters));
       });
     }
@@ -358,7 +360,9 @@ export namespace pages {
    * This object is usable only on the configuration frame.
    */
   export namespace config {
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     let saveHandler: (evt: SaveEvent) => void;
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     let removeHandler: (evt: RemoveEvent) => void;
 
     /**
@@ -642,6 +646,7 @@ export namespace pages {
    * Provides APIs for handling the user's navigational history.
    */
   export namespace backStack {
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     let backButtonPressHandler: () => boolean;
 
     export function _initialize(): void {

--- a/packages/teams-js/src/public/people.ts
+++ b/packages/teams-js/src/public/people.ts
@@ -46,7 +46,9 @@ export namespace people {
   ): Promise<PeoplePickerResult[]> {
     ensureInitialized(FrameContexts.content, FrameContexts.task, FrameContexts.settings);
 
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     let callback: (error: SdkError, people: PeoplePickerResult[]) => void;
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     let peoplePickerInputs: PeoplePickerInputs;
 
     if (typeof param1 === 'function') {
@@ -68,6 +70,7 @@ export namespace people {
         throw { errorCode: ErrorCode.OLD_PLATFORM };
       }
 
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       if (!validatePeoplePickerInput(peoplePickerInputs)) {
         throw { errorCode: ErrorCode.INVALID_ARGUMENTS };
       }
@@ -75,6 +78,7 @@ export namespace people {
       if (!isSupported()) {
         throw errorNotSupportedOnPlatform;
       }
+      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       resolve(sendAndHandleError('people.selectPeople', peoplePickerInputs));
     });
   }

--- a/packages/teams-js/src/public/sharing.ts
+++ b/packages/teams-js/src/public/sharing.ts
@@ -112,6 +112,7 @@ export namespace sharing {
   }
 
   function validateTypeConsistency(shareRequest: IShareRequest<IShareRequestContentType>): void {
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     let err: SdkError;
     if (shareRequest.content.some((item) => !item.type)) {
       err = {
@@ -130,6 +131,7 @@ export namespace sharing {
   }
 
   function validateContentForSupportedTypes(shareRequest: IShareRequest<IShareRequestContentType>): void {
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     let err: SdkError;
     if (shareRequest.content[0].type === 'URL') {
       if (shareRequest.content.some((item) => !item.url)) {

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -32,7 +32,8 @@ export namespace tasks {
     submitHandler?: (err: string, result: string | object) => void,
   ): IAppWindow {
     const dialogSubmitHandler = submitHandler
-      ? (sdkResponse: dialog.ISdkResponse) => submitHandler(sdkResponse.err, sdkResponse.result)
+      ? /* eslint-disable-next-line strict-null-checks/all */ /* fix tracked by 5730662 */
+        (sdkResponse: dialog.ISdkResponse) => submitHandler(sdkResponse.err, sdkResponse.result)
       : undefined;
     if (taskInfo.card !== undefined || taskInfo.url === undefined) {
       ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
@@ -83,6 +84,7 @@ export namespace tasks {
    * @returns - Converted UrlDialogInfo object
    */
   function getUrlDialogInfoFromTaskInfo(taskInfo: TaskInfo): UrlDialogInfo {
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     const urldialogInfo: UrlDialogInfo = {
       url: taskInfo.url,
       size: {
@@ -101,6 +103,7 @@ export namespace tasks {
    * @returns - converted BotUrlDialogInfo object
    */
   function getBotUrlDialogInfoFromTaskInfo(taskInfo: TaskInfo): BotUrlDialogInfo {
+    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     const botUrldialogInfo: BotUrlDialogInfo = {
       url: taskInfo.url,
       size: {

--- a/packages/teams-js/tsconfig.strictNullChecks.json
+++ b/packages/teams-js/tsconfig.strictNullChecks.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strictNullChecks": true
+  }
+}

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strictNullChecks": true
+  }
+}

--- a/tsconfig.strictNullChecks.json
+++ b/tsconfig.strictNullChecks.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "strictNullChecks": true
-  }
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2717,7 +2717,7 @@
   integrity sha512-iKc5L036hc/wu13DX5kGf//3/WqTAErAPTyYKG6zT3vG070xXaaP7PInODznfyZduhiOvavmrRlQb34ajeDTUA==
 
 "@microsoft/teams-js@file:packages/teams-js":
-  version "2.2.0"
+  version "2.3.0"
   dependencies:
     debug "4.3.3"
 
@@ -3156,6 +3156,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/json-schema@^7.0.9":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
 "@types/jszip@^3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@types/jszip/-/jszip-3.4.1.tgz#e7a4059486e494c949ef750933d009684227846f"
@@ -3349,6 +3354,21 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/eslint-plugin@^5.13.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.37.0.tgz#5ccdd5d9004120f28fc6e717fb4b5c9bddcfbc04"
+  integrity sha512-Fde6W0IafXktz1UlnhGkrrmnnGpAo1kyX7dnyHHVrmwJOn72Oqm3eYtddrpOwwel2W8PAK9F3pIL5S+lfoM0og==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.37.0"
+    "@typescript-eslint/type-utils" "5.37.0"
+    "@typescript-eslint/utils" "5.37.0"
+    debug "^4.3.4"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.2.0"
+    regexpp "^3.2.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/experimental-utils@4.31.2":
   version "4.31.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.2.tgz#98727a9c1e977dd5d20c8705e69cd3c2a86553fa"
@@ -3361,6 +3381,13 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
+"@typescript-eslint/experimental-utils@^5.13.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.37.0.tgz#e1a423658e265f50c9e944b4bbe36fab2a340197"
+  integrity sha512-mmzzOOK2YpwSgzhXpeSAtAlxBZVLGuq8OdvrfzibR4jfTTrTd3AjCy17M2dUKVFNsrNfLM0nWsxMsJz0kiYHqw==
+  dependencies:
+    "@typescript-eslint/utils" "5.37.0"
+
 "@typescript-eslint/parser@^4.29.0":
   version "4.31.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.31.2.tgz#54aa75986e3302d91eff2bbbaa6ecfa8084e9c34"
@@ -3371,6 +3398,16 @@
     "@typescript-eslint/typescript-estree" "4.31.2"
     debug "^4.3.1"
 
+"@typescript-eslint/parser@^5.13.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.37.0.tgz#c382077973f3a4ede7453fb14cadcad3970cbf3b"
+  integrity sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.37.0"
+    "@typescript-eslint/types" "5.37.0"
+    "@typescript-eslint/typescript-estree" "5.37.0"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@4.31.2":
   version "4.31.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.31.2.tgz#1d528cb3ed3bcd88019c20a57c18b897b073923a"
@@ -3379,10 +3416,33 @@
     "@typescript-eslint/types" "4.31.2"
     "@typescript-eslint/visitor-keys" "4.31.2"
 
+"@typescript-eslint/scope-manager@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz#044980e4f1516a774a418dafe701a483a6c9f9ca"
+  integrity sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==
+  dependencies:
+    "@typescript-eslint/types" "5.37.0"
+    "@typescript-eslint/visitor-keys" "5.37.0"
+
+"@typescript-eslint/type-utils@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz#43ed2f567ada49d7e33a6e4b6f9babd060445fe5"
+  integrity sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.37.0"
+    "@typescript-eslint/utils" "5.37.0"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/types@4.31.2":
   version "4.31.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.31.2.tgz#2aea7177d6d744521a168ed4668eddbd912dfadf"
   integrity sha512-kWiTTBCTKEdBGrZKwFvOlGNcAsKGJSBc8xLvSjSppFO88AqGxGNYtF36EuEYG6XZ9vT0xX8RNiHbQUKglbSi1w==
+
+"@typescript-eslint/types@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.37.0.tgz#09e4870a5f3af7af3f84e08d792644a87d232261"
+  integrity sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==
 
 "@typescript-eslint/typescript-estree@4.31.2":
   version "4.31.2"
@@ -3397,6 +3457,31 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz#956dcf5c98363bcb97bdd5463a0a86072ff79355"
+  integrity sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==
+  dependencies:
+    "@typescript-eslint/types" "5.37.0"
+    "@typescript-eslint/visitor-keys" "5.37.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.37.0.tgz#7784cb8e91390c4f90ccaffd24a0cf9874df81b2"
+  integrity sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.37.0"
+    "@typescript-eslint/types" "5.37.0"
+    "@typescript-eslint/typescript-estree" "5.37.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/visitor-keys@4.31.2":
   version "4.31.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.2.tgz#7d5b4a4705db7fe59ecffb273c1d082760f635cc"
@@ -3404,6 +3489,14 @@
   dependencies:
     "@typescript-eslint/types" "4.31.2"
     eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz#7b72dd343295ea11e89b624995abc7103c554eee"
+  integrity sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==
+  dependencies:
+    "@typescript-eslint/types" "5.37.0"
+    eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -5228,6 +5321,13 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -5832,6 +5932,16 @@ eslint-plugin-simple-import-sort@^7.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz#a1dad262f46d2184a90095a60c66fef74727f0f8"
   integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
 
+eslint-plugin-strict-null-checks@^0.0.19:
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-strict-null-checks/-/eslint-plugin-strict-null-checks-0.0.19.tgz#73ab2396f5085f61cd5791c723b19e4c2e98095f"
+  integrity sha512-fi8m8onqIveTNtKm7QGZ2aMW6aBabCBGb+otbut/f/3/j9a8MK9M7l0PAm61ZjZZ75P7hF0+9S7aXPFMSstuoA==
+  dependencies:
+    "@typescript-eslint/eslint-plugin" "^5.13.0"
+    "@typescript-eslint/experimental-utils" "^5.13.0"
+    "@typescript-eslint/parser" "^5.13.0"
+    requireindex "^1.2.0"
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -5863,6 +5973,11 @@ eslint-visitor-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^7.32.0:
   version "7.32.0"
@@ -6745,7 +6860,7 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.0:
+globby@^11.0.0, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -7578,7 +7693,7 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-glob@~4.0.1:
+is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -10761,7 +10876,7 @@ regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-regexpp@^3.1.0:
+regexpp@^3.1.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -10873,6 +10988,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 requires-port@^1.0.0:
   version "1.0.0"
@@ -11115,6 +11235,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"


### PR DESCRIPTION
## Description

Enabling the `strictNullChecks` TS compiler flag is a good thing; it results in better overall code and avoids bugs. You will find many resources on the internet extolling its virtues.

Enabling it in this project is not straightforward as there are many violations and some are complex to fix.

Unfortunately, the TS compiler does not allow a way to enable a compiler flag like `strictNullChecks` and then selectively suppress it (and only it) in your files/code lines. However, eslint does have such an ability -- and there's an npm package to enable `strictNullChecks` violations as an eslint rule (rather than a compiler flag). This allows us to turn on and get the benefit of `strictNullChecks` without having to fix them all at once (and it doesn't require us to disable all ts errors in our files).

The overall arc of this project is to:
1. Enable `strictNullChecks` as an eslint rule but suppress all current violations
2. Fix the violations incrementally
3. Enable `strictNullChecks` as a compiler flag and remove the eslint rule/package

This work is starting in the teams-js package for now and, over time, will eventually expand to the entire repo.

### Main changes in the PR:

Enable `strictNullChecks` as an eslint rule and suppress all violations

## Validation

### Validation performed:

Ensured build and tests pass without any outstanding eslint issues

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

This change adds no new functionality and thus no tests were added.

### End-to-end tests added:

No, for the same reason as above.

## Additional Requirements

### Change file added:

Yes

### Next/remaining steps:

Start fixing the violations!