### PR TITLE
Make version number public in TeamsJS and display it in the test app

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -40,6 +40,7 @@ import SharingAPIs from './components/SharingAPIs';
 import StageViewAPIs from './components/StageViewAPIs';
 import TeamsCoreAPIs from './components/TeamsCoreAPIs';
 import { isTestBackCompat } from './components/utils/isTestBackCompat';
+import Version from './components/Version';
 import WebStorageAPIs from './components/WebStorageAPIs';
 
 const urlParams = new URLSearchParams(window.location.search);
@@ -144,6 +145,7 @@ const App = (): ReactElement => {
       <StageViewAPIs />
       <TeamsCoreAPIs />
       <TeamsAPIs />
+      <Version />
     </div>
   );
 };

--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -107,44 +107,46 @@ export const generateRegistrationMsg = (changeCause: string): string => {
 
 const App = (): ReactElement => {
   return (
-    <div className="App-container">
-      <AppAPIs />
-      <AppInitializationAPIs />
-      <AppInstallDialogAPIs />
-      <AuthenticationAPIs />
-      <AppEntityAPIs />
-      <BarCodeAPIs />
-      <CalendarAPIs />
-      <CallAPIs />
-      <ChatAPIs />
-      <DialogAPIs />
-      <FilesAPIs />
-      <FullTrustAPIs />
-      <GeoLocationAPIs />
-      <Links />
-      <LocationAPIs />
-      <LogAPIs />
-      <MailAPIs />
-      <MediaAPIs />
-      <MeetingAPIs />
-      <MeetingRoomAPIs />
-      <MenusAPIs />
-      <MonetizationAPIs />
-      <NotificationAPIs />
-      <PagesAPIs />
-      <PagesAppButtonAPIs />
-      <PagesBackStackAPIs />
-      <PagesConfigAPIs />
-      <PagesTabsAPIs />
-      <PeopleAPIs />
-      <PrivateAPIs />
-      <RemoteCameraAPIs />
-      <SearchAPIs />
-      <SharingAPIs />
-      <WebStorageAPIs />
-      <StageViewAPIs />
-      <TeamsCoreAPIs />
-      <TeamsAPIs />
+    <div>
+      <div className="App-container">
+        <AppAPIs />
+        <AppInitializationAPIs />
+        <AppInstallDialogAPIs />
+        <AuthenticationAPIs />
+        <AppEntityAPIs />
+        <BarCodeAPIs />
+        <CalendarAPIs />
+        <CallAPIs />
+        <ChatAPIs />
+        <DialogAPIs />
+        <FilesAPIs />
+        <FullTrustAPIs />
+        <GeoLocationAPIs />
+        <Links />
+        <LocationAPIs />
+        <LogAPIs />
+        <MailAPIs />
+        <MediaAPIs />
+        <MeetingAPIs />
+        <MeetingRoomAPIs />
+        <MenusAPIs />
+        <MonetizationAPIs />
+        <NotificationAPIs />
+        <PagesAPIs />
+        <PagesAppButtonAPIs />
+        <PagesBackStackAPIs />
+        <PagesConfigAPIs />
+        <PagesTabsAPIs />
+        <PeopleAPIs />
+        <PrivateAPIs />
+        <RemoteCameraAPIs />
+        <SearchAPIs />
+        <SharingAPIs />
+        <WebStorageAPIs />
+        <StageViewAPIs />
+        <TeamsCoreAPIs />
+        <TeamsAPIs />
+      </div>
       <Version />
     </div>
   );

--- a/apps/teams-test-app/src/components/Version.tsx
+++ b/apps/teams-test-app/src/components/Version.tsx
@@ -1,43 +1,10 @@
 import { version } from '@microsoft/teams-js';
 import React from 'react';
 
-// const GetTeamsChannels = (): React.ReactElement =>
-//   ApiWithTextInput<string>({
-//     name: 'getTeamChannels2',
-//     title: 'Get Team Channels',
-//     onClick: {
-//       validateInput: (input) => {
-//         if (!input || typeof input !== 'string') {
-//           throw new Error('input is required and it has to be a string.');
-//         }
-//       },
-//       submit: async (groupId) => {
-//         return new Promise((res, rej) => {
-//           const onComplete = (error: SdkError, channels: teams.ChannelInfo[]): void => {
-//             if (error) {
-//               rej('getTeamChannels() error: ' + JSON.stringify(error));
-//             } else {
-//               res(JSON.stringify(channels));
-//             }
-//           };
-
-//           teams.getTeamChannels(groupId, onComplete);
-//         });
-//       },
-//     },
-//   });
-
 const Version = (): React.ReactElement => (
   <div>
     Current library version: <span id="version">{version ?? 'unavailable'}</span>
   </div>
 );
-
-// const Version: React.FC = () => (
-//   <ModuleWrapper title="TeamsAPIs">
-//     <GetTeamsChannels />
-//     <RefreshSiteUrl />
-//   </ModuleWrapper>
-// );
 
 export default Version;

--- a/apps/teams-test-app/src/components/Version.tsx
+++ b/apps/teams-test-app/src/components/Version.tsx
@@ -1,0 +1,43 @@
+import { version } from '@microsoft/teams-js';
+import React from 'react';
+
+// const GetTeamsChannels = (): React.ReactElement =>
+//   ApiWithTextInput<string>({
+//     name: 'getTeamChannels2',
+//     title: 'Get Team Channels',
+//     onClick: {
+//       validateInput: (input) => {
+//         if (!input || typeof input !== 'string') {
+//           throw new Error('input is required and it has to be a string.');
+//         }
+//       },
+//       submit: async (groupId) => {
+//         return new Promise((res, rej) => {
+//           const onComplete = (error: SdkError, channels: teams.ChannelInfo[]): void => {
+//             if (error) {
+//               rej('getTeamChannels() error: ' + JSON.stringify(error));
+//             } else {
+//               res(JSON.stringify(channels));
+//             }
+//           };
+
+//           teams.getTeamChannels(groupId, onComplete);
+//         });
+//       },
+//     },
+//   });
+
+const Version = (): React.ReactElement => (
+  <div>
+    Current library version: <span id="version">{version ?? 'unavailable'}</span>
+  </div>
+);
+
+// const Version: React.FC = () => (
+//   <ModuleWrapper title="TeamsAPIs">
+//     <GetTeamsChannels />
+//     <RefreshSiteUrl />
+//   </ModuleWrapper>
+// );
+
+export default Version;

--- a/change/@microsoft-teams-js-f23c5eb2-1636-4234-b6ed-e18dbca67463.json
+++ b/change/@microsoft-teams-js-f23c5eb2-1636-4234-b6ed-e18dbca67463.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added (moved) `version` as a public constant containing the library version",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -3,7 +3,7 @@
 
 import { FrameContexts } from '../public/constants';
 import { SdkError } from '../public/interfaces';
-import { version } from './constants';
+import { version } from '../public/version';
 import { GlobalVars } from './globalVars';
 import { callHandler } from './handlers';
 import { DOMMessageEvent, ExtendedWindow, MessageRequest, MessageResponse } from './interfaces';

--- a/packages/teams-js/src/internal/constants.ts
+++ b/packages/teams-js/src/internal/constants.ts
@@ -1,7 +1,3 @@
-/* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-declare const PACKAGE_VERSION: string;
-export const version = PACKAGE_VERSION;
-
 /**
  * @hidden
  * The client version when all SDK APIs started to check platform compatibility for the APIs was 1.6.0.

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -10,7 +10,7 @@ import {
   sendMessageToParent,
   uninitializeCommunication,
 } from '../internal/communication';
-import { defaultSDKVersionForCompatCheck, version } from '../internal/constants';
+import { defaultSDKVersionForCompatCheck } from '../internal/constants';
 import { GlobalVars } from '../internal/globalVars';
 import * as Handlers from '../internal/handlers'; // Conflict with some names
 import { ensureInitialized, processAdditionalValidOrigins } from '../internal/internalAPIs';
@@ -24,6 +24,7 @@ import { menus } from './menus';
 import { pages } from './pages';
 import { applyRuntimeConfig, generateBackCompatRuntimeConfig, IRuntime } from './runtime';
 import { teamsCore } from './teamsAPIs';
+import { version } from './version';
 
 /**
  * Namespace to interact with app initialization and lifecycle.

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -58,6 +58,7 @@ export { video } from './video';
 export { search } from './search';
 export { sharing } from './sharing';
 export { stageView } from './stageView';
+export { version } from './version';
 export { webStorage } from './webStorage';
 export { call } from './call';
 export { appInitialization } from './appInitialization';

--- a/packages/teams-js/src/public/version.ts
+++ b/packages/teams-js/src/public/version.ts
@@ -1,0 +1,3 @@
+/* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
+declare const PACKAGE_VERSION: string;
+export const version = PACKAGE_VERSION;

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -1,4 +1,3 @@
-import { version } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import * as privateAPIs from '../../src/private/privateAPIs';
@@ -20,6 +19,7 @@ import {
   SecondaryM365ContentIdName,
 } from '../../src/public/interfaces';
 import { _minRuntimeConfigToUninitialize, runtime, teamsRuntimeConfig } from '../../src/public/runtime';
+import { version } from '../../src/public/version';
 import { FramelessPostMocks } from '../framelessPostMocks';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/public/appInitialization.spec.ts
+++ b/packages/teams-js/test/public/appInitialization.spec.ts
@@ -1,6 +1,6 @@
-import { version } from '../../src/internal/constants';
 import { app } from '../../src/public/app';
 import { appInitialization } from '../../src/public/appInitialization';
+import { version } from '../../src/public/version';
 import { Utils } from '../utils';
 
 describe('appInitialization', () => {

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -1,4 +1,3 @@
-import { version } from '../../src/internal/constants';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { getGenericOnCompleteHandler } from '../../src/internal/utils';
 import { app } from '../../src/public/app';
@@ -6,6 +5,7 @@ import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/con
 import { FrameInfo, ShareDeepLinkParameters, TabInstance, TabInstanceParameters } from '../../src/public/interfaces';
 import { pages } from '../../src/public/pages';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
+import { version } from '../../src/public/version';
 import { FramelessPostMocks } from '../framelessPostMocks';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -1,4 +1,3 @@
-import { version } from '../../src/internal/constants';
 import * as utilFunc from '../../src/internal/utils';
 import { HostClientType, TeamType, UserTeamRole } from '../../src/public/constants';
 import { FrameContexts } from '../../src/public/constants';
@@ -27,6 +26,7 @@ import {
   shareDeepLink,
 } from '../../src/public/publicAPIs';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
+import { version } from '../../src/public/version';
 import { Utils } from '../utils';
 
 describe('MicrosoftTeams-publicAPIs', () => {


### PR DESCRIPTION
## Description

Make the version of TeamsJS a public constant, rather than an internal one. Then, display it on the main page in the test app so it can be validated by an E2E test.

In a subsequent change, I want to write the E2E test that checks this version to ensure it was "properly" set. The version is set by a plugin in webpack at compile time. Today it would be very easy for someone to write the bug that stopped replacing that version and it's not clear how we would ever discover that without a bug report from a user. Maybe some test would fail, but it would be best if we had a specific test for this so that we could see directly see the failure.

### Main changes in the PR:

1. Move the version constant from the internal section to the public section.
2. Write a component in the test app that displays the version. This needs to be backwards compatible since the latest test app is also used to validate tests against TeamsJS v1, and it's not triggered by a button.

## Validation

### Validation performed:

1. Build and run the test app, ensure the version is displayed properly.
2. Run current automated E2E tests as part of this PR and ensure the TJS v1 tests don't fail due to a problem in the test app.

### Unit Tests added:

No. Many existing unit tests use the `version` constant and they have been updated to use it from its new location, thus validating that it is properly exported.

### End-to-end tests added:

No, but in a subsequent change I will add a new E2E test that consumes this version to validate that it's been "properly" set.

## Additional Requirements

### Change file added:

Yes. By which I mean that I will add one when I finish publishing this draft PR.

### Next/remaining steps:

- Add E2E test that consumes this.

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| <img width="627" alt="image" src="https://user-images.githubusercontent.com/36546967/191136040-21345940-dcce-4546-bac1-4bd719184297.png"> | <img width="622" alt="image" src="https://user-images.githubusercontent.com/36546967/191136076-eb2d3367-9fd4-4bdb-815d-6081b7ae89c4.png">
 |
