### PR TITLE
Fix some places where undefined was tolerated but not explicitly part of the type declaration

### DIFF
--- a/change/@microsoft-teams-js-7a2e000c-6c51-4469-9ba1-e3dc2a4ce51c.json
+++ b/change/@microsoft-teams-js-7a2e000c-6c51-4469-9ba1-e3dc2a4ce51c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed some locations where `undefined` was properly handled but not explicitly in the type declaration",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/menus.ts
+++ b/packages/teams-js/src/public/menus.ts
@@ -142,11 +142,9 @@ export namespace menus {
     dropDown = 'dropDown',
     popOver = 'popOver',
   }
-  /* eslint-disable strict-null-checks/all */ /* Fix tracked by 5730662 */
-  let navBarMenuItemPressHandler: (id: string) => boolean;
-  let actionMenuItemPressHandler: (id: string) => boolean;
-  let viewConfigItemPressHandler: (id: string) => boolean;
-  /* eslint-enable strict-null-checks/all */ /* Fix tracked by 5730662 */
+  let navBarMenuItemPressHandler: ((id: string) => boolean) | undefined;
+  let actionMenuItemPressHandler: ((id: string) => boolean) | undefined;
+  let viewConfigItemPressHandler: ((id: string) => boolean) | undefined;
 
   export function initialize(): void {
     registerHandler('navBarMenuItemPress', handleNavBarMenuItemPress, false);

--- a/packages/teams-js/src/public/monetization.ts
+++ b/packages/teams-js/src/public/monetization.ts
@@ -66,8 +66,7 @@ export namespace monetization {
     param1: ((error: SdkError | null) => void) | PlanInfo | undefined,
     param2?: PlanInfo,
   ): Promise<void> {
-    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-    let callback: (error: SdkError | null) => void;
+    let callback: ((error: SdkError | null) => void) | undefined;
     /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     let planInfo: PlanInfo;
     if (typeof param1 === 'function') {

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -318,10 +318,8 @@ export namespace pages {
    * This object is usable only on the configuration frame.
    */
   export namespace config {
-    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-    let saveHandler: (evt: SaveEvent) => void;
-    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-    let removeHandler: (evt: RemoveEvent) => void;
+    let saveHandler: undefined | ((evt: SaveEvent) => void);
+    let removeHandler: undefined | ((evt: RemoveEvent) => void);
 
     /**
      * @hidden

--- a/packages/teams-js/src/public/sharing.ts
+++ b/packages/teams-js/src/public/sharing.ts
@@ -112,8 +112,7 @@ export namespace sharing {
   }
 
   function validateTypeConsistency(shareRequest: IShareRequest<IShareRequestContentType>): void {
-    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-    let err: SdkError;
+    let err: SdkError | undefined;
     if (shareRequest.content.some((item) => !item.type)) {
       err = {
         errorCode: ErrorCode.INVALID_ARGUMENTS,
@@ -131,8 +130,7 @@ export namespace sharing {
   }
 
   function validateContentForSupportedTypes(shareRequest: IShareRequest<IShareRequestContentType>): void {
-    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-    let err: SdkError;
+    let err: SdkError | undefined;
     if (shareRequest.content[0].type === 'URL') {
       if (shareRequest.content.some((item) => !item.url)) {
         err = {


### PR DESCRIPTION
## Description

Some of the locations in our code that were failing the `strictNullChecks` check were easy to fix by just adding `| undefined` to the type declaration, since the code already handled the case where those variables were `undefined.` This change fixes those places.

## Validation

### Validation performed:

Build, run unit tests, run e2e tests

### Unit Tests added:

No because functionality is being added/changed. This is a type-decoration-only change.

### End-to-end tests added:

No, see above.

## Additional Requirements

### Change file added:

Yep

### Related PRs:

#1352 

### Next/remaining steps:

Fix more `strictNullChecks` warnings. Most will not be as easy as this.
