### PR TITLE
3p cloud storage provider Upload API bug fix

### DIFF
--- a/change/@microsoft-teams-js-98d7ca14-14e6-4abe-b79a-c08d1da0dc2c.json
+++ b/change/@microsoft-teams-js-98d7ca14-14e6-4abe-b79a-c08d1da0dc2c.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
-  "comment": "Files upload API : 1. Changed datatype of `lastModified` field from Date to number 2. Added a new field `size` of type number",
+  "comment": "On the `File` interface changed the type of `lastModified` field from `Date` to `number` and added a new field `size` that contains the size in bytes of the file",
   "packageName": "@microsoft/teams-js",
-  "email": "jainharsh@microsof.com",
+  "email": "jainharsh@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@microsoft-teams-js-98d7ca14-14e6-4abe-b79a-c08d1da0dc2c.json
+++ b/change/@microsoft-teams-js-98d7ca14-14e6-4abe-b79a-c08d1da0dc2c.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Files upload API : 1. Changed datatype of `lastModified` field 2. Added a new field size",
+  "comment": "Files upload API : 1. Changed datatype of `lastModified` field from Date to number 2. Added a new field `size` of type number",
   "packageName": "@microsoft/teams-js",
   "email": "jainharsh@microsof.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-98d7ca14-14e6-4abe-b79a-c08d1da0dc2c.json
+++ b/change/@microsoft-teams-js-98d7ca14-14e6-4abe-b79a-c08d1da0dc2c.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "On the `File` interface changed the type of `lastModified` field from `Date` to `number` and added a new field `size` that contains the size in bytes of the file",
+  "comment": "On the `File` interface changed the type of `lastModified` field from `Date` to `number`",
   "packageName": "@microsoft/teams-js",
   "email": "jainharsh@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-98d7ca14-14e6-4abe-b79a-c08d1da0dc2c.json
+++ b/change/@microsoft-teams-js-98d7ca14-14e6-4abe-b79a-c08d1da0dc2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Files upload API : 1. Changed datatype of `lastModified` field 2. Added a new field size",
+  "packageName": "@microsoft/teams-js",
+  "email": "jainharsh@microsof.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/files.ts
+++ b/packages/teams-js/src/private/files.ts
@@ -433,10 +433,6 @@ export namespace files {
      * A string containing the path of the file relative to the ancestor directory the user selected
      */
     webkitRelativePath?: string;
-    /**
-     * The size, in bytes, of the data contained in the Blob object
-     */
-    size: number;
   }
 
   /**

--- a/packages/teams-js/src/private/files.ts
+++ b/packages/teams-js/src/private/files.ts
@@ -415,23 +415,28 @@ export namespace files {
   /**
    * @hidden
    * Object used to represent a file
+   * @beta
    *
    * @internal
    * Limited to Microsoft-internal use
    */
   export interface File extends Blob {
     /**
-     * Last modified timestamp
+     * A number that represents the number of milliseconds since the Unix epoch
      */
-    lastModified: Date;
+    lastModified: number;
     /**
      * Name of the file
      */
     name: string;
     /**
-     * The file path to uniquely identify it within the file hierarchy
+     * A string containing the path of the file relative to the ancestor directory the user selected
      */
     webkitRelativePath?: string;
+    /**
+     * The size, in bytes, of the data contained in the Blob object
+     */
+    size: number;
   }
 
   /**

--- a/packages/teams-js/test/private/files.spec.ts
+++ b/packages/teams-js/test/private/files.spec.ts
@@ -442,7 +442,7 @@ describe('files', () => {
     it('should trigger callback correctly', async () => {
       await utils.initializeWithContext('content');
 
-      const callback = jest.fn(err => {
+      const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
       });
 
@@ -525,7 +525,7 @@ describe('files', () => {
     it('should send the message to parent correctly with file path as null', () => {
       utils.initializeWithContext('content');
 
-      const callback = jest.fn(err => {
+      const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
       });
 
@@ -541,7 +541,7 @@ describe('files', () => {
     it('should send the message to parent correctly with non-null file path', () => {
       utils.initializeWithContext('content');
 
-      const callback = jest.fn(err => {
+      const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
       });
 
@@ -597,7 +597,7 @@ describe('files', () => {
         message: 'Error Message',
       };
 
-      const callback = jest.fn(err => {
+      const callback = jest.fn((err) => {
         expect(err).toEqual(sdkError);
       });
 
@@ -659,7 +659,7 @@ describe('files', () => {
     it('should send the message to parent correctly', () => {
       utils.initializeWithContext('content');
 
-      const callback = jest.fn(err => {
+      const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
       });
 
@@ -712,7 +712,7 @@ describe('files', () => {
     it('should send the message to parent correctly', () => {
       utils.initializeWithContext('content');
 
-      const callback = jest.fn(err => {
+      const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
       });
 
@@ -773,7 +773,7 @@ describe('files', () => {
     it('should send the message to parent correctly', () => {
       utils.initializeWithContext('content');
 
-      const callback = jest.fn(err => {
+      const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
       });
 
@@ -819,16 +819,18 @@ describe('files', () => {
       },
     };
 
-    const deleteFileRequestWithNullContent: files.CloudStorageProviderRequest<files.CloudStorageProviderDeleteFileContent> = {
-      content: null,
-    };
+    const deleteFileRequestWithNullContent: files.CloudStorageProviderRequest<files.CloudStorageProviderDeleteFileContent> =
+      {
+        content: null,
+      };
 
-    const deleteFileRequestWithEmptyItemList: files.CloudStorageProviderRequest<files.CloudStorageProviderDeleteFileContent> = {
-      content: {
-        providerCode: files.CloudStorageProvider.Box,
-        itemList: [],
-      },
-    };
+    const deleteFileRequestWithEmptyItemList: files.CloudStorageProviderRequest<files.CloudStorageProviderDeleteFileContent> =
+      {
+        content: {
+          providerCode: files.CloudStorageProvider.Box,
+          itemList: [],
+        },
+      };
 
     it('should not allow calls before initialization', () => {
       expect(() => files.deleteCloudStorageProviderFile(deleteFileRequest, emptyCallback)).toThrowError(
@@ -874,7 +876,7 @@ describe('files', () => {
     it('should send the message to parent correctly', () => {
       utils.initializeWithContext('content');
 
-      const callback = jest.fn(err => {
+      const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
       });
 
@@ -903,15 +905,17 @@ describe('files', () => {
         itemList: [mockDownloadFile],
       },
     };
-    const downloadFileRequestWithNullContent: files.CloudStorageProviderRequest<files.CloudStorageProviderDownloadFileContent> = {
-      content: null,
-    };
-    const downloadFileRequestWithEmptyItemList: files.CloudStorageProviderRequest<files.CloudStorageProviderDownloadFileContent> = {
-      content: {
-        providerCode: files.CloudStorageProvider.Box,
-        itemList: [],
-      },
-    };
+    const downloadFileRequestWithNullContent: files.CloudStorageProviderRequest<files.CloudStorageProviderDownloadFileContent> =
+      {
+        content: null,
+      };
+    const downloadFileRequestWithEmptyItemList: files.CloudStorageProviderRequest<files.CloudStorageProviderDownloadFileContent> =
+      {
+        content: {
+          providerCode: files.CloudStorageProvider.Box,
+          itemList: [],
+        },
+      };
 
     it('should not allow calls before initialization', () => {
       expect(() => files.downloadCloudStorageProviderFile(downloadFileRequest, emptyCallback)).toThrowError(
@@ -959,7 +963,7 @@ describe('files', () => {
     it('should send the message to parent correctly', () => {
       utils.initializeWithContext('content');
 
-      const callback = jest.fn(err => {
+      const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
       });
 
@@ -977,7 +981,7 @@ describe('files', () => {
       size: 32,
       type: 'pdf',
       name: 'file1',
-      lastModified: new Date(),
+      lastModified: 1663767892661,
       text: () => {
         return new Promise<string>(() => 'file text');
       },
@@ -1008,23 +1012,26 @@ describe('files', () => {
         destinationFolder: mockDestinationFolder,
       },
     };
-    const uploadFileRequestWithNullContent: files.CloudStorageProviderRequest<files.CloudStorageProviderUploadFileContent> = {
-      content: null,
-    };
-    const uploadFileRequestWithEmptyItemList: files.CloudStorageProviderRequest<files.CloudStorageProviderUploadFileContent> = {
-      content: {
-        providerCode: files.CloudStorageProvider.Dropbox,
-        itemList: [],
-        destinationFolder: mockDestinationFolder,
-      },
-    };
-    const uploadFileRequestWithNullDestinationFolder: files.CloudStorageProviderRequest<files.CloudStorageProviderUploadFileContent> = {
-      content: {
-        providerCode: files.CloudStorageProvider.Dropbox,
-        itemList: [mockUploadFile],
-        destinationFolder: null,
-      },
-    };
+    const uploadFileRequestWithNullContent: files.CloudStorageProviderRequest<files.CloudStorageProviderUploadFileContent> =
+      {
+        content: null,
+      };
+    const uploadFileRequestWithEmptyItemList: files.CloudStorageProviderRequest<files.CloudStorageProviderUploadFileContent> =
+      {
+        content: {
+          providerCode: files.CloudStorageProvider.Dropbox,
+          itemList: [],
+          destinationFolder: mockDestinationFolder,
+        },
+      };
+    const uploadFileRequestWithNullDestinationFolder: files.CloudStorageProviderRequest<files.CloudStorageProviderUploadFileContent> =
+      {
+        content: {
+          providerCode: files.CloudStorageProvider.Dropbox,
+          itemList: [mockUploadFile],
+          destinationFolder: null,
+        },
+      };
 
     it('should not allow calls before initialization', () => {
       expect(() => files.uploadCloudStorageProviderFile(uploadFileRequest, emptyCallback)).toThrowError(
@@ -1077,7 +1084,7 @@ describe('files', () => {
     it('should send the message to parent correctly', () => {
       utils.initializeWithContext('content');
 
-      const callback = jest.fn(err => {
+      const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
       });
 


### PR DESCRIPTION
This PR has following changes and corresponding test code update

1. Changed datatype of field **lastModified** from Date to number : This is required because of type incompatibility between the calling app API and SDK API, and  because of which the integration fails.
2. Added a new field named **size** representing the file size in bytes, being congruent with the calling app API. 

Below PRs contain the original 3P API changes.
https://github.com/OfficeDev/microsoft-teams-library-js/pull/1152
https://github.com/OfficeDev/microsoft-teams-library-js/pull/1251

File uploads to 3P providers should work as expected after this change.

Unit Tests added:
No, Modified the unit tests as applicable.

Change file added:
Yes