### PR TITLE
Remove old shareDeepLink control from test app

### DIFF
--- a/apps/teams-test-app/src/components/PagesAPIs.tsx
+++ b/apps/teams-test-app/src/components/PagesAPIs.tsx
@@ -84,46 +84,6 @@ const NavigateToApp = (): React.ReactElement =>
     },
   });
 
-// This will be removed shortly, after the UI tests are updated to look for the new name (reflected in the almost duplicative ShareDeepLink element)
-const ShareDeepLinkOld = (): ReactElement =>
-  ApiWithTextInput<DeepLinkParameters & ShareDeepLinkParameters>({
-    name: 'core.shareDeepLink',
-    title: 'Share Deeplink (Core)',
-    onClick: {
-      validateInput: (input) => {
-        if (!((input.subEntityId && input.subEntityLabel) || (input.subPageId && input.subPageLabel))) {
-          throw new Error('subPageId and subPageLabel OR subEntityId and subEntityLabel are required.');
-        }
-      },
-      submit: {
-        withPromise: async (input) => {
-          if (input.subEntityId && input.subEntityLabel) {
-            await pages.shareDeepLink({
-              subPageId: input.subEntityId,
-              subPageLabel: input.subEntityLabel,
-              subPageWebUrl: input.subEntityWebUrl,
-            });
-          } else {
-            await pages.shareDeepLink(input);
-          }
-          return 'called shareDeepLink';
-        },
-        withCallback: (input, setResult) => {
-          if (input.subEntityId && input.subEntityLabel) {
-            shareDeepLink(input);
-          } else {
-            shareDeepLink({
-              subEntityId: input.subPageId,
-              subEntityLabel: input.subPageLabel,
-              subEntityWebUrl: input.subPageWebUrl,
-            });
-          }
-          setResult('called shareDeepLink');
-        },
-      },
-    },
-  });
-
 const ShareDeepLink = (): ReactElement =>
   ApiWithTextInput<DeepLinkParameters & ShareDeepLinkParameters>({
     name: 'pages.shareDeepLink',
@@ -257,7 +217,6 @@ const PagesAPIs = (): ReactElement => (
     <GetConfig />
     <NavigateCrossDomain />
     <NavigateToApp />
-    <ShareDeepLinkOld />
     <ShareDeepLink />
     <ReturnFocus />
     <RegisterFocusEnterHandler />


### PR DESCRIPTION
## Description

In a previous pr (#1248) I updated some outdated references to the `core` namespace. Because one of these references was in the test app, I had to maintain the control with the old name and simultaneously create a new one while the E2E tests were updated to look for the new name. I have now updated the E2E tests to look for the new name, so I'm removing the control with the old name.

## Validation

### Validation performed:

E2E tests will run as part of this PR.

### Unit Tests added:

No because the only code changing here is the test app which is only consumed by E2E tests

### End-to-end tests added:

Yes, in a separate change.

## Additional Requirements

### Change file added:

No since this change does not affect the published package.

### Related PRs:

#1248 

### Next/remaining steps:

None. This completes the rename.
