### PR TITLE
Don't run v1 tests as part of TeamsJs CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,34 +106,6 @@ jobs:
           mergeTestResults: true
         condition: succeededOrFailed()
 
-  - job: E2ETest5
-    displayName: 'E2E Test - TeamsJS V1'
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      - template: tools/yaml-templates/build-app-host.yml
-        parameters:
-          appHostGitPath: git://$(AppHostingSdkGitPath5)@$(AppHostingSdkGitRef)
-
-      - task: Yarn@2
-        displayName: 'Build Teams Test App V1'
-        inputs:
-          Arguments: 'build-test-app-V1'
-          ProjectDirectory: '$(ClientSdkProjectDirectory)'
-
-      - bash: 'node tools/cli/runAppsWithE2ETests.js --envType=teamsV1 --targetClientSdkCheckpoint=1.12.1 --reportFileName=e2e-tests-report-V1'
-        displayName: 'Run E2E integration tests on Teams Test App V1'
-        condition: succeeded()
-        workingDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '**/e2e-tests-report*.xml'
-          testRunTitle: 'E2E Tests - TeamsJs V1'
-          mergeTestResults: true
-        condition: succeededOrFailed()
-
   - job: E2ETestCDN
     displayName: 'E2E Test - CDN (only runs on release builds)'
     # This test only runs after deployment from a release branch and the new CDN version has been deployed

--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -23,6 +23,7 @@ steps:
       Arguments: 'install'
       ProjectDirectory: '$(ClientSdkProjectDirectory)'
     displayName: 'Run yarn install on TeamsJS'
+    retryCountOnTaskFailure: 2
 
   - task: Yarn@2
     inputs:

--- a/tools/yaml-templates/build-app-host.yml
+++ b/tools/yaml-templates/build-app-host.yml
@@ -25,6 +25,7 @@ steps:
     inputs:
       Arguments:
       ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
+    retryCountOnTaskFailure: 2
 
   - task: Yarn@2
     displayName: 'Build app hosting sdk'
@@ -37,6 +38,7 @@ steps:
     inputs:
       Arguments:
       ProjectDirectory: '$(ClientSdkProjectDirectory)'
+    retryCountOnTaskFailure: 2
 
   - task: Yarn@2
     displayName: 'Build client sdk'

--- a/tools/yaml-templates/build-test-publish.yml
+++ b/tools/yaml-templates/build-test-publish.yml
@@ -16,6 +16,7 @@ steps:
     displayName: 'yarn install'
     inputs:
       Arguments: 'install'
+    retryCountOnTaskFailure: 2
 
   - script: 'node enforceBeachball.js'
     displayName: 'Check that changefile was created if needed'


### PR DESCRIPTION
## Description

Remove v1-targeted E2E test from TeamsJs CI run.

## Validation

### Validation performed:

N/A

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No