### PR TITLE
Clarify documentation for sharepoint property on Context object

### DIFF
--- a/change/@microsoft-teams-js-5b701dc1-c6e8-4d61-acde-7b786b791a59.json
+++ b/change/@microsoft-teams-js-5b701dc1-c6e8-4d61-acde-7b786b791a59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Clarified documentation for `sharepoint` property on `Context` object",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -487,7 +487,7 @@ export namespace app {
     meeting?: MeetingInfo;
 
     /**
-     * SharePoint context. This is only available when hosted in SharePoint.
+     * When hosted in SharePoint, this is the [SharePoint PageContext](https://learn.microsoft.com/en-us/javascript/api/sp-page-context/pagecontext?view=sp-typescript-latest), else `undefined`
      */
     sharepoint?: any;
 


### PR DESCRIPTION
## Description

The documentation for the `sharepoint` property on the `Context` object did not provide enough detail for someone to actually use it (e.g., what data would be in it and what would be the shape of that data?)

This change elaborates and provides a link to the docs when a developer can see the data available in the property.

## Validation

### Validation performed:

Generated typedocs locally and observed that they looked correct and that the link worked.

### Unit Tests added:

No, there is no functionality change with this fix.

### End-to-end tests added:

No, there is no functionality change with this fix.

## Additional Requirements

### Change file added:

Yes

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| <img width="662" alt="image" src="https://user-images.githubusercontent.com/36546967/192070803-cb0ae591-03a1-4be6-9530-a13ce5e4aa04.png"> | <img width="605" alt="image" src="https://user-images.githubusercontent.com/36546967/192070831-f0dd0850-7810-482a-8c8a-3ab2942eeae5.png">
 |
