### PR TITLE
Link updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ TIP: whenever building or testing the Teams client SDK, you can run `yarn build`
 
 See also: [Contributing](#Contributing)
 
-This JavaScript library is part of the [Microsoft Teams developer platform](https://docs.microsoft.com/en-us/microsoftteams/platform/overview?view=msteams-client-js-beta). See full [SDK reference documentation](https://docs.microsoft.com/en-us/javascript/api/overview/msteams-client?view=msteams-client-js-beta).
+This JavaScript library is part of the [Microsoft Teams developer platform](https://learn.microsoft.com/microsoftteams/platform/overview?view=msteams-client-js-latest). See full [SDK reference documentation](https://learn.microsoft.com/javascript/api/overview/msteams-client?view=msteams-client-js-latest).
 
 # Packages
 

--- a/apps/sample-app/src/App.tsx
+++ b/apps/sample-app/src/App.tsx
@@ -20,7 +20,7 @@ const App: React.FC = () => {
         app.notifySuccess();
         const context = await app.getContext();
         // Learn more about 'app' namespace from the link below
-        //https://docs.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/using-teams-client-sdk?tabs=javascript%2Cmanifest-teams-toolkit#differentiate-your-app-experience
+        //https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/using-teams-client-sdk?tabs=javascript%2Cmanifest-teams-toolkit#differentiate-your-app-experience
         if (context?.app?.host?.name === 'Teams') {
           const themeNow = getThemeTeams(context?.app?.theme);
           setCurrTheme(themeNow);

--- a/change/@microsoft-teams-js-428c45d4-9a6f-46ff-8c5a-33db61803db2.json
+++ b/change/@microsoft-teams-js-428c45d4-9a6f-46ff-8c5a-33db61803db2.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Updates to the URLs for docs links.",
   "packageName": "@microsoft/teams-js",
-  "email": "email not defined",
+  "email": "joshuapa@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@microsoft-teams-js-428c45d4-9a6f-46ff-8c5a-33db61803db2.json
+++ b/change/@microsoft-teams-js-428c45d4-9a6f-46ff-8c5a-33db61803db2.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Updates to the URLs for docs links.",
+  "comment": "Updated the URLs for docs links.",
   "packageName": "@microsoft/teams-js",
   "email": "joshuapa@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-428c45d4-9a6f-46ff-8c5a-33db61803db2.json
+++ b/change/@microsoft-teams-js-428c45d4-9a6f-46ff-8c5a-33db61803db2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updates to the URLs for docs links.",
+  "packageName": "@microsoft/teams-js",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the Teams JavaScript client SDK! For breaking changes, please refer to our [changelog](./CHANGELOG.md) in the current `<root>/packages/teams-js` directory.
 
-This JavaScript library is part of the [Microsoft Teams developer platform](https://docs.microsoft.com/en-us/microsoftteams/platform/). See full [SDK reference documentation](https://docs.microsoft.com/javascript/api/overview/msteams-client?view=msteams-client-js-latest).
+This JavaScript library is part of the [Microsoft Teams developer platform](https://learn.microsoft.com/microsoftteams/platform/). See full [SDK reference documentation](https://learn.microsoft.com/javascript/api/overview/msteams-client?view=msteams-client-js-latest).
 
 ## Getting Started
 
@@ -12,7 +12,7 @@ Whenever building or testing the Teams client SDK, you can run `yarn build` or `
 
 ## Installation
 
-To install the stable [version](https://docs.microsoft.com/javascript/api/overview/msteams-client?view=msteams-client-js-latest):
+To install the stable [version](https://learn.microsoft.com/javascript/api/overview/msteams-client?view=msteams-client-js-latest):
 
 ### npm
 

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -249,7 +249,7 @@ export interface ActionInfo {
  *
  * @remarks
  * For more details about the updated {@link app.Context} interface, visit the
- * [Teams JavaScript client SDK](https://docs.microsoft.com/microsoftteams/platform/tabs/how-to/using-teams-client-sdk#updates-to-the-context-interface)
+ * [Teams JavaScript client SDK](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/using-teams-client-sdk#updates-to-the-context-interface)
  * overview article.
  *
  * Represents the structure of the received context message.

--- a/packages/teams-js/src/public/profile.ts
+++ b/packages/teams-js/src/public/profile.ts
@@ -70,7 +70,7 @@ export namespace profile {
      *
      * This id is guaranteed to be unique for an object within a tenant,
      * and so if provided will lead to a more performant lookup. It can
-     * be resolved via MS Graph (see https://docs.microsoft.com/en-us/graph/api/resources/users
+     * be resolved via MS Graph (see https://learn.microsoft.com/graph/api/resources/users
      * for examples).
      */
     readonly AadObjectId?: string;


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> The docs.microsoft.com URL was changed to learn.microsoft.com. This PR updates any direct links in markdown or comments that used docs.microsoft.com. Also, ensured that the updated links did not use a hardcoded language path (en-us, etc) and that use of msteams-client-js-beta in the URL was now msteams-client-js-latest. 

### Main changes in the PR:

1. Updated all links that used the docs.microsoft.com URL to now use learn.microsoft.com

## Validation

### Validation performed:

1. Clicked links to ensure navigation was equivalent to prior docs.microsoft.com link

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

No - Changes were strictly to comments or markdown text with URLs to docs.microsoft.com 

### End-to-end tests added:

No - Changes were strictly to comments or markdown text with URLs to docs.microsoft.com

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes


