### PR TITLE
Update documentation for message property on app.IFailedRequest to indicate that it is unused

### DIFF
--- a/change/@microsoft-teams-js-57a0030b-c4bf-427f-9a3f-cf218d6c4bc3.json
+++ b/change/@microsoft-teams-js-57a0030b-c4bf-427f-9a3f-cf218d6c4bc3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated documentation for `app.IFailedRequest.message` property to clarify that it is unused.",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -98,7 +98,7 @@ export namespace app {
      */
     reason: FailedReason;
     /**
-     * A message that describes the failure
+     * This property is currently unused.
      */
     message?: string;
   }


### PR DESCRIPTION
## Description

In issue #1365, it was shown that the `message` property is unused. The documentation (here and elsewhere) does not explicitly state that the message is show in the UI, but it's natural for someone to expect that.

In this change the documentation for the `message` is updated to indicate that it's unused. Separately we have the issue tracking the work to either make it show up in the UI or decide that we don't want to enable that and then remove the `message` property altogether.

## Validation

### Validation performed:

- Ensure build and tests succeeded
- Generate documentation, verify it looks as expected.

### Unit Tests added:

No. There are no unit tests that validate documentation content.

### End-to-end tests added:

No. There are no E2E tests that validate documentation content.

## Additional Requirements

### Change file added:

Yes

### Screenshots:

| Before     | After      |
| ---------- | ---------- |
| <img width="658" alt="image" src="https://user-images.githubusercontent.com/36546967/195466647-fe5d3302-6aba-41df-ac1c-92d70ab285ba.png"> | <img width="603" alt="image" src="https://user-images.githubusercontent.com/36546967/195466670-e2219eb3-0a65-4655-8aa0-290950dca502.png"> |
