### PR TITLE
Update documentation for what result is returned when user closes dialog

### DIFF
--- a/change/@microsoft-teams-js-8b6459b8-aa6f-4f83-a71c-47b3d6022114.json
+++ b/change/@microsoft-teams-js-8b6459b8-aa6f-4f83-a71c-47b3d6022114.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated `ISdkResponse.result` field to indicate value when dialog is closed by user",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -26,8 +26,10 @@ export namespace dialog {
     err?: string;
 
     /**
-     * Result value that the dialog is submitted with using {@linkcode submit} function. If the dialog
-     * was closed by the user without submitting, this value will be `undefined`.
+     * Value provided in the `result` parameter by the dialog when the {@linkcode submit} function
+     * was called.
+     * If the dialog was closed by the user without submitting (e.g., using a control in the corner
+     * of the dialog), this value will be `undefined` here.
      */
     result?: string | object;
   }

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -26,8 +26,8 @@ export namespace dialog {
     err?: string;
 
     /**
-     * Result value that the dialog is submitted with using {@linkcode submit} function
-     *
+     * Result value that the dialog is submitted with using {@linkcode submit} function. If the dialog
+     * was closed by the user without submitting, this value will be `undefined`.
      */
     result?: string | object;
   }


### PR DESCRIPTION
## Description

There was no explicit documentation on what value `ISdkResponse.result` has if the user closes the dialog instead of submitting (e.g. using the X in the corner). This change adds documentation to indicate that it is `undefined` in that case.

## Validation

### Validation performed:

Create docs locally, ensured they looked correct.

### Unit Tests added:

No unit tests for documentation content.

### End-to-end tests added:

No E2E tests for documentation content.

## Additional Requirements

### Change file added:

Yes

### Screenshots:

| Before     | After      |
| ---------- | ---------- |
| <img width="667" alt="image" src="https://user-images.githubusercontent.com/36546967/195481796-3806ea45-a0f3-4b9c-85d3-521829d74c2d.png"> | <img width="608" alt="image" src="https://user-images.githubusercontent.com/36546967/195482455-a346f625-4cb0-4737-8fd0-06a8aba1e8ea.png"> |
