### PR TITLE
Fixing broken link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Welcome to the Teams client SDK monorepo! For breaking changes, please refer to 
 
 TIP: whenever building or testing the Teams client SDK, you can run `yarn build` or `yarn test` from the `packages/teams-js` directory.
 
-See also: [Contributing](./Contributing.md)
+See also: [Contributing](CONTRIBUTING.md)
 
 This JavaScript library is part of the [Microsoft Teams developer platform](https://learn.microsoft.com/microsoftteams/platform/overview?view=msteams-client-js-latest). See full [SDK reference documentation](https://learn.microsoft.com/javascript/api/overview/msteams-client?view=msteams-client-js-latest).
 


### PR DESCRIPTION
## Description

One of the links in the README file did not actually go to the CONTRIBUTING.md file. I fixed it so that it works now.

### Main changes in the PR:

1. Update the first link to CONTRIBUTING.md in the top-level README file to actually take users to that file.

## Validation

### Validation performed:

1. Clicked the link in the README file and made sure it works
2. Manually verified that the link is now the same as another link to the same file that already works correctly.

### Unit Tests added:

None necessary, README update only

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No, README update only

### Related PRs:

None
