### PR TITLE
Make sure initialize completes before most API calls are allowed

### DIFF
--- a/change/@microsoft-teams-js-51980b95-c86a-4b3c-a2d0-1b9e475014b3.json
+++ b/change/@microsoft-teams-js-51980b95-c86a-4b3c-a2d0-1b9e475014b3.json
@@ -1,5 +1,5 @@
 {
-  "type": "major",
+  "type": "minor",
   "comment": "Updated most APIs to require initialization to be fully finished before they are allowed to be called.",
   "packageName": "@microsoft/teams-js",
   "email": "email not defined",

--- a/change/@microsoft-teams-js-51980b95-c86a-4b3c-a2d0-1b9e475014b3.json
+++ b/change/@microsoft-teams-js-51980b95-c86a-4b3c-a2d0-1b9e475014b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Updated most APIs to require initialization to be fully finished before they are allowed to be called.",
+  "packageName": "@microsoft/teams-js",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -100,7 +100,8 @@ export function registerHandlerHelper(
   contexts: FrameContexts[],
   registrationHelper?: () => void,
 ): void {
-  ensureInitialized(...contexts);
+  // allow for registration cleanup even when not finished initializing
+  handler && ensureInitialized(...contexts);
   if (registrationHelper) {
     registrationHelper();
   }

--- a/packages/teams-js/src/internal/internalAPIs.ts
+++ b/packages/teams-js/src/internal/internalAPIs.ts
@@ -2,7 +2,12 @@ import { HostClientType } from '../public/constants';
 import { ErrorCode, SdkError } from '../public/interfaces';
 import { defaultSDKVersionForCompatCheck, userOriginUrlValidationRegExp } from './constants';
 import { GlobalVars } from './globalVars';
+import { getLogger } from './telemetry';
 import { compareSDKVersions } from './utils';
+
+const internalLogger = getLogger('internal');
+const ensureInitializeCalledLogger = internalLogger.extend('ensureInitializeCalled');
+const ensureInitializedLogger = internalLogger.extend('ensureInitialized');
 
 /**
  * Ensures `initialize` was called. This function does NOT verify that a response from Host was received and initialization completed.
@@ -19,6 +24,7 @@ import { compareSDKVersions } from './utils';
  */
 export function ensureInitializeCalled(): void {
   if (!GlobalVars.initializeCalled) {
+    ensureInitializeCalledLogger('The library has not yet been initialized.');
     throw new Error('The library has not yet been initialized');
   }
 }
@@ -32,6 +38,10 @@ export function ensureInitializeCalled(): void {
  */
 export function ensureInitialized(...expectedFrameContexts: string[]): void {
   if (!GlobalVars.initializeCompleted) {
+    ensureInitializedLogger(
+      'The library has not yet been initialized. initializeCalled: %s',
+      GlobalVars.initializeCalled.toString(),
+    );
     throw new Error('The library has not yet been initialized');
   }
 

--- a/packages/teams-js/src/internal/internalAPIs.ts
+++ b/packages/teams-js/src/internal/internalAPIs.ts
@@ -8,12 +8,22 @@ import { compareSDKVersions } from './utils';
  * @internal
  * Limited to Microsoft-internal use
  */
-export function ensureInitialized(...expectedFrameContexts: string[]): void {
+export function ensureInitializeCalled(): void {
   if (!GlobalVars.initializeCalled) {
     throw new Error('The library has not yet been initialized');
   }
+}
 
-  if (GlobalVars.frameContext && expectedFrameContexts && expectedFrameContexts.length > 0) {
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function ensureInitialized(...expectedFrameContexts: string[]): void {
+  if (!GlobalVars.initializeCompleted || !GlobalVars.frameContext) {
+    throw new Error('The library has not yet been initialized');
+  }
+
+  if (expectedFrameContexts && expectedFrameContexts.length > 0) {
     let found = false;
     for (let i = 0; i < expectedFrameContexts.length; i++) {
       if (expectedFrameContexts[i] === GlobalVars.frameContext) {

--- a/packages/teams-js/src/internal/internalAPIs.ts
+++ b/packages/teams-js/src/internal/internalAPIs.ts
@@ -5,6 +5,15 @@ import { GlobalVars } from './globalVars';
 import { compareSDKVersions } from './utils';
 
 /**
+ * Ensures `initialize` was called. This function does NOT verify that a response from Host was received and initialization completed.
+ *
+ * `ensureInitializeCalled` should only be used for APIs which:
+ * - work in all FrameContexts
+ * - are part of a required Capability
+ * - are suspected to be used directly after calling `initialize`, potentially without awaiting the `initialize` call itself
+ *
+ * For most APIs {@link ensureInitialized} is the right validation function to use instead.
+ *
  * @internal
  * Limited to Microsoft-internal use
  */
@@ -15,11 +24,14 @@ export function ensureInitializeCalled(): void {
 }
 
 /**
+ * Ensures `initialize` was called and response from Host was received and processed.
+ * If expected FrameContexts are provided, it also validates that the current FrameContext matches one of the expected ones.
+ *
  * @internal
  * Limited to Microsoft-internal use
  */
 export function ensureInitialized(...expectedFrameContexts: string[]): void {
-  if (!GlobalVars.initializeCompleted || !GlobalVars.frameContext) {
+  if (!GlobalVars.initializeCompleted) {
     throw new Error('The library has not yet been initialized');
   }
 

--- a/packages/teams-js/src/private/logs.ts
+++ b/packages/teams-js/src/private/logs.ts
@@ -24,7 +24,8 @@ export namespace logs {
    * Limited to Microsoft-internal use
    */
   export function registerGetLogHandler(handler: () => string): void {
-    ensureInitialized();
+    // allow for registration cleanup even when not finished initializing
+    handler && ensureInitialized();
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -13,7 +13,7 @@ import {
 import { defaultSDKVersionForCompatCheck } from '../internal/constants';
 import { GlobalVars } from '../internal/globalVars';
 import * as Handlers from '../internal/handlers'; // Conflict with some names
-import { ensureInitialized, processAdditionalValidOrigins } from '../internal/internalAPIs';
+import { ensureInitializeCalled, ensureInitialized, processAdditionalValidOrigins } from '../internal/internalAPIs';
 import { getLogger } from '../internal/telemetry';
 import { compareSDKVersions, runWithTimeout } from '../internal/utils';
 import { logs } from '../private/logs';
@@ -691,7 +691,7 @@ export namespace app {
    */
   export function getContext(): Promise<app.Context> {
     return new Promise<LegacyContext>((resolve) => {
-      ensureInitialized();
+      ensureInitializeCalled();
       resolve(sendAndUnwrap('getContext'));
     }).then((legacyContext) => transformLegacyContextToAppContext(legacyContext)); // converts globalcontext to app.context
   }
@@ -700,7 +700,7 @@ export namespace app {
    * Notifies the frame that app has loaded and to hide the loading indicator if one is shown.
    */
   export function notifyAppLoaded(): void {
-    ensureInitialized();
+    ensureInitializeCalled();
     sendMessageToParent(Messages.AppLoaded, [version]);
   }
 
@@ -708,7 +708,7 @@ export namespace app {
    * Notifies the frame that app initialization is successful and is ready for user interaction.
    */
   export function notifySuccess(): void {
-    ensureInitialized();
+    ensureInitializeCalled();
     sendMessageToParent(Messages.Success, [version]);
   }
 
@@ -719,7 +719,7 @@ export namespace app {
    * during initialization as well as an optional message.
    */
   export function notifyFailure(appInitializationFailedRequest: IFailedRequest): void {
-    ensureInitialized();
+    ensureInitializeCalled();
     sendMessageToParent(Messages.Failure, [
       appInitializationFailedRequest.reason,
       appInitializationFailedRequest.message,
@@ -732,7 +732,7 @@ export namespace app {
    * @param expectedFailureRequest - The expected failure request containing the reason and an optional message
    */
   export function notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void {
-    ensureInitialized();
+    ensureInitializeCalled();
     sendMessageToParent(Messages.ExpectedFailure, [expectedFailureRequest.reason, expectedFailureRequest.message]);
   }
 
@@ -745,7 +745,8 @@ export namespace app {
    * @param handler - The handler to invoke when the user changes their theme.
    */
   export function registerOnThemeChangeHandler(handler: (theme: string) => void): void {
-    ensureInitialized();
+    // allow for registration cleanup even when not called initialize
+    handler && ensureInitializeCalled();
     Handlers.registerOnThemeChangeHandler(handler);
   }
 

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -509,7 +509,7 @@ export namespace app {
    * @returns whether the Teams client SDK has been initialized.
    */
   export function isInitialized(): boolean {
-    return GlobalVars.initializeCalled;
+    return GlobalVars.initializeCompleted;
   }
 
   /**

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -7,7 +7,7 @@ import {
 } from '../internal/communication';
 import { GlobalVars } from '../internal/globalVars';
 import { registerHandler, removeHandler } from '../internal/handlers';
-import { ensureInitialized } from '../internal/internalAPIs';
+import { ensureInitializeCalled, ensureInitialized } from '../internal/internalAPIs';
 import { FrameContexts, HostClientType } from './constants';
 
 /**
@@ -167,7 +167,7 @@ export namespace authentication {
    */
   export function getAuthToken(authTokenRequest?: AuthTokenRequest): void;
   export function getAuthToken(authTokenRequest?: AuthTokenRequest): Promise<string> {
-    ensureInitialized();
+    ensureInitializeCalled();
     return getAuthTokenHelper(authTokenRequest)
       .then((value: string) => {
         if (authTokenRequest && authTokenRequest.successCallback) {
@@ -226,7 +226,7 @@ export namespace authentication {
    */
   export function getUser(userRequest: UserRequest): void;
   export function getUser(userRequest?: UserRequest): Promise<UserProfile> {
-    ensureInitialized();
+    ensureInitializeCalled();
     return getUserHelper()
       .then((value: UserProfile) => {
         if (userRequest && userRequest.successCallback) {

--- a/packages/teams-js/src/public/liveShareHost.ts
+++ b/packages/teams-js/src/public/liveShareHost.ts
@@ -133,14 +133,14 @@ export interface IFluidTenantInfo {
 
 /**
  * Live Share host implementation for O365 and Teams clients.
- * 
+ *
  * @beta
  */
 export class LiveShareHost {
   /**
    * @hidden
    * Returns the Fluid Tenant connection info for user's current context.
-   * 
+   *
    * @beta
    */
   public getFluidTenantInfo(): Promise<IFluidTenantInfo> {
@@ -157,7 +157,7 @@ export class LiveShareHost {
    *
    * @param containerId Fluid's container Id for the request. Undefined for new containers.
    * @returns token for connecting to Fluid's session.
-   * 
+   *
    * @beta
    */
   public getFluidToken(containerId?: string): Promise<string> {
@@ -172,7 +172,7 @@ export class LiveShareHost {
   /**
    * @hidden
    * Returns the ID of the fluid container associated with the user's current context.
-   * 
+   *
    * @beta
    */
   public getFluidContainerId(): Promise<IFluidContainerInfo> {
@@ -192,7 +192,7 @@ export class LiveShareHost {
    * `getFluidContainerId()` to get the ID of the container being used.
    * @param containerId ID of the fluid container the client created.
    * @returns A data structure with a `containerState` indicating the success or failure of the request.
-   * 
+   *
    * @beta
    */
   public setFluidContainerId(containerId: string): Promise<IFluidContainerInfo> {
@@ -206,7 +206,7 @@ export class LiveShareHost {
   /**
    * @hidden
    * Returns the shared clock server's current time.
-   * 
+   *
    * @beta
    */
   public getNtpTime(): Promise<INtpTimeInfo> {
@@ -223,7 +223,7 @@ export class LiveShareHost {
    *
    * @param clientId The ID for the current user's Fluid client. Changes on reconnects.
    * @returns The roles for the current user.
-   * 
+   *
    * @beta
    */
   public registerClientId(clientId: string): Promise<UserMeetingRole[]> {
@@ -240,7 +240,7 @@ export class LiveShareHost {
    *
    * @param clientId The Client ID the message was received from.
    * @returns The roles for a given client. Returns `undefined` if the client ID hasn't been registered yet.
-   * 
+   *
    * @beta
    */
   public getClientRoles(clientId: string): Promise<UserMeetingRole[] | undefined> {
@@ -256,7 +256,7 @@ export class LiveShareHost {
    *
    * @remarks
    * The application must first be initialized and may only be called from `meetingStage` or `sidePanel` contexts.
-   * 
+   *
    * @beta
    */
   public static create(): LiveShareHost {

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -395,7 +395,8 @@ export namespace pages {
       handler: (evt: SaveEvent) => void,
       versionSpecificHelper?: () => void,
     ): void {
-      ensureInitialized(FrameContexts.settings);
+      // allow for registration cleanup even when not finished initializing
+      handler && ensureInitialized(FrameContexts.settings);
       if (versionSpecificHelper) {
         versionSpecificHelper();
       }
@@ -432,7 +433,8 @@ export namespace pages {
       handler: (evt: RemoveEvent) => void,
       versionSpecificHelper?: () => void,
     ): void {
-      ensureInitialized(FrameContexts.remove, FrameContexts.settings);
+      // allow for registration cleanup even when not finished initializing
+      handler && ensureInitialized(FrameContexts.remove, FrameContexts.settings);
       if (versionSpecificHelper) {
         versionSpecificHelper();
       }
@@ -636,7 +638,8 @@ export namespace pages {
      * @param versionSpecificHelper - The helper function containing logic pertaining to a specific version of the API.
      */
     export function registerBackButtonHandlerHelper(handler: () => boolean, versionSpecificHelper?: () => void): void {
-      ensureInitialized();
+      // allow for registration cleanup even when not finished initializing
+      handler && ensureInitialized();
       if (versionSpecificHelper) {
         versionSpecificHelper();
       }

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -1,5 +1,5 @@
 import { registerHandlerHelper } from '../internal/handlers';
-import { ensureInitialized } from '../internal/internalAPIs';
+import { ensureInitializeCalled, ensureInitialized } from '../internal/internalAPIs';
 import { getGenericOnCompleteHandler } from '../internal/utils';
 import { app } from './app';
 import { FrameContexts } from './constants';
@@ -90,7 +90,7 @@ export function print(): void {
  * @param callback - The callback to invoke when the {@link Context} object is retrieved.
  */
 export function getContext(callback: (context: Context) => void): void {
-  ensureInitialized();
+  ensureInitializeCalled();
   app.getContext().then((context: app.Context) => {
     if (callback) {
       callback(transformAppContextToLegacyContext(context));

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -69,7 +69,8 @@ export namespace teamsCore {
     handler: (context: LoadContext) => void,
     versionSpecificHelper?: () => void,
   ): void {
-    ensureInitialized();
+    // allow for registration cleanup even when not finished initializing
+    handler && ensureInitialized();
 
     if (versionSpecificHelper) {
       versionSpecificHelper();
@@ -110,7 +111,8 @@ export namespace teamsCore {
     handler: (readyToUnload: () => void) => boolean,
     versionSpecificHelper?: () => void,
   ): void {
-    ensureInitialized();
+    // allow for registration cleanup even when not finished initializing
+    handler && ensureInitialized();
     if (versionSpecificHelper) {
       versionSpecificHelper();
     }

--- a/packages/teams-js/test/private/files.spec.ts
+++ b/packages/teams-js/test/private/files.spec.ts
@@ -522,8 +522,8 @@ describe('files', () => {
     });
 
     // null file path value is interpreted as opening cofigured download preference folder
-    it('should send the message to parent correctly with file path as null', () => {
-      utils.initializeWithContext('content');
+    it('should send the message to parent correctly with file path as null', async () => {
+      await utils.initializeWithContext('content');
 
       const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
@@ -538,8 +538,8 @@ describe('files', () => {
     });
 
     // non-null file path value is interpreted as opening containing folder for the given file path
-    it('should send the message to parent correctly with non-null file path', () => {
-      utils.initializeWithContext('content');
+    it('should send the message to parent correctly with non-null file path', async () => {
+      await utils.initializeWithContext('content');
 
       const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
@@ -573,8 +573,8 @@ describe('files', () => {
       );
     });
 
-    it('should send the message to parent correctly', () => {
-      utils.initializeWithContext('content');
+    it('should send the message to parent correctly', async () => {
+      await utils.initializeWithContext('content');
 
       const callback = jest.fn((err, provider) => {
         expect(err).toBeFalsy();
@@ -589,8 +589,8 @@ describe('files', () => {
       expect(callback).toHaveBeenCalled();
     });
 
-    it('should send the message to parent correctly and handle error scenario', () => {
-      utils.initializeWithContext('content');
+    it('should send the message to parent correctly and handle error scenario', async () => {
+      await utils.initializeWithContext('content');
 
       const sdkError: SdkError = {
         errorCode: ErrorCode.INTERNAL_ERROR,
@@ -609,8 +609,8 @@ describe('files', () => {
       expect(callback).toHaveBeenCalled();
     });
 
-    it('should send the message to parent correctly, handle error scenario and validate provider value', () => {
-      utils.initializeWithContext('content');
+    it('should send the message to parent correctly, handle error scenario and validate provider value', async () => {
+      await utils.initializeWithContext('content');
 
       const sdkError: SdkError = {
         errorCode: ErrorCode.INTERNAL_ERROR,
@@ -656,8 +656,8 @@ describe('files', () => {
       );
     });
 
-    it('should send the message to parent correctly', () => {
-      utils.initializeWithContext('content');
+    it('should send the message to parent correctly', async () => {
+      await utils.initializeWithContext('content');
 
       const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
@@ -709,8 +709,8 @@ describe('files', () => {
       );
     });
 
-    it('should send the message to parent correctly', () => {
-      utils.initializeWithContext('content');
+    it('should send the message to parent correctly', async () => {
+      await utils.initializeWithContext('content');
 
       const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
@@ -770,8 +770,8 @@ describe('files', () => {
       );
     });
 
-    it('should send the message to parent correctly', () => {
-      utils.initializeWithContext('content');
+    it('should send the message to parent correctly', async () => {
+      await utils.initializeWithContext('content');
 
       const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
@@ -873,8 +873,8 @@ describe('files', () => {
       );
     });
 
-    it('should send the message to parent correctly', () => {
-      utils.initializeWithContext('content');
+    it('should send the message to parent correctly', async () => {
+      await utils.initializeWithContext('content');
 
       const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
@@ -960,8 +960,8 @@ describe('files', () => {
       );
     });
 
-    it('should send the message to parent correctly', () => {
-      utils.initializeWithContext('content');
+    it('should send the message to parent correctly', async () => {
+      await utils.initializeWithContext('content');
 
       const callback = jest.fn((err) => {
         expect(err).toBeFalsy();
@@ -1081,8 +1081,8 @@ describe('files', () => {
       ).toThrowError('[files.uploadCloudStorageProviderFile] Invalid destination folder details');
     });
 
-    it('should send the message to parent correctly', () => {
-      utils.initializeWithContext('content');
+    it('should send the message to parent correctly', async () => {
+      await utils.initializeWithContext('content');
 
       const callback = jest.fn((err) => {
         expect(err).toBeFalsy();

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -61,8 +61,17 @@ describe('Testing app capability', () => {
         expect(app.isInitialized()).toBe(false);
       });
 
-      it('app.isInitialized should return true after initialized', () => {
-        app.initialize();
+      it('app.isInitialized should return false after initialized but before initialization completed, and true once initialization completes', async () => {
+        expect.assertions(2);
+
+        const initPromise = app.initialize();
+        expect(app.isInitialized()).toBe(false);
+
+        const initMessage = utils.findMessageByFunc('initialize');
+        utils.respondToMessage(initMessage, 'content');
+
+        await initPromise;
+
         expect(app.isInitialized()).toBe(true);
       });
     });
@@ -331,6 +340,25 @@ describe('Testing app capability', () => {
         await expect(app.getContext()).rejects.toThrowError('The library has not yet been initialized');
       });
 
+      it('app.getContext should allow calls after initialization called, but before it finished', async () => {
+        expect.assertions(3);
+
+        const initPromise = app.initialize();
+        const initMessage = utils.findMessageByFunc('initialize');
+        expect(initMessage).not.toBeNull();
+
+        app.getContext();
+        let message = utils.findMessageByFunc('getContext');
+        expect(message).toBeNull();
+
+        utils.respondToMessage(initMessage, 'content');
+
+        await initPromise;
+
+        message = utils.findMessageByFunc('getContext');
+        expect(message).not.toBeNull();
+      });
+
       Object.values(FrameContexts).forEach((context) => {
         it(`app.getContext should successfully get frame context in ${context} context`, async () => {
           await utils.initializeWithContext(context);
@@ -573,6 +601,25 @@ describe('Testing app capability', () => {
         expect(() => app.notifyAppLoaded()).toThrowError('The library has not yet been initialized');
       });
 
+      it('app.notifyAppLoaded should allow calls after initialization called, but before it finished', async () => {
+        expect.assertions(3);
+
+        const initPromise = app.initialize();
+        const initMessage = utils.findMessageByFunc('initialize');
+        expect(initMessage).not.toBeNull();
+
+        app.notifyAppLoaded();
+        let message = utils.findMessageByFunc('appInitialization.appLoaded');
+        expect(message).toBeNull();
+
+        utils.respondToMessage(initMessage, 'content');
+
+        await initPromise;
+
+        message = utils.findMessageByFunc('appInitialization.appLoaded');
+        expect(message).not.toBeNull();
+      });
+
       Object.values(FrameContexts).forEach((context) => {
         it(`app.notifyAppLoaded should successfully notify app is loaded with no error from ${context} context`, async () => {
           await utils.initializeWithContext(context);
@@ -588,6 +635,25 @@ describe('Testing app capability', () => {
     describe('Testing app.notifySuccess function', () => {
       it('app.notifySuccess should not allow calls before initialization', () => {
         expect(() => app.notifySuccess()).toThrowError('The library has not yet been initialized');
+      });
+
+      it('app.notifySuccess should allow calls after initialization called, but before it finished', async () => {
+        expect.assertions(3);
+
+        const initPromise = app.initialize();
+        const initMessage = utils.findMessageByFunc('initialize');
+        expect(initMessage).not.toBeNull();
+
+        app.notifySuccess();
+        let message = utils.findMessageByFunc('appInitialization.success');
+        expect(message).toBeNull();
+
+        utils.respondToMessage(initMessage, 'content');
+
+        await initPromise;
+
+        message = utils.findMessageByFunc('appInitialization.success');
+        expect(message).not.toBeNull();
       });
 
       Object.values(FrameContexts).forEach((context) => {
@@ -610,6 +676,28 @@ describe('Testing app capability', () => {
             message: 'Failed message',
           }),
         ).toThrowError('The library has not yet been initialized');
+      });
+
+      it('app.notifyFailure should allow calls after initialization called, but before it finished', async () => {
+        expect.assertions(3);
+
+        const initPromise = app.initialize();
+        const initMessage = utils.findMessageByFunc('initialize');
+        expect(initMessage).not.toBeNull();
+
+        app.notifyFailure({
+          reason: app.FailedReason.AuthFailed,
+          message: 'Failed message',
+        });
+        let message = utils.findMessageByFunc('appInitialization.failure');
+        expect(message).toBeNull();
+
+        utils.respondToMessage(initMessage, 'content');
+
+        await initPromise;
+
+        message = utils.findMessageByFunc('appInitialization.failure');
+        expect(message).not.toBeNull();
       });
 
       Object.values(FrameContexts).forEach((context) => {
@@ -770,8 +858,22 @@ describe('Testing app capability', () => {
         expect(app.isInitialized()).toBe(false);
       });
 
-      it('app.isInitialized should return true after initialized', () => {
-        app.initialize();
+      it('app.isInitialized should return false after initialized but before initialization completed, and true once initialization completes', async () => {
+        expect.assertions(2);
+
+        const initPromise = app.initialize();
+        expect(app.isInitialized()).toBe(false);
+
+        const initMessage = framelessPostMock.findMessageByFunc('initialize');
+        framelessPostMock.respondToMessage({
+          data: {
+            id: initMessage.id,
+            args: [],
+          },
+        } as DOMMessageEvent);
+
+        await initPromise;
+
         expect(app.isInitialized()).toBe(true);
       });
     });

--- a/packages/teams-js/test/public/appInstallDialog.spec.ts
+++ b/packages/teams-js/test/public/appInstallDialog.spec.ts
@@ -1,4 +1,3 @@
-import { isConstructorDeclaration } from 'typescript';
 import { teamsDeepLinkUrlPathForAppInstall } from '../../src/internal/deepLinkConstants';
 import { app, appInstallDialog, FrameContexts } from '../../src/public';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';

--- a/packages/teams-js/test/public/appInstallDialog.spec.ts
+++ b/packages/teams-js/test/public/appInstallDialog.spec.ts
@@ -1,3 +1,4 @@
+import { isConstructorDeclaration } from 'typescript';
 import { teamsDeepLinkUrlPathForAppInstall } from '../../src/internal/deepLinkConstants';
 import { app, appInstallDialog, FrameContexts } from '../../src/public';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
@@ -31,7 +32,14 @@ describe('appInstallDialog', () => {
   });
 
   it('Should not allow openAppInstallDialog if not supported', async () => {
-    utils.initializeWithContext(FrameContexts.content);
+    await utils.initializeWithContext(FrameContexts.content);
+    utils.setRuntimeConfig({
+      apiVersion: 1,
+      isLegacyTeams: false,
+      supports: {
+        appInstallDialog: undefined,
+      },
+    });
     await expect(appInstallDialog.openAppInstallDialog(mockOpenAppInstallDialogParams)).rejects.toThrowError(
       'Not supported',
     );

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -415,6 +415,25 @@ describe('Testing authentication capability', () => {
         );
       });
 
+      it('authentication.getAuthToken should allow calls after initialization called, but before it finished', async () => {
+        expect.assertions(3);
+
+        const initPromise = app.initialize();
+        const initMessage = utils.findMessageByFunc('initialize');
+        expect(initMessage).not.toBeNull();
+
+        authentication.getAuthToken();
+        let message = utils.findMessageByFunc('authentication.getAuthToken');
+        expect(message).toBeNull();
+
+        utils.respondToMessage(initMessage, 'content');
+
+        await initPromise;
+
+        message = utils.findMessageByFunc('authentication.getAuthToken');
+        expect(message).not.toBeNull();
+      });
+
       Object.values(FrameContexts).forEach((context) => {
         it(`authentication.getAuthToken should successfully return token in case of success in legacy flow from ${context} context`, (done) => {
           expect.assertions(6);
@@ -551,6 +570,25 @@ describe('Testing authentication capability', () => {
     describe('Testing authentication.getUser function', () => {
       it('authentication.getUser should not allow calls before initialization', () => {
         expect(() => authentication.getUser()).toThrowError('The library has not yet been initialized');
+      });
+
+      it('authentication.getUser should allow calls after initialization called, but before it finished', async () => {
+        expect.assertions(3);
+
+        const initPromise = app.initialize();
+        const initMessage = utils.findMessageByFunc('initialize');
+        expect(initMessage).not.toBeNull();
+
+        authentication.getUser();
+        let message = utils.findMessageByFunc('authentication.getUser');
+        expect(message).toBeNull();
+
+        utils.respondToMessage(initMessage, 'content');
+
+        await initPromise;
+
+        message = utils.findMessageByFunc('authentication.getUser');
+        expect(message).not.toBeNull();
       });
 
       Object.values(FrameContexts).forEach((context) => {

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -630,24 +630,17 @@ describe('Testing authentication capability', () => {
       });
 
       it('authentication.notifySuccess should not close auth window before notify success message has been sent', async () => {
-        expect.assertions(5);
+        expect.assertions(3);
         const closeWindowSpy = jest.spyOn(utils.mockWindow, 'close');
 
-        const initPromise = app.initialize();
-        const initMessage = utils.findMessageByFunc('initialize');
-        expect(initMessage).not.toBeNull();
-
-        authentication.notifySuccess(mockResult);
-        let message = utils.findMessageByFunc('authentication.authenticate.success');
-        expect(message).toBeNull();
+        await utils.initializeWithContext(FrameContexts.authentication);
         expect(closeWindowSpy).not.toHaveBeenCalled();
 
-        utils.respondToMessage(initMessage, 'authentication');
-        await initPromise;
-        message = utils.findMessageByFunc('authentication.authenticate.success');
+        authentication.notifySuccess();
+        const message = utils.findMessageByFunc('authentication.authenticate.success');
         expect(message).not.toBeNull();
 
-        // Wait 100ms for the message queue and 200ms for the close delay
+        // Wait 300ms for the close delay
         await new Promise<void>((resolve) =>
           setTimeout(() => {
             expect(closeWindowSpy).toHaveBeenCalled();
@@ -757,24 +750,17 @@ describe('Testing authentication capability', () => {
       });
 
       it('should not close auth window before notify failure message has been sent', async () => {
-        expect.assertions(5);
+        expect.assertions(3);
         const closeWindowSpy = jest.spyOn(utils.mockWindow, 'close');
 
-        const initPromise = app.initialize();
-        const initMessage = utils.findMessageByFunc('initialize');
-        expect(initMessage).not.toBeNull();
-
-        authentication.notifyFailure(errorMessage);
-        let message = utils.findMessageByFunc('authentication.authenticate.failure');
-        expect(message).toBeNull();
+        await utils.initializeWithContext(FrameContexts.authentication);
         expect(closeWindowSpy).not.toHaveBeenCalled();
 
-        utils.respondToMessage(initMessage, 'authentication');
-        await initPromise;
-        message = utils.findMessageByFunc('authentication.authenticate.failure');
+        authentication.notifyFailure(errorMessage);
+        const message = utils.findMessageByFunc('authentication.authenticate.failure');
         expect(message).not.toBeNull();
 
-        // Wait 100ms for the message queue and 200ms for the close delay
+        // Wait 300ms for the close delay
         await new Promise<void>((resolve) =>
           setTimeout(() => {
             expect(closeWindowSpy).toHaveBeenCalled();

--- a/packages/teams-js/test/public/call.spec.ts
+++ b/packages/teams-js/test/public/call.spec.ts
@@ -1,5 +1,6 @@
 import { app, call, FrameContexts } from '../../src/public';
 import { errorNotSupportedOnPlatform } from '../../src/public/constants';
+import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { validateCallDeepLinkPrefix, validateDeepLinkUsers } from '../internal/deepLinkUtilities.spec';
 import { Utils } from '../utils';
 
@@ -20,6 +21,7 @@ describe('call', () => {
 
   afterEach(() => {
     if (app._uninitialize) {
+      utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
       app._uninitialize();
     }
   });
@@ -29,12 +31,19 @@ describe('call', () => {
   });
 
   it('should not allow calls if not supported', async () => {
-    utils.initializeWithContext(FrameContexts.content);
+    await utils.initializeWithContext(FrameContexts.content);
+    utils.setRuntimeConfig({
+      apiVersion: 1,
+      isLegacyTeams: false,
+      supports: {
+        call: undefined,
+      },
+    });
     await expect(call.startCall(mockStartCallParams)).rejects.toEqual(errorNotSupportedOnPlatform);
   });
 
   it('startCall should be called if supported: Non-legacy host', async () => {
-    utils.initializeWithContext(FrameContexts.content);
+    await utils.initializeWithContext(FrameContexts.content);
     utils.setRuntimeConfig({
       apiVersion: 1,
       isLegacyTeams: false,
@@ -52,7 +61,7 @@ describe('call', () => {
   });
 
   it('startCall should be called if supported: Legacy host', async () => {
-    utils.initializeWithContext(FrameContexts.content);
+    await utils.initializeWithContext(FrameContexts.content);
     utils.setRuntimeConfig({
       apiVersion: 1,
       isLegacyTeams: true,

--- a/packages/teams-js/test/public/location.spec.ts
+++ b/packages/teams-js/test/public/location.spec.ts
@@ -241,8 +241,8 @@ describe('location', () => {
       });
     });
 
-    it('should allow showLocation calls in desktop', () => {
-      framedPlatform.initializeWithContext(FrameContexts.content);
+    it('should allow showLocation calls in desktop', async () => {
+      await framedPlatform.initializeWithContext(FrameContexts.content);
       framedPlatform.setClientSupportedSDKVersion(minVersionForLocationAPIs);
       framedPlatform.setRuntimeConfig({ apiVersion: 1, supports: { location: {} } });
       location.showLocation(defaultLocation, emptyCallback);
@@ -252,8 +252,8 @@ describe('location', () => {
       expect(message.args[0]).toEqual(defaultLocation);
     });
 
-    it('showLocation call in task frameContext works', () => {
-      framelessPlatform.initializeWithContext(FrameContexts.task);
+    it('showLocation call in task frameContext works', async () => {
+      await framelessPlatform.initializeWithContext(FrameContexts.task);
       framelessPlatform.setClientSupportedSDKVersion(minVersionForLocationAPIs);
       framedPlatform.setRuntimeConfig({ apiVersion: 1, supports: { location: {} } });
       location.showLocation(defaultLocation, emptyCallback);
@@ -263,8 +263,8 @@ describe('location', () => {
       expect(message.args[0]).toEqual(defaultLocation);
     });
 
-    it('showLocation call in content frameContext works', () => {
-      framelessPlatform.initializeWithContext(FrameContexts.content);
+    it('showLocation call in content frameContext works', async () => {
+      await framelessPlatform.initializeWithContext(FrameContexts.content);
       framelessPlatform.setClientSupportedSDKVersion(minVersionForLocationAPIs);
       framedPlatform.setRuntimeConfig({ apiVersion: 1, supports: { location: {} } });
       location.showLocation(defaultLocation, emptyCallback);
@@ -350,7 +350,7 @@ describe('location', () => {
     });
   });
 
-  it('Frameless - showLocation should throw error when location is not supported', async () => {
+  it('Frameless - showLocation should throw error when location is not supported', () => {
     framelessPlatform.setRuntimeConfig({ apiVersion: 1, supports: {} });
     framelessPlatform.initializeWithContext(FrameContexts.task).then(() => {
       expect.assertions(4);
@@ -376,7 +376,7 @@ describe('location', () => {
     });
   });
 
-  it('Framed - showLocation should throw error when location is not supported', async () => {
+  it('Framed - showLocation should throw error when location is not supported', () => {
     framedPlatform.setRuntimeConfig({ apiVersion: 1, supports: {} });
     framedPlatform.initializeWithContext(FrameContexts.task).then(() => {
       expect.assertions(1);

--- a/packages/teams-js/test/public/meeting.spec.ts
+++ b/packages/teams-js/test/public/meeting.spec.ts
@@ -1071,8 +1071,8 @@ describe('meeting', () => {
       ).toThrowError('The library has not yet been initialized');
     });
 
-    it('should successfully register a handler for when the array of participants speaking changes and frameContext=sidePanel', () => {
-      framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
+    it('should successfully register a handler for when the array of participants speaking changes and frameContext=sidePanel', async () => {
+      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
       const speakingState: meeting.ISpeakingState = { isSpeakingDetected: true };
 
       let handlerCalled = false;
@@ -1099,8 +1099,8 @@ describe('meeting', () => {
       expect(returnedSpeakingState).toBe(speakingState);
     });
 
-    it('should successfully register a handler for when the array of participants speaking changes and frameContext=meetingStage', () => {
-      framelessPlatformMock.initializeWithContext(FrameContexts.meetingStage);
+    it('should successfully register a handler for when the array of participants speaking changes and frameContext=meetingStage', async () => {
+      await framelessPlatformMock.initializeWithContext(FrameContexts.meetingStage);
       const speakingState: meeting.ISpeakingState = { isSpeakingDetected: true };
 
       let handlerCalled = false;
@@ -1143,8 +1143,8 @@ describe('meeting', () => {
       ).toThrowError('The library has not yet been initialized');
     });
 
-    it('should successfully register a handler for when the raiseHandState changes and frameContext=sidePanel', () => {
-      framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
+    it('should successfully register a handler for when the raiseHandState changes and frameContext=sidePanel', async () => {
+      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
       const raiseHandState: meeting.RaiseHandStateChangedEventData = {
         raiseHandState: { isHandRaised: true },
       };
@@ -1173,8 +1173,8 @@ describe('meeting', () => {
       expect(response).toBe(raiseHandState);
     });
 
-    it('should successfully register a handler for when the raiseHandState changes and frameContext=meetingStage', () => {
-      framelessPlatformMock.initializeWithContext(FrameContexts.meetingStage);
+    it('should successfully register a handler for when the raiseHandState changes and frameContext=meetingStage', async () => {
+      await framelessPlatformMock.initializeWithContext(FrameContexts.meetingStage);
       const raiseHandState: meeting.RaiseHandStateChangedEventData = {
         raiseHandState: { isHandRaised: true },
       };
@@ -1219,8 +1219,8 @@ describe('meeting', () => {
       ).toThrowError('The library has not yet been initialized');
     });
 
-    it('should successfully register a handler for when a meetingReaction is received and frameContext=sidePanel', () => {
-      framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
+    it('should successfully register a handler for when a meetingReaction is received and frameContext=sidePanel', async () => {
+      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
       const meetingReaction: meeting.MeetingReactionReceivedEventData = {
         meetingReactionType: meeting.MeetingReactionType.like,
       };
@@ -1249,8 +1249,8 @@ describe('meeting', () => {
       expect(response).toBe(meetingReaction);
     });
 
-    it('should successfully register a handler for when a meetingReaction is received and frameContext=meetingStage', () => {
-      framelessPlatformMock.initializeWithContext(FrameContexts.meetingStage);
+    it('should successfully register a handler for when a meetingReaction is received and frameContext=meetingStage', async () => {
+      await framelessPlatformMock.initializeWithContext(FrameContexts.meetingStage);
       const meetingReaction: meeting.MeetingReactionReceivedEventData = {
         meetingReactionType: meeting.MeetingReactionType.like,
       };

--- a/packages/teams-js/test/public/navigation.spec.ts
+++ b/packages/teams-js/test/public/navigation.spec.ts
@@ -74,8 +74,8 @@ describe('MicrosoftTeams-Navigation', () => {
         expect(pagesNavigateToTabs).toHaveBeenCalled();
       });
 
-      it(`navigation.navigateToTab should register the navigateToTab action when initialized with ${context} context`, () => {
-        utils.initializeWithContext(context);
+      it(`navigation.navigateToTab should register the navigateToTab action when initialized with ${context} context`, async () => {
+        await utils.initializeWithContext(context);
         navigateToTab(null);
         const navigateToTabMsg = utils.findMessageByFunc('navigateToTab');
         expect(navigateToTabMsg).not.toBeNull();
@@ -209,8 +209,8 @@ describe('MicrosoftTeams-Navigation', () => {
         navigateBack();
         expect(pagesBackStackNavigateBack).toHaveBeenCalled();
       });
-      it(`navigate.navigateBack should register the navigateBack action when initialized with ${context} context`, () => {
-        utils.initializeWithContext(context);
+      it(`navigate.navigateBack should register the navigateBack action when initialized with ${context} context`, async () => {
+        await utils.initializeWithContext(context);
         navigateBack();
         const navigateBackMessage = utils.findMessageByFunc('navigateBack');
         expect(navigateBackMessage).not.toBeNull();

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -9,7 +9,7 @@ import { version } from '../../src/public/version';
 import { FramelessPostMocks } from '../framelessPostMocks';
 import { MessageResponse, Utils } from '../utils';
 
-const emptyCallback = () => { };
+const emptyCallback = () => {};
 describe('Testing pages module', () => {
   describe('Framed - Testing pages module', () => {
     // Use to send a mock message from the app.
@@ -1195,7 +1195,7 @@ describe('Testing pages module', () => {
                 data: {
                   id: 100,
                   func: 'settings.save',
-                  args: []
+                  args: [],
                 } as MessageResponse,
               } as MessageEvent);
               expect(utils.childMessages.length).toBe(1);
@@ -1217,7 +1217,7 @@ describe('Testing pages module', () => {
                 data: {
                   id: 100,
                   func: 'settings.save',
-                  args: []
+                  args: [],
                 } as MessageResponse,
               } as MessageEvent);
               expect(handlerCalled).toBe(true);
@@ -1291,7 +1291,7 @@ describe('Testing pages module', () => {
                 data: {
                   id: 100,
                   func: 'settings.remove',
-                  args: []
+                  args: [],
                 } as MessageResponse,
               } as MessageEvent);
               expect(utils.childMessages.length).toBe(1);
@@ -1312,7 +1312,7 @@ describe('Testing pages module', () => {
                 data: {
                   id: 100,
                   func: 'settings.remove',
-                  args: []
+                  args: [],
                 } as MessageResponse,
               } as MessageEvent);
               expect(handlerCalled).toBe(true);
@@ -1470,8 +1470,8 @@ describe('Testing pages module', () => {
             expect(pages.backStack.navigateBack()).rejects.toEqual(errorNotSupportedOnPlatform);
           });
 
-          it(`pages.backStack.navigateBack should register the navigateBack action when initialized with ${context} context`, () => {
-            utils.initializeWithContext(context);
+          it(`pages.backStack.navigateBack should register the navigateBack action when initialized with ${context} context`, async () => {
+            await utils.initializeWithContext(context);
             pages.backStack.navigateBack();
             const navigateBackMessage = utils.findMessageByFunc('navigateBack');
             expect(navigateBackMessage).not.toBeNull();
@@ -3256,8 +3256,8 @@ describe('Testing pages module', () => {
             utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: {} } });
             expect(pages.backStack.navigateBack()).rejects.toEqual(errorNotSupportedOnPlatform);
           });
-          it(`pages.backStack.navigateBack should register the navigateBack action when initialized with ${context} context`, () => {
-            framelessPostMocks.initializeWithContext(context);
+          it(`pages.backStack.navigateBack should register the navigateBack action when initialized with ${context} context`, async () => {
+            await framelessPostMocks.initializeWithContext(context);
             pages.backStack.navigateBack();
             const navigateBackMessage = framelessPostMocks.findMessageByFunc('navigateBack');
             expect(navigateBackMessage).not.toBeNull();

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -786,9 +786,9 @@ describe('MicrosoftTeams-publicAPIs', () => {
     expect(handlerCalled).toBeFalsy();
   });
 
-  it('print handler should successfully call default print handler', () => {
+  it('print handler should successfully call default print handler', async () => {
     let handlerCalled = false;
-    initialize();
+    await utils.initializeWithContext(FrameContexts.content);
     enablePrintCapability();
     jest.spyOn(window, 'print').mockImplementation((): void => {
       handlerCalled = true;
@@ -799,9 +799,9 @@ describe('MicrosoftTeams-publicAPIs', () => {
     expect(handlerCalled).toBeTruthy();
   });
 
-  it('Ctrl+P should successfully call print handler', () => {
+  it('Ctrl+P should successfully call print handler', async () => {
     let handlerCalled = false;
-    initialize();
+    await utils.initializeWithContext(FrameContexts.content);
     enablePrintCapability();
     jest.spyOn(window, 'print').mockImplementation((): void => {
       handlerCalled = true;
@@ -816,9 +816,9 @@ describe('MicrosoftTeams-publicAPIs', () => {
     expect(handlerCalled).toBeTruthy();
   });
 
-  it('Cmd+P should successfully call print handler', () => {
+  it('Cmd+P should successfully call print handler', async () => {
     let handlerCalled = false;
-    initialize();
+    await utils.initializeWithContext(FrameContexts.content);
     enablePrintCapability();
     jest.spyOn(window, 'print').mockImplementation((): void => {
       handlerCalled = true;

--- a/packages/teams-js/test/public/tasks.spec.ts
+++ b/packages/teams-js/test/public/tasks.spec.ts
@@ -267,8 +267,8 @@ describe('tasks', () => {
       }
     });
 
-    it('should successfully pass result and appIds parameters when called from sidePanel context', () => {
-      utils.initializeWithContext('sidePanel');
+    it('should successfully pass result and appIds parameters when called from sidePanel context', async () => {
+      await utils.initializeWithContext('sidePanel');
 
       tasks.submitTask('someResult', ['someAppId', 'someOtherAppId']);
 


### PR DESCRIPTION
## Description

Make sure `initialize` call finishes and runtime information is correctly set up before other APIs can be used. There are exception for APIs I think people are most likely calling right after calling `initialize`, potentially before it finishes. I also had to allow `register*Handler` calls with `null`/`undefined` handler to go through, to keep UTs working (we clean registrations between many tests, some of which didn't run `initialize` at all (by design).

### Main changes in the PR:

1. Update `ensureInitialized` to check that `initialize` finished, not just got called.
2. Add `ensureInitializeCalled` to be used by APIs that we want to allow to be used before `initialize` finishes.
3. Update said APIs to use `ensureInitializeCalled` instead of `ensureInitialized`
4. Fix UTs

## Validation

### Validation performed:

1. UTs updated

### Unit Tests added:

Yes, added tests to validate that the APIs we do want to be callable before initialize finishes can actually be called after initialize called but before it completes.

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes
