### PR TITLE
Making our use of the @beta tag consistent

### DIFF
--- a/change/@microsoft-teams-js-8835237b-4a82-4082-b65a-5db37e32c03e.json
+++ b/change/@microsoft-teams-js-8835237b-4a82-4082-b65a-5db37e32c03e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Removed the @beta tag from `pages`, `app`, and `authentication`. Added @beta tags to `chat`, `dialog`, and `profile` capabilities.",
+  "packageName": "@microsoft/teams-js",
+  "email": "trharris@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -29,8 +29,6 @@ import { version } from './version';
 
 /**
  * Namespace to interact with app initialization and lifecycle.
- *
- * @beta
  */
 export namespace app {
   const appLogger = getLogger('app');

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -14,8 +14,6 @@ import { FrameContexts, HostClientType } from './constants';
  * Namespace to interact with the authentication-specific part of the SDK.
  *
  * This object is used for starting or completing authentication flows.
- *
- * @beta
  */
 export namespace authentication {
   let authHandlers: { success: (string) => void; fail: (string) => void } | undefined;

--- a/packages/teams-js/src/public/chat.ts
+++ b/packages/teams-js/src/public/chat.ts
@@ -61,6 +61,8 @@ export namespace chat {
    * @param openChatRequest: {@link OpenSingleChatRequest}- a request object that contains a user's email as well as an optional message parameter.
    *
    * @returns Promise resolved upon completion
+   *
+   * @beta
    */
   export function openChat(openChatRequest: OpenSingleChatRequest): Promise<void> {
     return new Promise<void>((resolve) => {
@@ -92,6 +94,8 @@ export namespace chat {
    * @param openChatRequest: {@link OpenGroupChatRequest} - a request object that contains a list of user emails as well as optional parameters for message and topic (display name for the group chat).
    *
    * @returns Promise resolved upon completion
+   *
+   * @beta
    */
   export function openGroupChat(openChatRequest: OpenGroupChatRequest): Promise<void> {
     return new Promise<void>((resolve) => {
@@ -128,6 +132,13 @@ export namespace chat {
     });
   }
 
+  /**
+   * Checks if chat capability is supported by the host
+   *
+   * @returns boolean to represent whether the chat capability is supported
+   *
+   * @beta
+   */
   export function isSupported(): boolean {
     return runtime.supports.chat ? true : false;
   }

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -44,7 +44,7 @@ export namespace dialog {
   export type PostMessageChannel = (message: any) => void;
 
   /**
-   * Handler used for receiving results when a dialog closes, either the value passed to {@linkcode submit}
+   * Handler used for receiving results when a dialog closes, either the value passed by {@linkcode submit}
    * or an error if the dialog was closed by the user.
    * @beta
    */

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -18,6 +18,8 @@ import { runtime } from './runtime';
 export namespace dialog {
   /**
    * Data Structure to represent the SDK response when dialog closes
+   *
+   * @beta
    */
   export interface ISdkResponse {
     /**
@@ -33,8 +35,19 @@ export namespace dialog {
      */
     result?: string | object;
   }
+
+  /**
+   * Handler used to receive and process messages sent between a dialog and the app that launched it
+   * @beta
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export type PostMessageChannel = (message: any) => void;
+
+  /**
+   * Handler used for receiving results when a dialog closes, either the value passed to {@linkcode submit}
+   * or an error if the dialog was closed by the user.
+   * @beta
+   */
   export type DialogSubmitHandler = (result: ISdkResponse) => void;
   const storedMessages: string[] = [];
 
@@ -46,6 +59,8 @@ export namespace dialog {
    * Function is called during app initialization
    * @internal
    * Limited to Microsoft-internal use
+   *
+   * @beta
    */
   export function initialize(): void {
     registerHandler('messageForChild', handleDialogMessage, false);
@@ -76,6 +91,8 @@ export namespace dialog {
    * @param messageFromChildHandler - Handler that triggers if dialog sends a message to the app.
    *
    * @returns a function that can be used to send messages to the dialog.
+   *
+   * @beta
    */
   export function open(
     urlDialogInfo: UrlDialogInfo,
@@ -102,6 +119,8 @@ export namespace dialog {
    *
    * @param result - The result to be sent to the bot or the app. Typically a JSON object or a serialized version of it
    * @param appIds - Valid application(s) that can receive the result of the submitted dialogs. Specifying this parameter helps prevent malicious apps from retrieving the dialog result. Multiple app IDs can be specified because a web app from a single underlying domain can power multiple apps across different environments and branding schemes.
+   *
+   * @beta
    */
   export function submit(result?: string | object, appIds?: string | string[]): void {
     ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.task, FrameContexts.meetingStage);
@@ -120,6 +139,8 @@ export namespace dialog {
    * This function is only called from inside of a dialog
    *
    * @param message - The message to send to the parent
+   *
+   * @beta
    */
   export function sendMessageToParentFromDialog(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -137,6 +158,8 @@ export namespace dialog {
    *  Send message to the dialog from the parent
    *
    * @param message - The message to send
+   *
+   * @beta
    */
   export function sendMessageToDialog(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -157,6 +180,8 @@ export namespace dialog {
    * This function is only called from inside of a dialog.
    *
    * @param listener - The listener that will be triggered.
+   *
+   * @beta
    */
   export function registerOnMessageFromParent(listener: PostMessageChannel): void {
     ensureInitialized(FrameContexts.task);
@@ -180,6 +205,8 @@ export namespace dialog {
    * Checks if dialog module is supported by the host
    *
    * @returns boolean to represent whether dialog module is supported
+   *
+   * @beta
    */
   export function isSupported(): boolean {
     return runtime.supports.dialog ? true : false;
@@ -187,12 +214,16 @@ export namespace dialog {
 
   /**
    * Namespace to update the dialog
+   *
+   * @beta
    */
   export namespace update {
     /**
      * Update dimensions - height/width of a dialog.
      *
      * @param dimensions - An object containing width and height properties.
+     *
+     * @beta
      */
     export function resize(dimensions: DialogSize): void {
       ensureInitialized(FrameContexts.content, FrameContexts.sidePanel, FrameContexts.task, FrameContexts.meetingStage);
@@ -206,6 +237,8 @@ export namespace dialog {
      * Checks if dialog.update capability is supported by the host
      *
      * @returns boolean to represent whether dialog.update is supported
+     *
+     * @beta
      */
     export function isSupported(): boolean {
       return runtime.supports.dialog ? (runtime.supports.dialog.update ? true : false) : false;
@@ -214,6 +247,8 @@ export namespace dialog {
 
   /**
    * Namespace to open a dialog that sends results to the bot framework
+   *
+   * @beta
    */
   export namespace bot {
     /**
@@ -224,6 +259,8 @@ export namespace dialog {
      * @param messageFromChildHandler - Handler that triggers if dialog sends a message to the app.
      *
      * @returns a function that can be used to send messages to the dialog.
+     *
+     * @beta
      */
     export function open(
       botUrlDialogInfo: BotUrlDialogInfo,
@@ -249,6 +286,8 @@ export namespace dialog {
      * Checks if dialog.bot capability is supported by the host
      *
      * @returns boolean to represent whether dialog.bot is supported
+     *
+     * @beta
      */
     export function isSupported(): boolean {
       return runtime.supports.dialog ? (runtime.supports.dialog.bot ? true : false) : false;
@@ -262,6 +301,8 @@ export namespace dialog {
    *
    * @internal
    * Limited to Microsoft-internal use
+   *
+   * @beta
    */
   export function getDialogInfoFromUrlDialogInfo(urlDialogInfo: UrlDialogInfo): DialogInfo {
     const dialogInfo: DialogInfo = {
@@ -281,6 +322,8 @@ export namespace dialog {
    *
    * @internal
    * Limited to Microsoft-internal use
+   *
+   * @beta
    */
   export function getDialogInfoFromBotUrlDialogInfo(botUrlDialogInfo: BotUrlDialogInfo): DialogInfo {
     const dialogInfo: DialogInfo = {

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -17,8 +17,6 @@ import { runtime } from './runtime';
 
 /**
  * Navigation-specific part of the SDK.
- *
- * @beta
  */
 export namespace pages {
   /**

--- a/packages/teams-js/src/public/profile.ts
+++ b/packages/teams-js/src/public/profile.ts
@@ -15,6 +15,8 @@ export namespace profile {
    * Opens a profile card at a specified position to show profile information about a persona.
    * @param showProfileRequest The parameters to position the card and identify the target user.
    * @returns Promise that will be fulfilled when the operation has completed
+   *
+   * @beta
    */
   export function showProfile(showProfileRequest: ShowProfileRequest): Promise<void> {
     ensureInitialized(FrameContexts.content);
@@ -46,6 +48,8 @@ export namespace profile {
    * The type of modalities that are supported when showing a profile.
    * Can be provided as an optional hint with the request and will be
    * respected if the hosting M365 application supports it.
+   *
+   * @beta
    */
   export type Modality = 'Card' | 'Expanded';
 
@@ -55,6 +59,8 @@ export namespace profile {
    *  - MouseClick: The user clicked a target.
    *  - KeyboardPress: The user initiated the show profile request with their keyboard.
    *  - AppRequest: The show profile request is happening programmatically, without direct user interaction.
+   *
+   * @beta
    */
   export type TriggerType = 'MouseHover' | 'MouseClick' | 'KeyboardPress' | 'AppRequest';
 
@@ -63,6 +69,8 @@ export namespace profile {
    *
    * At least one is required, and if multiple are provided then only the highest
    * priority one will be used (AadObjectId > Upn > Smtp).
+   *
+   * @beta
    */
   export type PersonaIdentifiers = {
     /**
@@ -88,6 +96,8 @@ export namespace profile {
 
   /**
    * The persona to show the profile for.
+   *
+   * @beta
    */
   export interface Persona {
     /**
@@ -103,6 +113,8 @@ export namespace profile {
 
   /**
    * Input parameters provided to the showProfile API.
+   *
+   * @beta
    */
   export interface ShowProfileRequest {
     /**
@@ -147,6 +159,13 @@ export namespace profile {
     triggerType: TriggerType;
   }
 
+  /**
+   * Checks if the profile capability is supported by the host
+   *
+   * @returns boolean to represent whether the profile capability is supported
+   *
+   * @beta
+   */
   export function isSupported(): boolean {
     return runtime.supports.profile ? true : false;
   }


### PR DESCRIPTION
## Description

Our use of the @beta tag in this repo was not consistent for a couple of reasons. We initially thought that the @beta tag would cascade down and apply to things contained within something marked with @beta, but it does not.

After this change, I believe we now correctly have applied the beta tag everywhere. This means:

- If a namespace has a @beta tag on it, all children also have the @beta tag
- We no longer mark certain namespaces with @beta because we feel that making breaking changes there would now require bumping the major version of the package
- @beta tags indicate to readers of documentation that the item in question could change shape or disappear at any time and we will not bump the major version if something like that happens. When we feel that new things are sufficiently stable the @beta tag will be removed, at which point making breaking changes there would constitute a major version change.

### Main changes in the PR:

1. Removed beta tags from app, authentication, pages capabilities.
2. All functions in chat, dialog, profile capabilities are now marked as @beta

## Validation

### Validation performed:

None, comment update only

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No, documentation only
