### PR TITLE
Adds Outlook consumer domain to domains' whitelist

### DIFF
--- a/change/@microsoft-teams-js-07f5d520-5217-4b90-9daf-95ed983a24b3.json
+++ b/change/@microsoft-teams-js-07f5d520-5217-4b90-9daf-95ed983a24b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adds Outlook's consumer domain to domains' whitelist",
+  "packageName": "@microsoft/teams-js",
+  "email": "rconti@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/constants.ts
+++ b/packages/teams-js/src/internal/constants.ts
@@ -136,6 +136,7 @@ export const validOrigins = [
   'outlook-sdf.office.com',
   'outlook.office365.com',
   'outlook-sdf.office365.com',
+  'outlook.live.com',
   '*.teams.microsoft.com',
   '*.www.office.com',
   'www.office.com',


### PR DESCRIPTION
## Description

The `app.initialize` call is failing for consumer mailboxes in Outlook because `outlook.live.com` (a sometimes origin used for consumer endpoints) is not listed as a valid domain. 
