### PR TITLE
Added showProfile to test app

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -35,6 +35,7 @@ import MonetizationAPIs from './components/privateApis/MonetizationAPIs';
 import NotificationAPIs from './components/privateApis/NotificationAPIs';
 import PrivateAPIs from './components/privateApis/PrivateAPIs';
 import TeamsAPIs from './components/privateApis/TeamsAPIs';
+import ProfileAPIs from './components/ProfileAPIs';
 import RemoteCameraAPIs from './components/RemoteCameraAPIs';
 import SearchAPIs from './components/SearchAPIs';
 import SharingAPIs from './components/SharingAPIs';
@@ -141,6 +142,7 @@ const App = (): ReactElement => {
         <PagesTabsAPIs />
         <PeopleAPIs />
         <PrivateAPIs />
+        <ProfileAPIs />
         <RemoteCameraAPIs />
         <SearchAPIs />
         <SharingAPIs />

--- a/apps/teams-test-app/src/components/ProfileAPIs.tsx
+++ b/apps/teams-test-app/src/components/ProfileAPIs.tsx
@@ -1,0 +1,49 @@
+import { profile } from '@microsoft/teams-js';
+import React, { ReactElement } from 'react';
+
+import { ApiWithoutInput, ApiWithTextInput } from './utils';
+import { ModuleWrapper } from './utils/ModuleWrapper';
+
+const CheckProfileCapability = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'checkCapabilityProfile',
+    title: 'Check Profile Call',
+    onClick: async () => `Profile module ${profile.isSupported() ? 'is' : 'is not'} supported`,
+  });
+
+const ShowProfile = (): React.ReactElement =>
+  ApiWithTextInput<profile.ShowProfileRequest>({
+    name: 'showProfile',
+    title: 'Show Profile',
+    defaultInput:
+      '{"modality":"Card","persona":{"identifiers":{"Smtp":"test@microsoft.com"}},"targetElementBoundingRect":{"x":0,"y":0,"width":0,"height":0},"triggerType":"MouseClick"}',
+    onClick: {
+      validateInput: (input) => {
+        if (!input) {
+          throw 'ShowProfileRequest is required';
+        }
+      },
+      submit: async (input) => {
+        try {
+          await profile.showProfile(input);
+        } catch (e) {
+          if (typeof e === 'object') {
+            return JSON.stringify(e);
+          }
+
+          throw e;
+        }
+
+        return '';
+      },
+    },
+  });
+
+const ProfileAPIs = (): ReactElement => (
+  <ModuleWrapper title="Profile">
+    <ShowProfile />
+    <CheckProfileCapability />
+  </ModuleWrapper>
+);
+
+export default ProfileAPIs;


### PR DESCRIPTION
## Description

Adding support for profile.showProfile calls to the test app.

### Main changes in the PR:

1. Add support for profile APIs to test app

## Validation

### Validation performed:

1. Tested manually in locally running test app and inside test hub

### Unit Tests added:

None, there is no test coverage for test page UI

### End-to-end tests added:

This change is to support end to end tests in hubs

## Additional Requirements

### Change file added:

No

### Screenshots:

![image](https://user-images.githubusercontent.com/83821800/198275681-f227575b-c782-4a08-8c53-18b20dcb98dd.png)
