### PR TITLE
Update terminology (SDK->library) in readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ the PR.
 
 [Beachball](https://microsoft.github.io/beachball/) is a semantic version bumper that also has an automated tool to ask contributors to log changes in a simple CLI manner.
 
-The TeamsJS Client SDK contains a [Change Log](./packages/teams-js/CHANGELOG.md) for substantial changes in the `<root>/packages/teams-js` directory. If you make any changes to the `<root>/packages/teams-js` directory (you can see the exception files and directories in [beachball.config.js](./beachball.config.js`)), you must run `yarn changefile` from the monorepo root to generate change files.
+The TeamsJS Client library contains a [Change Log](./packages/teams-js/CHANGELOG.md) for substantial changes in the `<root>/packages/teams-js` directory. If you make any changes to the `<root>/packages/teams-js` directory (you can see the exception files and directories in [beachball.config.js](./beachball.config.js`)), you must run `yarn changefile` from the monorepo root to generate change files.
 
 Beachball generates JSON change files based on a few simple answers from you:
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Microsoft Teams JavaScript client SDK
+# Microsoft Teams JavaScript client library
 
 [![Microsoft Teams Library JS CI](https://github.com/OfficeDev/microsoft-teams-library-js/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/OfficeDev/microsoft-teams-library-js/actions/workflows/main.yml)
 [![Build Status](https://office.visualstudio.com/ISS/_apis/build/status/Taos%20Platform/App%20SDK/OfficeDev.microsoft-teams-library-js)](https://office.visualstudio.com/ISS/_build/latest?definitionId=17483)
 
-Welcome to the Teams client SDK monorepo! For breaking changes, please refer to our [changelog](./packages/teams-js/CHANGELOG.md) in the `<root>/packages/teams-js` directory. This repository contains the core teams-js package as well as tools and applications for analyzing and testing.
+Welcome to the Teams client library monorepo! For breaking changes, please refer to our [changelog](./packages/teams-js/CHANGELOG.md) in the `<root>/packages/teams-js` directory. This repository contains the core teams-js package as well as tools and applications for analyzing and testing.
 
 ## Getting Started
 
@@ -12,11 +12,11 @@ Welcome to the Teams client SDK monorepo! For breaking changes, please refer to 
 3. Run `yarn build` from repo root
 4. To run Unit tests, run `yarn test`
 
-TIP: whenever building or testing the Teams client SDK, you can run `yarn build` or `yarn test` from the `packages/teams-js` directory.
+TIP: whenever building or testing the Teams client library, you can run `yarn build` or `yarn test` from the `packages/teams-js` directory.
 
 See also: [Contributing](CONTRIBUTING.md)
 
-This JavaScript library is part of the [Microsoft Teams developer platform](https://learn.microsoft.com/microsoftteams/platform/overview?view=msteams-client-js-latest). See full [SDK reference documentation](https://learn.microsoft.com/javascript/api/overview/msteams-client?view=msteams-client-js-latest).
+This JavaScript library is part of the [Microsoft Teams developer platform](https://learn.microsoft.com/microsoftteams/platform/overview?view=msteams-client-js-latest). See full [library reference documentation](https://learn.microsoft.com/javascript/api/overview/msteams-client?view=msteams-client-js-latest).
 
 # Packages
 
@@ -30,15 +30,15 @@ Used to integrate custom services and applications with Teams, Outlook, and Offi
 
 # Apps
 
-The apps folder contains applications used to test various aspects of the SDK.
+The apps folder contains applications used to test various aspects of the library.
 
 ### [Teams Perf Test App](./apps/teams-perf-test-app/README.md)
 
-React application used to locally test the loading times of the SDK.
+React application used to locally test the loading times of the library.
 
 ### [Teams Test App](./apps/teams-test-app/README.md)
 
-Application used to test the functionality of the various SDK APIs.
+Application used to test the functionality of the various library APIs.
 
 ---
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -1,14 +1,14 @@
-# Microsoft Teams JavaScript client SDK
+# Microsoft Teams JavaScript client library
 
-Welcome to the Teams JavaScript client SDK! For breaking changes, please refer to our [changelog](./CHANGELOG.md) in the current `<root>/packages/teams-js` directory.
+Welcome to the Teams JavaScript client library! For breaking changes, please refer to our [changelog](./CHANGELOG.md) in the current `<root>/packages/teams-js` directory.
 
-This JavaScript library is part of the [Microsoft Teams developer platform](https://learn.microsoft.com/microsoftteams/platform/). See full [SDK reference documentation](https://learn.microsoft.com/javascript/api/overview/msteams-client?view=msteams-client-js-latest).
+This JavaScript library is part of the [Microsoft Teams developer platform](https://learn.microsoft.com/microsoftteams/platform/). See full [library reference documentation](https://learn.microsoft.com/javascript/api/overview/msteams-client?view=msteams-client-js-latest).
 
 ## Getting Started
 
 See [instructions](../../README.md#Getting-Started) in the monorepo root for how to clone and build the repository.
 
-Whenever building or testing the Teams client SDK, you can run `yarn build` or `yarn test` from the packages/teams-js directory.
+Whenever building or testing the Teams client library, you can run `yarn build` or `yarn test` from the packages/teams-js directory.
 
 ## Installation
 
@@ -40,7 +40,7 @@ import { app } from '@microsoft/teams-js';
 
 ### As a script tag
 
-Reference the SDK inside of your `.html` page using:
+Reference the library inside of your `.html` page using:
 
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
@@ -59,7 +59,7 @@ Reference the SDK inside of your `.html` page using:
 
 ### Dependencies
 
-Teams client SDK depends on [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) type. If you support older browsers and devices which may not yet provide it natively (e.g. IE 11), you need to provide a global polyfill, such as [es6-promise](https://www.npmjs.com/package/es6-promise), in your bundled application. If you're using a script tag to reference the Teams client SDK, you need to make sure the polyfill is included and initialized before the Teams client SDK is.
+Teams client library depends on [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) type. If you support older browsers and devices which may not yet provide it natively (e.g. IE 11), you need to provide a global polyfill, such as [es6-promise](https://www.npmjs.com/package/es6-promise), in your bundled application. If you're using a script tag to reference the Teams client library, you need to make sure the polyfill is included and initialized before the Teams client library is initialized.
 
 ## Examples
 
@@ -67,7 +67,7 @@ Stay tuned for examples coming soon.
 
 ## Testing
 
-The [Teams Test App](https://aka.ms/teams-test-app) is used to validate the Teams client SDK APIs.
+The [Teams Test App](https://aka.ms/teams-test-app) is used to validate the Teams client library APIs.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description

Update terminology in repo and NPM readme landing pages to refer to TeamsJS as a _library_ rather than SDK. This lays the groundwork to integrate the story of Office Add-ins/Extensions ([OfficeJS library](https://github.com/OfficeDev/office-js)) with multi-hub Teams apps [in the future](https://devblogs.microsoft.com/microsoft365dev/ignite-2022-highlights-for-microsoft-teams-app-builders/#whats-next)   and help head off potential confusion.

### Main changes in the PR:

1. Change title/text instances of "SDK" to "library" in repo README
2. Change title/text instances of "SDK" to "library" in README for NPM package
3. Change text instances of "SDK" to "library" in CONTRIBUTING

## Validation

### Validation performed:
NA

### Unit Tests added:
No

### End-to-end tests added:
No

## Additional Requirements
None

### Change file added:

No

### Related PRs:

https://github.com/MicrosoftDocs/msteams-docs/pull/7306
https://github.com/OfficeDev/msteams-client-docs-ref-typescript/pull/106

### Next/remaining steps:

None. There might be scattered "SDK" references amongst Teams developer resources (and conversational usage) outside our direct control, and that's ok. Language is messy.