### PR TITLE
Create a common request message validator and use it in the pages test

### DIFF
--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -8,7 +8,7 @@ import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { version } from '../../src/public/version';
 import { FramelessPostMocks } from '../framelessPostMocks';
 import {
-  getNumberOfAssertionsUsedToValidateRequest,
+  getCountOfAssertionsUsedToValidateRequest,
   MatcherType,
   validateExpectedArgumentsInRequest,
   validateRequestWithoutArguments,
@@ -330,7 +330,7 @@ describe('Testing pages module', () => {
           });
 
           it(`pages.navigateCrossDomain should allow calls from ${context} context`, async () => {
-            expect.assertions(getNumberOfAssertionsUsedToValidateRequest(0) + 1);
+            expect.assertions(getCountOfAssertionsUsedToValidateRequest(0) + 1);
             await utils.initializeWithContext(context);
 
             const promise = pages.navigateCrossDomain('https://valid.origin.com');
@@ -423,7 +423,7 @@ describe('Testing pages module', () => {
           });
 
           it(`pages.navigateToApp should allow calls from ${context} context`, async () => {
-            expect.assertions(getNumberOfAssertionsUsedToValidateRequest(0) + 1);
+            expect.assertions(getCountOfAssertionsUsedToValidateRequest(0) + 1);
             await utils.initializeWithContext(context);
             utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: {} } });
 

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -1,4 +1,3 @@
-import { validOrigins } from '../../src/internal/constants';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { getGenericOnCompleteHandler } from '../../src/internal/utils';
 import { app } from '../../src/public/app';
@@ -8,7 +7,7 @@ import { pages } from '../../src/public/pages';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { version } from '../../src/public/version';
 import { FramelessPostMocks } from '../framelessPostMocks';
-import { MatcherType, validateExpectedValuesInRequest, validateRequestWithoutValues } from '../resultValidation';
+import { MatcherType, validateExpectedArgumentsInRequest, validateRequestWithoutArguments } from '../resultValidation';
 import { MessageResponse, Utils } from '../utils';
 
 /* eslint-disable */
@@ -63,7 +62,7 @@ describe('Testing pages module', () => {
           pages.returnFocus(true);
 
           const returnFocusMessage = utils.findMessageByFunc('returnFocus');
-          validateExpectedValuesInRequest(returnFocusMessage, MatcherType.ToBe, true);
+          validateExpectedArgumentsInRequest(returnFocusMessage, MatcherType.ToBe, true);
         });
 
         it(`pages.returnFocus should not successfully returnFocus when set to false and initialized with ${context} context`, async () => {
@@ -72,7 +71,7 @@ describe('Testing pages module', () => {
           pages.returnFocus(false);
 
           const returnFocusMessage = utils.findMessageByFunc('returnFocus');
-          validateExpectedValuesInRequest(returnFocusMessage, MatcherType.ToBe, false);
+          validateExpectedArgumentsInRequest(returnFocusMessage, MatcherType.ToBe, false);
         });
       });
     });
@@ -101,7 +100,7 @@ describe('Testing pages module', () => {
             return true;
           });
           const messageForRegister = utils.findMessageByFunc('registerHandler');
-          validateExpectedValuesInRequest(messageForRegister, MatcherType.ToBe, 'focusEnter');
+          validateExpectedArgumentsInRequest(messageForRegister, MatcherType.ToBe, 'focusEnter');
         });
 
         it(`pages.registerFocusEnterHandler should successfully invoke focus enter handler when set to true and initialized with ${context} context`, async () => {
@@ -160,7 +159,7 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             pages.setCurrentFrame(frameContext);
             const message = utils.findMessageByFunc('setFrameContext');
-            validateExpectedValuesInRequest(message, MatcherType.ToBe, frameContext);
+            validateExpectedArgumentsInRequest(message, MatcherType.ToBe, frameContext);
           });
         } else {
           it(`pages.setCurrentFrame should not allow calls from ${context} context`, async () => {
@@ -202,11 +201,11 @@ describe('Testing pages module', () => {
             expect(utils.messages.length).toBe(2);
 
             const initMessage = utils.findMessageByFunc('initialize');
-            validateExpectedValuesInRequest(initMessage, MatcherType.ToBe, version);
+            validateExpectedArgumentsInRequest(initMessage, MatcherType.ToBe, version);
             expect(initMessage.id).toBe(0);
             expect(initMessage.func).toBe('initialize');
             const message = utils.findMessageByFunc('setFrameContext');
-            validateExpectedValuesInRequest(message, MatcherType.ToBe, frameContext);
+            validateExpectedArgumentsInRequest(message, MatcherType.ToBe, frameContext);
           });
         } else {
           it(`pages.initializeWithFrameContext should not allow calls from ${context} context`, async () => {
@@ -247,8 +246,9 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.getConfig();
             const message = utils.findMessageByFunc('settings.getSettings');
-            expect(message).not.toBeNull();
-            utils.respondToMessage(message, expectedSettings);
+            validateRequestWithoutArguments(message);
+
+            utils.respondToMessage(message!, expectedSettings);
             return expect(promise).resolves.toBe(expectedSettings);
           });
         } else {
@@ -331,7 +331,9 @@ describe('Testing pages module', () => {
 
             const promise = pages.navigateCrossDomain('https://valid.origin.com');
             const navigateCrossDomainMessage = utils.findMessageByFunc('navigateCrossDomain');
-            utils.respondToMessage(navigateCrossDomainMessage, true);
+            validateRequestWithoutArguments(navigateCrossDomainMessage);
+
+            utils.respondToMessage(navigateCrossDomainMessage!, true);
 
             await expect(promise).resolves.not.toThrow();
           });
@@ -355,7 +357,7 @@ describe('Testing pages module', () => {
         pages.navigateCrossDomain('https://valid.origin.com');
 
         const navigateCrossDomainMessage = utils.findMessageByFunc('navigateCrossDomain');
-        validateExpectedValuesInRequest(navigateCrossDomainMessage, MatcherType.ToBe, 'https://valid.origin.com');
+        validateExpectedArgumentsInRequest(navigateCrossDomainMessage, MatcherType.ToBe, 'https://valid.origin.com');
       });
 
       it('pages.navigateCrossDomain should throw on invalid cross-origin navigation request', async () => {
@@ -364,7 +366,7 @@ describe('Testing pages module', () => {
         const promise = pages.navigateCrossDomain('https://invalid.origin.com');
 
         const navigateCrossDomainMessage = utils.findMessageByFunc('navigateCrossDomain');
-        validateExpectedValuesInRequest(navigateCrossDomainMessage, MatcherType.ToBe, 'https://invalid.origin.com');
+        validateExpectedArgumentsInRequest(navigateCrossDomainMessage, MatcherType.ToBe, 'https://invalid.origin.com');
 
         utils.respondToMessage(navigateCrossDomainMessage!, false);
 
@@ -414,7 +416,9 @@ describe('Testing pages module', () => {
             const promise = pages.navigateToApp(navigateToAppParams);
 
             const navigateToAppMessage = utils.findMessageByFunc('pages.navigateToApp');
-            utils.respondToMessage(navigateToAppMessage, true);
+            validateRequestWithoutArguments(navigateToAppMessage);
+
+            utils.respondToMessage(navigateToAppMessage!, true);
 
             await expect(promise).resolves.toBe(undefined);
           });
@@ -426,11 +430,10 @@ describe('Testing pages module', () => {
             const promise = pages.navigateToApp(navigateToAppParams);
 
             const navigateToAppMessage = utils.findMessageByFunc('pages.navigateToApp');
-            utils.respondToMessage(navigateToAppMessage, true);
-            await promise;
+            validateExpectedArgumentsInRequest(navigateToAppMessage, MatcherType.ToStrictEqual, navigateToAppParams);
 
-            expect(navigateToAppMessage).not.toBeNull();
-            expect(navigateToAppMessage.args[0]).toStrictEqual(navigateToAppParams);
+            utils.respondToMessage(navigateToAppMessage!, true);
+            await promise;
           });
 
           it('pages.navigateToApp should successfully send an executeDeepLink message for legacy teams clients', async () => {
@@ -446,12 +449,13 @@ describe('Testing pages module', () => {
             const promise = pages.navigateToApp(navigateToAppParams);
 
             const executeDeepLinkMessage = utils.findMessageByFunc('executeDeepLink');
-            validateExpectedValuesInRequest(
+            validateExpectedArgumentsInRequest(
               executeDeepLinkMessage,
               MatcherType.ToBe,
               'https://teams.microsoft.com/l/entity/fe4a8eba-2a31-4737-8e33-e5fae6fee194/tasklist123?webUrl=https%3A%2F%2Ftasklist.example.com%2F123&context=%7B%22channelId%22%3A%2219%3Acbe3683f25094106b826c9cada3afbe0%40thread.skype%22%2C%22subEntityId%22%3A%22task456%22%7D',
             );
-            utils.respondToMessage(executeDeepLinkMessage, true);
+
+            utils.respondToMessage(executeDeepLinkMessage!, true);
             await promise;
           });
         } else {
@@ -504,8 +508,9 @@ describe('Testing pages module', () => {
             const promise = pages.currentApp.navigateTo(NavigateToParams);
 
             const navigateToMessage = utils.findMessageByFunc('pages.currentApp.navigateTo');
-            validateRequestWithoutValues(navigateToMessage);
-            utils.respondToMessage(navigateToMessage);
+            validateRequestWithoutArguments(navigateToMessage);
+
+            utils.respondToMessage(navigateToMessage!);
 
             await expect(promise).resolves.toBe(undefined);
           });
@@ -517,11 +522,10 @@ describe('Testing pages module', () => {
             const promise = pages.currentApp.navigateTo(NavigateToParams);
 
             const navigateToMessage = utils.findMessageByFunc('pages.currentApp.navigateTo');
-            utils.respondToMessage(navigateToMessage);
-            await promise;
+            validateExpectedArgumentsInRequest(navigateToMessage, MatcherType.ToStrictEqual, NavigateToParams);
 
-            expect(navigateToMessage).not.toBeNull();
-            expect(navigateToMessage.args[0]).toStrictEqual(NavigateToParams);
+            utils.respondToMessage(navigateToMessage!);
+            await promise;
           });
         } else {
           it(`pages.currentApp.navigateTo  should not allow calls from ${context} context`, async () => {
@@ -568,7 +572,9 @@ describe('Testing pages module', () => {
             const promise = pages.currentApp.navigateToDefaultPage();
 
             const navigateToDefaultPageMessage = utils.findMessageByFunc('pages.currentApp.navigateToDefaultPage');
-            utils.respondToMessage(navigateToDefaultPageMessage);
+            validateRequestWithoutArguments(navigateToDefaultPageMessage);
+
+            utils.respondToMessage(navigateToDefaultPageMessage!);
 
             await expect(promise).resolves.toBe(undefined);
           });
@@ -580,7 +586,9 @@ describe('Testing pages module', () => {
             const promise = pages.currentApp.navigateToDefaultPage();
 
             const navigateToDefaultPageMessage = utils.findMessageByFunc('pages.currentApp.navigateToDefaultPage');
-            utils.respondToMessage(navigateToDefaultPageMessage);
+            validateRequestWithoutArguments(navigateToDefaultPageMessage);
+
+            utils.respondToMessage(navigateToDefaultPageMessage!);
             expect(await promise).toBeUndefined();
           });
         } else {
@@ -632,7 +640,7 @@ describe('Testing pages module', () => {
             });
 
             const message = utils.findMessageByFunc('shareDeepLink');
-            validateExpectedValuesInRequest(
+            validateExpectedArgumentsInRequest(
               message,
               MatcherType.ToBe,
               'someSubEntityId',
@@ -676,7 +684,7 @@ describe('Testing pages module', () => {
             return true;
           });
           const messageForRegister = utils.findMessageByFunc('registerHandler');
-          validateExpectedValuesInRequest(messageForRegister, MatcherType.ToBe, 'fullScreenChange');
+          validateExpectedArgumentsInRequest(messageForRegister, MatcherType.ToBe, 'fullScreenChange');
         });
 
         it(`pages.registerFullScreenHandler should successfully invoke full screen handler when set to true and  initialized with ${context} context`, async () => {
@@ -757,14 +765,15 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             pages.tabs.navigateToTab(tabInstance);
             const navigateToTabMsg = utils.findMessageByFunc('navigateToTab');
-            validateExpectedValuesInRequest(navigateToTabMsg, MatcherType.ToBe, tabInstance);
+            validateExpectedArgumentsInRequest(navigateToTabMsg, MatcherType.ToBe, tabInstance);
           });
 
           it(`pages.tabs.navigateToTab should throw error when initialized with ${context} context`, async () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.navigateToTab(null);
             const navigateToTabMsg = utils.findMessageByFunc('navigateToTab');
-            expect(navigateToTabMsg).not.toBeNull();
+            validateRequestWithoutArguments(navigateToTabMsg);
+
             utils.respondToMessage(navigateToTabMsg!, false);
             await promise.catch((e) =>
               expect(e).toMatchObject(new Error('Invalid internalTabInstanceId and/or channelId were/was provided')),
@@ -777,7 +786,7 @@ describe('Testing pages module', () => {
             const onComplete = getGenericOnCompleteHandler();
             onComplete(true);
             const navigateToTabMsg = utils.findMessageByFunc('navigateToTab');
-            validateExpectedValuesInRequest(navigateToTabMsg, MatcherType.ToBe, null);
+            validateExpectedArgumentsInRequest(navigateToTabMsg, MatcherType.ToBe, null);
           });
         });
       });
@@ -808,9 +817,9 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.getTabInstances();
             const message = utils.findMessageByFunc('getTabInstances');
+            validateRequestWithoutArguments(message);
 
-            utils.respondToMessage(message, expectedTabInstanceParameters);
-            expect(message).not.toBeNull();
+            utils.respondToMessage(message!, expectedTabInstanceParameters);
             expect(promise).resolves.toBe(expectedTabInstanceParameters);
           });
 
@@ -818,9 +827,9 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.getTabInstances(expectedTabInstanceParameters);
             const message = utils.findMessageByFunc('getTabInstances');
+            validateRequestWithoutArguments(message);
 
-            utils.respondToMessage(message);
-            expect(message).not.toBeNull();
+            utils.respondToMessage(message!);
             expect(promise).resolves.toBeUndefined();
           });
 
@@ -828,9 +837,9 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.getTabInstances();
             const message = utils.findMessageByFunc('getTabInstances');
+            validateRequestWithoutArguments(message);
 
-            utils.respondToMessage(message);
-            expect(message).not.toBeNull();
+            utils.respondToMessage(message!);
             expect(promise).resolves.toBeUndefined();
           });
         });
@@ -863,9 +872,9 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.getMruTabInstances();
             const message = utils.findMessageByFunc('getMruTabInstances');
+            validateRequestWithoutArguments(message);
 
-            utils.respondToMessage(message, expectedTabInstanceParameters);
-            expect(message).not.toBeNull();
+            utils.respondToMessage(message!, expectedTabInstanceParameters);
             expect(promise).resolves.toBe(expectedTabInstanceParameters);
           });
 
@@ -873,9 +882,9 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.getMruTabInstances(expectedTabInstanceParameters);
             const message = utils.findMessageByFunc('getMruTabInstances');
+            validateRequestWithoutArguments(message);
 
-            utils.respondToMessage(message);
-            expect(message).not.toBeNull();
+            utils.respondToMessage(message!);
             expect(promise).resolves.toBeUndefined();
           });
 
@@ -883,9 +892,9 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.getMruTabInstances();
             const message = utils.findMessageByFunc('getMruTabInstances');
+            validateRequestWithoutArguments(message);
 
-            utils.respondToMessage(message);
-            expect(message).not.toBeNull();
+            utils.respondToMessage(message!);
             expect(promise).resolves.toBeUndefined();
           });
         });
@@ -972,7 +981,7 @@ describe('Testing pages module', () => {
               pages.config.setValidityState(true);
 
               const message = utils.findMessageByFunc('settings.setValidityState');
-              validateExpectedValuesInRequest(message, MatcherType.ToBe, true);
+              validateExpectedArgumentsInRequest(message, MatcherType.ToBe, true);
             });
 
             it(`pages.config.setValidityState should successfully set validity state to false when initialized with ${context} context`, async () => {
@@ -980,7 +989,7 @@ describe('Testing pages module', () => {
               pages.config.setValidityState(false);
 
               const message = utils.findMessageByFunc('settings.setValidityState');
-              validateExpectedValuesInRequest(message, MatcherType.ToBe, false);
+              validateExpectedArgumentsInRequest(message, MatcherType.ToBe, false);
             });
           } else {
             it(`pages.config.setValidityState does not allow calls from ${context} context`, async () => {
@@ -1029,7 +1038,7 @@ describe('Testing pages module', () => {
               await utils.initializeWithContext(context);
               pages.config.setConfig(settingsObj);
               const message = utils.findMessageByFunc('settings.setSettings');
-              validateExpectedValuesInRequest(message, MatcherType.ToBe, settingsObj);
+              validateExpectedArgumentsInRequest(message, MatcherType.ToBe, settingsObj);
             });
           } else {
             it(`pages.config.setConfig does not allow calls from ${context} context`, async () => {
@@ -1130,7 +1139,7 @@ describe('Testing pages module', () => {
               utils.sendMessage('settings.save');
               expect(handlerCalled).toBe(true);
               const message = utils.findMessageByFunc('settings.save.success');
-              validateRequestWithoutValues(message);
+              validateRequestWithoutArguments(message);
             });
 
             it(`pages.config.registerOnSaveHandler should successfully notify failure from the registered save handler when initialized with ${context} context`, async () => {
@@ -1143,7 +1152,7 @@ describe('Testing pages module', () => {
               utils.sendMessage('settings.save');
               expect(handlerCalled).toBe(true);
               const message = utils.findMessageByFunc('settings.save.failure');
-              validateExpectedValuesInRequest(message, MatcherType.ToBe, 'someReason');
+              validateExpectedArgumentsInRequest(message, MatcherType.ToBe, 'someReason');
             });
 
             it(`pages.config.registerOnSaveHandler should not allow multiple notifies from the registered save handler when initialized with ${context} context`, async () => {
@@ -1162,7 +1171,7 @@ describe('Testing pages module', () => {
               utils.sendMessage('settings.save');
               expect(handlerCalled).toBe(true);
               const message = utils.findMessageByFunc('settings.save.success');
-              validateRequestWithoutValues(message);
+              validateRequestWithoutArguments(message);
             });
 
             it('pages.config.registerOnSaveHandler should proxy to childWindow if no handler in top window', async () => {
@@ -1310,7 +1319,7 @@ describe('Testing pages module', () => {
 
               expect(handlerCalled).toBe(true);
               const message = utils.findMessageByFunc('settings.remove.success');
-              validateRequestWithoutValues(message);
+              validateRequestWithoutArguments(message);
             });
 
             it(`pages.config.registerOnRemoveHandler should successfully notify failure from the registered remove handler when initialized with ${context} context`, async () => {
@@ -1326,7 +1335,7 @@ describe('Testing pages module', () => {
 
               expect(handlerCalled).toBe(true);
               const message = utils.findMessageByFunc('settings.remove.failure');
-              validateExpectedValuesInRequest(message, MatcherType.ToBe, 'someReason');
+              validateExpectedArgumentsInRequest(message, MatcherType.ToBe, 'someReason');
             });
           } else {
             it(`pages.config.registerOnRemoveHandler does not allow calls from ${context} context`, async () => {

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -7,7 +7,12 @@ import { pages } from '../../src/public/pages';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { version } from '../../src/public/version';
 import { FramelessPostMocks } from '../framelessPostMocks';
-import { MatcherType, validateExpectedArgumentsInRequest, validateRequestWithoutArguments } from '../resultValidation';
+import {
+  getNumberOfAssertionsUsedToValidateRequest,
+  MatcherType,
+  validateExpectedArgumentsInRequest,
+  validateRequestWithoutArguments,
+} from '../resultValidation';
 import { MessageResponse, Utils } from '../utils';
 
 /* eslint-disable */
@@ -326,7 +331,7 @@ describe('Testing pages module', () => {
           });
 
           it(`pages.navigateCrossDomain should allow calls from ${context} context`, async () => {
-            expect.assertions(1);
+            expect.assertions(getNumberOfAssertionsUsedToValidateRequest(0) + 1);
             await utils.initializeWithContext(context);
 
             const promise = pages.navigateCrossDomain('https://valid.origin.com');
@@ -409,7 +414,7 @@ describe('Testing pages module', () => {
           });
 
           it(`pages.navigateToApp should allow calls from ${context} context`, async () => {
-            expect.assertions(1);
+            expect.assertions(getNumberOfAssertionsUsedToValidateRequest(0) + 1);
             await utils.initializeWithContext(context);
             utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: {} } });
 

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -67,7 +67,7 @@ describe('Testing pages module', () => {
           pages.returnFocus(true);
 
           const returnFocusMessage = utils.findMessageByFunc('returnFocus');
-          validateExpectedArgumentsInRequest(returnFocusMessage, MatcherType.ToBe, true);
+          validateExpectedArgumentsInRequest(returnFocusMessage, 'returnFocus', MatcherType.ToBe, true);
         });
 
         it(`pages.returnFocus should not successfully returnFocus when set to false and initialized with ${context} context`, async () => {
@@ -76,7 +76,7 @@ describe('Testing pages module', () => {
           pages.returnFocus(false);
 
           const returnFocusMessage = utils.findMessageByFunc('returnFocus');
-          validateExpectedArgumentsInRequest(returnFocusMessage, MatcherType.ToBe, false);
+          validateExpectedArgumentsInRequest(returnFocusMessage, 'returnFocus', MatcherType.ToBe, false);
         });
       });
     });
@@ -105,7 +105,7 @@ describe('Testing pages module', () => {
             return true;
           });
           const messageForRegister = utils.findMessageByFunc('registerHandler');
-          validateExpectedArgumentsInRequest(messageForRegister, MatcherType.ToBe, 'focusEnter');
+          validateExpectedArgumentsInRequest(messageForRegister, 'registerHandler', MatcherType.ToBe, 'focusEnter');
         });
 
         it(`pages.registerFocusEnterHandler should successfully invoke focus enter handler when set to true and initialized with ${context} context`, async () => {
@@ -164,7 +164,7 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             pages.setCurrentFrame(frameContext);
             const message = utils.findMessageByFunc('setFrameContext');
-            validateExpectedArgumentsInRequest(message, MatcherType.ToBe, frameContext);
+            validateExpectedArgumentsInRequest(message, 'setFrameContext', MatcherType.ToBe, frameContext);
           });
         } else {
           it(`pages.setCurrentFrame should not allow calls from ${context} context`, async () => {
@@ -206,11 +206,10 @@ describe('Testing pages module', () => {
             expect(utils.messages.length).toBe(2);
 
             const initMessage = utils.findMessageByFunc('initialize');
-            validateExpectedArgumentsInRequest(initMessage, MatcherType.ToBe, version);
+            validateExpectedArgumentsInRequest(initMessage, 'initialize', MatcherType.ToBe, version);
             expect(initMessage.id).toBe(0);
-            expect(initMessage.func).toBe('initialize');
             const message = utils.findMessageByFunc('setFrameContext');
-            validateExpectedArgumentsInRequest(message, MatcherType.ToBe, frameContext);
+            validateExpectedArgumentsInRequest(message, 'setFrameContext', MatcherType.ToBe, frameContext);
           });
         } else {
           it(`pages.initializeWithFrameContext should not allow calls from ${context} context`, async () => {
@@ -251,7 +250,7 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.getConfig();
             const message = utils.findMessageByFunc('settings.getSettings');
-            validateRequestWithoutArguments(message);
+            validateRequestWithoutArguments(message, 'settings.getSettings');
 
             utils.respondToMessage(message!, expectedSettings);
             return expect(promise).resolves.toBe(expectedSettings);
@@ -336,7 +335,7 @@ describe('Testing pages module', () => {
 
             const promise = pages.navigateCrossDomain('https://valid.origin.com');
             const navigateCrossDomainMessage = utils.findMessageByFunc('navigateCrossDomain');
-            validateRequestWithoutArguments(navigateCrossDomainMessage);
+            validateRequestWithoutArguments(navigateCrossDomainMessage, 'navigateCrossDomain');
 
             utils.respondToMessage(navigateCrossDomainMessage!, true);
 
@@ -362,7 +361,12 @@ describe('Testing pages module', () => {
         pages.navigateCrossDomain('https://valid.origin.com');
 
         const navigateCrossDomainMessage = utils.findMessageByFunc('navigateCrossDomain');
-        validateExpectedArgumentsInRequest(navigateCrossDomainMessage, MatcherType.ToBe, 'https://valid.origin.com');
+        validateExpectedArgumentsInRequest(
+          navigateCrossDomainMessage,
+          'navigateCrossDomain',
+          MatcherType.ToBe,
+          'https://valid.origin.com',
+        );
       });
 
       it('pages.navigateCrossDomain should throw on invalid cross-origin navigation request', async () => {
@@ -371,7 +375,12 @@ describe('Testing pages module', () => {
         const promise = pages.navigateCrossDomain('https://invalid.origin.com');
 
         const navigateCrossDomainMessage = utils.findMessageByFunc('navigateCrossDomain');
-        validateExpectedArgumentsInRequest(navigateCrossDomainMessage, MatcherType.ToBe, 'https://invalid.origin.com');
+        validateExpectedArgumentsInRequest(
+          navigateCrossDomainMessage,
+          'navigateCrossDomain',
+          MatcherType.ToBe,
+          'https://invalid.origin.com',
+        );
 
         utils.respondToMessage(navigateCrossDomainMessage!, false);
 
@@ -421,7 +430,7 @@ describe('Testing pages module', () => {
             const promise = pages.navigateToApp(navigateToAppParams);
 
             const navigateToAppMessage = utils.findMessageByFunc('pages.navigateToApp');
-            validateRequestWithoutArguments(navigateToAppMessage);
+            validateRequestWithoutArguments(navigateToAppMessage, 'pages.navigateToApp');
 
             utils.respondToMessage(navigateToAppMessage!, true);
 
@@ -435,7 +444,12 @@ describe('Testing pages module', () => {
             const promise = pages.navigateToApp(navigateToAppParams);
 
             const navigateToAppMessage = utils.findMessageByFunc('pages.navigateToApp');
-            validateExpectedArgumentsInRequest(navigateToAppMessage, MatcherType.ToStrictEqual, navigateToAppParams);
+            validateExpectedArgumentsInRequest(
+              navigateToAppMessage,
+              'pages.navigateToApp',
+              MatcherType.ToStrictEqual,
+              navigateToAppParams,
+            );
 
             utils.respondToMessage(navigateToAppMessage!, true);
             await promise;
@@ -456,6 +470,7 @@ describe('Testing pages module', () => {
             const executeDeepLinkMessage = utils.findMessageByFunc('executeDeepLink');
             validateExpectedArgumentsInRequest(
               executeDeepLinkMessage,
+              'executeDeepLink',
               MatcherType.ToBe,
               'https://teams.microsoft.com/l/entity/fe4a8eba-2a31-4737-8e33-e5fae6fee194/tasklist123?webUrl=https%3A%2F%2Ftasklist.example.com%2F123&context=%7B%22channelId%22%3A%2219%3Acbe3683f25094106b826c9cada3afbe0%40thread.skype%22%2C%22subEntityId%22%3A%22task456%22%7D',
             );
@@ -513,7 +528,7 @@ describe('Testing pages module', () => {
             const promise = pages.currentApp.navigateTo(NavigateToParams);
 
             const navigateToMessage = utils.findMessageByFunc('pages.currentApp.navigateTo');
-            validateRequestWithoutArguments(navigateToMessage);
+            validateRequestWithoutArguments(navigateToMessage, 'pages.currentApp.navigateTo');
 
             utils.respondToMessage(navigateToMessage!);
 
@@ -527,7 +542,12 @@ describe('Testing pages module', () => {
             const promise = pages.currentApp.navigateTo(NavigateToParams);
 
             const navigateToMessage = utils.findMessageByFunc('pages.currentApp.navigateTo');
-            validateExpectedArgumentsInRequest(navigateToMessage, MatcherType.ToStrictEqual, NavigateToParams);
+            validateExpectedArgumentsInRequest(
+              navigateToMessage,
+              'pages.currentApp.navigateTo',
+              MatcherType.ToStrictEqual,
+              NavigateToParams,
+            );
 
             utils.respondToMessage(navigateToMessage!);
             await promise;
@@ -577,7 +597,7 @@ describe('Testing pages module', () => {
             const promise = pages.currentApp.navigateToDefaultPage();
 
             const navigateToDefaultPageMessage = utils.findMessageByFunc('pages.currentApp.navigateToDefaultPage');
-            validateRequestWithoutArguments(navigateToDefaultPageMessage);
+            validateRequestWithoutArguments(navigateToDefaultPageMessage, 'pages.currentApp.navigateToDefaultPage');
 
             utils.respondToMessage(navigateToDefaultPageMessage!);
 
@@ -591,7 +611,7 @@ describe('Testing pages module', () => {
             const promise = pages.currentApp.navigateToDefaultPage();
 
             const navigateToDefaultPageMessage = utils.findMessageByFunc('pages.currentApp.navigateToDefaultPage');
-            validateRequestWithoutArguments(navigateToDefaultPageMessage);
+            validateRequestWithoutArguments(navigateToDefaultPageMessage, 'pages.currentApp.navigateToDefaultPage');
 
             utils.respondToMessage(navigateToDefaultPageMessage!);
             expect(await promise).toBeUndefined();
@@ -647,6 +667,7 @@ describe('Testing pages module', () => {
             const message = utils.findMessageByFunc('shareDeepLink');
             validateExpectedArgumentsInRequest(
               message,
+              'shareDeepLink',
               MatcherType.ToBe,
               'someSubEntityId',
               'someSubEntityLabel',
@@ -689,7 +710,12 @@ describe('Testing pages module', () => {
             return true;
           });
           const messageForRegister = utils.findMessageByFunc('registerHandler');
-          validateExpectedArgumentsInRequest(messageForRegister, MatcherType.ToBe, 'fullScreenChange');
+          validateExpectedArgumentsInRequest(
+            messageForRegister,
+            'registerHandler',
+            MatcherType.ToBe,
+            'fullScreenChange',
+          );
         });
 
         it(`pages.registerFullScreenHandler should successfully invoke full screen handler when set to true and  initialized with ${context} context`, async () => {
@@ -770,14 +796,14 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             pages.tabs.navigateToTab(tabInstance);
             const navigateToTabMsg = utils.findMessageByFunc('navigateToTab');
-            validateExpectedArgumentsInRequest(navigateToTabMsg, MatcherType.ToBe, tabInstance);
+            validateExpectedArgumentsInRequest(navigateToTabMsg, 'navigateToTab', MatcherType.ToBe, tabInstance);
           });
 
           it(`pages.tabs.navigateToTab should throw error when initialized with ${context} context`, async () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.navigateToTab(null);
             const navigateToTabMsg = utils.findMessageByFunc('navigateToTab');
-            validateRequestWithoutArguments(navigateToTabMsg);
+            validateRequestWithoutArguments(navigateToTabMsg, 'navigateToTab');
 
             utils.respondToMessage(navigateToTabMsg!, false);
             await promise.catch((e) =>
@@ -791,7 +817,7 @@ describe('Testing pages module', () => {
             const onComplete = getGenericOnCompleteHandler();
             onComplete(true);
             const navigateToTabMsg = utils.findMessageByFunc('navigateToTab');
-            validateExpectedArgumentsInRequest(navigateToTabMsg, MatcherType.ToBe, null);
+            validateExpectedArgumentsInRequest(navigateToTabMsg, 'navigateToTab', MatcherType.ToBe, null);
           });
         });
       });
@@ -822,7 +848,7 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.getTabInstances();
             const message = utils.findMessageByFunc('getTabInstances');
-            validateRequestWithoutArguments(message);
+            validateRequestWithoutArguments(message, 'getTabInstances');
 
             utils.respondToMessage(message!, expectedTabInstanceParameters);
             expect(promise).resolves.toBe(expectedTabInstanceParameters);
@@ -832,7 +858,7 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.getTabInstances(expectedTabInstanceParameters);
             const message = utils.findMessageByFunc('getTabInstances');
-            validateRequestWithoutArguments(message);
+            validateRequestWithoutArguments(message, 'getTabInstances');
 
             utils.respondToMessage(message!);
             expect(promise).resolves.toBeUndefined();
@@ -842,7 +868,7 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.getTabInstances();
             const message = utils.findMessageByFunc('getTabInstances');
-            validateRequestWithoutArguments(message);
+            validateRequestWithoutArguments(message, 'getTabInstances');
 
             utils.respondToMessage(message!);
             expect(promise).resolves.toBeUndefined();
@@ -877,7 +903,7 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.getMruTabInstances();
             const message = utils.findMessageByFunc('getMruTabInstances');
-            validateRequestWithoutArguments(message);
+            validateRequestWithoutArguments(message, 'getMruTabInstances');
 
             utils.respondToMessage(message!, expectedTabInstanceParameters);
             expect(promise).resolves.toBe(expectedTabInstanceParameters);
@@ -887,7 +913,7 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.getMruTabInstances(expectedTabInstanceParameters);
             const message = utils.findMessageByFunc('getMruTabInstances');
-            validateRequestWithoutArguments(message);
+            validateRequestWithoutArguments(message, 'getMruTabInstances');
 
             utils.respondToMessage(message!);
             expect(promise).resolves.toBeUndefined();
@@ -897,7 +923,7 @@ describe('Testing pages module', () => {
             await utils.initializeWithContext(context);
             const promise = pages.tabs.getMruTabInstances();
             const message = utils.findMessageByFunc('getMruTabInstances');
-            validateRequestWithoutArguments(message);
+            validateRequestWithoutArguments(message, 'getMruTabInstances');
 
             utils.respondToMessage(message!);
             expect(promise).resolves.toBeUndefined();
@@ -986,7 +1012,7 @@ describe('Testing pages module', () => {
               pages.config.setValidityState(true);
 
               const message = utils.findMessageByFunc('settings.setValidityState');
-              validateExpectedArgumentsInRequest(message, MatcherType.ToBe, true);
+              validateExpectedArgumentsInRequest(message, 'settings.setValidityState', MatcherType.ToBe, true);
             });
 
             it(`pages.config.setValidityState should successfully set validity state to false when initialized with ${context} context`, async () => {
@@ -994,7 +1020,7 @@ describe('Testing pages module', () => {
               pages.config.setValidityState(false);
 
               const message = utils.findMessageByFunc('settings.setValidityState');
-              validateExpectedArgumentsInRequest(message, MatcherType.ToBe, false);
+              validateExpectedArgumentsInRequest(message, 'settings.setValidityState', MatcherType.ToBe, false);
             });
           } else {
             it(`pages.config.setValidityState does not allow calls from ${context} context`, async () => {
@@ -1043,7 +1069,7 @@ describe('Testing pages module', () => {
               await utils.initializeWithContext(context);
               pages.config.setConfig(settingsObj);
               const message = utils.findMessageByFunc('settings.setSettings');
-              validateExpectedArgumentsInRequest(message, MatcherType.ToBe, settingsObj);
+              validateExpectedArgumentsInRequest(message, 'settings.setSettings', MatcherType.ToBe, settingsObj);
             });
           } else {
             it(`pages.config.setConfig does not allow calls from ${context} context`, async () => {
@@ -1144,7 +1170,7 @@ describe('Testing pages module', () => {
               utils.sendMessage('settings.save');
               expect(handlerCalled).toBe(true);
               const message = utils.findMessageByFunc('settings.save.success');
-              validateRequestWithoutArguments(message);
+              validateRequestWithoutArguments(message, 'settings.save.success');
             });
 
             it(`pages.config.registerOnSaveHandler should successfully notify failure from the registered save handler when initialized with ${context} context`, async () => {
@@ -1157,7 +1183,7 @@ describe('Testing pages module', () => {
               utils.sendMessage('settings.save');
               expect(handlerCalled).toBe(true);
               const message = utils.findMessageByFunc('settings.save.failure');
-              validateExpectedArgumentsInRequest(message, MatcherType.ToBe, 'someReason');
+              validateExpectedArgumentsInRequest(message, 'settings.save.failure', MatcherType.ToBe, 'someReason');
             });
 
             it(`pages.config.registerOnSaveHandler should not allow multiple notifies from the registered save handler when initialized with ${context} context`, async () => {
@@ -1176,7 +1202,7 @@ describe('Testing pages module', () => {
               utils.sendMessage('settings.save');
               expect(handlerCalled).toBe(true);
               const message = utils.findMessageByFunc('settings.save.success');
-              validateRequestWithoutArguments(message);
+              validateRequestWithoutArguments(message, 'settings.save.success');
             });
 
             it('pages.config.registerOnSaveHandler should proxy to childWindow if no handler in top window', async () => {
@@ -1324,7 +1350,7 @@ describe('Testing pages module', () => {
 
               expect(handlerCalled).toBe(true);
               const message = utils.findMessageByFunc('settings.remove.success');
-              validateRequestWithoutArguments(message);
+              validateRequestWithoutArguments(message, 'settings.remove.success');
             });
 
             it(`pages.config.registerOnRemoveHandler should successfully notify failure from the registered remove handler when initialized with ${context} context`, async () => {
@@ -1340,7 +1366,7 @@ describe('Testing pages module', () => {
 
               expect(handlerCalled).toBe(true);
               const message = utils.findMessageByFunc('settings.remove.failure');
-              validateExpectedArgumentsInRequest(message, MatcherType.ToBe, 'someReason');
+              validateExpectedArgumentsInRequest(message, 'settings.remove.failure', MatcherType.ToBe, 'someReason');
             });
           } else {
             it(`pages.config.registerOnRemoveHandler does not allow calls from ${context} context`, async () => {

--- a/packages/teams-js/test/resultValidation.ts
+++ b/packages/teams-js/test/resultValidation.ts
@@ -9,7 +9,7 @@ export enum MatcherType {
 // validateRequestWithoutArguments or validateExpectedArgumentsInRequest.
 // The number of assertions used changes depending on how many arguments are being validated, so
 // you have to pass in the number of arguments being validated.
-// The value returned from this function can be used to in calls to expect.assertions() if you have them.
+// The value returned from this function can be used in calls to expect.assertions() if you have them.
 export function getNumberOfAssertionsUsedToValidateRequest(numberOfArgumentsBeingValidated: number): number {
   return 2 + (numberOfArgumentsBeingValidated === 0 ? 0 : 2 + numberOfArgumentsBeingValidated);
 }

--- a/packages/teams-js/test/resultValidation.ts
+++ b/packages/teams-js/test/resultValidation.ts
@@ -5,15 +5,16 @@ export enum MatcherType {
   ToStrictEqual,
 }
 
-export interface MatcherAndArguments {
-  matcher: MatcherType;
-  arguments: unknown[];
-}
-
+// This function will return the number of assertions used to validate a request object using
+// validateRequestWithoutArguments or validateExpectedArgumentsInRequest.
+// The number of assertions used changes depending on how many arguments are being validated, so
+// you have to pass in the number of arguments being validated.
+// The value returned from this function can be used to in calls to expect.assertions() if you have them.
 export function getNumberOfAssertionsUsedToValidateRequest(numberOfArgumentsBeingValidated: number): number {
   return 1 + (numberOfArgumentsBeingValidated === 0 ? 0 : 2 + numberOfArgumentsBeingValidated);
 }
 
+// Used to validate a request object you are expecting to contain no arguments.
 export function validateRequestWithoutArguments(request: MessageRequest | null): void {
   validateExpectedArgumentsInRequest(request, MatcherType.ToBe);
 }
@@ -22,6 +23,8 @@ export function validateRequestWithoutArguments(request: MessageRequest | null):
  * for null and undefined as part of validation and then using those values after testing them. */
 /* eslint-disable strict-null-checks/all */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+// Used to validate a request object you are expecting to contain arguments.
 export function validateExpectedArgumentsInRequest(
   request: MessageRequest | null,
   matcher: MatcherType,

--- a/packages/teams-js/test/resultValidation.ts
+++ b/packages/teams-js/test/resultValidation.ts
@@ -11,12 +11,12 @@ export enum MatcherType {
 // you have to pass in the number of arguments being validated.
 // The value returned from this function can be used to in calls to expect.assertions() if you have them.
 export function getNumberOfAssertionsUsedToValidateRequest(numberOfArgumentsBeingValidated: number): number {
-  return 1 + (numberOfArgumentsBeingValidated === 0 ? 0 : 2 + numberOfArgumentsBeingValidated);
+  return 2 + (numberOfArgumentsBeingValidated === 0 ? 0 : 2 + numberOfArgumentsBeingValidated);
 }
 
 // Used to validate a request object you are expecting to contain no arguments.
-export function validateRequestWithoutArguments(request: MessageRequest | null): void {
-  validateExpectedArgumentsInRequest(request, MatcherType.ToBe);
+export function validateRequestWithoutArguments(request: MessageRequest | null, expectedFunctionName: string): void {
+  validateExpectedArgumentsInRequest(request, expectedFunctionName, MatcherType.ToBe);
 }
 
 /* The following two lint rules are disabled for only this function since this function is specifically testing
@@ -27,10 +27,12 @@ export function validateRequestWithoutArguments(request: MessageRequest | null):
 // Used to validate a request object you are expecting to contain arguments.
 export function validateExpectedArgumentsInRequest(
   request: MessageRequest | null,
+  expectedFunctionName: string,
   matcher: MatcherType,
   ...expectedArgs: unknown[]
 ): void {
   expect(request).not.toBeNull();
+  expect(request?.func).toEqual(expectedFunctionName);
   if (expectedArgs.length > 0) {
     expect(request!.args).toBeDefined();
     expect(request!.args!.length).toBe(expectedArgs.length);

--- a/packages/teams-js/test/resultValidation.ts
+++ b/packages/teams-js/test/resultValidation.ts
@@ -1,0 +1,43 @@
+import { MessageRequest } from './utils';
+
+export enum MatcherType {
+  ToBe,
+  StrictEqual,
+}
+
+export interface MatcherAndArguments {
+  matcher: MatcherType;
+  arguments: unknown[];
+}
+
+export function validateRequestWithoutValues(request: MessageRequest | null): void {
+  validateExpectedValuesInRequest(request, MatcherType.ToBe);
+}
+
+/* The following two lint rules are disabled for only this function since this function is specifically testing
+ * for null and undefined as part of validation and then using those values after testing them. */
+/* eslint-disable strict-null-checks/all */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+export function validateExpectedValuesInRequest(
+  request: MessageRequest | null,
+  matcher: MatcherType,
+  ...expectedArgs: unknown[]
+): void {
+  expect(request).not.toBeNull();
+  if (expectedArgs.length > 0) {
+    expect(request!.args).toBeDefined();
+    expect(request!.args!.length).toBe(expectedArgs.length);
+
+    for (let i = 0; i < expectedArgs.length; ++i) {
+      if (matcher === MatcherType.ToBe) {
+        expect(request!.args![i]).toBe(expectedArgs[i]);
+      } else if (matcher === MatcherType.StrictEqual) {
+        expect(request!.args![i]).toStrictEqual(expectedArgs[i]);
+      } else {
+        throw new Error(`Unknown matcher type ${matcher}`);
+      }
+    }
+  }
+}
+/* eslint-enable @typescript-eslint/no-non-null-assertion */
+/* eslint-enable strict-null-checks/all */

--- a/packages/teams-js/test/resultValidation.ts
+++ b/packages/teams-js/test/resultValidation.ts
@@ -2,7 +2,7 @@ import { MessageRequest } from './utils';
 
 export enum MatcherType {
   ToBe,
-  StrictEqual,
+  ToStrictEqual,
 }
 
 export interface MatcherAndArguments {
@@ -10,15 +10,15 @@ export interface MatcherAndArguments {
   arguments: unknown[];
 }
 
-export function validateRequestWithoutValues(request: MessageRequest | null): void {
-  validateExpectedValuesInRequest(request, MatcherType.ToBe);
+export function validateRequestWithoutArguments(request: MessageRequest | null): void {
+  validateExpectedArgumentsInRequest(request, MatcherType.ToBe);
 }
 
 /* The following two lint rules are disabled for only this function since this function is specifically testing
  * for null and undefined as part of validation and then using those values after testing them. */
 /* eslint-disable strict-null-checks/all */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-export function validateExpectedValuesInRequest(
+export function validateExpectedArgumentsInRequest(
   request: MessageRequest | null,
   matcher: MatcherType,
   ...expectedArgs: unknown[]
@@ -31,7 +31,7 @@ export function validateExpectedValuesInRequest(
     for (let i = 0; i < expectedArgs.length; ++i) {
       if (matcher === MatcherType.ToBe) {
         expect(request!.args![i]).toBe(expectedArgs[i]);
-      } else if (matcher === MatcherType.StrictEqual) {
+      } else if (matcher === MatcherType.ToStrictEqual) {
         expect(request!.args![i]).toStrictEqual(expectedArgs[i]);
       } else {
         throw new Error(`Unknown matcher type ${matcher}`);

--- a/packages/teams-js/test/resultValidation.ts
+++ b/packages/teams-js/test/resultValidation.ts
@@ -10,6 +10,10 @@ export interface MatcherAndArguments {
   arguments: unknown[];
 }
 
+export function getNumberOfAssertionsUsedToValidateRequest(numberOfArgumentsBeingValidated: number): number {
+  return 1 + (numberOfArgumentsBeingValidated === 0 ? 0 : 2 + numberOfArgumentsBeingValidated);
+}
+
 export function validateRequestWithoutArguments(request: MessageRequest | null): void {
   validateExpectedArgumentsInRequest(request, MatcherType.ToBe);
 }

--- a/packages/teams-js/test/resultValidation.ts
+++ b/packages/teams-js/test/resultValidation.ts
@@ -10,8 +10,14 @@ export enum MatcherType {
 // The number of assertions used changes depending on how many arguments are being validated, so
 // you have to pass in the number of arguments being validated.
 // The value returned from this function can be used in calls to expect.assertions() if you have them.
-export function getNumberOfAssertionsUsedToValidateRequest(numberOfArgumentsBeingValidated: number): number {
-  return 2 + (numberOfArgumentsBeingValidated === 0 ? 0 : 2 + numberOfArgumentsBeingValidated);
+export function getCountOfAssertionsUsedToValidateRequest(numberOfArgumentsBeingValidated: number): number {
+  return (
+    countOfTestAssertionsRegardlessOfNumberOfArgumentsBeingValidated +
+    (numberOfArgumentsBeingValidated === 0
+      ? 0
+      : countOfTestAssertionsUsedWhenThereAreArgumentsToValidateRegardlessOfHowMany +
+        countOfTestAssertionsUsedToValidateEachArgument * numberOfArgumentsBeingValidated)
+  );
 }
 
 // Used to validate a request object you are expecting to contain no arguments.
@@ -23,6 +29,10 @@ export function validateRequestWithoutArguments(request: MessageRequest | null, 
  * for null and undefined as part of validation and then using those values after testing them. */
 /* eslint-disable strict-null-checks/all */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+const countOfTestAssertionsRegardlessOfNumberOfArgumentsBeingValidated = 2;
+const countOfTestAssertionsUsedWhenThereAreArgumentsToValidateRegardlessOfHowMany = 2;
+const countOfTestAssertionsUsedToValidateEachArgument = 1;
 
 // Used to validate a request object you are expecting to contain arguments.
 export function validateExpectedArgumentsInRequest(


### PR DESCRIPTION
## Description

As part of fixing the lint errors in the `pages` unit tests, I moved many repeated blocks of code which validated `MessageRequest` objects into a single, shared, helper. These tests now consistently validate their `MessageRequest` objects and have many of their lint errors fixed/removed.

Some of the validation places in pages still remain because they use a different type, also called `MessageRequest`. This type is only used by the "frameless" tests. Rather than also write another validator for these, it seemed like a future change would be to understand if these two types could be shared/reused since they are identically named (but not actually defined identically). I left those tests alone for the purposes of this change.

### Main changes in the PR:

1. Create request validation helper methods
2. Make the pages tests use them

## Validation

### Validation performed:

Unit tests were run and passed.

### Unit Tests added:

No new unit tests were added for this change.

### End-to-end tests added:

No.

## Additional Requirements

### Change file added:

It told me no changefile was needed (probably because none of the changes are in then teams-js package directory).

### Next/remaining steps:

Try to fix the frameless tests, then expand usage of this new helper to other unit tests outside of `pages`.