### PR TITLE
Unify MessageResponse objects

### DIFF
--- a/packages/teams-js/test/private/privateAPIs.spec.ts
+++ b/packages/teams-js/test/private/privateAPIs.spec.ts
@@ -1,3 +1,4 @@
+import { MessageResponse } from '../../src/internal/interfaces';
 import { UserSettingTypes, ViewerActionTypes } from '../../src/private/interfaces';
 import {
   openFilePreview,
@@ -9,7 +10,7 @@ import {
 import { app } from '../../src/public/app';
 import { FrameContexts, HostClientType, HostName, TeamType } from '../../src/public/constants';
 import { Context, FileOpenPreference } from '../../src/public/interfaces';
-import { MessageRequest, MessageResponse, Utils } from '../utils';
+import { MessageRequest, Utils } from '../utils';
 
 /* eslint-disable */
 /* As part of enabling eslint on test files, we need to disable eslint checking on the specific files with

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -1,4 +1,4 @@
-import { DOMMessageEvent } from '../../src/internal/interfaces';
+import { DOMMessageEvent, MessageResponse } from '../../src/internal/interfaces';
 import { getGenericOnCompleteHandler } from '../../src/internal/utils';
 import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
@@ -13,7 +13,7 @@ import {
   validateExpectedArgumentsInRequest,
   validateRequestWithoutArguments,
 } from '../resultValidation';
-import { MessageResponse, Utils } from '../utils';
+import { Utils } from '../utils';
 
 /* eslint-disable */
 /* As part of enabling eslint on test files, we need to disable eslint checking on the specific files with

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -1,6 +1,6 @@
 import { defaultSDKVersionForCompatCheck } from '../src/internal/constants';
 import { GlobalVars } from '../src/internal/globalVars';
-import { DOMMessageEvent, ExtendedWindow } from '../src/internal/interfaces';
+import { DOMMessageEvent, ExtendedWindow, MessageResponse } from '../src/internal/interfaces';
 import { app } from '../src/public/app';
 import { applyRuntimeConfig, IRuntime } from '../src/public/runtime';
 
@@ -10,11 +10,6 @@ export interface MessageRequest {
   args?: unknown[];
   timestamp?: number;
   isPartialResponse?: boolean;
-}
-
-export interface MessageResponse {
-  id: number;
-  args?: unknown[];
 }
 
 export class Utils {


### PR DESCRIPTION
## Description

There were two `MessageResponse` types in the library. One was used by the product code and one was used by the unit test code. This change updates the unit test code to use the one defined in the product code. The product code version had an extra (optional) property, which won't harm anything in the unit tests since it will just be unused. FOR NOW.

### Main changes in the PR:

Delete `MessageResponse` type in unit test code and update all references to product code version.

## Validation

### Validation performed:

Ensured unit tests passed

### Unit Tests added:

No.

### End-to-end tests added:

No.

## Additional Requirements

### Change file added:

beachball told me it was not required for this change
