### PR TITLE
Fix all lint errors in framelessPostMocks, remove unnecessary that=this

### DIFF
--- a/packages/teams-js/test/framelessPostMocks.ts
+++ b/packages/teams-js/test/framelessPostMocks.ts
@@ -4,10 +4,6 @@ import { DOMMessageEvent, ExtendedWindow, MessageRequest, MessageResponse } from
 import { app } from '../src/public/app';
 import { applyRuntimeConfig, IRuntime } from '../src/public/runtime';
 
-/* eslint-disable */
-/* As part of enabling eslint on test files, we need to disable eslint checking on the specific files with
-   large numbers of errors. Then, over time, we can fix the errors and reenable eslint on a per file basis. */
-
 export class FramelessPostMocks {
   public tabOrigin = 'https://example.com';
 
@@ -19,29 +15,33 @@ export class FramelessPostMocks {
   public messages: MessageRequest[] = [];
 
   public constructor() {
-    const that = this;
     this.messages = [];
     this.mockWindow = {
       outerWidth: 1024,
       outerHeight: 768,
       screenLeft: 0,
       screenTop: 0,
-      addEventListener: function (type: string, listener: (ev: MessageEvent) => void, useCapture?: boolean): void {},
-      removeEventListener: function (type: string, listener: (ev: MessageEvent) => void, useCapture?: boolean): void {},
+      addEventListener: (): void => {
+        /* mock does not support event listeners */
+      },
+      removeEventListener: (): void => {
+        /* mock does not support event listeners */
+      },
       nativeInterface: {
-        framelessPostMessage: function (message: string): void {
+        framelessPostMessage: (message: string): void => {
           const msg = JSON.parse(message);
-          that.messages.push(msg);
+          this.messages.push(msg);
         },
       },
       location: {
-        origin: that.tabOrigin,
-        href: that.validOrigin,
-        assign: function (url: string): void {
+        origin: this.tabOrigin,
+        href: this.validOrigin,
+        assign: function (): void {
           return;
         },
       },
-      setInterval: (handler: Function, timeout: number): number => setInterval(handler, timeout),
+      setInterval: (handler: TimerHandler, timeout?: number, ...args: unknown[]): number =>
+        setInterval(handler, timeout, args),
     };
     this.mockWindow.self = this.mockWindow as ExtendedWindow;
   }
@@ -54,7 +54,8 @@ export class FramelessPostMocks {
     app._initialize(this.mockWindow);
     const initPromise = app.initialize(validMessageOrigins);
     expect(GlobalVars.isFramelessWindow).toBeTruthy();
-    const initMessage = this.findMessageByFunc('initialize');
+    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */ /* If initMessage is null it will fail the expect call, so it's okay to just assume it's not */
+    const initMessage: MessageRequest = this.findMessageByFunc('initialize')!;
     expect(initMessage).not.toBeNull();
     this.respondToInitMessage(initMessage, frameContext, hostClientType);
     await initPromise;
@@ -75,7 +76,7 @@ export class FramelessPostMocks {
     applyRuntimeConfig(runtime);
   };
 
-  public findMessageByFunc = (func: string): MessageRequest => {
+  public findMessageByFunc = (func: string): MessageRequest | null => {
     for (let i = 0; i < this.messages.length; i++) {
       if (this.messages[i].func === func) {
         return this.messages[i];
@@ -84,7 +85,7 @@ export class FramelessPostMocks {
     return null;
   };
 
-  private respondToInitMessage = (message: MessageRequest, ...args: any[]): void => {
+  private respondToInitMessage = (message: MessageRequest, ...args: unknown[]): void => {
     const domEvent = {
       data: {
         id: message.id,

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -29,19 +29,17 @@ export class Utils {
   public parentWindow: Window;
 
   public constructor() {
-    /* eslint-disable-next-line @typescript-eslint/no-this-alias */ /* Intentionally making a copy of this and using both the old and new instance */
-    const that = this;
     this.messages = [];
     this.childMessages = [];
 
     this.parentWindow = {
-      postMessage: function (message: MessageRequest, targetOrigin: string): void {
+      postMessage: (message: MessageRequest, targetOrigin: string): void => {
         if (message.func === 'initialize' && targetOrigin !== '*') {
           throw new Error('initialize messages to parent window must have a targetOrigin of *');
-        } else if (message.func !== 'initialize' && targetOrigin !== that.validOrigin) {
-          throw new Error(`messages to parent window must have a targetOrigin of ${that.validOrigin}`);
+        } else if (message.func !== 'initialize' && targetOrigin !== this.validOrigin) {
+          throw new Error(`messages to parent window must have a targetOrigin of ${this.validOrigin}`);
         }
-        that.messages.push(message);
+        this.messages.push(message);
       },
     } as Window;
 
@@ -50,32 +48,32 @@ export class Utils {
       outerHeight: 768,
       screenLeft: 0,
       screenTop: 0,
-      addEventListener: function (type: string, listener: (ev: MessageEvent) => void): void {
+      addEventListener: (type: string, listener: (ev: MessageEvent) => void): void => {
         if (type === 'message') {
-          that.processMessage = listener;
+          this.processMessage = listener;
         }
       },
-      removeEventListener: function (type: string): void {
+      removeEventListener: (type: string): void => {
         if (type === 'message') {
-          that.processMessage = null;
+          this.processMessage = null;
         }
       },
       location: {
-        origin: that.tabOrigin,
-        href: that.validOrigin,
+        origin: this.tabOrigin,
+        href: this.validOrigin,
         assign: function (): void {
           return;
         },
       },
       parent: this.parentWindow,
       nativeInterface: {
-        framelessPostMessage: function (message: string): void {
-          that.messages.push(JSON.parse(message));
+        framelessPostMessage: (message: string): void => {
+          this.messages.push(JSON.parse(message));
         },
       },
       self: null as unknown as Window,
-      open: function (): Window {
-        return that.childWindow as Window;
+      open: (): Window => {
+        return this.childWindow as Window;
       },
       close: function (): void {
         return;
@@ -85,8 +83,8 @@ export class Utils {
     this.mockWindow.self = this.mockWindow as Window;
 
     this.childWindow = {
-      postMessage: function (message: MessageRequest): void {
-        that.childMessages.push(message);
+      postMessage: (message: MessageRequest): void => {
+        this.childMessages.push(message);
       },
       close: function (): void {
         return;


### PR DESCRIPTION
## Description

I was trying to understand how the framelessPostMock stuff in the unit tests work and one thing I kept tripping over was the whole `that = this` thing it was doing (with no explanation). After some more poking around I decided it was being done because the original author wanted to properly capture a `this` pointer to use in the callback methods. In this change, I have updated the callback methods to use arrow functions notation instead, which automatically captures the `this` pointer correctly and doesn't require any this/that stuff.

It's possible that really the whole thing needs to be reworked but, if that's true, at least it's something I can do iteratively by making the code less and less confusing until I understand better what it's doing and why.

I also fixed the other lint errors in `framelessPostMocks.ts`.

### Main changes in the PR:

- Use arrow functions to capture `this` pointer where it was previously using `that`
- Fix remaining lint errors in `framelessPostMocks.ts`

## Validation

### Validation performed:

Ensure all tests pass

### Unit Tests added:

No.

### End-to-end tests added:

No.

## Additional Requirements

### Change file added:

Beachball tells me it's not needed.