### PR TITLE
Post Android E2E Test Results on Cancellation and Remove Retry

### DIFF
--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -42,7 +42,6 @@ steps:
   - bash: 'chmod u+x ./gradlew && chmod u+x e2eTest.sh && ./e2eTest.sh'
     displayName: 'Run Android E2E Tests'
     workingDirectory: '$(Agent.BuildDirectory)/androidHost/apps/orangeandroid'
-    retryCountOnTaskFailure: 1
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'
@@ -52,4 +51,4 @@ steps:
       testRunTitle: 'E2E Tests - Android'
       searchFolder: '$(Agent.BuildDirectory)/androidHost'
       mergeTestResults: true
-    condition: succeededOrFailed()
+    condition: or(succeededOrFailed(), eq(variables['Agent.JobStatus'], 'Canceled'))


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description
Post Android E2E test results on cancellation so that we can see test results after timeout. Remove retry from Android E2E tests since the second run may not have enough time to finish before timing out

### Main changes in the PR:

1. Remove retry from Android E2E tests
2. Add on cancelled condition to test results publishing

## Validation

### Validation performed:

1. Run Android E2E tests, tests should complete and post results on success or failure.

### Unit Tests added:

No unit tests necessary: YAML change

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No

### Next/remaining steps:

Going to try implementing per-test retries on the Android side for more efficient flakey test mitigation
