### PR TITLE
Export notifyError function

### DIFF
--- a/change/@microsoft-teams-js-45469888-55eb-44b9-b72b-cb92a212e84b.json
+++ b/change/@microsoft-teams-js-45469888-55eb-44b9-b72b-cb92a212e84b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Export notifyError function",
+  "comment": "make notifyError function in videoEx public to enable video app notify host when meeting fatal errors",
   "packageName": "@microsoft/teams-js",
   "email": "Xukai.Wu@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-45469888-55eb-44b9-b72b-cb92a212e84b.json
+++ b/change/@microsoft-teams-js-45469888-55eb-44b9-b72b-cb92a212e84b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "add notifyFatalError function in videoEx to enable video app notify host when meeting fatal errors",
+  "comment": "Added `notifyFatalError` function in videoEx to enable video apps to notify the host of fatal errors.",
   "packageName": "@microsoft/teams-js",
   "email": "Xukai.Wu@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-45469888-55eb-44b9-b72b-cb92a212e84b.json
+++ b/change/@microsoft-teams-js-45469888-55eb-44b9-b72b-cb92a212e84b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Export notifyError function",
+  "packageName": "@microsoft/teams-js",
+  "email": "Xukai.Wu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-45469888-55eb-44b9-b72b-cb92a212e84b.json
+++ b/change/@microsoft-teams-js-45469888-55eb-44b9-b72b-cb92a212e84b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "make notifyError function in videoEx public to enable video app notify host when meeting fatal errors",
+  "comment": "add notifyFatalError function in videoEx to enable video app notify host when meeting fatal errors",
   "packageName": "@microsoft/teams-js",
   "email": "Xukai.Wu@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/private/videoEx.ts
+++ b/packages/teams-js/src/private/videoEx.ts
@@ -278,6 +278,10 @@ export namespace videoEx {
    * Limited to Microsoft-internal use
    */
   export function notifyFatalError(errorMessage: string): void {
+    ensureInitialized();
+    if (!video.isSupported()) {
+      throw errorNotSupportedOnPlatform;
+    }
     notifyError(errorMessage, ErrorLevel.Fatal);
   }
 }

--- a/packages/teams-js/src/private/videoEx.ts
+++ b/packages/teams-js/src/private/videoEx.ts
@@ -269,9 +269,7 @@ export namespace videoEx {
 
   /**
    * @hidden
-   * Sending fatal error notification to host
-   *
-   * **Note**: Call this function only when your app meets fatal error and can't continue.
+   * Sending fatal error notification to host. Call this function only when your app meets fatal error and can't continue.
    * The host will stop the video pipeline and terminate this session, and optionally, show an error message to the user.
    * @beta
    * @param errorMessage - The error message that will be sent to the host

--- a/packages/teams-js/src/private/videoEx.ts
+++ b/packages/teams-js/src/private/videoEx.ts
@@ -15,6 +15,18 @@ import { video } from '../public/video';
 export namespace videoEx {
   /**
    * @hidden
+   * Error level when notifying errors to the host, the host will decide what to do acording to the error level.
+   * @beta
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  export enum ErrorLevel {
+    Fatal = 'fatal',
+    Warn = 'warn',
+  }
+  /**
+   * @hidden
    * Video frame configuration supplied to the host to customize the generated video frame parameters
    * @beta
    *
@@ -104,9 +116,7 @@ export namespace videoEx {
             () => {
               notifyVideoFrameProcessed(timestamp);
             },
-            (errorMessage: string) => {
-              notifyError(`[VideoFrameProcessingFailed]: ${errorMessage}`);
-            },
+            notifyError,
           );
         }
       },
@@ -246,6 +256,20 @@ export namespace videoEx {
   /**
    * @hidden
    * Sending error notification to host
+   * @beta
+   * @param errorMessage - The error message that will be sent to the host
+   * @param errorLevel - The error level that will be sent to the host
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  function notifyError(errorMessage: string, errorLevel: ErrorLevel = ErrorLevel.Warn): void {
+    sendMessageToParent('video.notifyError', [errorMessage, errorLevel]);
+  }
+
+  /**
+   * @hidden
+   * Sending fatal error notification to host
    *
    * **Note**: Call this function only when your app meets fatal error and can't continue.
    * The host will stop the video pipeline and terminate this session, and optionally, show an error message to the user.
@@ -255,7 +279,7 @@ export namespace videoEx {
    * @internal
    * Limited to Microsoft-internal use
    */
-  export function notifyError(errorMessage: string): void {
-    sendMessageToParent('video.notifyError', [errorMessage]);
+  export function notifyFatalError(errorMessage: string): void {
+    notifyError(errorMessage, ErrorLevel.Fatal);
   }
 }

--- a/packages/teams-js/src/private/videoEx.ts
+++ b/packages/teams-js/src/private/videoEx.ts
@@ -250,7 +250,7 @@ export namespace videoEx {
    * @internal
    * Limited to Microsoft-internal use
    */
-  function notifyError(errorMessage: string): void {
+  export function notifyError(errorMessage: string): void {
     sendMessageToParent('video.notifyError', [errorMessage]);
   }
 }

--- a/packages/teams-js/src/private/videoEx.ts
+++ b/packages/teams-js/src/private/videoEx.ts
@@ -104,7 +104,9 @@ export namespace videoEx {
             () => {
               notifyVideoFrameProcessed(timestamp);
             },
-            notifyError,
+            (errorMessage: string) => {
+              notifyError(`[VideoFrameProcessingFailed]: ${errorMessage}`);
+            },
           );
         }
       },
@@ -244,6 +246,9 @@ export namespace videoEx {
   /**
    * @hidden
    * Sending error notification to host
+   *
+   * **Note**: Call this function only when your app meets fatal error and can't continue.
+   * The host will stop the video pipeline and terminate this session, and optionally, show an error message to the user.
    * @beta
    * @param errorMessage - The error message that will be sent to the host
    *

--- a/packages/teams-js/test/private/videoEx.spec.ts
+++ b/packages/teams-js/test/private/videoEx.spec.ts
@@ -634,4 +634,24 @@ describe('videoEx', () => {
       expect(() => videoEx.isSupported()).toThrowError('The library has not yet been initialized');
     });
   });
+
+  describe('notifyFatalError', () => {
+    it('FRAMED - should send error to host successfully', async () => {
+      await framedPlatformMock.initializeWithContext('sidePanel');
+      const fakeErrorMsg = 'fake error';
+      videoEx.notifyFatalError(fakeErrorMsg);
+      const message = framedPlatformMock.findMessageByFunc('video.notifyError');
+      expect(message.args.length).toBe(2);
+      expect(message.args[0]).toEqual(fakeErrorMsg);
+    });
+
+    it('FRAMELESS - should send error to host successfully', async () => {
+      await framelessPlatformMock.initializeWithContext('sidePanel');
+      const fakeErrorMsg = 'fake error';
+      videoEx.notifyFatalError(fakeErrorMsg);
+      const message = framelessPlatformMock.findMessageByFunc('video.notifyError');
+      expect(message.args.length).toBe(2);
+      expect(message.args[0]).toEqual(fakeErrorMsg);
+    });
+  });
 });

--- a/packages/teams-js/test/private/videoEx.spec.ts
+++ b/packages/teams-js/test/private/videoEx.spec.ts
@@ -305,7 +305,7 @@ describe('videoEx', () => {
       const message = framedPlatformMock.findMessageByFunc('video.notifyError');
 
       expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
+      expect(message.args.length).toBe(2);
       expect(message.args[0]).toEqual(errorMessage);
     });
 
@@ -335,7 +335,7 @@ describe('videoEx', () => {
       const message = framelessPlatformMock.findMessageByFunc('video.notifyError');
 
       expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
+      expect(message.args.length).toBe(2);
       expect(message.args[0]).toEqual(errorMessage);
     });
 

--- a/packages/teams-js/test/private/videoEx.spec.ts
+++ b/packages/teams-js/test/private/videoEx.spec.ts
@@ -307,6 +307,7 @@ describe('videoEx', () => {
       expect(message).not.toBeNull();
       expect(message.args.length).toBe(2);
       expect(message.args[0]).toEqual(errorMessage);
+      expect(message.args[1]).toEqual(videoEx.ErrorLevel.Warn);
     });
 
     it('FRAMELESS - should invoke video frame event handler and successfully send notifyError', async () => {
@@ -337,6 +338,7 @@ describe('videoEx', () => {
       expect(message).not.toBeNull();
       expect(message.args.length).toBe(2);
       expect(message.args[0]).toEqual(errorMessage);
+      expect(message.args[1]).toEqual(videoEx.ErrorLevel.Warn);
     });
 
     it('FRAMED - should not invoke video frame event handler when videoFrame is undefined', async () => {
@@ -636,6 +638,16 @@ describe('videoEx', () => {
   });
 
   describe('notifyFatalError', () => {
+    it('FRAMED - should not be supported before initialization', () => {
+      framedPlatformMock.setRuntimeConfig(_uninitializedRuntime);
+      expect(() => videoEx.notifyFatalError('')).toThrowError('The library has not yet been initialized');
+    });
+
+    it('FRAMELESS - should not be supported before initialization', () => {
+      framelessPlatformMock.setRuntimeConfig(_uninitializedRuntime);
+      expect(() => videoEx.notifyFatalError('')).toThrowError('The library has not yet been initialized');
+    });
+
     it('FRAMED - should send error to host successfully', async () => {
       await framedPlatformMock.initializeWithContext('sidePanel');
       const fakeErrorMsg = 'fake error';
@@ -643,6 +655,7 @@ describe('videoEx', () => {
       const message = framedPlatformMock.findMessageByFunc('video.notifyError');
       expect(message.args.length).toBe(2);
       expect(message.args[0]).toEqual(fakeErrorMsg);
+      expect(message.args[1]).toEqual(videoEx.ErrorLevel.Fatal);
     });
 
     it('FRAMELESS - should send error to host successfully', async () => {
@@ -652,6 +665,7 @@ describe('videoEx', () => {
       const message = framelessPlatformMock.findMessageByFunc('video.notifyError');
       expect(message.args.length).toBe(2);
       expect(message.args[0]).toEqual(fakeErrorMsg);
+      expect(message.args[1]).toEqual(videoEx.ErrorLevel.Fatal);
     });
   });
 });


### PR DESCRIPTION
## Description
Add a `notifyFatalError` function in videoEx to enable video apps to notify the host of fatal errors.

### Main changes in the PR:

1. Add `notifyFatalError` function in videoEx

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:
Yes

### End-to-end tests added:
No

## Additional Requirements

### Change file added:

Yes
