### PR TITLE
Fix incorrect profile.IsSupported check

### DIFF
--- a/change/@microsoft-teams-js-848281b2-f558-438a-a404-c6b53ae7d496.json
+++ b/change/@microsoft-teams-js-848281b2-f558-438a-a404-c6b53ae7d496.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix incorrect profile.IsSupported check",
+  "packageName": "@microsoft/teams-js",
+  "email": "grhewitt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -191,10 +191,6 @@ export const versionConstants: Record<string, Array<ICapabilityReqs>> = {
       capability: { webStorage: {} },
       hostClientTypes: [HostClientType.desktop],
     },
-    {
-      capability: { profile: {} },
-      hostClientTypes: [HostClientType.desktop, HostClientType.web],
-    },
   ],
   '2.0.5': [
     {


### PR DESCRIPTION
## Description

IsSupported was set to true incorrectly when platform support in Teams was not correctly in place. This PR reverts it back to false until platform support is confirmed.

fixes #1450 

### Main changes in the PR:

1. Set IsSupported to false in Teams web and desktop clients.

## Validation

### Validation performed:

1. Checked that IsSupported returns false in Teams

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes