### PR TITLE
Add dataResidency interface in the SDK within getUser API

### DIFF
--- a/change/@microsoft-teams-js-9e642ffe-0bf6-4775-a92f-99a31e897e32.json
+++ b/change/@microsoft-teams-js-9e642ffe-0bf6-4775-a92f-99a31e897e32.json
@@ -1,7 +1,7 @@
 {
-  "type": "major",
-  "comment": "Added dataResidencySlim interface in teams-js SDK within getUser API. Exposed a limited set of data residencies information to 1P app developers.",
+  "type": "minor",
+  "comment": "Added `dataResidency` property to `UserProfile` interface to expose a limited set of data residency information to 1P app developers.",
   "packageName": "@microsoft/teams-js",
-  "email": "email not defined",
+  "email": "liuella@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/change/@microsoft-teams-js-9e642ffe-0bf6-4775-a92f-99a31e897e32.json
+++ b/change/@microsoft-teams-js-9e642ffe-0bf6-4775-a92f-99a31e897e32.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Added dataResidencySlim interface in teams-js SDK within getUser API. Exposed a limited set of data residencies information to 1P app developers.",
+  "packageName": "@microsoft/teams-js",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -679,7 +679,11 @@ export namespace authentication {
   }
 
   /**
+   * @hidden
    * Limited set of data residencies information exposed to 1P application developers
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    */
   export enum DataResidency {
     /**

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -670,7 +670,7 @@ export namespace authentication {
     ver: string;
     /**
      * @hidden
-     * Stores the residency of the user.
+     * Stores the data residency of the user.
      *
      * @internal
      * Limited to Microsoft-internal use

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -668,6 +668,34 @@ export namespace authentication {
      * Limited to Microsoft-internal use
      */
     ver: string;
+    /**
+     * @hidden
+     * Stores the residency of the user.
+     *
+     * @internal
+     * Limited to Microsoft-internal use
+     */
+    dataResidency: DataResidencySlim;
+  }
+
+  /**
+   * Limited set of data residencies inforamtion exposed to 1P application developers
+   */
+  export enum DataResidencySlim {
+    /**
+     * Public
+     */
+    Public = 'public',
+
+    /**
+     * European Union Data Boundary
+     */
+    EUDB = 'eudb',
+
+    /**
+     * Other, stored to cover fields that will not be exposed
+     */
+    Other = 'other',
   }
 
   /**

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -679,7 +679,7 @@ export namespace authentication {
   }
 
   /**
-   * Limited set of data residencies inforamtion exposed to 1P application developers
+   * Limited set of data residencies information exposed to 1P application developers
    */
   export enum DataResidencySlim {
     /**

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -675,13 +675,13 @@ export namespace authentication {
      * @internal
      * Limited to Microsoft-internal use
      */
-    dataResidency: DataResidencySlim;
+    dataResidency?: DataResidency;
   }
 
   /**
    * Limited set of data residencies information exposed to 1P application developers
    */
-  export enum DataResidencySlim {
+  export enum DataResidency {
     /**
      * Public
      */

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -20,6 +20,26 @@ describe('Testing authentication capability', () => {
   const mockResult = 'someResult';
   const mockResource = 'https://someresource/';
   const mockClaim = 'some_claim';
+  const mockUser: authentication.UserProfile = {
+    aud: 'test_aud',
+    amr: ['test_amr'],
+    iat: 0,
+    iss: 'test_iss',
+    family_name: 'test_family_name',
+    given_name: 'test_given_name',
+    unique_name: 'test_unique_name',
+    oid: 'test_oid',
+    sub: 'test_sub',
+    tid: 'test_tid',
+    exp: 0,
+    nbf: 0,
+    upn: 'test_upn',
+    ver: 'test_ver',
+  };
+  const mockUserWithDataResidency = {
+    ...mockUser,
+    dataResidency: authentication.DataResidency.Public,
+  };
   const allowedContexts = [
     FrameContexts.content,
     FrameContexts.sidePanel,
@@ -614,6 +634,50 @@ describe('Testing authentication capability', () => {
             expect(message.id).toBe(1);
             expect(message.args[0]).toBe(undefined);
             utils.respondToMessage(message, true, mockResult);
+          });
+        });
+
+        it(`authentication.getUser should successfully get user profile with data residency info if dataResidency is provided by hosts`, (done) => {
+          utils.initializeWithContext(context).then(() => {
+            const successCallback = (user: authentication.UserProfile): void => {
+              expect(user).toEqual(mockUserWithDataResidency);
+              done();
+            };
+            const failureCallback = (): void => {
+              done();
+            };
+            const userRequest: authentication.UserRequest = {
+              successCallback: successCallback,
+              failureCallback: failureCallback,
+            };
+            authentication.getUser(userRequest);
+            const message = utils.findMessageByFunc('authentication.getUser');
+            expect(message).not.toBeNull();
+            expect(message.id).toBe(1);
+            expect(message.args[0]).toBe(undefined);
+            utils.respondToMessage(message, true, mockUserWithDataResidency);
+          });
+        });
+
+        it(`authentication.getUser should successfully get user profile with no data residency info if dataResidency is not provided by hosts`, (done) => {
+          utils.initializeWithContext(context).then(() => {
+            const successCallback = (user: authentication.UserProfile): void => {
+              expect(user).toEqual(mockUser);
+              done();
+            };
+            const failureCallback = (): void => {
+              done();
+            };
+            const userRequest: authentication.UserRequest = {
+              successCallback: successCallback,
+              failureCallback: failureCallback,
+            };
+            authentication.getUser(userRequest);
+            const message = utils.findMessageByFunc('authentication.getUser');
+            expect(message).not.toBeNull();
+            expect(message.id).toBe(1);
+            expect(message.args[0]).toBe(undefined);
+            utils.respondToMessage(message, true, mockUser);
           });
         });
 
@@ -1254,6 +1318,60 @@ describe('Testing authentication capability', () => {
               data: {
                 id: message.id,
                 args: [true, mockResult],
+              },
+            } as DOMMessageEvent);
+          });
+        });
+
+        it(`authentication.getUser should successfully get user profile with data residency info if dataResidency is provided by hosts`, (done) => {
+          framelessPostMock.initializeWithContext(context).then(() => {
+            const successCallback = (user: authentication.UserProfile): void => {
+              expect(user).toEqual(mockUserWithDataResidency);
+              done();
+            };
+            const failureCallback = (): void => {
+              done();
+            };
+            const userRequest: authentication.UserRequest = {
+              successCallback: successCallback,
+              failureCallback: failureCallback,
+            };
+            authentication.getUser(userRequest);
+            const message = framelessPostMock.findMessageByFunc('authentication.getUser');
+            expect(message).not.toBeNull();
+            expect(message.id).toBe(1);
+            expect(message.args[0]).toBe(undefined);
+            framelessPostMock.respondToMessage({
+              data: {
+                id: message.id,
+                args: [true, mockUserWithDataResidency],
+              },
+            } as DOMMessageEvent);
+          });
+        });
+
+        it(`authentication.getUser should successfully get user profile without data residency info if dataResidency is not provided by hosts`, (done) => {
+          framelessPostMock.initializeWithContext(context).then(() => {
+            const successCallback = (user: authentication.UserProfile): void => {
+              expect(user).toEqual(mockUser);
+              done();
+            };
+            const failureCallback = (): void => {
+              done();
+            };
+            const userRequest: authentication.UserRequest = {
+              successCallback: successCallback,
+              failureCallback: failureCallback,
+            };
+            authentication.getUser(userRequest);
+            const message = framelessPostMock.findMessageByFunc('authentication.getUser');
+            expect(message).not.toBeNull();
+            expect(message.id).toBe(1);
+            expect(message.args[0]).toBe(undefined);
+            framelessPostMock.respondToMessage({
+              data: {
+                id: message.id,
+                args: [true, mockUser],
               },
             } as DOMMessageEvent);
           });

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -637,50 +637,6 @@ describe('Testing authentication capability', () => {
           });
         });
 
-        it(`authentication.getUser should successfully get user profile with data residency info if dataResidency is provided by hosts`, (done) => {
-          utils.initializeWithContext(context).then(() => {
-            const successCallback = (user: authentication.UserProfile): void => {
-              expect(user).toEqual(mockUserWithDataResidency);
-              done();
-            };
-            const failureCallback = (): void => {
-              done();
-            };
-            const userRequest: authentication.UserRequest = {
-              successCallback: successCallback,
-              failureCallback: failureCallback,
-            };
-            authentication.getUser(userRequest);
-            const message = utils.findMessageByFunc('authentication.getUser');
-            expect(message).not.toBeNull();
-            expect(message.id).toBe(1);
-            expect(message.args[0]).toBe(undefined);
-            utils.respondToMessage(message, true, mockUserWithDataResidency);
-          });
-        });
-
-        it(`authentication.getUser should successfully get user profile with no data residency info if dataResidency is not provided by hosts`, (done) => {
-          utils.initializeWithContext(context).then(() => {
-            const successCallback = (user: authentication.UserProfile): void => {
-              expect(user).toEqual(mockUser);
-              done();
-            };
-            const failureCallback = (): void => {
-              done();
-            };
-            const userRequest: authentication.UserRequest = {
-              successCallback: successCallback,
-              failureCallback: failureCallback,
-            };
-            authentication.getUser(userRequest);
-            const message = utils.findMessageByFunc('authentication.getUser');
-            expect(message).not.toBeNull();
-            expect(message.id).toBe(1);
-            expect(message.args[0]).toBe(undefined);
-            utils.respondToMessage(message, true, mockUser);
-          });
-        });
-
         it(`authentication.getUser should throw error in getting user profile in legacy flow with ${context} context`, (done) => {
           utils.initializeWithContext(context).then(() => {
             const successCallback = (): void => {
@@ -704,6 +660,7 @@ describe('Testing authentication capability', () => {
         });
 
         it(`authentication.getUser should throw error in getting user profile with ${context} context`, async () => {
+          expect.assertions(4);
           await utils.initializeWithContext(context);
           const promise = authentication.getUser();
           const message = utils.findMessageByFunc('authentication.getUser');
@@ -715,14 +672,27 @@ describe('Testing authentication capability', () => {
         });
 
         it(`authentication.getUser should successfully get user profile with ${context} context`, async () => {
+          expect.assertions(4);
           await utils.initializeWithContext(context);
           const promise = authentication.getUser();
           const message = utils.findMessageByFunc('authentication.getUser');
           expect(message).not.toBeNull();
           expect(message.id).toBe(1);
           expect(message.args[0]).toBe(undefined);
-          utils.respondToMessage(message, true, mockResult);
-          await expect(promise).resolves.toEqual(mockResult);
+          utils.respondToMessage(message, true, mockUser);
+          await expect(promise).resolves.toEqual(mockUser);
+        });
+
+        it(`authentication.getUser should successfully get user profile including data residency info with ${context} context if data residency is provided by hosts`, async () => {
+          expect.assertions(4);
+          await utils.initializeWithContext(context);
+          const promise = authentication.getUser();
+          const message = utils.findMessageByFunc('authentication.getUser');
+          expect(message).not.toBeNull();
+          expect(message.id).toBe(1);
+          expect(message.args[0]).toBe(undefined);
+          utils.respondToMessage(message, true, mockUserWithDataResidency);
+          await expect(promise).resolves.toEqual(mockUserWithDataResidency);
         });
       });
     });
@@ -1323,60 +1293,6 @@ describe('Testing authentication capability', () => {
           });
         });
 
-        it(`authentication.getUser should successfully get user profile with data residency info if dataResidency is provided by hosts`, (done) => {
-          framelessPostMock.initializeWithContext(context).then(() => {
-            const successCallback = (user: authentication.UserProfile): void => {
-              expect(user).toEqual(mockUserWithDataResidency);
-              done();
-            };
-            const failureCallback = (): void => {
-              done();
-            };
-            const userRequest: authentication.UserRequest = {
-              successCallback: successCallback,
-              failureCallback: failureCallback,
-            };
-            authentication.getUser(userRequest);
-            const message = framelessPostMock.findMessageByFunc('authentication.getUser');
-            expect(message).not.toBeNull();
-            expect(message.id).toBe(1);
-            expect(message.args[0]).toBe(undefined);
-            framelessPostMock.respondToMessage({
-              data: {
-                id: message.id,
-                args: [true, mockUserWithDataResidency],
-              },
-            } as DOMMessageEvent);
-          });
-        });
-
-        it(`authentication.getUser should successfully get user profile without data residency info if dataResidency is not provided by hosts`, (done) => {
-          framelessPostMock.initializeWithContext(context).then(() => {
-            const successCallback = (user: authentication.UserProfile): void => {
-              expect(user).toEqual(mockUser);
-              done();
-            };
-            const failureCallback = (): void => {
-              done();
-            };
-            const userRequest: authentication.UserRequest = {
-              successCallback: successCallback,
-              failureCallback: failureCallback,
-            };
-            authentication.getUser(userRequest);
-            const message = framelessPostMock.findMessageByFunc('authentication.getUser');
-            expect(message).not.toBeNull();
-            expect(message.id).toBe(1);
-            expect(message.args[0]).toBe(undefined);
-            framelessPostMock.respondToMessage({
-              data: {
-                id: message.id,
-                args: [true, mockUser],
-              },
-            } as DOMMessageEvent);
-          });
-        });
-
         it(`authentication.getUser should throw error in getting user profile in legacy flow with ${context} context`, (done) => {
           framelessPostMock.initializeWithContext(context).then(() => {
             const successCallback = (): void => {
@@ -1405,6 +1321,7 @@ describe('Testing authentication capability', () => {
         });
 
         it(`authentication.getUser should throw error in getting user profile with ${context} context`, async () => {
+          expect.assertions(7);
           await framelessPostMock.initializeWithContext(context);
           const promise = authentication.getUser();
           const message = framelessPostMock.findMessageByFunc('authentication.getUser');
@@ -1421,6 +1338,7 @@ describe('Testing authentication capability', () => {
         });
 
         it(`authentication.getUser should successfully get user profile with ${context} context`, async () => {
+          expect.assertions(7);
           await framelessPostMock.initializeWithContext(context);
           const promise = authentication.getUser();
           const message = framelessPostMock.findMessageByFunc('authentication.getUser');
@@ -1430,10 +1348,27 @@ describe('Testing authentication capability', () => {
           framelessPostMock.respondToMessage({
             data: {
               id: message.id,
-              args: [false, mockResult],
+              args: [true, mockUser],
             },
           } as DOMMessageEvent);
-          await expect(promise).rejects.toThrow(mockResult);
+          await expect(promise).resolves.toEqual(mockUser);
+        });
+
+        it(`authentication.getUser should successfully get user profile including data residency info with ${context} context if data residency is provided by hosts`, async () => {
+          expect.assertions(7);
+          await framelessPostMock.initializeWithContext(context);
+          const promise = authentication.getUser();
+          const message = framelessPostMock.findMessageByFunc('authentication.getUser');
+          expect(message).not.toBeNull();
+          expect(message.id).toBe(1);
+          expect(message.args[0]).toBe(undefined);
+          framelessPostMock.respondToMessage({
+            data: {
+              id: message.id,
+              args: [true, mockUserWithDataResidency],
+            },
+          } as DOMMessageEvent);
+          await expect(promise).resolves.toEqual(mockUserWithDataResidency);
         });
       });
     });


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

### Main changes in the PR:

1. Added `dataResidency` interface in teams-js SDK within `getUser` API. Exposed a limited set of data residencies information to 1P app developers.

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

Yes.

### End-to-end tests added:

No.

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes.

### Related PRs: