### PR TITLE
Add teams.microsoft.net to valid domain allowlist

### DIFF
--- a/packages/teams-js/src/internal/constants.ts
+++ b/packages/teams-js/src/internal/constants.ts
@@ -147,6 +147,7 @@ export const validOrigins = [
   'www.officeppe.com',
   '*.www.microsoft365.com',
   'www.microsoft365.com',
+  '*.teams.microsoft.net',
 ];
 
 /**

--- a/packages/teams-js/test/private/privateAPIs.spec.ts
+++ b/packages/teams-js/test/private/privateAPIs.spec.ts
@@ -123,6 +123,9 @@ describe('AppSDK-privateAPIs', () => {
     'https://www.microsoft365.com',
     'https://tasks.office.com',
     'https://www.example.com',
+    'https://admin-local.teams.microsoft.net',
+    'https://admin-dev.teams.microsoft.net',
+    'https://admin-int.teams.microsoft.net',
   ];
 
   supportedDomains.forEach((supportedDomain) => {


### PR DESCRIPTION
List `*.teams.microsoft.net` in the valid domains so that `app.initialize` can call successfully in Teams Admin Center test staging including local, dev and int

contact: weifengjiang@microsoft.com