### PR TITLE
Use ubuntu-20.04 explicitly for native electron tests

### DIFF
--- a/apps/teams-test-app/src/components/utils/ApiWithTextInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithTextInput.tsx
@@ -6,7 +6,7 @@ import { isTestBackCompat } from './isTestBackCompat';
 
 export interface ApiWithTextInputProps<T> {
   title: string;
-  name: string; // system identifiable unique name in context of Teams Client and should contain no spaces
+  name: string; // system identifiable unique name in context of Teams Client and should contain no spaces at all
   onClick:
     | ((input: Partial<T>) => Promise<string>)
     | {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
   - job: E2ETest2
     displayName: 'E2E Test - Default'
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: 'ubuntu-20.04'
     steps:
       - template: tools/yaml-templates/build-app-host.yml
         parameters:
@@ -91,12 +91,6 @@ jobs:
         displayName: 'Run E2E integration tests with local script tag'
         condition: succeeded()
         workingDirectory: '$(AppHostingSdkProjectDirectory)'
-
-      - task: Yarn@2
-        displayName: 'Run tests for electron webview'
-        inputs:
-          Arguments: 'run xvfb-maybe mocha'
-          ProjectDirectory: '$(AppHostingSdkProjectDirectory)'
 
       - task: PublishTestResults@2
         inputs:


### PR DESCRIPTION
## Description
Spectron tests relies on chrome driver/node js started failing as it was unable to open chrome browser. Recent migration to of tag ubuntu-latest to 22.04 is buggy as can be seen reported at below link. Reverting to old to unblock work and until the latest one gets stable by ADO team.
https://github.com/actions/runner-images/issues/6399 

### Main changes in the PR:
1. Keep the native tests in only one job of E2E test to remove redundancy.
2. Explicitly Pooled to ubuntu-20.04 because of the reason mentioned above. 

## Validation
> E2E Tests with electron tests should work fine
 
### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:
NA
> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

No, NA

### End-to-end tests added:

Yes

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:
