### PR TITLE
Added missing slash in URL in comment on `app.initialize`

### DIFF
--- a/change/@microsoft-teams-js-7c96f1b9-e26e-4ac8-85be-f7b602a68543.json
+++ b/change/@microsoft-teams-js-7c96f1b9-e26e-4ac8-85be-f7b602a68543.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed missing slash in URL in comment on `app.initialize`",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -530,7 +530,7 @@ export namespace app {
    * Initialize must have completed successfully (as determined by the resolved Promise) before any other library calls are made
    *
    * @param validMessageOrigins - Optionally specify a list of cross frame message origins. They must have
-   * https: protocol otherwise they will be ignored. Example: https:www.example.com
+   * https: protocol otherwise they will be ignored. Example: https://www.example.com
    * @returns Promise that will be fulfilled when initialization has completed, or rejected if the initialization fails or times out
    */
   export function initialize(validMessageOrigins?: string[]): Promise<void> {


### PR DESCRIPTION
## Description

Fixed missing slash in URL in comment on `app.initialize`

The documentation for this parameter could certainly be improved but at least I can fix the typo easily.

## Validation

### Validation performed:

Automated tests passed.

### Unit Tests added:

No because there's no unit tests that validate the content of documentation.

### End-to-end tests added:

No because there's no e2e tests that validate the content of documentation.

## Additional Requirements

### Change file added:

Yes sir or m'am.

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
|![image](https://user-images.githubusercontent.com/36546967/206797702-effbde9d-78cd-4e68-9bba-4e0240377abd.png)|<img width="575" alt="image" src="https://user-images.githubusercontent.com/36546967/206797737-5c0af0da-0ff3-478b-829e-bcaeefc81dc9.png">|
