### PR TITLE
Remove entityId and title as required fields from openFilePreview parameters

### DIFF
--- a/change/@microsoft-teams-js-57c14eb2-51df-4f2a-b20a-c99a73f235d4.json
+++ b/change/@microsoft-teams-js-57c14eb2-51df-4f2a-b20a-c99a73f235d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed entityId and title as required fields from openFilePreview parameters",
+  "packageName": "@microsoft/teams-js",
+  "email": "sthousto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-57c14eb2-51df-4f2a-b20a-c99a73f235d4.json
+++ b/change/@microsoft-teams-js-57c14eb2-51df-4f2a-b20a-c99a73f235d4.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Removed entityId and title as required fields from openFilePreview parameters",
+  "comment": "Removed `entityId` and `title` as required fields from `openFilePreview` parameters",
   "packageName": "@microsoft/teams-js",
   "email": "sthousto@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/private/interfaces.ts
+++ b/packages/teams-js/src/private/interfaces.ts
@@ -103,7 +103,7 @@ export interface FilePreviewParameters {
    * @internal
    * Limited to Microsoft-internal use
    */
-  entityId: string;
+  entityId?: string;
 
   /**
    * @hidden
@@ -112,7 +112,7 @@ export interface FilePreviewParameters {
    * @internal
    * Limited to Microsoft-internal use
    */
-  title: string;
+  title?: string;
 
   /**
    * @hidden


### PR DESCRIPTION
## Description

Remove entityId and title as required fields from openFilePreview parameters. This is currently enforced at the hubSDK level but will be removed following this change.

## Validation

### Validation performed:

Automated tests passed.

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes





