### PR TITLE
changed webpack globalObject to 'this'

### DIFF
--- a/packages/teams-js/webpack.config.js
+++ b/packages/teams-js/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
       type: 'umd',
       umdNamedDefine: true,
     },
+    //Prevents 'self' object conflict between nodejs and nextjs
     globalObject: 'this',
   },
   devtool: 'source-map',

--- a/packages/teams-js/webpack.config.js
+++ b/packages/teams-js/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
       type: 'umd',
       umdNamedDefine: true,
     },
+    globalObject: 'this',
   },
   devtool: 'source-map',
   resolve: {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Changed globalObject to 'this' in the webpack config. This is to allow for use of teams-js with nextjs. Without the change, nextjs conflicts with nodejs as they both use the 'self' reference

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes
