### PR TITLE
add redirectUrl to oauth test flow

### DIFF
--- a/apps/teams-test-app/src/public/auth_end.html
+++ b/apps/teams-test-app/src/public/auth_end.html
@@ -11,11 +11,16 @@
       const { authId, method, hostName } = JSON.parse(params.get('state'));
 
       // Redirect back to Orange host
-      if (method === 'deeplink' && hostName === 'Orange') {
-        window.location.href = `msorange://testapp.com/auth_callback?authId=${authId}&result=${result}`;
-      } else {
-        document.getElementById('errorMessage').textContent = 'Unable to redirect back to the App';
+      if (method === 'deeplink') {
+        const storedRedirectUrl = sessionStorage.getItem('hostRedirectUrl')
+        if (storedRedirectUrl && storedRedirectUrl.trim() !== '') {
+          window.location.href = storedRedirectUrl.replace('{result}',result)
+        } else if (hostName === 'Orange') {
+          window.location.href = `msorange://testapp.com/auth_callback?authId=${authId}&result=${result}`;
+        }
       }
+      document.getElementById('errorMessage').textContent = 'Unable to redirect back to the App';
     </script>
+
   </body>
 </html>

--- a/apps/teams-test-app/src/public/auth_end.html
+++ b/apps/teams-test-app/src/public/auth_end.html
@@ -13,7 +13,7 @@
       // Redirect back to Orange host
       if (method === 'deeplink') {
         const storedRedirectUrl = sessionStorage.getItem('hostRedirectUrl')
-        if (storedRedirectUrl && storedRedirectUrl.trim() !== '') {
+        if (storedRedirectUrl) {
           window.location.href = storedRedirectUrl.replace('{result}',result)
         } else if (hostName === 'Orange') {
           window.location.href = `msorange://testapp.com/auth_callback?authId=${authId}&result=${result}`;

--- a/apps/teams-test-app/src/public/auth_start.html
+++ b/apps/teams-test-app/src/public/auth_start.html
@@ -10,8 +10,13 @@
       const mockOAuth = params.get('mockOAuth');
       const authId = params.get('authId');
       const method = params.get('oauthRedirectMethod');
+      const redirectUrl = params.get('hostRedirectUrl')
       const hostName = params.get('hostName');
-      const state = `{"authId":"${authId}","method":"${method}", "hostName":"${hostName}"}`;
+      const state = `{"authId":"${authId}","method":"${method}","hostName":"${hostName}"}`;
+
+      if (redirectUrl.trim() !== '') {
+        sessionStorage.setItem('hostRedirectUrl', redirectUrl)
+      }
 
       const getRedirectUri = () => {
         const idx = window.location.href.lastIndexOf('/');

--- a/apps/teams-test-app/src/public/auth_start.html
+++ b/apps/teams-test-app/src/public/auth_start.html
@@ -14,7 +14,7 @@
       const hostName = params.get('hostName');
       const state = `{"authId":"${authId}","method":"${method}","hostName":"${hostName}"}`;
 
-      if (redirectUrl.trim() !== '') {
+      if (redirectUrl) {
         sessionStorage.setItem('hostRedirectUrl', redirectUrl)
       }
 


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Changes to the test app to utilize the revised OAuth flow. auth_start.html will try to retrieve the redirect URL from the query parameters and redirect to this instead of the msorange URL currently used if it is present. These changes enable E2E testing for this flow.

### Main changes in the PR:

1. Update OAuth test flow to try to use the hostRedirectUrl query parameter, keeping original url as a fallback to test the original flow.

## Validation

### Validation performed:

1. Tested against new redirect flow

### Unit Tests added:

No unit tests added as this only affects the test app.

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No