### PR TITLE
noahdarveau/reverted webpack globalObject: this

### DIFF
--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -5,10 +5,7 @@ import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { FrameInfo, ShareDeepLinkParameters, TabInstance, TabInstanceParameters } from '../../src/public/interfaces';
 import { pages } from '../../src/public/pages';
-import {
-  _minRuntimeConfigToUninitialize,
-  latestRuntimeApiVersion,
-} from '../../src/public/runtime';
+import { _minRuntimeConfigToUninitialize, latestRuntimeApiVersion } from '../../src/public/runtime';
 import { version } from '../../src/public/version';
 import { FramelessPostMocks } from '../framelessPostMocks';
 import {

--- a/packages/teams-js/webpack.config.js
+++ b/packages/teams-js/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = {
       umdNamedDefine: true,
     },
     //Prevents 'self' object conflict between nodejs and nextjs
-    globalObject: 'this',
+    //globalObject: 'this',
   },
   devtool: 'source-map',
   resolve: {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

>Reverted globalObject: "this" webpack change due to reports of it breaking C#/Blazor Teams Tab apps

### Main changes in the PR:

1. Webpack globalObject: this revert

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>
