### PR TITLE
Adding placeholder to test app

### DIFF
--- a/apps/teams-test-app/src/components/utils/ApiWithCheckboxInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithCheckboxInput.tsx
@@ -47,7 +47,7 @@ export const ApiWithCheckboxInput = (props: ApiWithCheckboxInputProps): React.Re
     <ApiContainer title={title} result={result} name={name}>
       <input name={`button_${name}`} type="button" value={title} onClick={onClickCallback} />
       {label}
-      <input type="checkbox" name={label} onChange={(e) => setValue(e.target.checked)} />
+      <input type="checkbox" name={label} onChange={(e) => setValue(e.target.checked)} placeholder={name} />
     </ApiContainer>
   );
 };

--- a/apps/teams-test-app/src/components/utils/ApiWithTextInput.tsx
+++ b/apps/teams-test-app/src/components/utils/ApiWithTextInput.tsx
@@ -62,7 +62,7 @@ export const ApiWithTextInput = <T extends unknown>(props: ApiWithTextInputProps
   return (
     <ApiContainer title={title} result={result} name={name}>
       <span>
-        <input type="text" name={`input_${name}`} defaultValue={defaultInput} ref={inputRef} />
+        <input type="text" name={`input_${name}`} defaultValue={defaultInput} ref={inputRef} placeholder={name} />
         <input name={`button_${name}`} type="button" value={title} onClick={onClickCallback} />
       </span>
     </ApiContainer>


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Adding placeholder to make sure iOS gets the resource ID. Whenever we add a UI component to test app the iOS pipeline fails because iOS web view doesn't allow us to get UI components by resource ID, we have to come up with a workaround which is to add place holder to the input fields in the test app by which on the iOS side we can access those by placeholder value. 

> Make iOS pipeline test different version
### Main changes in the PR:
Adding a placeholder to test app
## Validation

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

N/A

### End-to-end tests added:

N/A

