### PR TITLE
Removed deprecated _initialize and _uninitialize methods only used by unit tests

### DIFF
--- a/change/@microsoft-teams-js-9a93c2f8-94c4-415d-adb3-5fb8d8b16692.json
+++ b/change/@microsoft-teams-js-9a93c2f8-94c4-415d-adb3-5fb8d8b16692.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed deprecated `_initialize` and `_uninitialize_` methods only used by unit tests",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-9a93c2f8-94c4-415d-adb3-5fb8d8b16692.json
+++ b/change/@microsoft-teams-js-9a93c2f8-94c4-415d-adb3-5fb8d8b16692.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Removed deprecated `_initialize` and `_uninitialize_` methods only used by unit tests",
+  "comment": "Removed deprecated `_initialize` and `_uninitialize` methods only used by unit tests",
   "packageName": "@microsoft/teams-js",
   "email": "36546967+AE-MS@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -35,35 +35,6 @@ export function initialize(callback?: () => void, validMessageOrigins?: string[]
 
 /**
  * @deprecated
- * As of 2.0.0, please use {@link app._initialize app._initialize(hostWindow: any): void} instead.
- *
- * @hidden
- * Undocumented function used to set a mock window for unit tests
- *
- * @internal
- * Limited to Microsoft-internal use
- */
-// eslint-disable-next-line
-export function _initialize(hostWindow: any): void {
-  app._initialize(hostWindow);
-}
-
-/**
- * @deprecated
- * As of 2.0.0, please use {@link app._uninitialize app._uninitialize(): void} instead.
- *
- * @hidden
- * Undocumented function used to clear state between unit tests
- *
- * @internal
- * Limited to Microsoft-internal use
- */
-export function _uninitialize(): void {
-  app._uninitialize();
-}
-
-/**
- * @deprecated
  * As of 2.0.0, please use {@link teamsCore.enablePrintCapability teamsCore.enablePrintCapability(): void} instead.
  *
  * Enable print capability to support printing page using Ctrl+P and cmd+P

--- a/packages/teams-js/test/private/files.spec.ts
+++ b/packages/teams-js/test/private/files.spec.ts
@@ -1,7 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { files } from '../../src/private/files';
-import { ErrorCode, FileOpenPreference, SdkError } from '../../src/public';
-import { _initialize, _uninitialize } from '../../src/public/publicAPIs';
+import { app, ErrorCode, FileOpenPreference, SdkError } from '../../src/public';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';
 
@@ -23,14 +22,14 @@ describe('files', () => {
     utils.mockWindow.parent = utils.parentWindow;
 
     // Set a mock window for testing
-    _initialize(utils.mockWindow);
+    app._initialize(utils.mockWindow);
   });
 
   afterEach(() => {
     // Reset the object since it's a singleton
-    if (_uninitialize) {
+    if (app._uninitialize) {
       utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
-      _uninitialize();
+      app._uninitialize();
     }
   });
 

--- a/packages/teams-js/test/public/navigation.spec.ts
+++ b/packages/teams-js/test/public/navigation.spec.ts
@@ -1,8 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import * as utilFunc from '../../src/internal/utils';
-import { FrameContexts, pages } from '../../src/public';
+import { app, FrameContexts, pages } from '../../src/public';
 import { navigateBack, navigateCrossDomain, navigateToTab, returnFocus } from '../../src/public/navigation';
-import { _uninitialize } from '../../src/public/publicAPIs';
 import { Utils } from '../utils';
 
 /* eslint-disable */
@@ -22,8 +21,8 @@ describe('MicrosoftTeams-Navigation', () => {
   });
   afterEach(() => {
     // Reset the object since it's a singleton
-    if (_uninitialize) {
-      _uninitialize();
+    if (app._uninitialize) {
+      app._uninitialize();
     }
   });
 

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -1,12 +1,11 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import * as utilFunc from '../../src/internal/utils';
+import { app } from '../../src/public';
 import { HostClientType, TeamType, UserTeamRole } from '../../src/public/constants';
 import { FrameContexts } from '../../src/public/constants';
 import { Context, FrameContext, TabInstanceParameters } from '../../src/public/interfaces';
 import * as microsoftTeams from '../../src/public/publicAPIs';
 import {
-  _initialize,
-  _uninitialize,
   enablePrintCapability,
   executeDeepLink,
   getContext,
@@ -46,14 +45,14 @@ describe('MicrosoftTeams-publicAPIs', () => {
     utils.mockWindow.parent = utils.parentWindow;
 
     // Set a mock window for testing
-    _initialize(utils.mockWindow);
+    app._initialize(utils.mockWindow);
   });
 
   afterEach(() => {
     // Reset the object since it's a singleton
-    if (_uninitialize) {
+    if (app._uninitialize) {
       utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
-      _uninitialize();
+      app._uninitialize();
     }
   });
 

--- a/packages/teams-js/test/public/settings.spec.ts
+++ b/packages/teams-js/test/public/settings.spec.ts
@@ -1,6 +1,5 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
-import { FrameContexts } from '../../src/public';
-import { _uninitialize } from '../../src/public/publicAPIs';
+import { app, FrameContexts } from '../../src/public';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { settings } from '../../src/public/settings';
 import { Utils } from '../utils';
@@ -26,9 +25,9 @@ describe('settings', () => {
 
   afterEach(() => {
     // Reset the object since it's a singleton
-    if (_uninitialize) {
+    if (app._uninitialize) {
       utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
-      _uninitialize();
+      app._uninitialize();
     }
   });
 


### PR DESCRIPTION
## Description

Removed deprecated _initialize and _uninitialize methods only used by unit tests, then updated the unit tests to use the non-deprecated versions.

## Validation

### Validation performed:

### Unit Tests added:

No, but I ensured these unit tests passed.

### Change file added:

Yes.
