### PR TITLE
[DRAFT] Runtime upgrade testing

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -52,6 +52,10 @@ if (!urlParams.has('customInit') || !urlParams.get('customInit')) {
   if (isTestBackCompat()) {
     initialize();
   } else {
+    if (urlParams.has('runtimeVersion')) {
+      const runtimeVersion = Number(urlParams.get('runtimeVersion'));
+      app.initializeWithRuntimeVersion(runtimeVersion);
+    }
     app.initialize();
   }
 }

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -57,7 +57,10 @@ interface InitializeResponse {
  * @internal
  * Limited to Microsoft-internal use
  */
-export function initializeCommunication(validMessageOrigins: string[] | undefined): Promise<InitializeResponse> {
+export function initializeCommunication(
+  validMessageOrigins: string[] | undefined,
+  runtimeVersion?: number,
+): Promise<InitializeResponse> {
   // Listen for messages post to our window
   CommunicationPrivate.messageListener = (evt: DOMMessageEvent): void => processMessage(evt);
 
@@ -92,7 +95,7 @@ export function initializeCommunication(validMessageOrigins: string[] | undefine
     Communication.parentOrigin = '*';
     return sendMessageToParentAsync<[FrameContexts, string, string, string]>('initialize', [
       version,
-      latestRuntimeApiVersion,
+      runtimeVersion || latestRuntimeApiVersion,
     ]).then(
       ([context, clientType, runtimeConfig, clientSupportedSDKVersion]: [FrameContexts, string, string, string]) => {
         return { context, clientType, runtimeConfig, clientSupportedSDKVersion };


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Add app.initializeWithRuntimeVersion() to request a specific version of the runtime object from the host. This will enable E2E testing for the runtime upgrade mechanism by allowing the test app to receive outdated runtimes from the test host which will be upgraded to the latest version.

### Main changes in the PR:

1. Add `app.initializeWithRuntimeVersion()` to send a specific runtime version to the host instead of always using the latest version.
2. Add URL query parameter to test app for initializing with `app.initializeWithRuntimeVersion()`.

## Validation

### Validation performed:

1. Validated requesting outdated versions against the test host.

### Unit Tests added:

No tests added, changes only impact the test app.

### End-to-end tests added:

E2E tests will be added once this functionality is implemented.

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
