### PR TITLE
add internal and hidden tags to RH and Reaction APIs

### DIFF
--- a/change/@microsoft-teams-js-ccce9925-3c49-48bc-96bd-3aa8a0247dd6.json
+++ b/change/@microsoft-teams-js-ccce9925-3c49-48bc-96bd-3aa8a0247dd6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Changing user facing documentation associated with `meeting.ts`",
+  "comment": "Changed user facing documentation associated with `meeting.ts`",
   "packageName": "@microsoft/teams-js",
   "email": "trharris@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-ccce9925-3c49-48bc-96bd-3aa8a0247dd6.json
+++ b/change/@microsoft-teams-js-ccce9925-3c49-48bc-96bd-3aa8a0247dd6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Changing user facing documentation associated with `meeting.ts`",
+  "packageName": "@microsoft/teams-js",
+  "email": "trharris@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -170,15 +170,27 @@ export namespace meeting {
   /**
    * Property bag for the meeting reaction received event
    *
+   * @hidden
+   * Hide from docs.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
    * @beta
    */
   export interface MeetingReactionReceivedEventData {
     /**
      * Indicates the type of meeting reaction received
+     *
+     * @hidden
+     * Hide from docs.
      */
     meetingReactionType?: MeetingReactionType;
     /**
      * error object in case there is a failure
+     *
+     * @hidden
+     * Hide from docs.
      */
     error?: SdkError;
   }
@@ -186,32 +198,61 @@ export namespace meeting {
   /**
    * Interface for raiseHandState properties
    *
+   * @hidden
+   * Hide from docs.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
    * @beta
    */
   export interface IRaiseHandState {
-    /** Indicates whether the selfParticipant's hand is raised or not*/
+    /** Indicates whether the selfParticipant's hand is raised or not
+     *
+     * @hidden
+     * Hide from docs.
+     */
+
     isHandRaised: boolean;
   }
 
   /**
    * Property bag for the raiseHandState changed event
    *
+   * @hidden
+   * Hide from docs.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
    * @beta
    */
   export interface RaiseHandStateChangedEventData {
     /**
      * entire raiseHandState object for the selfParticipant
+     *
+     * @hidden
+     * Hide from docs.
      */
     raiseHandState: IRaiseHandState;
 
     /**
      * error object in case there is a failure
+     *
+     * @hidden
+     * Hide from docs.
      */
     error?: SdkError;
   }
 
   /**
    * Different types of meeting reactions that can be sent/received
+   *
+   * @hidden
+   * Hide from docs.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    *
    * @beta
    */
@@ -491,6 +532,12 @@ export namespace meeting {
    *
    * @param handler The handler to invoke when the selfParticipant's (current user's) raiseHandState changes.
    *
+   * @hidden
+   * Hide from docs.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
    * @beta
    */
   export function registerRaiseHandStateChangedHandler(
@@ -508,6 +555,12 @@ export namespace meeting {
    * at a time. A subsequent registration replaces an existing registration.
    *
    * @param handler The handler to invoke when the selfParticipant (current user) successfully sends a meeting reaction
+   *
+   * @hidden
+   * Hide from docs.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
    *
    * @beta
    */


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description
Updating the RaiseHand and MeetingRection Meeting APIs with the @hidden and @internal tag in order to hide the documentation and let app developers know that it may not work in 3p apps yet.


### Main changes in the PR:

1. Add @hidden and @internal tags to the 

## Validation

### Validation performed:

1. None

### Unit Tests added:
No, just adding tags

### End-to-end tests added:
No

## Additional Requirements

### Change file added:

No, no file was generated when running the changefile command.