### PR TITLE
remove entityId and title as required parameters for openFilePreview api

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/PrivateAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/PrivateAPIs.tsx
@@ -93,8 +93,8 @@ const PrivateAPIs = (): ReactElement => {
       title: 'Open File Preview',
       onClick: {
         validateInput: (input) => {
-          if (!input.entityId || !input.title || !input.type || !input.objectUrl) {
-            throw new Error('entityId, title, type and objectUrl are all required on the input object.');
+          if (!input.type || !input.objectUrl) {
+            throw new Error('type and objectUrl are all required on the input object.');
           }
         },
         submit: async (input) => {


### PR DESCRIPTION
## Description
In one of the PR earlier (https://github.com/OfficeDev/microsoft-teams-library-js/pull/1492/files), it updated the entityId and title parameters to be optional in FilePreviewParameters, but didn't update the test app. This PR is to update the parameters accordingly in test app. Hub sdk will make similar parameters update(change entityId/title to be optional) which will leverage the test app for e2e testing.

### Main changes in the PR:

1. Update entityId and title parameters to be optional

## Validation

### Validation performed:

1. <Step 1>
3. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
