### PR TITLE
Fix a getContext() bug where it does incorrect conversion and causing properties loss

### DIFF
--- a/change/@microsoft-teams-js-2210d153-a06d-4432-9da4-5a47febbc045.json
+++ b/change/@microsoft-teams-js-2210d153-a06d-4432-9da4-5a47febbc045.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Fixed a bug where getContext() was incorrectly dropping propertoes by performing a lossy conversion via app.getContext()",
+  "comment": "Fixed a bug where `getContext()` was incorrectly dropping properties by performing a lossy conversion via `app.getContext()`",
   "packageName": "@microsoft/teams-js",
   "email": "magli@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-2210d153-a06d-4432-9da4-5a47febbc045.json
+++ b/change/@microsoft-teams-js-2210d153-a06d-4432-9da4-5a47febbc045.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "V1 getContext() call should call into hub sdk directly",
+  "packageName": "@microsoft/teams-js",
+  "email": "magli@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-2210d153-a06d-4432-9da4-5a47febbc045.json
+++ b/change/@microsoft-teams-js-2210d153-a06d-4432-9da4-5a47febbc045.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "V1 getContext() call should call into hub sdk directly",
+  "comment": "Fixed a bug where getContext() was incorrectly dropping propertoes by performing a lossy conversion via app.getContext()",
   "packageName": "@microsoft/teams-js",
   "email": "magli@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -1,3 +1,4 @@
+import { sendMessageToParent } from '../internal/communication';
 import { registerHandlerHelper } from '../internal/handlers';
 import { ensureInitializeCalled, ensureInitialized } from '../internal/internalAPIs';
 import { getGenericOnCompleteHandler } from '../internal/utils';
@@ -63,11 +64,7 @@ export function print(): void {
  */
 export function getContext(callback: (context: Context) => void): void {
   ensureInitializeCalled();
-  app.getContext().then((context: app.Context) => {
-    if (callback) {
-      callback(transformAppContextToLegacyContext(context));
-    }
-  });
+  sendMessageToParent('getContext', callback);
 }
 
 /**
@@ -315,99 +312,4 @@ export function initializeWithFrameContext(
   validMessageOrigins?: string[],
 ): void {
   pages.initializeWithFrameContext(frameContext, callback, validMessageOrigins);
-}
-
-/**
- * Transforms the app.Context object received to the legacy global Context object
- * @param appContext - The app.Context object to be transformed
- * @returns The transformed legacy global Context object
- */
-function transformAppContextToLegacyContext(appContext: app.Context): Context {
-  const context: Context = {
-    // actionInfo
-    actionInfo: appContext.actionInfo,
-
-    // app
-    locale: appContext.app.locale,
-    appSessionId: appContext.app.sessionId,
-    theme: appContext.app.theme,
-    appIconPosition: appContext.app.iconPositionVertical,
-    osLocaleInfo: appContext.app.osLocaleInfo,
-    parentMessageId: appContext.app.parentMessageId,
-    userClickTime: appContext.app.userClickTime,
-    userFileOpenPreference: appContext.app.userFileOpenPreference,
-    appLaunchId: appContext.app.appLaunchId,
-
-    // app.host
-    hostClientType: appContext.app.host.clientType,
-    sessionId: appContext.app.host.sessionId,
-    ringId: appContext.app.host.ringId,
-
-    // page
-    entityId: appContext.page.id,
-    frameContext: appContext.page.frameContext,
-    subEntityId: appContext.page.subPageId,
-    isFullScreen: appContext.page.isFullScreen,
-    isMultiWindow: appContext.page.isMultiWindow,
-    sourceOrigin: appContext.page.sourceOrigin,
-
-    // user
-    userObjectId: appContext.user !== undefined ? appContext.user.id : undefined,
-    isCallingAllowed: appContext.user !== undefined ? appContext.user.isCallingAllowed : undefined,
-    isPSTNCallingAllowed: appContext.user !== undefined ? appContext.user.isPSTNCallingAllowed : undefined,
-    userLicenseType: appContext.user !== undefined ? appContext.user.licenseType : undefined,
-    loginHint: appContext.user !== undefined ? appContext.user.loginHint : undefined,
-    userPrincipalName: appContext.user !== undefined ? appContext.user.userPrincipalName : undefined,
-
-    // user.tenant
-    tid:
-      appContext.user !== undefined
-        ? appContext.user.tenant !== undefined
-          ? appContext.user.tenant.id
-          : undefined
-        : undefined,
-    tenantSKU:
-      appContext.user !== undefined
-        ? appContext.user.tenant !== undefined
-          ? appContext.user.tenant.teamsSku
-          : undefined
-        : undefined,
-
-    // channel
-    channelId: appContext.channel !== undefined ? appContext.channel.id : undefined,
-    channelName: appContext.channel !== undefined ? appContext.channel.displayName : undefined,
-    channelRelativeUrl: appContext.channel !== undefined ? appContext.channel.relativeUrl : undefined,
-    channelType: appContext.channel !== undefined ? appContext.channel.membershipType : undefined,
-    defaultOneNoteSectionId: appContext.channel !== undefined ? appContext.channel.defaultOneNoteSectionId : undefined,
-    hostTeamGroupId: appContext.channel !== undefined ? appContext.channel.ownerGroupId : undefined,
-    hostTeamTenantId: appContext.channel !== undefined ? appContext.channel.ownerTenantId : undefined,
-
-    // chat
-    chatId: appContext.chat !== undefined ? appContext.chat.id : undefined,
-
-    // meeting
-    meetingId: appContext.meeting !== undefined ? appContext.meeting.id : undefined,
-
-    // sharepoint
-    sharepoint: appContext.sharepoint,
-
-    // team
-    teamId: appContext.team !== undefined ? appContext.team.internalId : undefined,
-    teamName: appContext.team !== undefined ? appContext.team.displayName : undefined,
-    teamType: appContext.team !== undefined ? appContext.team.type : undefined,
-    groupId: appContext.team !== undefined ? appContext.team.groupId : undefined,
-    teamTemplateId: appContext.team !== undefined ? appContext.team.templateId : undefined,
-    isTeamArchived: appContext.team !== undefined ? appContext.team.isArchived : undefined,
-    userTeamRole: appContext.team !== undefined ? appContext.team.userRole : undefined,
-
-    // sharepointSite
-    teamSiteUrl: appContext.sharePointSite !== undefined ? appContext.sharePointSite.teamSiteUrl : undefined,
-    teamSiteDomain: appContext.sharePointSite !== undefined ? appContext.sharePointSite.teamSiteDomain : undefined,
-    teamSitePath: appContext.sharePointSite !== undefined ? appContext.sharePointSite.teamSitePath : undefined,
-    teamSiteId: appContext.sharePointSite !== undefined ? appContext.sharePointSite.teamSiteId : undefined,
-    mySitePath: appContext.sharePointSite !== undefined ? appContext.sharePointSite.mySitePath : undefined,
-    mySiteDomain: appContext.sharePointSite !== undefined ? appContext.sharePointSite.mySiteDomain : undefined,
-  };
-
-  return context;
 }

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -1,4 +1,5 @@
 import { sendMessageToParent } from '../internal/communication';
+import { GlobalVars } from '../internal/globalVars';
 import { registerHandlerHelper } from '../internal/handlers';
 import { ensureInitializeCalled, ensureInitialized } from '../internal/internalAPIs';
 import { getGenericOnCompleteHandler } from '../internal/utils';
@@ -64,7 +65,13 @@ export function print(): void {
  */
 export function getContext(callback: (context: Context) => void): void {
   ensureInitializeCalled();
-  sendMessageToParent('getContext', callback);
+  sendMessageToParent('getContext', (context: Context) => {
+    if (!context.frameContext) {
+      // Fallback logic for frameContext properties
+      context.frameContext = GlobalVars.frameContext;
+    }
+    callback(context);
+  });
 }
 
 /**

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -1,4 +1,3 @@
-import { ContextReplacementPlugin } from 'webpack';
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import * as utilFunc from '../../src/internal/utils';

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -1,5 +1,4 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
-import { GlobalVars } from '../../src/internal/globalVars';
 import * as utilFunc from '../../src/internal/utils';
 import { app } from '../../src/public';
 import { HostClientType, TeamType, UserTeamRole } from '../../src/public/constants';

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -354,7 +354,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
         Object.keys(expectedContext).forEach((e) => {
           expect(JSON.stringify(expectedContext[e])).toBe(JSON.stringify(context[e]));
         });
-        expect(context.frameContext ? context.frameContext : GlobalVars.frameContext).toBe(FrameContexts.content);
+        expect(context.frameContext).toBe(FrameContexts.content);
         expect(context.meetingId).toBe('dummyMeetingId');
         done();
       });
@@ -369,7 +369,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
   it('should successfully get frame context in side panel', (done) => {
     utils.initializeWithContext(FrameContexts.sidePanel).then(() => {
       getContext((context) => {
-        expect(context.frameContext ? context.frameContext : GlobalVars.frameContext).toBe(FrameContexts.sidePanel);
+        expect(context.frameContext).toBe(FrameContexts.sidePanel);
         done();
       });
 
@@ -397,7 +397,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
   it('should successfully get frame context in side panel with fallback logic if not returned from client', (done) => {
     utils.initializeWithContext(FrameContexts.sidePanel).then(() => {
       getContext((context) => {
-        expect(context.frameContext ? context.frameContext : GlobalVars.frameContext).toBe(FrameContexts.sidePanel);
+        expect(context.frameContext).toBe(FrameContexts.sidePanel);
         done();
       });
 

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -1,4 +1,6 @@
+import { ContextReplacementPlugin } from 'webpack';
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
+import { GlobalVars } from '../../src/internal/globalVars';
 import * as utilFunc from '../../src/internal/utils';
 import { app } from '../../src/public';
 import { HostClientType, TeamType, UserTeamRole } from '../../src/public/constants';
@@ -340,6 +342,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
         userObjectId: 'someUserObjectId',
         isTeamArchived: false,
         hostClientType: HostClientType.web,
+        frameContext: FrameContexts.content,
         sharepoint: {},
         tenantSKU: 'someTenantSKU',
         userLicenseType: 'someUserLicenseType',
@@ -368,7 +371,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
   it('should successfully get frame context in side panel', (done) => {
     utils.initializeWithContext(FrameContexts.sidePanel).then(() => {
       getContext((context) => {
-        expect(context.frameContext).toBe(FrameContexts.sidePanel);
+        expect(context.frameContext ? context.frameContext : GlobalVars.frameContext).toBe(FrameContexts.sidePanel);
         done();
       });
 
@@ -396,7 +399,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
   it('should successfully get frame context in side panel with fallback logic if not returned from client', (done) => {
     utils.initializeWithContext(FrameContexts.sidePanel).then(() => {
       getContext((context) => {
-        expect(context.frameContext).toBe(FrameContexts.sidePanel);
+        expect(context.frameContext ? context.frameContext : GlobalVars.frameContext).toBe(FrameContexts.sidePanel);
         done();
       });
 

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -342,7 +342,6 @@ describe('MicrosoftTeams-publicAPIs', () => {
         userObjectId: 'someUserObjectId',
         isTeamArchived: false,
         hostClientType: HostClientType.web,
-        frameContext: FrameContexts.content,
         sharepoint: {},
         tenantSKU: 'someTenantSKU',
         userLicenseType: 'someUserLicenseType',
@@ -356,7 +355,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
         Object.keys(expectedContext).forEach((e) => {
           expect(JSON.stringify(expectedContext[e])).toBe(JSON.stringify(context[e]));
         });
-        expect(context.frameContext).toBe(FrameContexts.content);
+        expect(context.frameContext ? context.frameContext : GlobalVars.frameContext).toBe(FrameContexts.content);
         expect(context.meetingId).toBe('dummyMeetingId');
         done();
       });


### PR DESCRIPTION
## Description
Facts:
1. We have V1 and V2 version of getContext() call. 
    V1 is in /packages/teams-js/src/public/publicAPIs.ts, V2 is in /packages/teams-js/src/public/app.ts
2. V2 getContext() call should return app.Context() object
     V1 getContext() call should return LegacyContext object (=packages/teams-js/src/public/interfaces.ts#L257)
3. Host sdk returns LegacyContext
4. For V2 getContext() call, since host sdk returns LegacyContext, it needs a map between legacyContext to app.Context. 
    This logic is currently correct in our code base
     ![image](https://user-images.githubusercontent.com/8062622/213813986-938e620e-01d5-4d9f-ab3d-a17dd0fff7fc.png)

Issues:
The current bug happens in V1 getContext() call. Since V1 getContext() expects LegacyContext object and host sdk returns LegacyContext, it should be just straightly call into host sdk. Currently what it does: V1 getContext() -> call V2 app.getContext() -> which returns app.Context() -> V1 needs to convert app.Context() back to LegacyContext. Extra logics and also missed some fields due to double conversion process.

Fix:
V1 getContext() calls host sdk directly through sendMessageToParent, instead of previous app.getContext()

### Main changes in the PR:

1. V1 getContext() calls into host sdk directly without conversion.

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:
It looks test app doesn't have V1 apis testing. It will be nice to have those test coverages so we can validate this bug e2e. Will create WI for later improvement.

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
