### PR TITLE
Adding more communication unit tests

### DIFF
--- a/change/@microsoft-teams-js-042f478a-ce62-4e29-8ae5-d7918506bb95.json
+++ b/change/@microsoft-teams-js-042f478a-ce62-4e29-8ae5-d7918506bb95.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Stopped exporting `communication.processMessage` and `communication.shouldProcessMessage`.",
+  "packageName": "@microsoft/teams-js",
+  "email": "trharris@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -303,7 +303,7 @@ function processMessage(evt: DOMMessageEvent): void {
  * @internal
  * Limited to Microsoft-internal use
  */
-export function shouldProcessMessage(messageSource: Window, messageOrigin: string): boolean {
+function shouldProcessMessage(messageSource: Window, messageOrigin: string): boolean {
   // Process if message source is a different window and if origin is either in
   // Teams' pre-known whitelist or supplied as valid origin by user during initialization
   if (Communication.currentWindow && messageSource === Communication.currentWindow) {

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -271,7 +271,7 @@ function sendMessageToParentHelper(actionName: string, args: any[]): MessageRequ
  * @internal
  * Limited to Microsoft-internal use
  */
-export function processMessage(evt: DOMMessageEvent): void {
+function processMessage(evt: DOMMessageEvent): void {
   // Process only if we received a valid message
   if (!evt || !evt.data || typeof evt.data !== 'object') {
     return;

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -1136,8 +1136,57 @@ describe('Testing communication', () => {
     });
   });
   describe('sendMessageEventToChild', () => {
-    it('', () => {
-      return;
+    let utils: Utils = new Utils();
+    beforeEach(() => {
+      utils = new Utils();
+      communication.uninitializeCommunication();
+    });
+    afterAll(() => {
+      communication.uninitializeCommunication();
+    });
+    it('should post message to window if Communication.childWindow is set', () => {
+      communication.Communication.childWindow = utils.childWindow;
+      communication.Communication.childOrigin = utils.validOrigin;
+      expect(utils.childMessages.length).toBe(0);
+      communication.sendMessageEventToChild('testAction', ['arg zero']);
+      expect(utils.childMessages.length).toBe(1);
+      expect(utils.childMessages[0].func).toBe('testAction');
+      if (!utils.childMessages[0].args) {
+        throw new Error('No args found on message');
+      }
+      expect(utils.childMessages[0].args[0]).toBe('arg zero');
+    });
+
+    it('should add message to childWindow message queue if Communication.childOrigin is not set', () => {
+      expect.assertions(1);
+      communication.Communication.childWindow = utils.childWindow;
+      communication.Communication.currentWindow = utils.mockWindow;
+      communication.Communication.currentWindow.setInterval = (fn) => {
+        fn();
+      };
+      communication.waitForMessageQueue(communication.Communication.childWindow, () => {
+        expect(false).toBeFalsy();
+      });
+      communication.sendMessageEventToChild('testAction', ['arg zero']);
+      communication.waitForMessageQueue(communication.Communication.childWindow, () => {
+        expect(true).toBeFalsy();
+      });
+    });
+
+    it('should add message to childWindow message queue if Communication.childWindow is not set', () => {
+      expect.assertions(1);
+      communication.Communication.childOrigin = utils.validOrigin;
+      communication.Communication.currentWindow = utils.mockWindow;
+      communication.Communication.currentWindow.setInterval = (fn) => {
+        fn();
+      };
+      communication.waitForMessageQueue(communication.Communication.childWindow, () => {
+        expect(false).toBeFalsy();
+      });
+      communication.sendMessageEventToChild('testAction', ['arg zero']);
+      communication.waitForMessageQueue(communication.Communication.childWindow, () => {
+        expect(true).toBeFalsy();
+      });
     });
   });
 });

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -715,6 +715,20 @@ describe('Testing communication', () => {
 
       await expect(messagePromise).resolves.toBeUndefined();
     });
+    it('should pass all args to host', async () => {
+      expect.assertions(3);
+      communication.initializeCommunication(undefined);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      utils.respondToMessage(initializeMessage);
+
+      communication.sendAndHandleStatusAndReason(actionName, 'arg1', 'arg2', 'arg3');
+      const sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage?.args) {
+        expect(sentMessage?.args[0]).toStrictEqual('arg1');
+        expect(sentMessage?.args[1]).toStrictEqual('arg2');
+        expect(sentMessage?.args[2]).toStrictEqual('arg3');
+      }
+    });
   });
   describe('sendAndHandleStatusAndReasonWithDefaultError', () => {
     let utils: Utils = new Utils();
@@ -787,17 +801,20 @@ describe('Testing communication', () => {
 
       await expect(messagePromise).resolves.toBeUndefined();
     });
-    // it('should pass all args to host', async () => {
-    //   expect.assertions(1);
-    //   communication.initializeCommunication(undefined);
-    //   const initializeMessage = utils.findInitializeMessageOrThrow();
-    //   utils.respondToMessage(initializeMessage);
+    it('should pass all args to host', async () => {
+      expect.assertions(3);
+      communication.initializeCommunication(undefined);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      utils.respondToMessage(initializeMessage);
 
-    //   const sentMessage = utils.findMessageByFunc(actionName);
-    //   // expect(sentMessage?.args?.length).toBe(4);
-    //   const zero = sentMessage?.args ? sentMessage?.args[0] : 'test';
-    //   expect(zero).toStrictEqual('arg1');
-    // });
+      communication.sendAndHandleStatusAndReasonWithDefaultError(actionName, 'default error', 'arg1', 'arg2', 'arg3');
+      const sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage?.args) {
+        expect(sentMessage?.args[0]).toStrictEqual('arg1');
+        expect(sentMessage?.args[1]).toStrictEqual('arg2');
+        expect(sentMessage?.args[2]).toStrictEqual('arg3');
+      }
+    });
   });
   describe('processMessage', () => {
     it('fail if message has a missing data property', () => {

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -1070,36 +1070,6 @@ describe('Testing communication', () => {
       }
     });
   });
-  describe('shouldProcessMessage', () => {
-    it('fail if message source is same window ', () => {
-      communication.Communication.currentWindow = window;
-      // window object should now equal Communication.currentWindow
-      const result = communication.shouldProcessMessage(window, 'testOrigin.com');
-      expect(result).toBe(false);
-    });
-    it('fail if message source is same window ', () => {
-      communication.Communication.currentWindow = window;
-      // window object should now equal Communication.currentWindow
-      const result = communication.shouldProcessMessage(window, 'testOrigin.com');
-      expect(result).toBe(false);
-    });
-    it('success if origin matches current window ', () => {
-      const messageOrigin = window.location.origin;
-      communication.Communication.currentWindow = window;
-      const result = communication.shouldProcessMessage({} as Window, messageOrigin);
-      expect(result).toBe(true);
-    });
-    it('calls validateOrigin', () => {
-      communication.Communication.currentWindow = window;
-      jest.spyOn(utils, 'validateOrigin').mockReturnValue(true);
-      const messageOrigin = 'https://someorigin';
-      const messageOriginURL = new URL(messageOrigin);
-      const result = communication.shouldProcessMessage({} as Window, messageOrigin);
-      expect(utils.validateOrigin).toBeCalled();
-      expect(utils.validateOrigin).toBeCalledWith(messageOriginURL);
-      expect(result).toBe(utils.validateOrigin(messageOriginURL));
-    });
-  });
   describe('waitForMessageQueue', () => {
     it('', () => {
       return;

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -766,7 +766,6 @@ describe('Testing communication', () => {
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
-      const errorMessage = 'this message should show up in the error';
       utils.respondToMessage(sentMessage, false);
 
       await expect(messagePromise).rejects.toThrowError(defaultErrorMessage);
@@ -788,26 +787,17 @@ describe('Testing communication', () => {
 
       await expect(messagePromise).resolves.toBeUndefined();
     });
-    it('should pass all args to host', async () => {
-      expect.assertions(2);
-      communication.initializeCommunication(undefined);
-      const initializeMessage = utils.findInitializeMessageOrThrow();
-      utils.respondToMessage(initializeMessage);
+    // it('should pass all args to host', async () => {
+    //   expect.assertions(1);
+    //   communication.initializeCommunication(undefined);
+    //   const initializeMessage = utils.findInitializeMessageOrThrow();
+    //   utils.respondToMessage(initializeMessage);
 
-      const messagePromise = communication.sendAndHandleStatusAndReasonWithDefaultError(
-        actionName,
-        'default error',
-        'arg1',
-        'arg2',
-        'arg3',
-        'arg4',
-      );
-
-      const sentMessage = utils.findMessageByFunc(actionName);
-      expect(sentMessage?.args?.length).toBe(4);
-      const zero = sentMessage?.args ? sentMessage?.args[0] : 'test';
-      expect(zero).toStrictEqual('arg1');
-    });
+    //   const sentMessage = utils.findMessageByFunc(actionName);
+    //   // expect(sentMessage?.args?.length).toBe(4);
+    //   const zero = sentMessage?.args ? sentMessage?.args[0] : 'test';
+    //   expect(zero).toStrictEqual('arg1');
+    // });
   });
   describe('processMessage', () => {
     it('fail if message has a missing data property', () => {

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -8,7 +8,6 @@ describe('Testing communication', () => {
   describe('initializeCommunication', () => {
     describe('frameless', () => {
       let utils: Utils = new Utils();
-
       beforeEach(() => {
         // Set a mock window for testing
         utils = new Utils();
@@ -17,26 +16,20 @@ describe('Testing communication', () => {
         communication.Communication.parentWindow = undefined;
         GlobalVars.isFramelessWindow = false;
       });
-
       afterAll(() => {
         communication.uninitializeCommunication();
         GlobalVars.isFramelessWindow = false;
       });
-
       it('should throw if there is no parent window and no native interface on the current window', async () => {
         app._initialize(undefined);
         const initPromise = communication.initializeCommunication(undefined);
         await expect(initPromise).rejects.toThrowError('Initialization Failed. No Parent window found.');
       });
-
       it('should receive valid initialize response from parent when there is no parent window but the window has a native interface', async () => {
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
-
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
-
         const initializeResponse = await initPromise;
-
         const expectedResponse = {
           context: FrameContexts.content,
           clientType: undefined,
@@ -45,115 +38,83 @@ describe('Testing communication', () => {
         };
         expect(initializeResponse).toStrictEqual(expectedResponse);
       });
-
       it('Communication.currentWindow should be unchanged by initializeCommunication', async () => {
         expect(communication.Communication.currentWindow).toStrictEqual(utils.mockWindow);
-
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
-
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
-
         await initPromise;
-
         expect(communication.Communication.currentWindow).toStrictEqual(utils.mockWindow);
       });
-
       it('should set Communication.parentWindow to undefined when the current window has a parent that is undefined', async () => {
         expect(utils.mockWindow.parent).toBeUndefined();
-
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
-
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
-
         await initPromise;
-
         expect(communication.Communication.parentWindow).toBeUndefined();
       });
-
       it('should set window.onNativeMessage for handling responses when the current window has a parent that is undefined', async () => {
         expect(utils.mockWindow.onNativeMessage).toBeUndefined();
-
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
-
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
-
         await initPromise;
-
         expect(communication.Communication.currentWindow.onNativeMessage).not.toBeUndefined();
       });
-
       it('if there is a parent window that IS NOT self, we will not send messages using onNativeMessage, will not register onNativeMessage, and Communication.parentWindow will be set to the parent of the curent window', async () => {
         expect.assertions(5);
         utils.mockWindow.parent = utils.parentWindow;
         expect(utils.mockWindow.onNativeMessage).toBeUndefined();
-
         const initPromise = communication.initializeCommunication(undefined);
         try {
           const initMessage = utils.findInitializeMessageOrThrow();
           utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
-
           await initPromise;
         } catch (e) {
           expect(e).not.toBeNull();
         }
-
         expect(GlobalVars.isFramelessWindow).toBeFalsy();
         expect(communication.Communication.parentWindow).toStrictEqual(
           communication.Communication.currentWindow.parent,
         );
         expect(communication.Communication.currentWindow.onNativeMessage).toBeUndefined();
       });
-
       it('if there is a parent window that IS self, we will not send messages using onNativeMessage, will not register onNativeMessage, and Communication.parentWindow will be set to the opener of the curent window', async () => {
         expect.assertions(5);
         expect(utils.mockWindow.onNativeMessage).toBeUndefined();
         utils.mockWindow.parent = utils.mockWindow;
         utils.mockWindow.opener = utils.parentWindow;
-
         const initPromise = communication.initializeCommunication(undefined);
         try {
           const initMessage = utils.findInitializeMessageOrThrow();
           utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
-
           await initPromise;
         } catch (e) {
           expect(e).not.toBeNull();
         }
-
         expect(GlobalVars.isFramelessWindow).toBeFalsy();
         expect(communication.Communication.parentWindow).toStrictEqual(utils.mockWindow.opener);
         expect(communication.Communication.currentWindow.onNativeMessage).toBeUndefined();
       });
-
       it('if there is a parent window that IS self and NO opener, we will send messages using onNativeMessage, will register onNativeMessage, and Communication.parentWindow will be undefined', async () => {
         expect(utils.mockWindow.onNativeMessage).toBeUndefined();
         utils.mockWindow.parent = utils.mockWindow;
-
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
-
         await initPromise;
-
         expect(GlobalVars.isFramelessWindow).toBeTruthy();
         expect(communication.Communication.parentWindow).toBeUndefined();
         expect(communication.Communication.currentWindow.onNativeMessage).not.toBeUndefined();
       });
-
       it('should put sdk in frameless window mode when the current window has a parent that is undefined', async () => {
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
-
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
-
         await initPromise;
-
         expect(GlobalVars.isFramelessWindow).toBeTruthy();
       });
-
       it('should set sdk parentOrigin to null', async () => {
         /**
          * This is an interesting difference from the framed version.
@@ -162,21 +123,16 @@ describe('Testing communication', () => {
          */
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findMessageByFunc('initialize');
-
         if (!initMessage) {
           throw new Error('initialize message not found');
         }
-
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
-
         await initPromise;
-
         expect(communication.Communication.parentOrigin).toBeNull();
       });
     });
     describe('framed', () => {
       let utils: Utils = new Utils();
-
       beforeEach(() => {
         // Set a mock window for testing
         utils = new Utils();
@@ -184,17 +140,14 @@ describe('Testing communication', () => {
         communication.Communication.parentWindow = undefined;
         GlobalVars.isFramelessWindow = false;
       });
-
       afterEach(() => {
         communication.uninitializeCommunication();
       });
-
       afterAll(() => {
         communication.Communication.currentWindow = undefined;
         communication.Communication.parentWindow = undefined;
         GlobalVars.isFramelessWindow = false;
       });
-
       it('should reject if no parent window and current window does not have nativeInterface defined', async () => {
         // In this case, because Communication.currentWindow is being initialized to undefined we fall back to the actual
         // window object created by jest, which does not have nativeInterface defined on it
@@ -202,14 +155,11 @@ describe('Testing communication', () => {
         const initPromise = communication.initializeCommunication(undefined);
         await expect(initPromise).rejects.toThrowError('Initialization Failed. No Parent window found.');
       });
-
       it('should receive valid initialize response from parent when currentWindow has a parent with postMessage defined', async () => {
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
-
         utils.respondToMessage(initMessage, FrameContexts.content);
         const initializeResponse = await initPromise;
-
         const expectedResponse = {
           context: FrameContexts.content,
           clientType: undefined,
@@ -218,31 +168,24 @@ describe('Testing communication', () => {
         };
         expect(initializeResponse).toStrictEqual(expectedResponse);
       });
-
       it('should set Communication.currentWindow to the value that was passed to app._initialize', async () => {
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
-
         utils.respondToMessage(initMessage, FrameContexts.content);
         await initPromise;
-
         expect(communication.Communication.currentWindow).toStrictEqual(utils.mockWindow);
       });
-
       it('should set Communication.parentOrigin to null and then update to the message origin once a response is received', async () => {
         const initPromise = communication.initializeCommunication(undefined);
         expect(communication.Communication.parentOrigin).toBeNull();
         const initMessage = utils.findInitializeMessageOrThrow();
-
         utils.respondToMessage(initMessage, FrameContexts.content);
         await initPromise;
         expect(communication.Communication.parentOrigin).toBe(utils.validOrigin);
       });
-
       it('should set Communication.parentWindow and Communication.parentOrigin to null if the parent window is closed during the initialization call', async () => {
         expect.assertions(4);
-
-        /* 
+        /*
           This promise is intentionally not being awaited
           If the parent window is closed during the initialize call,
           the initialize response never resolves (even though we receive it)
@@ -251,51 +194,38 @@ describe('Testing communication', () => {
           (which is the function that resolves the promise)
         */
         communication.initializeCommunication(undefined);
-
         expect(communication.Communication.parentOrigin).toBeNull();
         expect(communication.Communication.parentWindow).not.toBeNull();
-
         communication.Communication.parentWindow.closed = true;
         const initMessage = utils.findInitializeMessageOrThrow();
-
         utils.respondToMessage(initMessage, FrameContexts.content);
-
         expect(communication.Communication.parentWindow).toBeNull();
         expect(communication.Communication.parentOrigin).toBeNull();
       });
-
       it('should be in framed mode when there is a parent window that is not self', async () => {
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
         utils.respondToMessage(initMessage, FrameContexts.content);
         await initPromise;
-
         expect(GlobalVars.isFramelessWindow).toBeFalsy();
         expect(utils.mockWindow.onNativeMessage).toBeUndefined();
       });
-
       it('should be in framed mode when the parent window is self, and Communication.parentWindow should be set to opener', async () => {
         utils.mockWindow.opener = utils.mockWindow.parent;
         utils.mockWindow.parent = communication.Communication.currentWindow.self;
-
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
         utils.respondToMessageAsOpener(initMessage, FrameContexts.content);
         await initPromise;
-
         expect(GlobalVars.isFramelessWindow).toBeFalsy();
         expect(utils.mockWindow.onNativeMessage).toBeUndefined();
         expect(communication.Communication.parentWindow).toStrictEqual(utils.mockWindow.opener);
       });
-
       it('should be in frameless mode when the parent window is self and there is no opener, and Communication.parentWindow should be set to undefined', async () => {
         expect.assertions(3);
-
         utils.mockWindow.opener = undefined;
         utils.mockWindow.parent = communication.Communication.currentWindow.self;
-
         communication.initializeCommunication(undefined);
-
         expect(GlobalVars.isFramelessWindow).toBeTruthy();
         expect(utils.mockWindow.onNativeMessage).not.toBeUndefined();
         expect(communication.Communication.parentWindow).toBeUndefined();
@@ -319,7 +249,6 @@ describe('Testing communication', () => {
       communication.uninitializeCommunication();
       expect(communication.Communication.parentWindow).toBeNull();
     });
-
     it('should set Communication.parentOrigin to null', () => {
       app._initialize(utils.mockWindow);
       communication.Communication.parentOrigin = utils.mockWindow.parentOrigin;
@@ -327,7 +256,6 @@ describe('Testing communication', () => {
       communication.uninitializeCommunication();
       expect(communication.Communication.parentOrigin).toBeNull();
     });
-
     it('should set Communication.childWindow to null', () => {
       app._initialize(utils.mockWindow);
       communication.Communication.childWindow = utils.mockWindow;
@@ -335,7 +263,6 @@ describe('Testing communication', () => {
       communication.uninitializeCommunication();
       expect(communication.Communication.childWindow).toBeNull();
     });
-
     it('should set Communication.childOrigin to null', () => {
       app._initialize(utils.mockWindow);
       communication.Communication.childOrigin = utils.mockWindow.origin;
@@ -343,7 +270,6 @@ describe('Testing communication', () => {
       communication.uninitializeCommunication();
       expect(communication.Communication.childOrigin).toBeNull();
     });
-
     it('should empty the queue of messages for the current parent', () => {
       expect.assertions(1);
       communication.Communication.childWindow = utils.mockWindow;
@@ -352,7 +278,6 @@ describe('Testing communication', () => {
       // This function inserts a message into the parentMessageQueue
       communication.sendMessageEventToChild('testMessage');
       communication.uninitializeCommunication();
-
       communication.Communication.parentWindow = utils.mockWindow;
       communication.Communication.currentWindow = utils.mockWindow;
       communication.Communication.currentWindow.setInterval = (fn) => {
@@ -363,7 +288,6 @@ describe('Testing communication', () => {
         expect(true).toBeTruthy();
       });
     });
-
     it('should empty the queue of messages for the current child', () => {
       expect.assertions(1);
       communication.Communication.childWindow = utils.mockWindow;
@@ -372,7 +296,6 @@ describe('Testing communication', () => {
       // This function inserts a message into the parentMessageQueue
       communication.sendMessageEventToChild('testMessage');
       communication.uninitializeCommunication();
-
       communication.Communication.childWindow = utils.mockWindow;
       communication.Communication.currentWindow = utils.mockWindow;
       communication.Communication.currentWindow.setInterval = (fn) => {
@@ -383,7 +306,6 @@ describe('Testing communication', () => {
         expect(true).toBeTruthy();
       });
     });
-
     it('should reset messageIds to start at 0 again', () => {
       expect.assertions(2);
       app._initialize(utils.mockWindow);
@@ -393,71 +315,54 @@ describe('Testing communication', () => {
       communication.sendMessageToParent('testAction');
       communication.sendMessageToParent('testAction2');
       const message = utils.findMessageByFunc('testAction2');
-
       if (message) {
         expect(message.id).toBe(1);
       }
-
       communication.uninitializeCommunication();
       GlobalVars.isFramelessWindow = false;
       communication.Communication.parentWindow = utils.mockWindow.parent;
       communication.Communication.parentOrigin = utils.validOrigin;
       communication.sendMessageToParent('testAction3');
-
       const messageAfterUninitialize = utils.findMessageByFunc('testAction3');
       if (messageAfterUninitialize) {
         expect(messageAfterUninitialize.id).toBe(0);
       }
     });
-
     it('unresolved message callbacks should not be triggered after communication has been uninitialized', () => {
       app._initialize(utils.mockWindow);
       communication.initializeCommunication(undefined);
       let callbackWasCalled = false;
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       communication.sendMessageToParent('testAction', () => {
         callbackWasCalled = true;
       });
       const tempProcessMessage = utils.processMessage;
       communication.uninitializeCommunication();
       utils.processMessage = tempProcessMessage;
-
       utils.respondToMessage({ id: 1, func: 'testAction' }, false);
-
       expect(callbackWasCalled).toBeFalsy();
     });
-
     it('unresolved message promises should not be triggered after communication has been uninitialized', async () => {
-      expect.assertions(1);
       app._initialize(utils.mockWindow);
       communication.initializeCommunication(undefined);
-
       const messageParent = communication.sendMessageToParentAsync('testAction');
-
       const tempProcessMessage = utils.processMessage;
       communication.uninitializeCommunication();
       utils.processMessage = tempProcessMessage;
-
       utils.respondToMessage({ id: 1, func: 'testAction' }, false);
-
-      messageParent.then(() => expect(true).toBeTruthy());
+      messageParent.then(() => expect(false).toBeTruthy());
       expect(true).toBeTruthy();
     });
-
     it('the current window should not have a message listener on it after communication has been uninitialized', async () => {
       app._initialize(utils.mockWindow);
       utils.mockWindow.addEventListener('message', () => {
         // This listener should not be called during the unit test
         expect(true).toBeFalsy();
       });
-
       // eslint-disable-next-line strict-null-checks/all
       expect(utils.processMessage).not.toBeNull();
-
       communication.uninitializeCommunication();
-
       // eslint-disable-next-line strict-null-checks/all
       expect(utils.processMessage).toBeNull();
     });
@@ -476,9 +381,7 @@ describe('Testing communication', () => {
     });
     it('should send framelessPostMessage to window when running in a frameless window and Communication.currentWindow is set and has a nativeInterface', () => {
       GlobalVars.isFramelessWindow = true;
-
       communication.sendMessageToParentAsync(actionName);
-
       expect(utils.messages.length).toBe(1);
       expect(utils.messages[0].id).toBe(0);
       expect(utils.messages[0].func).toBe(actionName);
@@ -486,23 +389,18 @@ describe('Testing communication', () => {
     it('should receive response to framelessPostMessage when running in a frameless window and Communication.currentWindow is set and has a nativeInterface', async () => {
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
-
       const messagePromise = communication.sendMessageToParentAsync(actionName);
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       utils.respondToNativeMessage(sentMessage, false, []);
-
       return expect(messagePromise).resolves;
     });
     it('should never send message if there is no Communication.currentWindow when message is sent', () => {
       GlobalVars.isFramelessWindow = true;
       communication.Communication.currentWindow = undefined;
-
       communication.sendMessageToParentAsync(actionName);
-
       expect(utils.messages.length).toBe(0);
     });
     it('should still receive response to framelessPostMessage even if there is no Communication.currentWindow when message is sent', async () => {
@@ -511,11 +409,8 @@ describe('Testing communication', () => {
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
       communication.Communication.currentWindow = undefined;
-
       const messagePromise = communication.sendMessageToParentAsync(actionName);
-
       utils.respondToNativeMessage({ id: 1, func: actionName }, false, []);
-
       await messagePromise;
       const sentMessage = utils.findMessageByFunc(actionName);
       // eslint-disable-next-line strict-null-checks/all
@@ -524,9 +419,7 @@ describe('Testing communication', () => {
     it('should never send message if there is no nativeInterface on the currentWindow when message is sent', () => {
       GlobalVars.isFramelessWindow = true;
       communication.Communication.currentWindow.nativeInterface = undefined;
-
       communication.sendMessageToParentAsync(actionName);
-
       expect(utils.messages.length).toBe(0);
     });
     it('should receive response to framelessPostMessage even if there is no nativeInterface on the currentWindow when message is sent', async () => {
@@ -536,21 +429,16 @@ describe('Testing communication', () => {
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
       communication.Communication.currentWindow.nativeInterface = undefined;
-
       const messagePromise = communication.sendMessageToParentAsync(actionName);
-
       utils.respondToNativeMessage({ id: 1, func: actionName }, false, []);
-
       messagePromise.then(() => {
-        expect(true).toBeFalsy();
+        expect(true).toBeTruthy();
       });
     });
     it('args passed in should be sent with the framelessPostMessage', () => {
       GlobalVars.isFramelessWindow = true;
-
       const arg1 = 'testArg1';
       communication.sendMessageToParentAsync(actionName, [arg1]);
-
       expect(utils.messages.length).toBe(1);
       if (utils.messages[0].args === undefined) {
         throw new Error('args expected on message');
@@ -562,9 +450,7 @@ describe('Testing communication', () => {
       GlobalVars.isFramelessWindow = false;
       communication.Communication.parentWindow = utils.mockWindow.parent;
       communication.Communication.parentOrigin = utils.validOrigin;
-
       communication.sendMessageToParentAsync(actionName);
-
       expect(utils.messages.length).toBe(1);
       expect(utils.messages[0].id).toBe(0);
       expect(utils.messages[0].func).toBe(actionName);
@@ -573,30 +459,24 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const messagePromise = communication.sendMessageToParentAsync(actionName);
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       utils.respondToMessage(sentMessage, false, []);
-
       return expect(messagePromise).resolves;
     });
     it('args passed in should be sent with the postMessage', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const arg1 = 'testArg1';
       communication.sendMessageToParentAsync(actionName, [arg1]);
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
-
       if (sentMessage.args === undefined) {
         throw new Error('args expected on message');
       }
@@ -606,16 +486,12 @@ describe('Testing communication', () => {
     it('should not send postMessage until after initialization response received', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
-
       communication.sendMessageToParentAsync(actionName);
-
       let sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage !== null) {
         throw new Error('Should not find a sent message until after the initialization response was received');
       }
-
       utils.respondToMessage(initializeMessage);
-
       sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('Did not find any message even after initialization response was received');
@@ -637,9 +513,7 @@ describe('Testing communication', () => {
     it('should send framelessPostMessage to window when running in a frameless window and Communication.currentWindow is set and has a nativeInterface', () => {
       expect.assertions(5);
       GlobalVars.isFramelessWindow = true;
-
       communication.sendMessageToParent(actionName, ['zero', 'one']);
-
       expect(utils.messages.length).toBe(1);
       expect(utils.messages[0].id).toBe(0);
       expect(utils.messages[0].func).toBe(actionName);
@@ -650,15 +524,12 @@ describe('Testing communication', () => {
     });
     it('should receive response via callback when sending framelessPostMessage to window when running in a frameless window and Communication.currentWindow is set and has a nativeInterface', () => {
       expect.assertions(1);
-
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
-
       communication.sendMessageToParent(actionName, () => {
         expect(true).toBeTruthy();
       });
       const sentMessage = utils.findMessageByFunc(actionName);
-
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
@@ -667,9 +538,7 @@ describe('Testing communication', () => {
     it('should never send message if there is no Communication.currentWindow when message is sent', () => {
       GlobalVars.isFramelessWindow = true;
       communication.Communication.currentWindow = undefined;
-
       communication.sendMessageToParent(actionName);
-
       expect(utils.messages.length).toBe(0);
     });
     it('should still receive response to framelessPostMessage even if there is no Communication.currentWindow when message is sent', async () => {
@@ -679,13 +548,10 @@ describe('Testing communication', () => {
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
       communication.Communication.currentWindow = undefined;
-
       communication.sendMessageToParent(actionName, () => {
         expect(true).toBeTruthy();
       });
-
       utils.respondToNativeMessage({ id: 1, func: actionName }, false, []);
-
       const sentMessage = utils.findMessageByFunc(actionName);
       // eslint-disable-next-line strict-null-checks/all
       expect(sentMessage).toBeDefined();
@@ -693,9 +559,7 @@ describe('Testing communication', () => {
     it('should never send message if there is no nativeInterface on the currentWindow when message is sent', () => {
       GlobalVars.isFramelessWindow = true;
       communication.Communication.currentWindow.nativeInterface = undefined;
-
       communication.sendMessageToParent(actionName);
-
       expect(utils.messages.length).toBe(0);
     });
     it('should receive response to framelessPostMessage even if there is no nativeInterface on the currentWindow when message is sent', async () => {
@@ -705,18 +569,14 @@ describe('Testing communication', () => {
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
       communication.Communication.currentWindow.nativeInterface = undefined;
-
       communication.sendMessageToParent(actionName, () => expect(true).toBeTruthy());
-
       utils.respondToNativeMessage({ id: 1, func: actionName }, false, []);
     });
     it('should send a message to window when running in a framed window and Communication.parentWindow and Communication.parentOrigin are set', () => {
       GlobalVars.isFramelessWindow = false;
       communication.Communication.parentWindow = utils.mockWindow.parent;
       communication.Communication.parentOrigin = utils.validOrigin;
-
       communication.sendMessageToParent(actionName);
-
       expect(utils.messages.length).toBe(1);
       expect(utils.messages[0].id).toBe(0);
       expect(utils.messages[0].func).toBe(actionName);
@@ -726,9 +586,7 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       communication.sendMessageToParent(actionName, () => expect(true).toBeTruthy());
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
@@ -739,15 +597,12 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const arg1 = 'testArg1';
       communication.sendMessageToParent(actionName, [arg1]);
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
-
       if (sentMessage.args === undefined) {
         throw new Error('args expected on message');
       }
@@ -757,16 +612,12 @@ describe('Testing communication', () => {
     it('should not send postMessage until after initialization response received', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
-
       communication.sendMessageToParent(actionName);
-
       let sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage !== null) {
         throw new Error('Should not find a sent message until after the initialization response was received');
       }
-
       utils.respondToMessage(initializeMessage);
-
       sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('Did not find any message even after initialization response was received');
@@ -791,26 +642,20 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const messagePromise = communication.sendAndUnwrap(actionName);
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       utils.respondToMessage(sentMessage, actionName);
-
       const response = await messagePromise;
       expect(response).toBe(actionName);
-
       const messagePromise2 = communication.sendMessageToParentAsync(actionName2);
-
       const sentMessage2 = utils.findMessageByFunc(actionName2);
       if (sentMessage2 === null) {
         throw new Error('No sent message was found');
       }
       utils.respondToMessage(sentMessage2, actionName2);
-
       const response2 = await messagePromise2;
       expect(response2).toStrictEqual([actionName2]);
     });
@@ -832,43 +677,34 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const messagePromise = communication.sendAndHandleStatusAndReason(actionName);
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       const errorMessage = 'this message should show up in the error';
       utils.respondToMessage(sentMessage, false, errorMessage);
-
       await expect(messagePromise).rejects.toThrowError(errorMessage);
     });
-
     it('should not throw an error if first returned value from host is true', async () => {
       expect.assertions(1);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const messagePromise = communication.sendAndHandleStatusAndReason(actionName);
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       const errorMessage = 'this message should show up in the error';
       utils.respondToMessage(sentMessage, true, errorMessage);
-
       await expect(messagePromise).resolves.toBeUndefined();
     });
-
     it('should pass all args to host', async () => {
       expect.assertions(3);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       communication.sendAndHandleStatusAndReason(actionName, 'arg1', 'arg2', 'arg3');
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage?.args) {
@@ -895,41 +731,34 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const defaultErrorMessage = 'This is the default error message';
       const messagePromise = communication.sendAndHandleStatusAndReasonWithDefaultError(
         actionName,
         defaultErrorMessage,
       );
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       const errorMessage = 'this message should show up in the error';
       utils.respondToMessage(sentMessage, false, errorMessage);
-
       await expect(messagePromise).rejects.toThrowError(errorMessage);
     });
-
     it('should throw the default error passed in to the function if first returned value from host is false and host does not provide a custom error', async () => {
       expect.assertions(1);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const defaultErrorMessage = 'This is the default error message';
       const messagePromise = communication.sendAndHandleStatusAndReasonWithDefaultError(
         actionName,
         defaultErrorMessage,
       );
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       utils.respondToMessage(sentMessage, false);
-
       await expect(messagePromise).rejects.toThrowError(defaultErrorMessage);
     });
     it('should not throw an error if first returned value from host is true', async () => {
@@ -937,25 +766,20 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const messagePromise = communication.sendAndHandleStatusAndReasonWithDefaultError(actionName, 'default error');
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       const errorMessage = 'this message should show up in the error';
       utils.respondToMessage(sentMessage, true, errorMessage);
-
       await expect(messagePromise).resolves.toBeUndefined();
     });
-
     it('should pass all args to host', async () => {
       expect.assertions(3);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       communication.sendAndHandleStatusAndReasonWithDefaultError(actionName, 'default error', 'arg1', 'arg2', 'arg3');
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage?.args) {
@@ -965,7 +789,6 @@ describe('Testing communication', () => {
       }
     });
   });
-
   describe('sendAndHandleSdkError', () => {
     let utils: Utils = new Utils();
     const actionName = 'test';
@@ -983,82 +806,62 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const messagePromise = communication.sendAndHandleSdkError(actionName);
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       const sdkError = { errorCode: 1, message: 'SdkError Message' };
       utils.respondToMessage(sentMessage, sdkError, 'result value');
-
       await messagePromise.catch((e) => expect(e).toStrictEqual(sdkError));
     });
-
     it('should throw true if first value returned from host is true', async () => {
       // this is a bug that should be fixed
       expect.assertions(1);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const messagePromise = communication.sendAndHandleSdkError(actionName);
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
-
       utils.respondToMessage(sentMessage, true, 'result value');
-
       await messagePromise.catch((e) => expect(e).toStrictEqual(true));
     });
-
     it('should return the second parameter returned from the host if undefined is returned from the host as the first parameter', async () => {
       expect.assertions(1);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const messagePromise = communication.sendAndHandleSdkError(actionName);
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
-
       // eslint-disable-next-line strict-null-checks/all
       utils.respondToMessage(sentMessage, undefined, 'result value');
-
       await messagePromise.then((value) => expect(value).toBe('result value'));
     });
-
     it('should return the second parameter returned from the host if false is returned from the host as the first parameter', async () => {
       // this is a bug that should be fixed
       expect.assertions(1);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       const messagePromise = communication.sendAndHandleSdkError(actionName);
-
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
-
       utils.respondToMessage(sentMessage, false, 'result value');
-
       await messagePromise.then((value) => expect(value).toBe('result value'));
     });
-
     it('should pass all args to host', async () => {
       expect.assertions(3);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
-
       communication.sendAndHandleSdkError(actionName, 'arg1', 'arg2', 'arg3');
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage?.args) {
@@ -1087,7 +890,6 @@ describe('Testing communication', () => {
       communication.Communication.currentWindow.setInterval = (fn) => {
         fn();
       };
-
       // This function inserts a message into the parentMessageQueue
       communication.sendMessageEventToChild('testMessage');
       communication.waitForMessageQueue(communication.Communication.parentWindow, () => {
@@ -1103,7 +905,6 @@ describe('Testing communication', () => {
       communication.Communication.currentWindow.setInterval = (fn) => {
         fn();
       };
-
       communication.waitForMessageQueue(communication.Communication.parentWindow, () => {
         // this callback only ever fires if the message queue associated with the passed in window is empty
         expect(true).toBeTruthy();
@@ -1116,7 +917,6 @@ describe('Testing communication', () => {
     it('should throw if Communication.currentWindow is undefined', () => {
       expect.assertions(1);
       communication.Communication.currentWindow = undefined;
-
       expect(() => {
         communication.waitForMessageQueue(communication.Communication.parentWindow, () => {
           expect(false).toBeTruthy();
@@ -1127,7 +927,6 @@ describe('Testing communication', () => {
       expect.assertions(1);
       communication.Communication.currentWindow = utils.mockWindow;
       communication.Communication.currentWindow.setInterval = undefined;
-
       expect(() => {
         communication.waitForMessageQueue(communication.Communication.parentWindow, () => {
           expect(false).toBeTruthy();
@@ -1156,7 +955,6 @@ describe('Testing communication', () => {
       }
       expect(utils.childMessages[0].args[0]).toBe('arg zero');
     });
-
     it('should add message to childWindow message queue if Communication.childOrigin is not set', () => {
       expect.assertions(1);
       communication.Communication.childWindow = utils.childWindow;
@@ -1172,7 +970,6 @@ describe('Testing communication', () => {
         expect(true).toBeFalsy();
       });
     });
-
     it('should add message to childWindow message queue if Communication.childWindow is not set', () => {
       expect.assertions(1);
       communication.Communication.childOrigin = utils.validOrigin;

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -668,6 +668,147 @@ describe('Testing communication', () => {
       expect(response2).toStrictEqual([actionName2]);
     });
   });
+  describe('sendAndHandleStatusAndReason', () => {
+    let utils: Utils = new Utils();
+    const actionName = 'test';
+    beforeEach(() => {
+      utils = new Utils();
+      communication.uninitializeCommunication();
+      app._initialize(utils.mockWindow);
+    });
+    afterAll(() => {
+      communication.Communication.currentWindow = utils.mockWindow;
+      communication.uninitializeCommunication();
+    });
+    it('should throw correct error if first returned value from host is false', async () => {
+      expect.assertions(1);
+      communication.initializeCommunication(undefined);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      utils.respondToMessage(initializeMessage);
+
+      const messagePromise = communication.sendAndHandleStatusAndReason(actionName);
+
+      const sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage === null) {
+        throw new Error('No sent message was found');
+      }
+      const errorMessage = 'this message should show up in the error';
+      utils.respondToMessage(sentMessage, false, errorMessage);
+
+      await expect(messagePromise).rejects.toThrowError(errorMessage);
+    });
+
+    it('should not throw an error if first returned value from host is true', async () => {
+      expect.assertions(1);
+      communication.initializeCommunication(undefined);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      utils.respondToMessage(initializeMessage);
+
+      const messagePromise = communication.sendAndHandleStatusAndReason(actionName);
+
+      const sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage === null) {
+        throw new Error('No sent message was found');
+      }
+      const errorMessage = 'this message should show up in the error';
+      utils.respondToMessage(sentMessage, true, errorMessage);
+
+      await expect(messagePromise).resolves.toBeUndefined();
+    });
+  });
+  describe('sendAndHandleStatusAndReasonWithDefaultError', () => {
+    let utils: Utils = new Utils();
+    const actionName = 'test';
+    beforeEach(() => {
+      utils = new Utils();
+      communication.uninitializeCommunication();
+      app._initialize(utils.mockWindow);
+    });
+    afterAll(() => {
+      communication.Communication.currentWindow = utils.mockWindow;
+      communication.uninitializeCommunication();
+    });
+    it('should throw error from host if first returned value from host is false and host provides a custom error', async () => {
+      expect.assertions(1);
+      communication.initializeCommunication(undefined);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      utils.respondToMessage(initializeMessage);
+
+      const defaultErrorMessage = 'This is the default error message';
+      const messagePromise = communication.sendAndHandleStatusAndReasonWithDefaultError(
+        actionName,
+        defaultErrorMessage,
+      );
+
+      const sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage === null) {
+        throw new Error('No sent message was found');
+      }
+      const errorMessage = 'this message should show up in the error';
+      utils.respondToMessage(sentMessage, false, errorMessage);
+
+      await expect(messagePromise).rejects.toThrowError(errorMessage);
+    });
+
+    it('should throw the default error passed in to the function if first returned value from host is false and host does not provide a custom error', async () => {
+      expect.assertions(1);
+      communication.initializeCommunication(undefined);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      utils.respondToMessage(initializeMessage);
+
+      const defaultErrorMessage = 'This is the default error message';
+      const messagePromise = communication.sendAndHandleStatusAndReasonWithDefaultError(
+        actionName,
+        defaultErrorMessage,
+      );
+
+      const sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage === null) {
+        throw new Error('No sent message was found');
+      }
+      const errorMessage = 'this message should show up in the error';
+      utils.respondToMessage(sentMessage, false);
+
+      await expect(messagePromise).rejects.toThrowError(defaultErrorMessage);
+    });
+    it('should not throw an error if first returned value from host is true', async () => {
+      expect.assertions(1);
+      communication.initializeCommunication(undefined);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      utils.respondToMessage(initializeMessage);
+
+      const messagePromise = communication.sendAndHandleStatusAndReasonWithDefaultError(actionName, 'default error');
+
+      const sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage === null) {
+        throw new Error('No sent message was found');
+      }
+      const errorMessage = 'this message should show up in the error';
+      utils.respondToMessage(sentMessage, true, errorMessage);
+
+      await expect(messagePromise).resolves.toBeUndefined();
+    });
+    it('should pass all args to host', async () => {
+      expect.assertions(2);
+      communication.initializeCommunication(undefined);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      utils.respondToMessage(initializeMessage);
+
+      const messagePromise = communication.sendAndHandleStatusAndReasonWithDefaultError(
+        actionName,
+        'default error',
+        'arg1',
+        'arg2',
+        'arg3',
+        'arg4',
+      );
+
+      const sentMessage = utils.findMessageByFunc(actionName);
+      expect(sentMessage?.args?.length).toBe(4);
+      const zero = sentMessage?.args ? sentMessage?.args[0] : 'test';
+      expect(zero).toStrictEqual('arg1');
+    });
+  });
   describe('processMessage', () => {
     it('fail if message has a missing data property', () => {
       const event = { badData: '' } as unknown as DOMMessageEvent;

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -8,6 +8,7 @@ describe('Testing communication', () => {
   describe('initializeCommunication', () => {
     describe('frameless', () => {
       let utils: Utils = new Utils();
+
       beforeEach(() => {
         // Set a mock window for testing
         utils = new Utils();
@@ -16,20 +17,26 @@ describe('Testing communication', () => {
         communication.Communication.parentWindow = undefined;
         GlobalVars.isFramelessWindow = false;
       });
+
       afterAll(() => {
         communication.uninitializeCommunication();
         GlobalVars.isFramelessWindow = false;
       });
+
       it('should throw if there is no parent window and no native interface on the current window', async () => {
         app._initialize(undefined);
         const initPromise = communication.initializeCommunication(undefined);
         await expect(initPromise).rejects.toThrowError('Initialization Failed. No Parent window found.');
       });
+
       it('should receive valid initialize response from parent when there is no parent window but the window has a native interface', async () => {
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
+
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
+
         const initializeResponse = await initPromise;
+
         const expectedResponse = {
           context: FrameContexts.content,
           clientType: undefined,
@@ -38,83 +45,115 @@ describe('Testing communication', () => {
         };
         expect(initializeResponse).toStrictEqual(expectedResponse);
       });
+
       it('Communication.currentWindow should be unchanged by initializeCommunication', async () => {
         expect(communication.Communication.currentWindow).toStrictEqual(utils.mockWindow);
+
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
+
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
+
         await initPromise;
+
         expect(communication.Communication.currentWindow).toStrictEqual(utils.mockWindow);
       });
+
       it('should set Communication.parentWindow to undefined when the current window has a parent that is undefined', async () => {
         expect(utils.mockWindow.parent).toBeUndefined();
+
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
+
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
+
         await initPromise;
+
         expect(communication.Communication.parentWindow).toBeUndefined();
       });
+
       it('should set window.onNativeMessage for handling responses when the current window has a parent that is undefined', async () => {
         expect(utils.mockWindow.onNativeMessage).toBeUndefined();
+
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
+
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
+
         await initPromise;
+
         expect(communication.Communication.currentWindow.onNativeMessage).not.toBeUndefined();
       });
+
       it('if there is a parent window that IS NOT self, we will not send messages using onNativeMessage, will not register onNativeMessage, and Communication.parentWindow will be set to the parent of the curent window', async () => {
         expect.assertions(5);
         utils.mockWindow.parent = utils.parentWindow;
         expect(utils.mockWindow.onNativeMessage).toBeUndefined();
+
         const initPromise = communication.initializeCommunication(undefined);
         try {
           const initMessage = utils.findInitializeMessageOrThrow();
           utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
+
           await initPromise;
         } catch (e) {
           expect(e).not.toBeNull();
         }
+
         expect(GlobalVars.isFramelessWindow).toBeFalsy();
         expect(communication.Communication.parentWindow).toStrictEqual(
           communication.Communication.currentWindow.parent,
         );
         expect(communication.Communication.currentWindow.onNativeMessage).toBeUndefined();
       });
+
       it('if there is a parent window that IS self, we will not send messages using onNativeMessage, will not register onNativeMessage, and Communication.parentWindow will be set to the opener of the curent window', async () => {
         expect.assertions(5);
         expect(utils.mockWindow.onNativeMessage).toBeUndefined();
         utils.mockWindow.parent = utils.mockWindow;
         utils.mockWindow.opener = utils.parentWindow;
+
         const initPromise = communication.initializeCommunication(undefined);
         try {
           const initMessage = utils.findInitializeMessageOrThrow();
           utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
+
           await initPromise;
         } catch (e) {
           expect(e).not.toBeNull();
         }
+
         expect(GlobalVars.isFramelessWindow).toBeFalsy();
         expect(communication.Communication.parentWindow).toStrictEqual(utils.mockWindow.opener);
         expect(communication.Communication.currentWindow.onNativeMessage).toBeUndefined();
       });
+
       it('if there is a parent window that IS self and NO opener, we will send messages using onNativeMessage, will register onNativeMessage, and Communication.parentWindow will be undefined', async () => {
         expect(utils.mockWindow.onNativeMessage).toBeUndefined();
         utils.mockWindow.parent = utils.mockWindow;
+
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
+
         await initPromise;
+
         expect(GlobalVars.isFramelessWindow).toBeTruthy();
         expect(communication.Communication.parentWindow).toBeUndefined();
         expect(communication.Communication.currentWindow.onNativeMessage).not.toBeUndefined();
       });
+
       it('should put sdk in frameless window mode when the current window has a parent that is undefined', async () => {
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
+
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
+
         await initPromise;
+
         expect(GlobalVars.isFramelessWindow).toBeTruthy();
       });
+
       it('should set sdk parentOrigin to null', async () => {
         /**
          * This is an interesting difference from the framed version.
@@ -123,16 +162,21 @@ describe('Testing communication', () => {
          */
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findMessageByFunc('initialize');
+
         if (!initMessage) {
           throw new Error('initialize message not found');
         }
+
         utils.respondToNativeMessage(initMessage, false, FrameContexts.content);
+
         await initPromise;
+
         expect(communication.Communication.parentOrigin).toBeNull();
       });
     });
     describe('framed', () => {
       let utils: Utils = new Utils();
+
       beforeEach(() => {
         // Set a mock window for testing
         utils = new Utils();
@@ -140,14 +184,17 @@ describe('Testing communication', () => {
         communication.Communication.parentWindow = undefined;
         GlobalVars.isFramelessWindow = false;
       });
+
       afterEach(() => {
         communication.uninitializeCommunication();
       });
+
       afterAll(() => {
         communication.Communication.currentWindow = undefined;
         communication.Communication.parentWindow = undefined;
         GlobalVars.isFramelessWindow = false;
       });
+
       it('should reject if no parent window and current window does not have nativeInterface defined', async () => {
         // In this case, because Communication.currentWindow is being initialized to undefined we fall back to the actual
         // window object created by jest, which does not have nativeInterface defined on it
@@ -155,11 +202,14 @@ describe('Testing communication', () => {
         const initPromise = communication.initializeCommunication(undefined);
         await expect(initPromise).rejects.toThrowError('Initialization Failed. No Parent window found.');
       });
+
       it('should receive valid initialize response from parent when currentWindow has a parent with postMessage defined', async () => {
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
+
         utils.respondToMessage(initMessage, FrameContexts.content);
         const initializeResponse = await initPromise;
+
         const expectedResponse = {
           context: FrameContexts.content,
           clientType: undefined,
@@ -168,24 +218,31 @@ describe('Testing communication', () => {
         };
         expect(initializeResponse).toStrictEqual(expectedResponse);
       });
+
       it('should set Communication.currentWindow to the value that was passed to app._initialize', async () => {
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
+
         utils.respondToMessage(initMessage, FrameContexts.content);
         await initPromise;
+
         expect(communication.Communication.currentWindow).toStrictEqual(utils.mockWindow);
       });
+
       it('should set Communication.parentOrigin to null and then update to the message origin once a response is received', async () => {
         const initPromise = communication.initializeCommunication(undefined);
         expect(communication.Communication.parentOrigin).toBeNull();
         const initMessage = utils.findInitializeMessageOrThrow();
+
         utils.respondToMessage(initMessage, FrameContexts.content);
         await initPromise;
         expect(communication.Communication.parentOrigin).toBe(utils.validOrigin);
       });
+
       it('should set Communication.parentWindow and Communication.parentOrigin to null if the parent window is closed during the initialization call', async () => {
         expect.assertions(4);
-        /*
+
+        /* 
           This promise is intentionally not being awaited
           If the parent window is closed during the initialize call,
           the initialize response never resolves (even though we receive it)
@@ -194,38 +251,51 @@ describe('Testing communication', () => {
           (which is the function that resolves the promise)
         */
         communication.initializeCommunication(undefined);
+
         expect(communication.Communication.parentOrigin).toBeNull();
         expect(communication.Communication.parentWindow).not.toBeNull();
+
         communication.Communication.parentWindow.closed = true;
         const initMessage = utils.findInitializeMessageOrThrow();
+
         utils.respondToMessage(initMessage, FrameContexts.content);
+
         expect(communication.Communication.parentWindow).toBeNull();
         expect(communication.Communication.parentOrigin).toBeNull();
       });
+
       it('should be in framed mode when there is a parent window that is not self', async () => {
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
         utils.respondToMessage(initMessage, FrameContexts.content);
         await initPromise;
+
         expect(GlobalVars.isFramelessWindow).toBeFalsy();
         expect(utils.mockWindow.onNativeMessage).toBeUndefined();
       });
+
       it('should be in framed mode when the parent window is self, and Communication.parentWindow should be set to opener', async () => {
         utils.mockWindow.opener = utils.mockWindow.parent;
         utils.mockWindow.parent = communication.Communication.currentWindow.self;
+
         const initPromise = communication.initializeCommunication(undefined);
         const initMessage = utils.findInitializeMessageOrThrow();
         utils.respondToMessageAsOpener(initMessage, FrameContexts.content);
         await initPromise;
+
         expect(GlobalVars.isFramelessWindow).toBeFalsy();
         expect(utils.mockWindow.onNativeMessage).toBeUndefined();
         expect(communication.Communication.parentWindow).toStrictEqual(utils.mockWindow.opener);
       });
+
       it('should be in frameless mode when the parent window is self and there is no opener, and Communication.parentWindow should be set to undefined', async () => {
         expect.assertions(3);
+
         utils.mockWindow.opener = undefined;
         utils.mockWindow.parent = communication.Communication.currentWindow.self;
+
         communication.initializeCommunication(undefined);
+
         expect(GlobalVars.isFramelessWindow).toBeTruthy();
         expect(utils.mockWindow.onNativeMessage).not.toBeUndefined();
         expect(communication.Communication.parentWindow).toBeUndefined();
@@ -249,6 +319,7 @@ describe('Testing communication', () => {
       communication.uninitializeCommunication();
       expect(communication.Communication.parentWindow).toBeNull();
     });
+
     it('should set Communication.parentOrigin to null', () => {
       app._initialize(utils.mockWindow);
       communication.Communication.parentOrigin = utils.mockWindow.parentOrigin;
@@ -256,6 +327,7 @@ describe('Testing communication', () => {
       communication.uninitializeCommunication();
       expect(communication.Communication.parentOrigin).toBeNull();
     });
+
     it('should set Communication.childWindow to null', () => {
       app._initialize(utils.mockWindow);
       communication.Communication.childWindow = utils.mockWindow;
@@ -263,6 +335,7 @@ describe('Testing communication', () => {
       communication.uninitializeCommunication();
       expect(communication.Communication.childWindow).toBeNull();
     });
+
     it('should set Communication.childOrigin to null', () => {
       app._initialize(utils.mockWindow);
       communication.Communication.childOrigin = utils.mockWindow.origin;
@@ -270,6 +343,7 @@ describe('Testing communication', () => {
       communication.uninitializeCommunication();
       expect(communication.Communication.childOrigin).toBeNull();
     });
+
     it('should empty the queue of messages for the current parent', () => {
       expect.assertions(1);
       communication.Communication.childWindow = utils.mockWindow;
@@ -278,6 +352,7 @@ describe('Testing communication', () => {
       // This function inserts a message into the parentMessageQueue
       communication.sendMessageEventToChild('testMessage');
       communication.uninitializeCommunication();
+
       communication.Communication.parentWindow = utils.mockWindow;
       communication.Communication.currentWindow = utils.mockWindow;
       communication.Communication.currentWindow.setInterval = (fn) => {
@@ -288,6 +363,7 @@ describe('Testing communication', () => {
         expect(true).toBeTruthy();
       });
     });
+
     it('should empty the queue of messages for the current child', () => {
       expect.assertions(1);
       communication.Communication.childWindow = utils.mockWindow;
@@ -296,6 +372,7 @@ describe('Testing communication', () => {
       // This function inserts a message into the parentMessageQueue
       communication.sendMessageEventToChild('testMessage');
       communication.uninitializeCommunication();
+
       communication.Communication.childWindow = utils.mockWindow;
       communication.Communication.currentWindow = utils.mockWindow;
       communication.Communication.currentWindow.setInterval = (fn) => {
@@ -306,6 +383,7 @@ describe('Testing communication', () => {
         expect(true).toBeTruthy();
       });
     });
+
     it('should reset messageIds to start at 0 again', () => {
       expect.assertions(2);
       app._initialize(utils.mockWindow);
@@ -315,54 +393,70 @@ describe('Testing communication', () => {
       communication.sendMessageToParent('testAction');
       communication.sendMessageToParent('testAction2');
       const message = utils.findMessageByFunc('testAction2');
+
       if (message) {
         expect(message.id).toBe(1);
       }
+
       communication.uninitializeCommunication();
       GlobalVars.isFramelessWindow = false;
       communication.Communication.parentWindow = utils.mockWindow.parent;
       communication.Communication.parentOrigin = utils.validOrigin;
       communication.sendMessageToParent('testAction3');
+
       const messageAfterUninitialize = utils.findMessageByFunc('testAction3');
       if (messageAfterUninitialize) {
         expect(messageAfterUninitialize.id).toBe(0);
       }
     });
+
     it('unresolved message callbacks should not be triggered after communication has been uninitialized', () => {
       app._initialize(utils.mockWindow);
       communication.initializeCommunication(undefined);
       let callbackWasCalled = false;
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       communication.sendMessageToParent('testAction', () => {
         callbackWasCalled = true;
       });
       const tempProcessMessage = utils.processMessage;
       communication.uninitializeCommunication();
       utils.processMessage = tempProcessMessage;
+
       utils.respondToMessage({ id: 1, func: 'testAction' }, false);
+
       expect(callbackWasCalled).toBeFalsy();
     });
+
     it('unresolved message promises should not be triggered after communication has been uninitialized', async () => {
       app._initialize(utils.mockWindow);
       communication.initializeCommunication(undefined);
+
       const messageParent = communication.sendMessageToParentAsync('testAction');
+
       const tempProcessMessage = utils.processMessage;
       communication.uninitializeCommunication();
       utils.processMessage = tempProcessMessage;
+
       utils.respondToMessage({ id: 1, func: 'testAction' }, false);
+
       messageParent.then(() => expect(false).toBeTruthy());
       expect(true).toBeTruthy();
     });
+
     it('the current window should not have a message listener on it after communication has been uninitialized', async () => {
       app._initialize(utils.mockWindow);
       utils.mockWindow.addEventListener('message', () => {
         // This listener should not be called during the unit test
         expect(true).toBeFalsy();
       });
+
       // eslint-disable-next-line strict-null-checks/all
       expect(utils.processMessage).not.toBeNull();
+
       communication.uninitializeCommunication();
+
       // eslint-disable-next-line strict-null-checks/all
       expect(utils.processMessage).toBeNull();
     });
@@ -381,7 +475,9 @@ describe('Testing communication', () => {
     });
     it('should send framelessPostMessage to window when running in a frameless window and Communication.currentWindow is set and has a nativeInterface', () => {
       GlobalVars.isFramelessWindow = true;
+
       communication.sendMessageToParentAsync(actionName);
+
       expect(utils.messages.length).toBe(1);
       expect(utils.messages[0].id).toBe(0);
       expect(utils.messages[0].func).toBe(actionName);
@@ -389,18 +485,23 @@ describe('Testing communication', () => {
     it('should receive response to framelessPostMessage when running in a frameless window and Communication.currentWindow is set and has a nativeInterface', async () => {
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
+
       const messagePromise = communication.sendMessageToParentAsync(actionName);
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       utils.respondToNativeMessage(sentMessage, false, []);
+
       return expect(messagePromise).resolves;
     });
     it('should never send message if there is no Communication.currentWindow when message is sent', () => {
       GlobalVars.isFramelessWindow = true;
       communication.Communication.currentWindow = undefined;
+
       communication.sendMessageToParentAsync(actionName);
+
       expect(utils.messages.length).toBe(0);
     });
     it('should still receive response to framelessPostMessage even if there is no Communication.currentWindow when message is sent', async () => {
@@ -409,8 +510,11 @@ describe('Testing communication', () => {
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
       communication.Communication.currentWindow = undefined;
+
       const messagePromise = communication.sendMessageToParentAsync(actionName);
+
       utils.respondToNativeMessage({ id: 1, func: actionName }, false, []);
+
       await messagePromise;
       const sentMessage = utils.findMessageByFunc(actionName);
       // eslint-disable-next-line strict-null-checks/all
@@ -419,7 +523,9 @@ describe('Testing communication', () => {
     it('should never send message if there is no nativeInterface on the currentWindow when message is sent', () => {
       GlobalVars.isFramelessWindow = true;
       communication.Communication.currentWindow.nativeInterface = undefined;
+
       communication.sendMessageToParentAsync(actionName);
+
       expect(utils.messages.length).toBe(0);
     });
     it('should receive response to framelessPostMessage even if there is no nativeInterface on the currentWindow when message is sent', async () => {
@@ -429,16 +535,21 @@ describe('Testing communication', () => {
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
       communication.Communication.currentWindow.nativeInterface = undefined;
+
       const messagePromise = communication.sendMessageToParentAsync(actionName);
+
       utils.respondToNativeMessage({ id: 1, func: actionName }, false, []);
+
       messagePromise.then(() => {
         expect(true).toBeTruthy();
       });
     });
     it('args passed in should be sent with the framelessPostMessage', () => {
       GlobalVars.isFramelessWindow = true;
+
       const arg1 = 'testArg1';
       communication.sendMessageToParentAsync(actionName, [arg1]);
+
       expect(utils.messages.length).toBe(1);
       if (utils.messages[0].args === undefined) {
         throw new Error('args expected on message');
@@ -450,7 +561,9 @@ describe('Testing communication', () => {
       GlobalVars.isFramelessWindow = false;
       communication.Communication.parentWindow = utils.mockWindow.parent;
       communication.Communication.parentOrigin = utils.validOrigin;
+
       communication.sendMessageToParentAsync(actionName);
+
       expect(utils.messages.length).toBe(1);
       expect(utils.messages[0].id).toBe(0);
       expect(utils.messages[0].func).toBe(actionName);
@@ -459,24 +572,30 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const messagePromise = communication.sendMessageToParentAsync(actionName);
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       utils.respondToMessage(sentMessage, false, []);
+
       return expect(messagePromise).resolves;
     });
     it('args passed in should be sent with the postMessage', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const arg1 = 'testArg1';
       communication.sendMessageToParentAsync(actionName, [arg1]);
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
+
       if (sentMessage.args === undefined) {
         throw new Error('args expected on message');
       }
@@ -486,12 +605,16 @@ describe('Testing communication', () => {
     it('should not send postMessage until after initialization response received', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
+
       communication.sendMessageToParentAsync(actionName);
+
       let sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage !== null) {
         throw new Error('Should not find a sent message until after the initialization response was received');
       }
+
       utils.respondToMessage(initializeMessage);
+
       sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('Did not find any message even after initialization response was received');
@@ -513,7 +636,9 @@ describe('Testing communication', () => {
     it('should send framelessPostMessage to window when running in a frameless window and Communication.currentWindow is set and has a nativeInterface', () => {
       expect.assertions(5);
       GlobalVars.isFramelessWindow = true;
+
       communication.sendMessageToParent(actionName, ['zero', 'one']);
+
       expect(utils.messages.length).toBe(1);
       expect(utils.messages[0].id).toBe(0);
       expect(utils.messages[0].func).toBe(actionName);
@@ -524,12 +649,15 @@ describe('Testing communication', () => {
     });
     it('should receive response via callback when sending framelessPostMessage to window when running in a frameless window and Communication.currentWindow is set and has a nativeInterface', () => {
       expect.assertions(1);
+
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
+
       communication.sendMessageToParent(actionName, () => {
         expect(true).toBeTruthy();
       });
       const sentMessage = utils.findMessageByFunc(actionName);
+
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
@@ -538,7 +666,9 @@ describe('Testing communication', () => {
     it('should never send message if there is no Communication.currentWindow when message is sent', () => {
       GlobalVars.isFramelessWindow = true;
       communication.Communication.currentWindow = undefined;
+
       communication.sendMessageToParent(actionName);
+
       expect(utils.messages.length).toBe(0);
     });
     it('should still receive response to framelessPostMessage even if there is no Communication.currentWindow when message is sent', async () => {
@@ -548,10 +678,13 @@ describe('Testing communication', () => {
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
       communication.Communication.currentWindow = undefined;
+
       communication.sendMessageToParent(actionName, () => {
         expect(true).toBeTruthy();
       });
+
       utils.respondToNativeMessage({ id: 1, func: actionName }, false, []);
+
       const sentMessage = utils.findMessageByFunc(actionName);
       // eslint-disable-next-line strict-null-checks/all
       expect(sentMessage).toBeDefined();
@@ -559,7 +692,9 @@ describe('Testing communication', () => {
     it('should never send message if there is no nativeInterface on the currentWindow when message is sent', () => {
       GlobalVars.isFramelessWindow = true;
       communication.Communication.currentWindow.nativeInterface = undefined;
+
       communication.sendMessageToParent(actionName);
+
       expect(utils.messages.length).toBe(0);
     });
     it('should receive response to framelessPostMessage even if there is no nativeInterface on the currentWindow when message is sent', async () => {
@@ -569,14 +704,18 @@ describe('Testing communication', () => {
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
       communication.Communication.currentWindow.nativeInterface = undefined;
+
       communication.sendMessageToParent(actionName, () => expect(true).toBeTruthy());
+
       utils.respondToNativeMessage({ id: 1, func: actionName }, false, []);
     });
     it('should send a message to window when running in a framed window and Communication.parentWindow and Communication.parentOrigin are set', () => {
       GlobalVars.isFramelessWindow = false;
       communication.Communication.parentWindow = utils.mockWindow.parent;
       communication.Communication.parentOrigin = utils.validOrigin;
+
       communication.sendMessageToParent(actionName);
+
       expect(utils.messages.length).toBe(1);
       expect(utils.messages[0].id).toBe(0);
       expect(utils.messages[0].func).toBe(actionName);
@@ -586,7 +725,9 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       communication.sendMessageToParent(actionName, () => expect(true).toBeTruthy());
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
@@ -597,12 +738,15 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const arg1 = 'testArg1';
       communication.sendMessageToParent(actionName, [arg1]);
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
+
       if (sentMessage.args === undefined) {
         throw new Error('args expected on message');
       }
@@ -612,12 +756,16 @@ describe('Testing communication', () => {
     it('should not send postMessage until after initialization response received', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
+
       communication.sendMessageToParent(actionName);
+
       let sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage !== null) {
         throw new Error('Should not find a sent message until after the initialization response was received');
       }
+
       utils.respondToMessage(initializeMessage);
+
       sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('Did not find any message even after initialization response was received');
@@ -642,20 +790,26 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const messagePromise = communication.sendAndUnwrap(actionName);
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       utils.respondToMessage(sentMessage, actionName);
+
       const response = await messagePromise;
       expect(response).toBe(actionName);
+
       const messagePromise2 = communication.sendMessageToParentAsync(actionName2);
+
       const sentMessage2 = utils.findMessageByFunc(actionName2);
       if (sentMessage2 === null) {
         throw new Error('No sent message was found');
       }
       utils.respondToMessage(sentMessage2, actionName2);
+
       const response2 = await messagePromise2;
       expect(response2).toStrictEqual([actionName2]);
     });
@@ -677,34 +831,43 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const messagePromise = communication.sendAndHandleStatusAndReason(actionName);
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       const errorMessage = 'this message should show up in the error';
       utils.respondToMessage(sentMessage, false, errorMessage);
+
       await expect(messagePromise).rejects.toThrowError(errorMessage);
     });
+
     it('should not throw an error if first returned value from host is true', async () => {
       expect.assertions(1);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const messagePromise = communication.sendAndHandleStatusAndReason(actionName);
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       const errorMessage = 'this message should show up in the error';
       utils.respondToMessage(sentMessage, true, errorMessage);
+
       await expect(messagePromise).resolves.toBeUndefined();
     });
+
     it('should pass all args to host', async () => {
       expect.assertions(3);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       communication.sendAndHandleStatusAndReason(actionName, 'arg1', 'arg2', 'arg3');
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage?.args) {
@@ -731,34 +894,41 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const defaultErrorMessage = 'This is the default error message';
       const messagePromise = communication.sendAndHandleStatusAndReasonWithDefaultError(
         actionName,
         defaultErrorMessage,
       );
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       const errorMessage = 'this message should show up in the error';
       utils.respondToMessage(sentMessage, false, errorMessage);
+
       await expect(messagePromise).rejects.toThrowError(errorMessage);
     });
+
     it('should throw the default error passed in to the function if first returned value from host is false and host does not provide a custom error', async () => {
       expect.assertions(1);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const defaultErrorMessage = 'This is the default error message';
       const messagePromise = communication.sendAndHandleStatusAndReasonWithDefaultError(
         actionName,
         defaultErrorMessage,
       );
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       utils.respondToMessage(sentMessage, false);
+
       await expect(messagePromise).rejects.toThrowError(defaultErrorMessage);
     });
     it('should not throw an error if first returned value from host is true', async () => {
@@ -766,20 +936,25 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const messagePromise = communication.sendAndHandleStatusAndReasonWithDefaultError(actionName, 'default error');
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       const errorMessage = 'this message should show up in the error';
       utils.respondToMessage(sentMessage, true, errorMessage);
+
       await expect(messagePromise).resolves.toBeUndefined();
     });
+
     it('should pass all args to host', async () => {
       expect.assertions(3);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       communication.sendAndHandleStatusAndReasonWithDefaultError(actionName, 'default error', 'arg1', 'arg2', 'arg3');
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage?.args) {
@@ -789,6 +964,7 @@ describe('Testing communication', () => {
       }
     });
   });
+
   describe('sendAndHandleSdkError', () => {
     let utils: Utils = new Utils();
     const actionName = 'test';
@@ -806,62 +982,82 @@ describe('Testing communication', () => {
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const messagePromise = communication.sendAndHandleSdkError(actionName);
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
       const sdkError = { errorCode: 1, message: 'SdkError Message' };
       utils.respondToMessage(sentMessage, sdkError, 'result value');
+
       await messagePromise.catch((e) => expect(e).toStrictEqual(sdkError));
     });
+
     it('should throw true if first value returned from host is true', async () => {
       // this is a bug that should be fixed
       expect.assertions(1);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const messagePromise = communication.sendAndHandleSdkError(actionName);
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
+
       utils.respondToMessage(sentMessage, true, 'result value');
+
       await messagePromise.catch((e) => expect(e).toStrictEqual(true));
     });
+
     it('should return the second parameter returned from the host if undefined is returned from the host as the first parameter', async () => {
       expect.assertions(1);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const messagePromise = communication.sendAndHandleSdkError(actionName);
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
+
       // eslint-disable-next-line strict-null-checks/all
       utils.respondToMessage(sentMessage, undefined, 'result value');
+
       await messagePromise.then((value) => expect(value).toBe('result value'));
     });
+
     it('should return the second parameter returned from the host if false is returned from the host as the first parameter', async () => {
       // this is a bug that should be fixed
       expect.assertions(1);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       const messagePromise = communication.sendAndHandleSdkError(actionName);
+
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
         throw new Error('No sent message was found');
       }
+
       utils.respondToMessage(sentMessage, false, 'result value');
+
       await messagePromise.then((value) => expect(value).toBe('result value'));
     });
+
     it('should pass all args to host', async () => {
       expect.assertions(3);
       communication.initializeCommunication(undefined);
       const initializeMessage = utils.findInitializeMessageOrThrow();
       utils.respondToMessage(initializeMessage);
+
       communication.sendAndHandleSdkError(actionName, 'arg1', 'arg2', 'arg3');
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage?.args) {
@@ -890,6 +1086,7 @@ describe('Testing communication', () => {
       communication.Communication.currentWindow.setInterval = (fn) => {
         fn();
       };
+
       // This function inserts a message into the parentMessageQueue
       communication.sendMessageEventToChild('testMessage');
       communication.waitForMessageQueue(communication.Communication.parentWindow, () => {
@@ -905,6 +1102,7 @@ describe('Testing communication', () => {
       communication.Communication.currentWindow.setInterval = (fn) => {
         fn();
       };
+
       communication.waitForMessageQueue(communication.Communication.parentWindow, () => {
         // this callback only ever fires if the message queue associated with the passed in window is empty
         expect(true).toBeTruthy();
@@ -917,6 +1115,7 @@ describe('Testing communication', () => {
     it('should throw if Communication.currentWindow is undefined', () => {
       expect.assertions(1);
       communication.Communication.currentWindow = undefined;
+
       expect(() => {
         communication.waitForMessageQueue(communication.Communication.parentWindow, () => {
           expect(false).toBeTruthy();
@@ -927,6 +1126,7 @@ describe('Testing communication', () => {
       expect.assertions(1);
       communication.Communication.currentWindow = utils.mockWindow;
       communication.Communication.currentWindow.setInterval = undefined;
+
       expect(() => {
         communication.waitForMessageQueue(communication.Communication.parentWindow, () => {
           expect(false).toBeTruthy();
@@ -955,6 +1155,7 @@ describe('Testing communication', () => {
       }
       expect(utils.childMessages[0].args[0]).toBe('arg zero');
     });
+
     it('should add message to childWindow message queue if Communication.childOrigin is not set', () => {
       expect.assertions(1);
       communication.Communication.childWindow = utils.childWindow;
@@ -970,6 +1171,7 @@ describe('Testing communication', () => {
         expect(true).toBeFalsy();
       });
     });
+
     it('should add message to childWindow message queue if Communication.childWindow is not set', () => {
       expect.assertions(1);
       communication.Communication.childOrigin = utils.validOrigin;

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -519,16 +519,21 @@ describe('Testing communication', () => {
 
       expect(utils.messages.length).toBe(0);
     });
-    it('should never receive response to framelessPostMessage if there is no Communication.currentWindow when message is sent', async () => {
+    it('should still receive response to framelessPostMessage even if there is no Communication.currentWindow when message is sent', async () => {
+      // This should probably be fixed, but if the host passes back a response with the right message id we will still notify the caller
+      // even if they never actually sent their message to the host
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
       communication.Communication.currentWindow = undefined;
 
       const messagePromise = communication.sendMessageToParentAsync(actionName);
 
-      utils.respondToNativeMessage({ id: 0, func: actionName }, false, []);
+      utils.respondToNativeMessage({ id: 1, func: actionName }, false, []);
 
-      messagePromise.then(() => expect(true).toBeFalsy());
+      await messagePromise;
+      const sentMessage = utils.findMessageByFunc(actionName);
+      // eslint-disable-next-line strict-null-checks/all
+      expect(sentMessage).toBeDefined();
     });
     it('should never send message if there is no nativeInterface on the currentWindow when message is sent', () => {
       GlobalVars.isFramelessWindow = true;
@@ -538,16 +543,21 @@ describe('Testing communication', () => {
 
       expect(utils.messages.length).toBe(0);
     });
-    it('should never receive response to framelessPostMessage if there is no nativeInterface on the currentWindow when message is sent', async () => {
+    it('should receive response to framelessPostMessage even if there is no nativeInterface on the currentWindow when message is sent', async () => {
+      // This should probably be fixed, but if the host passes back a response with the right message id we will still notify the caller
+      // even if they never actually sent their message to the host
+      expect.assertions(1);
       utils.mockWindow.parent = undefined;
       communication.initializeCommunication(undefined);
       communication.Communication.currentWindow.nativeInterface = undefined;
 
       const messagePromise = communication.sendMessageToParentAsync(actionName);
 
-      utils.respondToNativeMessage({ id: 0, func: actionName }, false, []);
+      utils.respondToNativeMessage({ id: 1, func: actionName }, false, []);
 
-      messagePromise.then(() => expect(true).toBeFalsy());
+      messagePromise.then(() => {
+        expect(true).toBeFalsy();
+      });
     });
     it('args passed in should be sent with the framelessPostMessage', () => {
       GlobalVars.isFramelessWindow = true;
@@ -612,6 +622,157 @@ describe('Testing communication', () => {
       const initializeMessage = utils.findInitializeMessageOrThrow();
 
       communication.sendMessageToParentAsync(actionName);
+
+      let sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage !== null) {
+        throw new Error('Should not find a sent message until after the initialization response was received');
+      }
+
+      utils.respondToMessage(initializeMessage);
+
+      sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage === null) {
+        throw new Error('Did not find any message even after initialization response was received');
+      }
+    });
+  });
+  describe('sendMessageToParent', () => {
+    let utils: Utils = new Utils();
+    const actionName = 'test';
+    beforeEach(() => {
+      utils = new Utils();
+      communication.uninitializeCommunication();
+      app._initialize(utils.mockWindow);
+    });
+    afterAll(() => {
+      communication.Communication.currentWindow = utils.mockWindow;
+      communication.uninitializeCommunication();
+    });
+    it('should send framelessPostMessage to window when running in a frameless window and Communication.currentWindow is set and has a nativeInterface', () => {
+      expect.assertions(5);
+      GlobalVars.isFramelessWindow = true;
+
+      communication.sendMessageToParent(actionName, ['zero', 'one']);
+
+      expect(utils.messages.length).toBe(1);
+      expect(utils.messages[0].id).toBe(0);
+      expect(utils.messages[0].func).toBe(actionName);
+      if (utils.messages[0].args) {
+        expect(utils.messages[0].args[0]).toBe('zero');
+        expect(utils.messages[0].args[1]).toBe('one');
+      }
+    });
+    it('should receive response via callback when sending framelessPostMessage to window when running in a frameless window and Communication.currentWindow is set and has a nativeInterface', () => {
+      expect.assertions(1);
+
+      utils.mockWindow.parent = undefined;
+      communication.initializeCommunication(undefined);
+
+      communication.sendMessageToParent(actionName, () => {
+        expect(true).toBeTruthy();
+      });
+      const sentMessage = utils.findMessageByFunc(actionName);
+
+      if (sentMessage === null) {
+        throw new Error('No sent message was found');
+      }
+      utils.respondToNativeMessage(sentMessage, false, []);
+    });
+    it('should never send message if there is no Communication.currentWindow when message is sent', () => {
+      GlobalVars.isFramelessWindow = true;
+      communication.Communication.currentWindow = undefined;
+
+      communication.sendMessageToParent(actionName);
+
+      expect(utils.messages.length).toBe(0);
+    });
+    it('should still receive response to framelessPostMessage even if there is no Communication.currentWindow when message is sent', async () => {
+      // This should probably be fixed, but if the host passes back a response with the right message id we will still notify the caller
+      // even if they never actually sent their message to the host
+      expect.assertions(2);
+      utils.mockWindow.parent = undefined;
+      communication.initializeCommunication(undefined);
+      communication.Communication.currentWindow = undefined;
+
+      communication.sendMessageToParent(actionName, () => {
+        expect(true).toBeTruthy();
+      });
+
+      utils.respondToNativeMessage({ id: 1, func: actionName }, false, []);
+
+      const sentMessage = utils.findMessageByFunc(actionName);
+      // eslint-disable-next-line strict-null-checks/all
+      expect(sentMessage).toBeDefined();
+    });
+    it('should never send message if there is no nativeInterface on the currentWindow when message is sent', () => {
+      GlobalVars.isFramelessWindow = true;
+      communication.Communication.currentWindow.nativeInterface = undefined;
+
+      communication.sendMessageToParent(actionName);
+
+      expect(utils.messages.length).toBe(0);
+    });
+    it('should receive response to framelessPostMessage even if there is no nativeInterface on the currentWindow when message is sent', async () => {
+      // This should probably be fixed, but if the host passes back a response with the right message id we will still notify the caller
+      // even if they never actually sent their message to the host
+      expect.assertions(1);
+      utils.mockWindow.parent = undefined;
+      communication.initializeCommunication(undefined);
+      communication.Communication.currentWindow.nativeInterface = undefined;
+
+      communication.sendMessageToParent(actionName, () => expect(true).toBeTruthy());
+
+      utils.respondToNativeMessage({ id: 1, func: actionName }, false, []);
+    });
+    it('should send a message to window when running in a framed window and Communication.parentWindow and Communication.parentOrigin are set', () => {
+      GlobalVars.isFramelessWindow = false;
+      communication.Communication.parentWindow = utils.mockWindow.parent;
+      communication.Communication.parentOrigin = utils.validOrigin;
+
+      communication.sendMessageToParent(actionName);
+
+      expect(utils.messages.length).toBe(1);
+      expect(utils.messages[0].id).toBe(0);
+      expect(utils.messages[0].func).toBe(actionName);
+    });
+    it('should receive response to postMessage when running in a framed window and Communication.currentWindow has a parent with an origin', async () => {
+      expect.assertions(1);
+      communication.initializeCommunication(undefined);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      utils.respondToMessage(initializeMessage);
+
+      communication.sendMessageToParent(actionName, () => expect(true).toBeTruthy());
+
+      const sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage === null) {
+        throw new Error('No sent message was found');
+      }
+      utils.respondToMessage(sentMessage, false, []);
+    });
+    it('args passed in should be sent with the postMessage', () => {
+      communication.initializeCommunication(undefined);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      utils.respondToMessage(initializeMessage);
+
+      const arg1 = 'testArg1';
+      communication.sendMessageToParent(actionName, [arg1]);
+
+      const sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage === null) {
+        throw new Error('No sent message was found');
+      }
+
+      if (sentMessage.args === undefined) {
+        throw new Error('args expected on message');
+      }
+      expect(sentMessage.args.length).toBe(1);
+      expect(sentMessage.args[0]).toBe(arg1);
+    });
+    it('should not send postMessage until after initialization response received', () => {
+      communication.initializeCommunication(undefined);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+
+      communication.sendMessageToParent(actionName);
 
       let sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage !== null) {


### PR DESCRIPTION
## Description

Finished writing unit tests for all exported functions in communication.ts

### Main changes in the PR:

1. Stopped exporting processMessage and shouldProcessMessage from communication: they were only being called by the test files
2. Added unit tests for `sendMessageToParent`, `sendAndUnwrap`, `sendAndHandleStatusAndReason`, `sendAndHandleStatusAndReasonWithDefaultError`, `sendAndHandleSdkError`, `waitForMessageQueue`, and `sendMessageEventToChild`.

## Validation

### Validation performed:

1. Ran all unit tests.

### Unit Tests added:

Yes

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes