### PR TITLE
Update some dialog related documentation links

### DIFF
--- a/change/@microsoft-teams-js-427db183-7770-469e-bb2e-b9b7803b56ce.json
+++ b/change/@microsoft-teams-js-427db183-7770-469e-bb2e-b9b7803b56ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated `dialog` and `tasks` documentation to add and fix doc links",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -811,7 +811,7 @@ export interface UrlDialogInfo extends BaseDialogInfo {
    *
    * @remarks
    * The domain of the url must match at least one of the
-   * valid domains specified in the validDomains block of the manifest
+   * valid domains specified in the [validDomains block](https://learn.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema#validdomains) of the app manifest
    */
   url: string;
 

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -71,7 +71,7 @@ export namespace tasks {
 
   /**
    * @deprecated
-   * As of 2.0.0, please use {@link dialog.submit} instead.
+   * As of 2.0.0, please use {@link dialog.url.submit} instead.
    *
    * Submit the task module.
    *


### PR DESCRIPTION
## Description

The reference documentation for the [url property](https://learn.microsoft.com/en-us/javascript/api/@microsoft/teams-js/urldialoginfo?view=msteams-client-js-latest#@microsoft-teams-js-urldialoginfo-url) used when opening a dialog mentioned the `validDomains` property in the manifest but did not link to the documentation for it. As a convenience, I've added that link.

As part of generating documentation for this change, I coincidentally found that the documentation generator was showing this error:
```
Warning:
[MarkedLinksPlugin]: Found invalid symbol reference(s) in JSDocs, they will not render as links in the generated documentation.
  In tasks: {@link dialog.submit}
```
To address this, I also updated the documentation link for the `tasks.submitTask` method to refer to the correct non-deprecated method.

### Screenshots:

<img width="611" alt="image" src="https://user-images.githubusercontent.com/36546967/214149471-754b9c0d-b830-4a8c-9d33-55a1b96a8c2c.png">

<img width="619" alt="image" src="https://user-images.githubusercontent.com/36546967/214149537-7d1f176c-2ebb-4e8e-812f-6854efbb8f62.png">
