### PR TITLE
Treat Typedoc warnings as errors

### DIFF
--- a/change/@microsoft-teams-js-c1a77265-c9b2-400a-93e8-54e461fcc1fb.json
+++ b/change/@microsoft-teams-js-c1a77265-c9b2-400a-93e8-54e461fcc1fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated typedoc configuration to treat warnings as errors",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/typedoc.json
+++ b/packages/teams-js/typedoc.json
@@ -2,6 +2,7 @@
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["./src/index.ts"],
   "out": "docs",
+  "treatWarningsAsErrors": true,
   "validation": {
     "notExported": true,
     "invalidLink": true,


### PR DESCRIPTION
## Description

While making a code change for a recent PR (#1551) I discovered that there was a documentation error in the code (that I didn't cause with my change). To prevent this from happening again, this change updates the documentation generation code to treat warnings as errors and fail the step.

*Before*
```
yarn run v1.22.15
$ yarn workspace @microsoft/teams-js docs
$ yarn typedoc
$ D:\repos\tjsfork\node_modules\.bin\typedoc
Warning:
[MarkedLinksPlugin]: Found invalid symbol reference(s) in JSDocs, they will not render as links in the generated documentation.
  In tasks: {@link dialog.submit}
Info: Documentation generated at ./docs
Done in 11.87s.
```

*After*
```
yarn run v1.22.15
$ yarn workspace @microsoft/teams-js docs
$ yarn typedoc
$ D:\repos\tjsfork\node_modules\.bin\typedoc
Warning:
[MarkedLinksPlugin]: Found invalid symbol reference(s) in JSDocs, they will not render as links in the generated documentation.
  In tasks: {@link dialog.submit}
Info: Documentation generated at ./docs
error Command failed with exit code 5.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 5.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 5
Command: D:\Program Files\nodejs\node.exe
Arguments: C:\Users\name\.node\corepack\yarn\1.22.15\lib\cli.js docs
Directory: D:\repos\tjsfork\packages\teams-js
Output:

info Visit https://yarnpkg.com/en/docs/cli/workspace for documentation about this command.
error Command failed with exit code 5.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
