### PR TITLE
Enable typedoc warnings and errors to fail the build

### DIFF
--- a/change/@microsoft-teams-js-7bd9ac03-29ae-40f5-93ce-f96b2aa8cccc.json
+++ b/change/@microsoft-teams-js-7bd9ac03-29ae-40f5-93ce-f96b2aa8cccc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed --emit:none from typedoc command so it would actually output errors",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -14,7 +14,7 @@
     "build": "yarn lint && webpack && yarn docs:validate",
     "clean": "rimraf ./dist",
     "docs": "yarn typedoc",
-    "docs:validate": "yarn typedoc --treatWarningsAsErrors --emit none",
+    "docs:validate": "yarn typedoc --treatWarningsAsErrors",
     "lint": "yarn eslint ./src ./test --max-warnings 0 --fix --ext .ts",
     "prettier": "prettier --write '**/*.{ts,js,css,html}'",
     "test": "jest"


### PR DESCRIPTION
## Description

As part of the build, typedoc was being run with the `--emit:none` parameter. This is supposed to run documentation validation but just not output any documentation. Despite this being the documented typedoc behavior, having `--emit:none` as a parameter was causing typedoc errors to be suppressed. Once `--emit:none` was removed, the errors show up again (and correctly fail the build).

For now, to ensure that errors do fail the build, I'm just removing the `--emit:none` parameter. Someone suggested earlier that this is just a bug in the old version of typedoc we are using and if I just upgraded then the behavior of `--emit:none` would be correct. I tried upgrading typedoc but it requires a newer version of typescript, and upgrading typescript is non-trivial. As such, I'm just removing `--emit:none` for now (so we get errors) and will follow-up by trying to upgrade typedoc and its dependencies in a subsequent change.

## Validation

### Validation performed:

- Ensured that documentation warnings/errors fail the build
- Ensured that the build passes when there are no documentation errors
- Ensured that all automated tests continue to pass.