### PR TITLE
Update Typescript to 4.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "ts-loader": "^9.2.5",
     "ts-node": "^10.2.1",
     "typedoc": "^0.22.17",
-    "typescript": "^4.1.2",
+    "typescript": "4.6.2",
     "webpack": "^5.10.0",
     "webpack-assets-manifest": "^5.0.6",
     "webpack-bundle-analyzer": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "ts-loader": "^9.2.5",
     "ts-node": "^10.2.1",
     "typedoc": "^0.22.17",
-    "typescript": "4.6.2",
+    "typescript": "4.6.4",
     "webpack": "^5.10.0",
     "webpack-assets-manifest": "^5.0.6",
     "webpack-bundle-analyzer": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12485,10 +12485,10 @@ typedoc@^0.22.17:
     minimatch "^5.1.0"
     shiki "^0.10.1"
 
-typescript@^4.1.2:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+typescript@4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
 uglify-js@^3.1.4:
   version "3.14.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12485,10 +12485,10 @@ typedoc@^0.22.17:
     minimatch "^5.1.0"
     shiki "^0.10.1"
 
-typescript@4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
-  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+typescript@4.6.4:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 uglify-js@^3.1.4:
   version "3.14.2"


### PR DESCRIPTION
## Description

The version of Typescript used by this repo is very old. I tried updating it to the latest version but it causes some build errors that are non-trivial to investigate. For now, I'm upgrading it as far as I can, to 4.6.4. Going to the next version (4.7.2) is where the errors start appearing.

Fortunately 4.6.2 is far enough along where I can update typedoc to the latest version in a subsequent PR and see if it fixes the `--emit:none` problem described in #1555 

## Validation

### Validation performed:

Ensure builds succeed and tests pass.