### PR TITLE
Remove node 12 from the matrix we use for pipeline builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
## Description

@shrshindeMSFT is in the process of retiring node 12 from this repo. The typedoc updates I'm trying to make in #1558 don't work with node 12. As such, I'm removing the node 12 build step and requirement from the repo to unblock #1558.

### Main changes in the PR:

Remove node 12 from the matrix of node versions that builds are run against.

## Validation

### Validation performed:

Ensure builds succeed and tests pass.