### PR TITLE
Add possible values to documentation for licenseType property on UserInfo interface

### DIFF
--- a/change/@microsoft-teams-js-5ffb59b5-7122-4ab8-912f-7fdd2e7d62c7.json
+++ b/change/@microsoft-teams-js-5ffb59b5-7122-4ab8-912f-7fdd2e7d62c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added possible values to documentation for `licenseType` property on `UserInfo` interface",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -367,7 +367,8 @@ export namespace app {
     isPSTNCallingAllowed?: boolean;
 
     /**
-     * The license type for the current user.
+     * The license type for the current user. Possible values are:
+     * "Unknown", "Teacher", "Student", "Free", "SmbBusinessVoice", "SmbNonVoice", "FrontlineWorker"
      */
     licenseType?: string;
 


### PR DESCRIPTION
## Description

The `licenseType` property on the `UserInfo` interface said it was a string but did not provide possible values. I have added those possible values in this change.

## Validation

### Validation performed:

Ensured builds and tests pass.

### Unit Tests added:

No because there are no unit tests which validate correctness of documentation content.
