### PR TITLE
Updated documentation links to avoid using locale in URLs and use markdown format for external links

### DIFF
--- a/change/@microsoft-teams-js-99eca3fb-24d8-4c34-95d3-d83b96469721.json
+++ b/change/@microsoft-teams-js-99eca3fb-24d8-4c34-95d3-d83b96469721.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Update documentation links to not use locale",
+  "comment": "Updated documentation links to avoid using locale in URLs and use markdown format for external links",
   "packageName": "@microsoft/teams-js",
   "email": "36546967+AE-MS@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-99eca3fb-24d8-4c34-95d3-d83b96469721.json
+++ b/change/@microsoft-teams-js-99eca3fb-24d8-4c34-95d3-d83b96469721.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update documentation links to not use locale",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -486,7 +486,7 @@ export namespace app {
     meeting?: MeetingInfo;
 
     /**
-     * When hosted in SharePoint, this is the [SharePoint PageContext](https://learn.microsoft.com/en-us/javascript/api/sp-page-context/pagecontext?view=sp-typescript-latest), else `undefined`
+     * When hosted in SharePoint, this is the [SharePoint PageContext](https://learn.microsoft.com/javascript/api/sp-page-context/pagecontext?view=sp-typescript-latest), else `undefined`
      */
     sharepoint?: any;
 

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -811,7 +811,7 @@ export interface UrlDialogInfo extends BaseDialogInfo {
    *
    * @remarks
    * The domain of the url must match at least one of the
-   * valid domains specified in the [validDomains block](https://learn.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema#validdomains) of the app manifest
+   * valid domains specified in the [validDomains block](https://learn.microsoft.com/microsoftteams/platform/resources/schema/manifest-schema#validdomains) of the app manifest
    */
   url: string;
 

--- a/packages/teams-js/src/public/sharing.ts
+++ b/packages/teams-js/src/public/sharing.ts
@@ -7,7 +7,7 @@ import { runtime } from './runtime';
 
 /**
  * Namespace to open a share dialog for web content.
- * For more info, see {@link https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/share-to-teams-from-personal-app-or-tab Share to Teams from personal app or tab}
+ * For more info, see [Share to Teams from personal app or tab](https://learn.microsoft.com/microsoftteams/platform/concepts/build-and-test/share-to-teams-from-personal-app-or-tab)
  */
 export namespace sharing {
   export const SharingAPIMessages = {


### PR DESCRIPTION
## Description

External links to other documentation pages (i.e., documentation that is not within this teams-js library) should avoid using the locale in their URLs. The Microsoft documentation site will automatically redirect to the correct locale for the user.

Also, per [the typedoc documentation](https://typedoc.org/tags/link/#:~:text=%7B%40link%7D%201%20TSDoc%20Compatibility%20TypeDoc%20implements%20the%20beta,other%20links.%203%20See%20Also%20The%20%40template%20tag), external links should use markdown and not the `@link` tag. I fixed the one instance of this.

## Validation

### Validation performed:

1. Built the documentation locally and tested each of the three updated URLs to ensure they worked and navigated to the correct place.
2. Ensured builds and tests passed
