### PR TITLE
Released v2.8.0 (#1566)

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.7.1/js/MicrosoftTeams.min.js"
-      integrity="sha384-4Gy2G+qxzDVdrdemcVqKVQvaSK1Ghg3x6xcsaMLPc/pw7KPtiogHGM97LTWF2PWg"
+      src="https://res.cdn.office.net/teams-js/2.8.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-/DJ9oJEFZSpGiUQx9Na5Yb5svOPPqSb3khKxJ/YgoZ2GtrkzWgSTBpESy3LvMPVk"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "scripts": {
     "build": "yarn build:bundle",
     "build:bundle": "yarn lint && webpack",

--- a/change/@microsoft-teams-js-042f478a-ce62-4e29-8ae5-d7918506bb95.json
+++ b/change/@microsoft-teams-js-042f478a-ce62-4e29-8ae5-d7918506bb95.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Stopped exporting `communication.processMessage` and `communication.shouldProcessMessage`.",
-  "packageName": "@microsoft/teams-js",
-  "email": "trharris@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-0b1c5f33-af90-49a2-a637-7c12271f5dd3.json
+++ b/change/@microsoft-teams-js-0b1c5f33-af90-49a2-a637-7c12271f5dd3.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added adaptive card subcapability to `dialog` capability",
-  "packageName": "@microsoft/teams-js",
-  "email": "98348000+shrshindeMSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-1a92789b-0878-4870-a138-44c71320bae2.json
+++ b/change/@microsoft-teams-js-1a92789b-0878-4870-a138-44c71320bae2.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Added `@hidden` and `@internal` tags for the meeting `requestAppAudioHandling` and `updateMicState` APIs, and improved how the `teams-test-app` app uses the APIs",
-  "packageName": "@microsoft/teams-js",
-  "email": "tnakagawa@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-2210d153-a06d-4432-9da4-5a47febbc045.json
+++ b/change/@microsoft-teams-js-2210d153-a06d-4432-9da4-5a47febbc045.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Fixed a bug where `getContext()` was incorrectly dropping properties by performing a lossy conversion via `app.getContext()`",
-  "packageName": "@microsoft/teams-js",
-  "email": "magli@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-33245b64-d379-4af7-893d-ade24f7988a3.json
+++ b/change/@microsoft-teams-js-33245b64-d379-4af7-893d-ade24f7988a3.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Added remarks to authentication.authenticate() code comments",
-  "packageName": "@microsoft/teams-js",
-  "email": "joshuapa@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-427db183-7770-469e-bb2e-b9b7803b56ce.json
+++ b/change/@microsoft-teams-js-427db183-7770-469e-bb2e-b9b7803b56ce.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Updated `dialog` and `tasks` documentation to add and fix doc links",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-5ffb59b5-7122-4ab8-912f-7fdd2e7d62c7.json
+++ b/change/@microsoft-teams-js-5ffb59b5-7122-4ab8-912f-7fdd2e7d62c7.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Added possible values to documentation for `licenseType` property on `UserInfo` interface",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-6c8134e5-38ad-43ff-806d-fa6be94a2807.json
+++ b/change/@microsoft-teams-js-6c8134e5-38ad-43ff-806d-fa6be94a2807.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Added unit tests for `communication.initializeCommunication`",
-  "packageName": "@microsoft/teams-js",
-  "email": "trharris@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-6ffe0681-75ea-4146-bdbd-31fd134ce89a.json
+++ b/change/@microsoft-teams-js-6ffe0681-75ea-4146-bdbd-31fd134ce89a.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Added unit tests for `communication.uninitializeCommunication`, `communication.sendAndUnwrap`, and `communication.sendMessageToParentAsync` and updated `communication.uninitializeCommunication` to handle `currentWindow` correctly.",
-  "packageName": "@microsoft/teams-js",
-  "email": "trharris@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-7bd9ac03-29ae-40f5-93ce-f96b2aa8cccc.json
+++ b/change/@microsoft-teams-js-7bd9ac03-29ae-40f5-93ce-f96b2aa8cccc.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Removed --emit:none from typedoc command so it would actually output errors",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-99eca3fb-24d8-4c34-95d3-d83b96469721.json
+++ b/change/@microsoft-teams-js-99eca3fb-24d8-4c34-95d3-d83b96469721.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Updated documentation links to avoid using locale in URLs and use markdown format for external links",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-9a93c2f8-94c4-415d-adb3-5fb8d8b16692.json
+++ b/change/@microsoft-teams-js-9a93c2f8-94c4-415d-adb3-5fb8d8b16692.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Removed deprecated `_initialize` and `_uninitialize` methods only used by unit tests",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-9e8f53e2-d30b-4fb1-9e78-5d17daaffb9d.json
+++ b/change/@microsoft-teams-js-9e8f53e2-d30b-4fb1-9e78-5d17daaffb9d.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added `requestAppAudioHandling` and `updateMicState` meeting APIs",
-  "packageName": "@microsoft/teams-js",
-  "email": "kiran.pyapali@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-af9e09b7-52f5-480d-8cbd-57c747ba45b3.json
+++ b/change/@microsoft-teams-js-af9e09b7-52f5-480d-8cbd-57c747ba45b3.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Adding comments",
-  "packageName": "@microsoft/teams-js",
-  "email": "98348000+shrshindeMSFT@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-c1a77265-c9b2-400a-93e8-54e461fcc1fb.json
+++ b/change/@microsoft-teams-js-c1a77265-c9b2-400a-93e8-54e461fcc1fb.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Updated typedoc configuration to treat warnings as errors",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-ccce9925-3c49-48bc-96bd-3aa8a0247dd6.json
+++ b/change/@microsoft-teams-js-ccce9925-3c49-48bc-96bd-3aa8a0247dd6.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Changed user facing documentation associated with `meeting.ts`",
-  "packageName": "@microsoft/teams-js",
-  "email": "trharris@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-d4f9a6b2-5995-4f8a-9d52-e52a245d9b00.json
+++ b/change/@microsoft-teams-js-d4f9a6b2-5995-4f8a-9d52-e52a245d9b00.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Unpin the version of the debug package; it was originally pinned unintentionally.",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-df28b481-c73e-468a-ae82-7b1c5feff040.json
+++ b/change/@microsoft-teams-js-df28b481-c73e-468a-ae82-7b1c5feff040.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Added documentation for `dialog.submit`",
-  "packageName": "@microsoft/teams-js",
-  "email": "lakhveerkaur@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-fb7d03a6-a374-4fc3-a9cd-6f72c9b0952a.json
+++ b/change/@microsoft-teams-js-fb7d03a6-a374-4fc3-a9cd-6f72c9b0952a.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Updated typedoc version and fixed doc issues raised by it",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,36 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Fri, 06 Jan 2023 04:15:12 GMT and should not be manually modified.
+This log was last generated on Wed, 01 Feb 2023 23:22:55 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.8.0
+
+Wed, 01 Feb 2023 23:22:55 GMT
+
+### Minor changes
+
+- Added `requestAppAudioHandling` and `updateMicState` meeting APIs
+- Fixed a bug where `getContext()` was incorrectly dropping properties by performing a lossy conversion via `app.getContext()`
+- Added adaptive card subcapability to `dialog` capability
+
+### Patches
+
+- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
+- Updated typedoc version and fixed doc issues raised by it
+- Added documentation for `dialog.submit`
+- Changed user facing documentation associated with `meeting.ts`
+- Unpin the version of the debug package; it was originally pinned unintentionally.
+- Removed deprecated `_initialize` and `_uninitialize` methods only used by unit tests
+- Added unit tests for `communication.uninitializeCommunication`, `communication.sendAndUnwrap`, and `communication.sendMessageToParentAsync` and updated `communication.uninitializeCommunication` to handle `currentWindow` correctly.
+- Removed --emit:none from typedoc command so it would actually output errors
+- Updated documentation links to avoid using locale in URLs and use markdown format for external links
+- Added possible values to documentation for `licenseType` property on `UserInfo` interface
+- Added unit tests for `communication.initializeCommunication`
+- Updated `dialog` and `tasks` documentation to add and fix doc links
+- Added remarks to authentication.authenticate() code comments
+- Added `@hidden` and `@internal` tags for the meeting `requestAppAudioHandling` and `updateMicState` APIs, and improved how the `teams-test-app` app uses the APIs
+- Stopped exporting `communication.processMessage` and `communication.shouldProcessMessage`.
 
 ## 2.7.1
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.7.1/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.8.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.7.1/js/MicrosoftTeams.min.js"
-  integrity="sha384-4Gy2G+qxzDVdrdemcVqKVQvaSK1Ghg3x6xcsaMLPc/pw7KPtiogHGM97LTWF2PWg"
+  src="https://res.cdn.office.net/teams-js/2.8.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-/DJ9oJEFZSpGiUQx9Na5Yb5svOPPqSb3khKxJ/YgoZ2GtrkzWgSTBpESy3LvMPVk"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.7.1/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.8.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -890,20 +890,16 @@ export interface DialogSize {
   width: DialogDimension | number;
 }
 /**
- * @hidden
- *
- * @internal
- * Limited to Microsoft-internal use
+ * @beta
+ * Data structure to be used with the {@link teamsCore.registerOnLoadHandler teamsCore.registerOnLoadHandler(handler: (context: LoadContext) => void): void} to pass the context to the app.
  */
 export interface LoadContext {
   /**
-   * @hidden
    * The entity that is requested to be loaded
    */
   entityId: string;
 
   /**
-   * @hidden
    * The content URL that is requested to be loaded
    */
   contentUrl: string;

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -46,12 +46,14 @@ export namespace teamsCore {
   }
 
   /**
-   * @hidden
    * Registers a handler to be called when the page has been requested to load.
+   *
+   * @remarks Check out [App Caching in Teams](https://learn.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/build-tabs-for-meeting?tabs=desktop%2Cmeeting-chat-view-desktop%2Cmeeting-stage-view-desktop%2Cchannel-meeting-desktop#app-caching)
+   * for a more detailed explanation about using this API.
    *
    * @param handler - The handler to invoke when the page is loaded.
    *
-   * @internal
+   * @beta
    */
   export function registerOnLoadHandler(handler: (context: LoadContext) => void): void {
     registerOnLoadHandlerHelper(handler, () => {
@@ -86,13 +88,15 @@ export namespace teamsCore {
   }
 
   /**
-   * @hidden
    * Registers a handler to be called before the page is unloaded.
+   *
+   * @remarks Check out [App Caching in Teams](https://learn.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/build-tabs-for-meeting?tabs=desktop%2Cmeeting-chat-view-desktop%2Cmeeting-stage-view-desktop%2Cchannel-meeting-desktop#app-caching)
+   * for a more detailed explanation about using this API.
    *
    * @param handler - The handler to invoke before the page is unloaded. If this handler returns true the page should
    * invoke the readyToUnload function provided to it once it's ready to be unloaded.
    *
-   * @internal
+   * @beta
    */
   export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void {
     registerBeforeUnloadHandlerHelper(handler, () => {


### PR DESCRIPTION
* Change onLoad/onBeforeUnload register handlers to beta #1565 (#1569)

* update teamscore docs to expose caching handlers

* fix build issue

* update link

* update caching links

* change see tag to remarks

* add changefile

* Merged in main

---------

Co-authored-by: alexneyman-MSFT <112656629+alexneyman-MSFT@users.noreply.github.com>
Co-authored-by: jadahiya-MSFT <jdahiya8719@outlook.com>

For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
