### PR TITLE
Fixing incorrect version name being chosen in prepBetaRelease script

### DIFF
--- a/change/@microsoft-teams-js-856c0e77-b263-4d92-ba73-eeb35a3c66b1.json
+++ b/change/@microsoft-teams-js-856c0e77-b263-4d92-ba73-eeb35a3c66b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Modified prepBetaRelease script",
+  "packageName": "@microsoft/teams-js",
+  "email": "jdahiya8719@outlook.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/prepBetaRelease.js
+++ b/packages/teams-js/prepBetaRelease.js
@@ -75,10 +75,12 @@ function getNewerPrefix(currBetaVer, currPkgJsonVer) {
   const pkgParts = currPkgPrefix.split('.');
 
   for (let i = 0; i < betaParts.length; i++) {
-    if (betaParts[i] > pkgParts[i]) {
+    const betaPart = Number(betaParts[i]);
+    const pkgPart = Number(pkgParts[i]);
+    if (betaPart > pkgPart) {
       return currBetaPrefix;
     }
-    if (pkgParts[i] > betaParts[i]) {
+    if (pkgPart > betaPart) {
       return currPkgPrefix;
     }
   }


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Converting pkgParts and betaParts values into numbers before comparisons. String comparison checker was comparing '10' to '9' and that caused '10' < '9' due to checking each character at a time rather than the full number.