### PR TITLE
Bug fix on sharing.isSupported() returning true while not supported on mobile

### DIFF
--- a/change/@microsoft-teams-js-0921e3b3-3094-48eb-9bc3-26740e08336f.json
+++ b/change/@microsoft-teams-js-0921e3b3-3094-48eb-9bc3-26740e08336f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix sharing.isSupported bug which returns true while not supported on mobile",
+  "packageName": "@microsoft/teams-js",
+  "email": "magli@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-0921e3b3-3094-48eb-9bc3-26740e08336f.json
+++ b/change/@microsoft-teams-js-0921e3b3-3094-48eb-9bc3-26740e08336f.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Added a bug fix for sharing.isSupported which returns true while not supported on mobile",
+  "comment": "`sharing.isSupported` now returns the correct value on mobile platforms",
   "packageName": "@microsoft/teams-js",
   "email": "magli@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-0921e3b3-3094-48eb-9bc3-26740e08336f.json
+++ b/change/@microsoft-teams-js-0921e3b3-3094-48eb-9bc3-26740e08336f.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix sharing.isSupported bug which returns true while not supported on mobile",
+  "comment": "Added a bug fix for sharing.isSupported which returns true while not supported on mobile",
   "packageName": "@microsoft/teams-js",
   "email": "magli@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -307,6 +307,10 @@ export const versionConstants: Record<string, Array<ICapabilityReqs>> = {
       capability: { people: {} },
       hostClientTypes: v1HostClientTypes,
     },
+    {
+      capability: { sharing: {} },
+      hostClientTypes: [HostClientType.desktop, HostClientType.web],
+    },
   ],
   '2.0.1': [
     {
@@ -324,10 +328,6 @@ export const versionConstants: Record<string, Array<ICapabilityReqs>> = {
     {
       capability: { webStorage: {} },
       hostClientTypes: [HostClientType.desktop],
-    },
-    {
-      capability: { sharing: {} },
-      hostClientTypes: [HostClientType.desktop, HostClientType.web],
     },
   ],
   '2.0.5': [

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -196,7 +196,6 @@ export const teamsRuntimeConfig: Runtime = {
       fullTrust: {},
     },
     remoteCamera: {},
-    sharing: {},
     stageView: {},
     teams: {
       fullTrust: {},
@@ -323,6 +322,10 @@ export const versionConstants: Record<string, Array<ICapabilityReqs>> = {
     {
       capability: { webStorage: {} },
       hostClientTypes: [HostClientType.desktop],
+    },
+    {
+      capability: { sharing: {} },
+      hostClientTypes: [HostClientType.desktop, HostClientType.web],
     },
   ],
   '2.0.5': [

--- a/packages/teams-js/test/public/sharing.spec.ts
+++ b/packages/teams-js/test/public/sharing.spec.ts
@@ -81,6 +81,7 @@ describe('sharing_v1', () => {
           it(`sharing.shareWebContent should successfully call the callback function when given the share web content in correct format when initialized with ${frameContext} context- success scenario`, (done) => {
             utils.initializeWithContext(frameContext).then(() => {
               // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { sharing: {} } });
               const callback = () => {
                 done();
               };
@@ -257,7 +258,7 @@ describe('sharing_v1', () => {
                 errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM,
                 message: 'Feature is not supported.',
               };
-
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { sharing: {} } });
               sharing.shareWebContent(shareRequest, (response) => {
                 expect(response).toEqual(error);
                 done();
@@ -402,6 +403,7 @@ describe('sharing_v2', () => {
         } else {
           it(`sharing.shareWebContent should successfully resolves when given the share web content in correct format when initialized with ${frameContext} context - success scenario`, async () => {
             await utils.initializeWithContext(FrameContexts.content);
+            utils.setRuntimeConfig({ apiVersion: 2, supports: { sharing: {} } });
             const shareRequest: sharing.IShareRequest<sharing.IURLContent> = {
               content: [
                 {
@@ -542,6 +544,7 @@ describe('sharing_v2', () => {
 
           it(`sharing.shareWebContent should throw a SdkError when other errors occur when initialized with ${frameContext} context`, async () => {
             await utils.initializeWithContext(FrameContexts.content);
+            utils.setRuntimeConfig({ apiVersion: 2, supports: { sharing: {} } });
             const shareRequest: sharing.IShareRequest<sharing.IURLContent> = {
               content: [
                 {

--- a/packages/teams-js/test/public/sharing.spec.ts
+++ b/packages/teams-js/test/public/sharing.spec.ts
@@ -81,7 +81,7 @@ describe('sharing_v1', () => {
           it(`sharing.shareWebContent should successfully call the callback function when given the share web content in correct format when initialized with ${frameContext} context- success scenario`, (done) => {
             utils.initializeWithContext(frameContext).then(() => {
               // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-              utils.setRuntimeConfig({ apiVersion: 2, supports: { sharing: {} } });
+              utils.setRuntimeConfig({ apiVersion: 1, supports: { sharing: {} } });
               const callback = () => {
                 done();
               };
@@ -258,7 +258,7 @@ describe('sharing_v1', () => {
                 errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM,
                 message: 'Feature is not supported.',
               };
-              utils.setRuntimeConfig({ apiVersion: 2, supports: { sharing: {} } });
+              utils.setRuntimeConfig({ apiVersion: 1, supports: { sharing: {} } });
               sharing.shareWebContent(shareRequest, (response) => {
                 expect(response).toEqual(error);
                 done();
@@ -403,7 +403,7 @@ describe('sharing_v2', () => {
         } else {
           it(`sharing.shareWebContent should successfully resolves when given the share web content in correct format when initialized with ${frameContext} context - success scenario`, async () => {
             await utils.initializeWithContext(FrameContexts.content);
-            utils.setRuntimeConfig({ apiVersion: 2, supports: { sharing: {} } });
+            utils.setRuntimeConfig({ apiVersion: 1, supports: { sharing: {} } });
             const shareRequest: sharing.IShareRequest<sharing.IURLContent> = {
               content: [
                 {
@@ -544,7 +544,7 @@ describe('sharing_v2', () => {
 
           it(`sharing.shareWebContent should throw a SdkError when other errors occur when initialized with ${frameContext} context`, async () => {
             await utils.initializeWithContext(FrameContexts.content);
-            utils.setRuntimeConfig({ apiVersion: 2, supports: { sharing: {} } });
+            utils.setRuntimeConfig({ apiVersion: 1, supports: { sharing: {} } });
             const shareRequest: sharing.IShareRequest<sharing.IURLContent> = {
               content: [
                 {

--- a/packages/teams-js/test/public/sharing.spec.ts
+++ b/packages/teams-js/test/public/sharing.spec.ts
@@ -393,7 +393,7 @@ describe('sharing_v2', () => {
               expect(sharing.isSupported()).toBeTruthy();
             });
           } else {
-            it(`sharing.isSupported() should return false for web and desktop when version is greater than supported version ${minDesktopAndWebVersionForSharing}}`, async () => {
+            it(`sharing.isSupported() should return false for web and desktop when version is lower than supported version ${minDesktopAndWebVersionForSharing}}`, async () => {
               await utils.initializeWithContext(FrameContexts.content, clientType);
               utils.setRuntimeConfig(generateBackCompatRuntimeConfig(version));
               expect(sharing.isSupported()).toBeFalsy();
@@ -401,7 +401,7 @@ describe('sharing_v2', () => {
           }
         });
       } else {
-        it(`sharing.isSupported() should return false for platforms other than desktop and web regardless version`, async () => {
+        it(`sharing.isSupported() should return false for platforms other than desktop and web, regardless version`, async () => {
           await utils.initializeWithContext(FrameContexts.content, clientType);
           expect(sharing.isSupported()).toBeFalsy();
         });


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

During my last DRI session, there was a bug reported on sharing.isSupported() returning true while we can repro that it is not  supported on mobile. The root cause is: if host doesn't send empty object to app sdk during runtime, app sdk will provide a default empty object, meaning that capability is supported. Sharing is in the list of this default setting regardless platform. In this PR, we are removing the default support and instead we start to specify in which version that it gets supported and also provide platform info(currently, sharing is only supported on desktop and web)
> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Removing sharing from supported default list
2. Providing a default version on when sharing starts to be supported on desktop and web

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:
Yes, updated existing

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
