### PR TITLE
Use a different event name when calling video.mediaStream.registerForVideoFrame

### DIFF
--- a/change/@microsoft-teams-js-ad46a5c7-5cc0-4176-8539-0b126be3e1f5.json
+++ b/change/@microsoft-teams-js-ad46a5c7-5cc0-4176-8539-0b126be3e1f5.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix bug that when calling both video.registerForVideoFrame and video.mediaStream.registerForVideoStream an error happens: \"stream id is already registered\"",
+  "comment": "Updated message sent to host by `video.registerForVideoFrame` to avoid duplication with message sent by `video.mediaStream.registerForVideoStream` (bug would manifest in \"stream id is already registered\" error message)",
   "packageName": "@microsoft/teams-js",
   "email": "wenghe@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-ad46a5c7-5cc0-4176-8539-0b126be3e1f5.json
+++ b/change/@microsoft-teams-js-ad46a5c7-5cc0-4176-8539-0b126be3e1f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bug that when calling both video.registerForVideoFrame and video.mediaStream.registerForVideoStream an error happens: \"stream id is already registered\"",
+  "packageName": "@microsoft/teams-js",
+  "email": "wenghe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/video.ts
+++ b/packages/teams-js/src/public/video.ts
@@ -302,7 +302,7 @@ export namespace video {
         typeof window !== 'undefined' && window['chrome']?.webview?.registerTextureStream(streamId, generator);
       });
 
-      sendMessageToParent('video.registerForVideoFrame', [
+      sendMessageToParent('video.mediaStream.registerForVideoFrame', [
         {
           format: VideoFrameFormat.NV12,
         },

--- a/packages/teams-js/test/public/video.spec.ts
+++ b/packages/teams-js/test/public/video.spec.ts
@@ -721,6 +721,20 @@ describe('video', () => {
       expect(registeredStreamId).toEqual(streamId);
     });
 
+    it('should send event to parent to inform the registeration', async () => {
+      await init();
+      setRuntimeConfig({ apiVersion: 1, supports: { video: { mediaStream: {} } } });
+      const streamId = 'testStreamId';
+      video.mediaStream.registerForVideoFrame(() => Promise.resolve({ close: () => {} } as VideoFrame));
+      postMessage('video.startVideoExtensibilityVideoStream', { streamId });
+      const msg = findMessageByFunc('video.mediaStream.registerForVideoFrame');
+      expect(msg).not.toBeNull();
+      expect(msg.args.length).toBe(1);
+      expect(msg.args).toEqual([{
+        format: video.VideoFrameFormat.NV12,
+      }]);
+    });
+
     it('should invoke callback', async () => {
       await init();
       setRuntimeConfig({ apiVersion: 1, supports: { video: { mediaStream: {} } } });

--- a/packages/teams-js/test/public/video.spec.ts
+++ b/packages/teams-js/test/public/video.spec.ts
@@ -721,7 +721,7 @@ describe('video', () => {
       expect(registeredStreamId).toEqual(streamId);
     });
 
-    it('should send event to parent to inform the registeration', async () => {
+    it('should send event to parent to inform the registration', async () => {
       await init();
       setRuntimeConfig({ apiVersion: 1, supports: { video: { mediaStream: {} } } });
       const streamId = 'testStreamId';


### PR DESCRIPTION
## Description
When incidentally calling both video.registerForVideoFrame and video.mediaStream.registerForVideoFrame, two events with the same name are sent to the host and the host can't identify what triggered the event.

### Main changes in the PR:
Changed the event name to "video.mediaStream.registerForVideoFrame" in the API `video.mediaStream.registerForVideoFrame`.

### Unit Tests added:
Yes

### End-to-end tests added:
No

## Additional Requirements

### Change file added:
Yes

