### PR TITLE
Change buttons' name to unblock iOS UI tests

### DIFF
--- a/apps/teams-test-app/src/components/BarCodeAPIs.tsx
+++ b/apps/teams-test-app/src/components/BarCodeAPIs.tsx
@@ -31,7 +31,7 @@ const ScanBarCode = (): React.ReactElement =>
 const HasBarCodePermission = (): React.ReactElement =>
   ApiWithoutInput({
     name: 'hasBarCodePermission',
-    title: 'Has Permission',
+    title: 'Has BarCode Permission',
     onClick: async () => {
       const result = await barCode.hasPermission();
       return JSON.stringify(result);
@@ -41,7 +41,7 @@ const HasBarCodePermission = (): React.ReactElement =>
 const RequestBarCodePermission = (): React.ReactElement =>
   ApiWithoutInput({
     name: 'requestBarCodePermission',
-    title: 'Request Permission',
+    title: 'Request BarCode Permission',
     onClick: async () => {
       const result = await barCode.requestPermission();
       return JSON.stringify(result);

--- a/apps/teams-test-app/src/components/GeoLocationAPIs.tsx
+++ b/apps/teams-test-app/src/components/GeoLocationAPIs.tsx
@@ -58,7 +58,7 @@ const ShowLocation = (): React.ReactElement =>
 const HasGeoLocationPermission = (): React.ReactElement =>
   ApiWithoutInput({
     name: 'hasGeoLocationPermission',
-    title: 'Has Permission',
+    title: 'Has GeoLocation Permission',
     onClick: async () => {
       const result = await geoLocation.hasPermission();
       return JSON.stringify(result);
@@ -68,7 +68,7 @@ const HasGeoLocationPermission = (): React.ReactElement =>
 const RequestGeoLocationPermission = (): React.ReactElement =>
   ApiWithoutInput({
     name: 'requestGeoLocationPermission',
-    title: 'Request Permission',
+    title: 'Request GeoLocation Permission',
     onClick: async () => {
       const result = await geoLocation.requestPermission();
       return JSON.stringify(result);


### PR DESCRIPTION
## Description
Renamed the `Has Permission` and `Request Permission` buttons for GeoLocation API and BarCode API.

What changes: Renaming button labels (which is the `title` field in the codebase) of `Has Permission` and `Request Permission` the same as the button name.
Why made this change: iOS UI test lib `XCTest` can get the item by label only. If more than one button have the same label name, we could use index for accessing different buttons with same label name but then the UI layers change may break index order, which cause E2E test failure. This is a scenario we hope could be avoided, thus, in iOS side, we would like to edit button label name to make them to be unique and function as what box selector id does.

### Main changes in the PR:

1. Renaming `Has Permission` and `Request Permission` buttons under GeoLocationAPI to `Has GeoLocation Permission` and `Request GeoLocation Permission`
2. Renaming `Has Permission` and `Request Permission` buttons under BarCodeAPI to `Has BarCode Permission` and `Request BarCode Permission`

## Validation

### Validation performed:

1. Build and run iOS orange app
2. Open test-app in the iOS orange and run the GeoLocation UI test locally: from the local log, iOS UI testing lib find the button by label.
3. Manually tested all the GeoLocation APIs made sure they all worked as expected.

### Unit Tests added:

No button naming covered in the unit tests.

<No>

### End-to-end tests added:
Will add UI tests in the iOS codebase
<No>

## Additional Requirements
No
### Change file added:
Checking for changes against "origin/main"
fetching latest from remotes "origin/main"
Validating no private package among package dependencies
 OK!

No change files are needed

<Yes>


### Next/remaining steps:
Start implementing GeoLocation E2E tests in iOS-hub-sdk

### Screenshots:

| Before     | After      |
| ---------- | ---------- |
|  <img width="233" alt="geolocation-before" src="https://user-images.githubusercontent.com/3358651/225466967-3825cc71-6567-4453-a25f-81bf54a01c20.png">| <img width="218" alt="geolocation_after" src="https://user-images.githubusercontent.com/3358651/225467006-3e36f3d0-6b35-44f7-bb0a-2c0b27af54a7.png">|


