### PR TITLE
Disable cache for App hosting sdk .

### DIFF
--- a/tools/yaml-templates/build-app-host.yml
+++ b/tools/yaml-templates/build-app-host.yml
@@ -22,11 +22,11 @@ steps:
   # in our case it is 'pnpm | "$(Agent.OS)" | $(AppHostingSdkProjectDirectory)/pnpm-lock.yaml'
   # and for the path is the directory which needs to be cached.
   # Here `node_modules` are cached which are dowloaded from the scoped/private registry to build the mono-repo.
-  - task: Cache@2
-    inputs:
-      key: 'pnpm | "$(Agent.OS)" | $(AppHostingSdkProjectDirectory)/pnpm-lock.yaml'
-      path: $(Pipeline.Workspace)/.pnpm-store
-    displayName: Cache pnpm
+  # - task: Cache@2
+  #   inputs:
+  #     key: 'pnpm | "$(Agent.OS)" | $(AppHostingSdkProjectDirectory)/pnpm-lock.yaml'
+  #     path: $(Pipeline.Workspace)/.pnpm-store
+  #   displayName: Cache pnpm
 
   - script: |
       corepack enable


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description
Disabling cache for App Hosting SDK for now, it'll be enabled when migration from `yarn` to `pnpm` is completed in teams-js-sdk.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

Commenting cache for now.

