### PR TITLE
Lakhveer/dialog submit fix

### DIFF
--- a/change/@microsoft-teams-js-eb335d99-fb08-4075-845b-2e540a4268aa.json
+++ b/change/@microsoft-teams-js-eb335d99-fb08-4075-845b-2e540a4268aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated `dialog.url.submit` to work only from frameContext `task`. ",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -148,10 +148,7 @@ export namespace dialog {
      * @beta
      */
     export function submit(result?: string | object, appIds?: string | string[]): void {
-      // FrameContext content should not be here because dialog.submit can be called only from inside of a dialog (FrameContext task)
-      // but it's here because Teams mobile incorrectly returns FrameContext.content when calling app.getFrameContext().
-      // FrameContexts.content will be removed once the bug is fixed.
-      ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+      ensureInitialized(runtime, FrameContexts.task);
       if (!isSupported()) {
         throw errorNotSupportedOnPlatform;
       }

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -436,7 +436,7 @@ describe('Dialog', () => {
     it('should not allow calls before initialization', () => {
       expect(() => dialog.url.submit()).toThrowError(errorLibraryNotInitialized);
     });
-    const allowedContexts = [FrameContexts.content, FrameContexts.task];
+    const allowedContexts = [FrameContexts.task];
     Object.values(FrameContexts).forEach((context) => {
       if (allowedContexts.some((allowedContexts) => allowedContexts === context)) {
         it(`FRAMED: should throw error when dialog is not supported in ${context} context`, async () => {

--- a/packages/teams-js/test/public/tasks.spec.ts
+++ b/packages/teams-js/test/public/tasks.spec.ts
@@ -268,7 +268,7 @@ describe('tasks', () => {
   });
 
   describe('submitTask', () => {
-    const allowedContexts = [FrameContexts.content, FrameContexts.task];
+    const allowedContexts = [FrameContexts.task];
     it('should not allow calls before initialization', () => {
       expect(() => tasks.submitTask()).toThrowError(new Error(errorLibraryNotInitialized));
     });


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Deleted `frameContext.content` from `ensureInitialized` call in `dailog.url.submit`. dialog.submit call should work only from inside of a dialog. Previously, we were allowing `content` because the Mobile Clients had a bug. They incorrectly set the frameContext for task modules to "content" instead of "task" They have now fixed the bug.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:
> yes

### End-to-end tests added:
> No, not needed

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

