### PR TITLE
added pnpm commands to force blazor build in pipeline

### DIFF
--- a/apps/blazor-test-app/package.json
+++ b/apps/blazor-test-app/package.json
@@ -5,6 +5,7 @@
   "description": "Blazor test app to ensure teams-js changes don't break Blazor app functionality",
   "version": "1.0.0",
   "scripts": {
+    "blazor-build": "dotnet build",
     "start": "dotnet run"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "author": "Microsoft Teams",
   "scripts": {
     "build": "lerna run build --stream",
+    "build-force-blazor": "pnpm build && pnpm build-blazor-app",
     "build:clean": "pnpm clean && pnpm build",
     "bundleAnalyze": "pnpm --filter @microsoft/bundle-analysis-app webpack:profile",
     "bundleAnalyze:collect": "pnpm bundleAnalyze && node tools/cli/collectBundleAnalysis.js --folderName bundleAnalysis",
+    "build-blazor-app": "pnpm --filter blazor-test-app blazor-build",
     "build-test-app-CDN": "pnpm --filter teams-test-app build:CDN",
     "build-test-app-local": "pnpm --filter teams-test-app build:local",
     "build-test-app-V1": "pnpm --filter teams-test-app build:CDNV1",

--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -38,7 +38,7 @@ steps:
     workingDirectory: '$(ClientSdkProjectDirectory)'
 
   - script: |
-      pnpm build
+      pnpm build-force-blazor
     displayName: 'Build client sdk'
     workingDirectory: '$(ClientSdkProjectDirectory)'
 

--- a/tools/yaml-templates/build-app-host.yml
+++ b/tools/yaml-templates/build-app-host.yml
@@ -80,7 +80,7 @@ steps:
     workingDirectory: '$(ClientSdkProjectDirectory)'
 
   - script: |
-      pnpm build
+      pnpm build-force-blazor
     displayName: 'Build client sdk'
     workingDirectory: '$(ClientSdkProjectDirectory)'
 

--- a/tools/yaml-templates/build-test-publish.yml
+++ b/tools/yaml-templates/build-test-publish.yml
@@ -35,7 +35,7 @@ steps:
       )
 
   - script: |
-      pnpm build
+      pnpm build-force-blazor
     displayName: 'pnpm build'
 
   - script: |

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -69,7 +69,7 @@ steps:
     workingDirectory: '$(ClientSdkProjectDirectory)'
 
   - script: |
-      pnpm build
+      pnpm build-force-blazor
     displayName: 'Build client sdk'
     workingDirectory: '$(ClientSdkProjectDirectory)'
 


### PR DESCRIPTION
Added pnpm commands so Lerna does not build the blazor-test-app when simply running `pnpm build`. Instead, I added a `build-force-blazor` option that will build everything, including the blazor-test-app. I then changed all of the build commands that get run in the pipeline to use the `build-force-blazor` command instead.