### PR TITLE
Specify version for pnpm

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@7.30.1
 
       - name: Install dependencies
         run: pnpm install

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Welcome to the Teams client library monorepo! For breaking changes, please refer
 3. Run `pnpm build` from repo root
 4. To run Unit tests, run `pnpm test`
 
+NOTE: Make sure `pnpm@7.30.1` is installed as a global tool, by running `npm install -g pnpm@7.30.1`.  
+
 TIP: whenever building or testing the Teams client library, you can run `pnpm build` or `pnpm test` from the `packages/teams-js` directory.
 
 See also: [Contributing](CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "teams-js-monorepo",
   "private": true,
   "author": "Microsoft Teams",
+  "engines": {
+    "pnpm": "7.30.1"
+  },
   "scripts": {
     "build": "lerna run build --stream",
     "build:clean": "pnpm clean && pnpm build",

--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -28,7 +28,7 @@ steps:
 
   - script: |
       corepack enable
-      corepack prepare pnpm@latest --activate
+      corepack prepare pnpm@7.30.1 --activate
       pnpm config set store-dir $(Pipeline.Workspace)/.pnpm-store
     displayName: 'Setup pnpm'
 

--- a/tools/yaml-templates/build-app-host.yml
+++ b/tools/yaml-templates/build-app-host.yml
@@ -36,7 +36,7 @@ steps:
 
   - script: |
       corepack enable
-      corepack prepare pnpm@latest --activate
+      corepack prepare pnpm@7.30.1 --activate
       pnpm config set store-dir $(Pipeline.Workspace)/.pnpm-store
     displayName: 'Setup pnpm'
 

--- a/tools/yaml-templates/build-test-publish.yml
+++ b/tools/yaml-templates/build-test-publish.yml
@@ -8,7 +8,7 @@ steps:
       versionSpec: '14.x'
 
   - script: |
-      npm install -g pnpm
+      npm install -g pnpm@7.30.1
       pnpm config set store-dir $(Pipeline.Workspace)/.pnpm-store
     displayName: 'Setup pnpm'
 

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -59,7 +59,7 @@ steps:
 
   - script: |
       corepack enable
-      corepack prepare pnpm@latest --activate
+      corepack prepare pnpm@7.30.1 --activate
       pnpm config set store-dir $(Pipeline.Workspace)/.pnpm-store
     displayName: 'Setup pnpm'
 


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Using different `pnpm` versions creates a different lock file version, which leads to inconsistency in `pnpm-lock.yaml` file. 

### Main changes in the PR:

Add specific version to `pnpm` to avoid inconsistency.

## Validation
N/A

### Unit Tests added:
N/A
