### PR TITLE
Mail docs

### DIFF
--- a/change/@microsoft-teams-js-a0800215-912f-43ae-9644-fddd101c0c0d.json
+++ b/change/@microsoft-teams-js-a0800215-912f-43ae-9644-fddd101c0c0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added documentation to interfaces in mail capability",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-a0800215-912f-43ae-9644-fddd101c0c0d.json
+++ b/change/@microsoft-teams-js-a0800215-912f-43ae-9644-fddd101c0c0d.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Added documentation to interfaces in mail capability",
+  "comment": "Added documentation to interfaces in `mail` capability",
   "packageName": "@microsoft/teams-js",
   "email": "36546967+AE-MS@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/public/mail.ts
+++ b/packages/teams-js/src/public/mail.ts
@@ -53,7 +53,7 @@ export namespace mail {
 
   /**
    * Foundational interface for all other mail compose interfaces
-   * Used to holding the type of mail item being composed
+   * Used for holding the type of mail item being composed
    *
    * @see {@link ComposeMailType}
    */
@@ -101,7 +101,7 @@ export namespace mail {
   }
 
   /**
-   * Parameters supplied to {@link composeMail} to compose a new mail item
+   * Parameters supplied to {@link composeMail} when composing a new mail item
    *
    * @see {@link ComposeNewParams}
    * @see {@link ComposeReplyOrForwardParams}

--- a/packages/teams-js/src/public/mail.ts
+++ b/packages/teams-js/src/public/mail.ts
@@ -52,25 +52,61 @@ export namespace mail {
   }
 
   /**
-   * Base of a discriminated union between compose scenarios.
+   * Foundational interface for all other mail compose interfaces
+   * Used to holding the type of mail item being composed
+   *
+   * @see {@link ComposeMailType}
    */
   interface ComposeMailBase<T extends ComposeMailType> {
     type: T;
   }
+
   /**
-   * Interfaces for each type.
+   * Parameters supplied when composing a new mail item
    */
   export interface ComposeNewParams extends ComposeMailBase<ComposeMailType.New> {
+    /**
+     * The To: recipients for the message
+     */
     toRecipients?: string[];
+
+    /**
+     * The Cc: recipients for the message
+     */
     ccRecipients?: string[];
+
+    /**
+     * The Bcc: recipients for the message
+     */
     bccRecipients?: string[];
+
+    /**
+     * The subject of the message
+     */
     subject?: string;
+
+    /**
+     * The body of the message
+     */
     message?: string;
   }
+
+  /**
+   * Parameters supplied when composing a reply to or forward of a message
+   *
+   * @see {@link ComposeMailType}
+   */
   export interface ComposeReplyOrForwardParams<T extends ComposeMailType> extends ComposeMailBase<T> {
     itemid: string;
   }
 
+  /**
+   * Parameters supplied to {@link composeMail} to compose a new mail item
+   *
+   * @see {@link ComposeNewParams}
+   * @see {@link ComposeReplyOrForwardParams}
+   * @see {@link ComposeMailType}
+   */
   export type ComposeMailParams =
     | ComposeNewParams
     | ComposeReplyOrForwardParams<ComposeMailType.Reply>


### PR DESCRIPTION
Added documentation to the `mail` capability. This is far from comprehensive: there are still open questions (and thus undocumented properties) around the acceptable IDs, format for body, etc. While I'm chasing down answers to those, I figured I would update what I could.