### PR TITLE
Remove unnecessary documentation on enums properties

### DIFF
--- a/change/@microsoft-teams-js-3adbd356-cd9d-4e1d-81f3-e10c19920ba6.json
+++ b/change/@microsoft-teams-js-3adbd356-cd9d-4e1d-81f3-e10c19920ba6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Remove unnecessary (and outdated) docs on enums",
+  "comment": "Removed unnecessary (and outdated) docs on various `enum` properties",
   "packageName": "@microsoft/teams-js",
   "email": "36546967+AE-MS@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-3adbd356-cd9d-4e1d-81f3-e10c19920ba6.json
+++ b/change/@microsoft-teams-js-3adbd356-cd9d-4e1d-81f3-e10c19920ba6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove unnecessary (and outdated) docs on enums",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -178,12 +178,12 @@ export namespace app {
    */
   export interface AppHostInfo {
     /**
-     * The name of the host client. Possible values are: Office, Orange, Outlook, Teams
+     * Identifies which host is running your app
      */
     name: HostName;
 
     /**
-     * The type of the host client. Possible values are : android, ios, web, desktop, rigel
+     * The client type on which the host is running
      */
     clientType: HostClientType;
 


### PR DESCRIPTION
The documentation for some `enum` properties was wrong (out of date) and unnecessary since it was just literally listing the enum values. I have removed said documentation.
