### PR TITLE
Adding context task to getAuthenticationTokenForAnonymousUserToken API

### DIFF
--- a/change/@microsoft-teams-js-566f31c2-a1bc-4ac2-b16a-06ce2ca5f7ef.json
+++ b/change/@microsoft-teams-js-566f31c2-a1bc-4ac2-b16a-06ce2ca5f7ef.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Added task module context to allow getAuthenticationTokenForAnonymousUser API to be called in task modules",
+  "comment": "`meeting.getAuthenticationTokenForAnonymousUser` can now be called from dialogs",
   "packageName": "@microsoft/teams-js",
   "email": "melu@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-566f31c2-a1bc-4ac2-b16a-06ce2ca5f7ef.json
+++ b/change/@microsoft-teams-js-566f31c2-a1bc-4ac2-b16a-06ce2ca5f7ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added task module context to allow getAuthenticationTokenForAnonymousUser API to be called in task modules",
+  "packageName": "@microsoft/teams-js",
+  "email": "melu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -410,7 +410,7 @@ export namespace meeting {
     if (!callback) {
       throw new Error('[get Authentication Token For AnonymousUser] Callback cannot be null');
     }
-    ensureInitialized(runtime, FrameContexts.sidePanel, FrameContexts.meetingStage);
+    ensureInitialized(runtime, FrameContexts.sidePanel, FrameContexts.meetingStage, FrameContexts.task);
     sendMessageToParent('meeting.getAuthenticationTokenForAnonymousUser', callback);
   }
 

--- a/packages/teams-js/test/public/meeting.spec.ts
+++ b/packages/teams-js/test/public/meeting.spec.ts
@@ -314,7 +314,7 @@ describe('meeting', () => {
         new Error(errorLibraryNotInitialized),
       );
     });
-    const allowedContexts = [FrameContexts.sidePanel, FrameContexts.meetingStage];
+    const allowedContexts = [FrameContexts.sidePanel, FrameContexts.meetingStage, FrameContexts.task];
 
     Object.values(FrameContexts).forEach((context) => {
       if (allowedContexts.some((allowedContext) => allowedContext === context)) {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

Per the partner team Polls feedback, they would like to access the getAuthenticationTokenForAnonymousUsers in task context (content bubble and task modules).

### Main changes in the PR:

1. Added tadk context as an acceptable context to call the API
2. Updated test files to reflect the above change

## Validation

### Validation performed:

1. Validated using the test app using anon user

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes, updated unit test cases to reflect the change

### End-to-end tests added:

No, validation done through manual testing

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes

