### PR TITLE
Fix android tests failure due to Java version

### DIFF
--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -50,6 +50,13 @@ steps:
     displayName: 'Install Emulator'
     workingDirectory: '$(Agent.BuildDirectory)/androidHost/devtools/ci'
 
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: '11'
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
+    displayName: 'Set default Java to x64'
+
   - bash: 'chmod u+x ./gradlew && chmod u+x e2eTest.sh && ./e2eTest.sh'
     displayName: 'Run Android E2E Tests'
     workingDirectory: '$(Agent.BuildDirectory)/androidHost/apps/orangeandroid'


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Android tests failing in the pipeline due to the dependency on the 64bit Java after recent upgrade in Hosts layer.

### Main changes in the PR:

1. Added a yaml step in the android tests pipeline to set Java 11 x64 bit as default when running the Android tests.

## Validation

### Validation performed:

1. Android E2E tests should run fine in all pipelines.

### Unit Tests added:

No, NA

### End-to-end tests added:

No, NA

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).