### PR TITLE
Clarify proper usage of user identity properties in context

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -38,6 +38,8 @@ import MonetizationAPIs from './components/privateApis/MonetizationAPIs';
 import NotificationAPIs from './components/privateApis/NotificationAPIs';
 import PrivateAPIs from './components/privateApis/PrivateAPIs';
 import TeamsAPIs from './components/privateApis/TeamsAPIs';
+import VideoExAPIs from './components/privateApis/VideoExAPIs';
+import VideoExSharedFrameAPIs from './components/privateApis/VideoExSharedFrameAPIs';
 import ProfileAPIs from './components/ProfileAPIs';
 import RemoteCameraAPIs from './components/RemoteCameraAPIs';
 import SearchAPIs from './components/SearchAPIs';
@@ -47,11 +49,9 @@ import TeamsCoreAPIs from './components/TeamsCoreAPIs';
 import { isTestBackCompat } from './components/utils/isTestBackCompat';
 import Version from './components/Version';
 import VideoAPIs from './components/VideoAPIs';
-import VideoExAPIs from './components/privateApis/VideoExAPIs';
-import WebStorageAPIs from './components/WebStorageAPIs';
 import VideoMediaStreamAPIs from './components/VideoMediaStreamAPIs';
 import VideoSharedFrameAPIs from './components/VideoSharedFrameAPIs';
-import VideoExSharedFrameAPIs from './components/privateApis/VideoExSharedFrameAPIs';
+import WebStorageAPIs from './components/WebStorageAPIs';
 
 const urlParams = new URLSearchParams(window.location.search);
 

--- a/change/@microsoft-teams-js-04be2fe1-06e4-4f4b-ad33-425646831a7e.json
+++ b/change/@microsoft-teams-js-04be2fe1-06e4-4f4b-ad33-425646831a7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Clarified documentation on proper use of various user identity properties",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -333,6 +333,7 @@ export namespace app {
 
     /**
      * The user's role in the team.
+
      * Because a malicious party can run your content in a browser, this value should
      * be used only as a hint as to the user's role, and never as proof of her role.
      */
@@ -345,8 +346,13 @@ export namespace app {
   export interface UserInfo {
     /**
      * The Azure AD object id of the current user.
-     * Because a malicious party run your content in a browser, this value should
-     * be used only as a hint as to who the user is and never as proof of identity.
+     *
+     * Because a malicious party can run your content in a browser, this value should
+     * be used only as a optimization hint as to who the user is and never as proof of identity.
+     * Specifically, this value should never be used to determine if a user is authorized to access
+     * a resource; access tokens should be used for that.
+     * See {@link authentication.getAuthToken} and {@link authentication.authenticate} for more information on access tokens.
+     *
      * This field is available only when the identity permission is requested in the manifest.
      */
     id: string;
@@ -373,18 +379,26 @@ export namespace app {
     licenseType?: string;
 
     /**
-     * A value suitable for use as a login_hint when authenticating with Azure AD.
+     * A value suitable for use when providing a login_hint to Azure Active Directory for authentication purposes.
+     * See [Provide optional claims to your app](https://learn.microsoft.com/azure/active-directory/develop/active-directory-optional-claims#v10-and-v20-optional-claims-set)
+     * for more information about the use of login_hint
+     *
      * Because a malicious party can run your content in a browser, this value should
-     * be used only as a hint as to who the user is and never as proof of identity.
-     * This field is available only when the identity permission is requested in the manifest.
+     * be used only as a optimization hint as to who the user is and never as proof of identity.
+     * Specifically, this value should never be used to determine if a user is authorized to access
+     * a resource; access tokens should be used for that.
+     * See {@link authentication.getAuthToken} and {@link authentication.authenticate} for more information on access tokens.
      */
     loginHint?: string;
 
     /**
      * The UPN of the current user. This may be an externally-authenticated UPN (e.g., guest users).
-     * Because a malicious party run your content in a browser, this value should
-     * be used only as a hint as to who the user is and never as proof of identity.
-     * This field is available only when the identity permission is requested in the manifest.
+
+     * Because a malicious party can run your content in a browser, this value should
+     * be used only as a optimization hint as to who the user is and never as proof of identity.
+     * Specifically, this value should never be used to determine if a user is authorized to access
+     * a resource; access tokens should be used for that.
+     * See {@link authentication.getAuthToken} and {@link authentication.authenticate} for more information on access tokens.
      */
     userPrincipalName?: string;
 
@@ -400,9 +414,12 @@ export namespace app {
   export interface TenantInfo {
     /**
      * The Azure AD tenant ID of the current user.
+
      * Because a malicious party can run your content in a browser, this value should
-     * be used only as a hint as to who the user is and never as proof of identity.
-     * This field is available only when the identity permission is requested in the manifest.
+     * be used only as a optimization hint as to who the user is and never as proof of identity.
+     * Specifically, this value should never be used to determine if a user is authorized to access
+     * a resource; access tokens should be used for that.
+     * See {@link authentication.getAuthToken} and {@link authentication.authenticate} for more information on access tokens.
      */
     id: string;
 


### PR DESCRIPTION
## Description

Some of the user info properties in the context came with a warning against misuse but were not clear on exactly what type of misuse should be avoided and the preferred alternative approaches.

There were also some items automatically reordered in the `App.tsx` file that appear to have been leftover from previous developers who did not check in the automated prettier changes.
