### PR TITLE
Update the title for the deprecated OpenConversation api in teams app

### DIFF
--- a/apps/teams-test-app/src/components/GeoLocationAPIs.tsx
+++ b/apps/teams-test-app/src/components/GeoLocationAPIs.tsx
@@ -107,4 +107,5 @@ const GeoLocationAPIs = (): ReactElement => (
   </ModuleWrapper>
 );
 
+
 export default GeoLocationAPIs;

--- a/apps/teams-test-app/src/components/privateApis/ChatAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/ChatAPIs.tsx
@@ -89,7 +89,7 @@ const OpenGroupChat = (): React.ReactElement =>
 const DeprecatedOpenConversation = (): React.ReactElement =>
   ApiWithTextInput<OpenConversationRequest>({
     name: 'openConversation2',
-    title: 'Open Conversation',
+    title: '[Deprecated] Open Conversation',
     onClick: {
       validateInput: (input) => {
         if (!input.entityId || !input.title || !input.subEntityId) {


### PR DESCRIPTION


## Description

Updated the title for Deprecated OpenConversation capability. In IOS, UI test will fail if we have duplicate title for same capability. Need to change the title for conversation api UI test case in IOS.

### Main changes in the PR:

1. Change the title to Deprecated Open Conversation in test app.

## Validation

### Validation performed:

1. Test the open conversation in test app


### Unit Tests added:

N/A

### End-to-end tests added:

N/A

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
