### PR TITLE
upgrade image and improve yaml file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ jobs:
   - job: E2ETestIOS
     displayName: 'E2E Test - IOS'
     pool:
-      vmImage: 'internal-macos-11'
+      vmImage: 'internal-macos12'
     steps:
       - template: tools/yaml-templates/ios-test.yml
         parameters:

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -36,10 +36,6 @@ steps:
     displayName: 'Install XCTestHtmlReport for publishing result'
     workingDirectory: '$(System.DefaultWorkingDirectory)'
 
-  - bash: 'sh build_ios_host_sdk.sh'
-    displayName: 'Build iOS Host SDK'
-    workingDirectory: '$(Agent.BuildDirectory)/iOSHost/jobs/ciDevTools'
-
   - task: NodeTool@0
     inputs:
       versionSpec: '14.x'
@@ -77,17 +73,43 @@ steps:
     displayName: 'Run sample test app in background'
     workingDirectory: '$(ClientSdkProjectDirectory)'
 
-  - bash: 'sh disable_slow_animation.sh'
+  - bash: cd ~/Library/Preferences
+      defaults write com.apple.iphonesimulator SlowMotionAnimation -bool NO
     displayName: 'Disable Slow Animation'
-    workingDirectory: '$(Agent.BuildDirectory)/iOSHost/jobs/ciDevTools'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
 
-  - bash: 'sh parallel_ui_testing_for_publishing.sh'
+  - bash: /usr/bin/xcodebuild \
+      -configuration Release \
+      $(parameters.IOSSdkLocalWorkspaceAndScheme) \
+      -sdk iphonesimulator \
+      -parallel-testing-enabled YES \
+      -parallel-testing-worker-count 2 \
+      -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2' \
+      -quiet \
+      -resultBundlePath TestResults \
+      test > report.out 2>&1
+      if [[ $? == 0 ]]
+      then
+      echo "E2E Test passes successfully"
+      exit 0
+      else
+      echo "E2E Test failed"
+      exit 1
+      fi
     displayName: 'iOS UI/E2E Tests'
-    workingDirectory: '$(Agent.BuildDirectory)/iOSHost/jobs/ciDevTools'
+    workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
-  - bash: 'sh generate_junit_report.sh'
+  - bash: xchtmlreport -r TestResults -j > /dev/null
+      if [[ $? == 0 ]]
+      then
+      echo "Test report has been generated successfully."
+      exit 0
+      else
+      echo "Test report generating process failed for some reasons."
+      exit 1
+      fi
     displayName: 'Generate E2E test report'
-    workingDirectory: '$(Agent.BuildDirectory)/iOSHost/jobs/ciDevTools'
+    workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
     condition: succeededOrFailed()
 
   - task: PublishTestResults@2

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -27,11 +27,6 @@ steps:
     workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   - bash: |
-      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    displayName: Install Homebrew
-    workingDirectory: '$(System.DefaultWorkingDirectory)'
-
-  - bash: |
       brew install xctesthtmlreport
     displayName: 'Install XCTestHtmlReport for publishing result'
     workingDirectory: '$(System.DefaultWorkingDirectory)'
@@ -80,7 +75,7 @@ steps:
 
   - bash: /usr/bin/xcodebuild \
       -configuration Release \
-      $(parameters.IOSSdkLocalWorkspaceAndScheme) \
+      ${{ parameters.IOSSdkLocalWorkspaceAndScheme }} \
       -sdk iphonesimulator \
       -parallel-testing-enabled YES \
       -parallel-testing-worker-count 2 \

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -8,12 +8,6 @@ steps:
   - checkout: ${{ parameters.iOSAppHostingSdkGitPath }}
     path: iOSHost
     persistCredentials: true
-  # - checkout: ${{ parameters.IOSSdkWorkspace}}
-  #   path: workspaceName
-  #   persistCredentials: true
-  # - checkout: ${{ parameters.IOSSdkScheme}}
-  #   path: schemeName
-  #   persistCredentials: true
 
   - task: InstallSSHKey@0
     displayName: 'Install an SSH key for OneDSTelemetry'
@@ -90,27 +84,26 @@ steps:
       -quiet
       -resultBundlePath TestResults
       test > report.out 2>&1
-
-      if [[ $? == 0 ]]
+      if [[ $? == 0 ]];
       then
       echo "E2E Test passes successfully"
-      exit 0
+      exit 0;
       else
       echo "E2E Test failed"
-      exit 1
-      fi
+      exit 1;
+      fi;
     displayName: 'iOS UI/E2E Tests'
     workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   - bash: xchtmlreport -r TestResults -j > /dev/null
-      if [[ $? == 0 ]]
+      if [[ $? == 0 ]];
       then
       echo "Test report has been generated successfully."
-      exit 0
+      exit 0;
       else
       echo "Test report generating process failed for some reasons."
-      exit 1
-      fi
+      exit 1;
+      fi;
     displayName: 'Generate E2E test report'
     workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
     condition: succeededOrFailed()

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -8,12 +8,12 @@ steps:
   - checkout: ${{ parameters.iOSAppHostingSdkGitPath }}
     path: iOSHost
     persistCredentials: true
-  - checkout: ${{ parameters.IOSSdkWorkspace}}
-    path: workspaceName
-    persistCredentials: true
-  - checkout: ${{ parameters.IOSSdkScheme}}
-    path: schemeName
-    persistCredentials: true
+  # - checkout: ${{ parameters.IOSSdkWorkspace}}
+  #   path: workspaceName
+  #   persistCredentials: true
+  # - checkout: ${{ parameters.IOSSdkScheme}}
+  #   path: schemeName
+  #   persistCredentials: true
 
   - task: InstallSSHKey@0
     displayName: 'Install an SSH key for OneDSTelemetry'
@@ -81,8 +81,8 @@ steps:
 
   - bash: /usr/bin/xcodebuild \
       -configuration Release \
-      -workspace /Users/runner/work/1/iOSHost/workspaceName.xcworkspace \
-      -scheme schemeName \
+      -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace \
+      -scheme $(IOSSdkScheme) \
       -sdk iphonesimulator \
       -parallel-testing-enabled YES \
       -parallel-testing-worker-count 2 \

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -8,8 +8,11 @@ steps:
   - checkout: ${{ parameters.iOSAppHostingSdkGitPath }}
     path: iOSHost
     persistCredentials: true
-  - checkout: ${{ parameters.IOSSdkLocalWorkspaceAndScheme}}
-    path: workspaceAndSchemePath
+  - checkout: ${{ parameters.IOSSdkWorkspace}}
+    path: workspaceName
+    persistCredentials: true
+  - checkout: ${{ parameters.IOSSdkScheme}}
+    path: schemeName
     persistCredentials: true
 
   - task: InstallSSHKey@0
@@ -78,7 +81,8 @@ steps:
 
   - bash: /usr/bin/xcodebuild \
       -configuration Release \
-      workspaceAndSchemePath \
+      -workspace /Users/runner/work/1/iOSHost/workspaceName.xcworkspace \
+      -scheme schemeName \
       -sdk iphonesimulator \
       -parallel-testing-enabled YES \
       -parallel-testing-worker-count 2 \

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -10,7 +10,7 @@ steps:
     persistCredentials: true
   - checkout: ${{ parameters.IOSSdkLocalWorkspaceAndScheme}}
     path: workspaceAndSchemePath
-    persistCredetials: true
+    persistCredentials: true
 
   - task: InstallSSHKey@0
     displayName: 'Install an SSH key for OneDSTelemetry'

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -75,7 +75,7 @@ steps:
 
   - bash: /usr/bin/xcodebuild \
       -configuration Release \
-      ${{ parameters.IOSSdkLocalWorkspaceAndScheme }} \
+      ${{parameters.IOSSdkLocalWorkspaceAndScheme}} \
       -sdk iphonesimulator \
       -parallel-testing-enabled YES \
       -parallel-testing-worker-count 2 \

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -8,6 +8,9 @@ steps:
   - checkout: ${{ parameters.iOSAppHostingSdkGitPath }}
     path: iOSHost
     persistCredentials: true
+  - checkout: ${{ parameters.IOSSdkLocalWorkspaceAndScheme}}
+    path: workspaceAndSchemePath
+    persistCredetials: true
 
   - task: InstallSSHKey@0
     displayName: 'Install an SSH key for OneDSTelemetry'
@@ -75,7 +78,7 @@ steps:
 
   - bash: /usr/bin/xcodebuild \
       -configuration Release \
-      ${{parameters.IOSSdkLocalWorkspaceAndScheme}} \
+      workspaceAndSchemePath \
       -sdk iphonesimulator \
       -parallel-testing-enabled YES \
       -parallel-testing-worker-count 2 \

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -79,17 +79,18 @@ steps:
     displayName: 'Disable Slow Animation'
     workingDirectory: '$(System.DefaultWorkingDirectory)'
 
-  - bash: /usr/bin/xcodebuild \
-      -configuration Release \
-      -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace \
-      -scheme $(IOSSdkScheme) \
-      -sdk iphonesimulator \
-      -parallel-testing-enabled YES \
-      -parallel-testing-worker-count 2 \
-      -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2' \
-      -quiet \
-      -resultBundlePath TestResults \
+  - bash: /usr/bin/xcodebuild
+      -configuration Release
+      -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace
+      -scheme $(IOSSdkScheme)
+      -sdk iphonesimulator
+      -parallel-testing-enabled YES
+      -parallel-testing-worker-count 2
+      -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2'
+      -quiet
+      -resultBundlePath TestResults
       test > report.out 2>&1
+
       if [[ $? == 0 ]]
       then
       echo "E2E Test passes successfully"


### PR DESCRIPTION
## Description

Currently we are facing an issue on internal-macos-11 VM image in Azure pipeline that XCTest runner could not be launched. This issue could be intimidated by upgrading to internal-macos12 VM image.

Meanwhile, this PR remove the bash script dependencies in iOS host SDK repo so that Teams-JS library side will has less chance to be broken by the change in iOS side.

### Main changes in the PR:

1. Upgrade VM image from internal-macos-11 to internal-macos12
2. Bash scripts dependencies are removed.

## Validation

CI pipeline checkin in iOS should not be timeout. It should pass after this PR.

### Validation performed:

1. All CI pipelines check are past.

### Unit Tests added: No

### End-to-end tests added: No

