### PR TITLE
Unit Test Case update: appWindow.spec.ts

### DIFF
--- a/packages/teams-js/test/public/appWindow.spec.ts
+++ b/packages/teams-js/test/public/appWindow.spec.ts
@@ -1,8 +1,8 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
+import { GlobalVars } from '../../src/internal/globalVars';
 import { ChildAppWindow, ParentAppWindow } from '../../src/public';
 import { app } from '../../src/public/app';
 import { FrameContexts } from '../../src/public/constants';
-import { FramelessPostMocks } from '../framelessPostMocks';
 import { Utils } from '../utils';
 
 /* eslint-disable */
@@ -10,171 +10,227 @@ import { Utils } from '../utils';
    large numbers of errors. Then, over time, we can fix the errors and reenable eslint on a per file basis. */
 
 describe('appWindow', () => {
-  // Use to send a mock message from the app.
-
-  const framedMock = new Utils();
-  const framelessMock = new FramelessPostMocks();
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const emptyCallback = (): void => {};
-
-  beforeEach(() => {
-    framedMock.processMessage = null;
-    framedMock.messages = [];
-    framelessMock.messages = [];
-    framedMock.childMessages = [];
-    framedMock.childWindow.closed = false;
-  });
-
-  afterEach(() => {
-    // Reset the object since it's a singleton
-    if (app._uninitialize) {
-      app._uninitialize();
-    }
-  });
-
-  describe('ChildAppWindow', () => {
+  describe('Child app window', () => {
     const childAppWindow = new ChildAppWindow();
-
-    describe('ChildAppWindow.postMessage', () => {
-      it('should not allow calls before initialization', () => {
-        expect.assertions(1);
-        expect(() => childAppWindow.postMessage('message')).toThrowError(new Error(errorLibraryNotInitialized));
+    it('childAppWindow.postMessage should not allow calls before initialization', () => {
+      expect.assertions(1);
+      expect(() => childAppWindow.postMessage('message')).toThrowError(new Error(errorLibraryNotInitialized));
+    });
+    it('childAppWindow.addEventListener should not allow calls before initialization', () => {
+      expect.assertions(1);
+      expect(() => childAppWindow.addEventListener('message', emptyCallback)).toThrowError(
+        new Error(errorLibraryNotInitialized),
+      );
+    });
+    describe('frameless', () => {
+      let utils: Utils = new Utils();
+      beforeEach(() => {
+        utils = new Utils();
+        utils.mockWindow.parent = undefined;
+        utils.messages = [];
+        GlobalVars.isFramelessWindow = false;
+      });
+      afterEach(() => {
+        app._uninitialize();
+        GlobalVars.isFramelessWindow = false;
       });
 
-      Object.values(FrameContexts).forEach((frameContext) => {
-        it(`FRAMED: should initiate the post message to child: ${frameContext}`, async () => {
-          await framedMock.initializeWithContext(frameContext);
-          childAppWindow.postMessage('exampleMessage');
-          const message = framedMock.findMessageByFunc('messageForChild');
-          expect(message).not.toBeUndefined();
-          expect(message.args).toStrictEqual(['exampleMessage']);
+      describe('ChildAppWindow.postMessage', () => {
+        Object.values(FrameContexts).forEach((frameContext) => {
+          it(`should initiate the post message to child: ${frameContext}`, async () => {
+            await utils.initializeWithContext(frameContext);
+            expect(GlobalVars.isFramelessWindow).toBeTruthy();
+            childAppWindow.postMessage('exampleMessage');
+            const message = utils.findMessageByFunc('messageForChild');
+            expect(message).not.toBeUndefined();
+            expect(message.args).toStrictEqual(['exampleMessage']);
+          });
         });
+      });
 
-        it(`FRAMELESS: should initiate the post message to child: ${frameContext}`, async () => {
-          await framelessMock.initializeWithContext(frameContext);
-          childAppWindow.postMessage('exampleMessage');
-          const message = framelessMock.findMessageByFunc('messageForChild');
-          expect(message).not.toBeUndefined();
-          expect(message.args).toStrictEqual(['exampleMessage']);
+      describe('ChildAppWindow.addEventListener', () => {
+        Object.values(FrameContexts).forEach((frameContext) => {
+          it(`should initiate the registration call for 'messageForParent: ${frameContext}`, async () => {
+            await utils.initializeWithContext(frameContext);
+            expect(GlobalVars.isFramelessWindow).toBeTruthy();
+            childAppWindow.addEventListener('message', emptyCallback);
+            const message = utils.findMessageByFunc('registerHandler');
+            expect(message).not.toBeUndefined();
+            expect(message.args).toStrictEqual(['messageForParent']);
+          });
         });
       });
     });
-    describe('ChildAppWindow.addEventListener', () => {
-      it('should not allow calls before initialization', () => {
-        expect.assertions(1);
-        expect(() => childAppWindow.addEventListener('message', emptyCallback)).toThrowError(
-          new Error(errorLibraryNotInitialized),
-        );
+    describe('framed', () => {
+      let utils: Utils = new Utils();
+      beforeEach(() => {
+        utils = new Utils();
+        utils.messages = [];
       });
-
-      Object.values(FrameContexts).forEach((frameContext) => {
-        it(`FRAMED: should initiate the registration call for messageForParent: ${frameContext}`, async () => {
-          await framedMock.initializeWithContext(frameContext);
-          childAppWindow.addEventListener('message', emptyCallback);
-          const message = framedMock.findMessageByFunc('registerHandler');
-          expect(message).not.toBeUndefined();
-          expect(message.args).toStrictEqual(['messageForParent']);
+      afterEach(() => {
+        app._uninitialize();
+      });
+      describe('ChildAppWindow.postMessage', () => {
+        Object.values(FrameContexts).forEach((frameContext) => {
+          it(`should initiate the post message to child: ${frameContext}`, async () => {
+            await utils.initializeWithContext(frameContext);
+            expect(GlobalVars.isFramelessWindow).toBeFalsy();
+            childAppWindow.postMessage('exampleMessage');
+            const message = utils.findMessageByFunc('messageForChild');
+            expect(message).not.toBeUndefined();
+            expect(message.args).toStrictEqual(['exampleMessage']);
+          });
         });
-
-        it(`FRAMELESS: should initiate the registration call for 'messageForParent: ${frameContext}`, async () => {
-          await framelessMock.initializeWithContext(frameContext);
-          childAppWindow.addEventListener('message', emptyCallback);
-          const message = framelessMock.findMessageByFunc('registerHandler');
-          expect(message).not.toBeUndefined();
-          expect(message.args).toStrictEqual(['messageForParent']);
+      });
+      describe('ChildAppWindow.addEventListener', () => {
+        Object.values(FrameContexts).forEach((frameContext) => {
+          it(`should initiate the registration call for messageForParent: ${frameContext}`, async () => {
+            await utils.initializeWithContext(frameContext);
+            expect(GlobalVars.isFramelessWindow).toBeFalsy();
+            childAppWindow.addEventListener('message', emptyCallback);
+            const message = utils.findMessageByFunc('registerHandler');
+            expect(message).not.toBeUndefined();
+            expect(message.args).toStrictEqual(['messageForParent']);
+          });
         });
       });
     });
   });
-  describe('ParentAppWindow', () => {
+
+  describe('Parent app window', () => {
     const parentAppWindow = new ParentAppWindow();
     const allowedContexts = [FrameContexts.task];
-    describe('ParentAppWindow.postMessage', () => {
-      it('should not allow calls before initialization', () => {
-        expect.assertions(1);
-        expect(() => parentAppWindow.postMessage('message')).toThrowError(new Error(errorLibraryNotInitialized));
+    it('ParentAppWindow.postMessage should not allow calls before initialization', () => {
+      expect.assertions(1);
+      expect(() => parentAppWindow.postMessage('message')).toThrowError(new Error(errorLibraryNotInitialized));
+    });
+    it('ParentAppWindow.addEventListner should not allow calls before initialization', () => {
+      expect.assertions(1);
+      expect(() => parentAppWindow.addEventListener('message', emptyCallback)).toThrowError(
+        new Error(errorLibraryNotInitialized),
+      );
+    });
+    describe('frameless', () => {
+      let utils: Utils = new Utils();
+      beforeEach(() => {
+        utils = new Utils();
+        utils.mockWindow.parent = undefined;
+        utils.messages = [];
+        GlobalVars.isFramelessWindow = false;
+      });
+      afterEach(() => {
+        app._uninitialize();
+        GlobalVars.isFramelessWindow = false;
       });
 
-      Object.values(FrameContexts).forEach((frameContext) => {
-        if (allowedContexts.some((allowedContext) => allowedContext == frameContext)) {
-          it(`FRAMED: should initiate the post message to parent: ${frameContext}`, async () => {
-            await framedMock.initializeWithContext(frameContext);
-            parentAppWindow.postMessage('exampleMessage');
-            const message = framedMock.findMessageByFunc('messageForParent');
-            expect(message).not.toBeUndefined();
-            expect(message.args).toStrictEqual(['exampleMessage']);
-          });
+      describe('ParentAppWindow.postMessage', () => {
+        Object.values(allowedContexts).forEach((frameContext) => {
+          if (allowedContexts.some((allowedContext) => allowedContext == frameContext)) {
+            it(`should initiate the post message to parent: ${frameContext}`, async () => {
+              await utils.initializeWithContext(frameContext);
+              expect(GlobalVars.isFramelessWindow).toBeTruthy();
+              parentAppWindow.postMessage('exampleMessage');
+              const message = utils.findMessageByFunc('messageForParent');
+              expect(message).not.toBeUndefined();
+              expect(message.args).toStrictEqual(['exampleMessage']);
+            });
+          } else {
+            it(`should to not allow to initialize FramContext with context: ${frameContext}.`, async () => {
+              await utils.initializeWithContext(frameContext);
+              expect(GlobalVars.isFramelessWindow).toBeTruthy();
+              expect(parentAppWindow.postMessage).toThrowError(
+                `This call is only allowed in following contexts: ${JSON.stringify(
+                  allowedContexts,
+                )}. Current context: "${frameContext}".`,
+              );
+            });
+          }
+        });
+      });
 
-          it(`FRAMELESS: should initiate the post message to parent: ${frameContext}`, async () => {
-            await framelessMock.initializeWithContext(frameContext);
-            parentAppWindow.postMessage('exampleMessage');
-            const message = framelessMock.findMessageByFunc('messageForParent');
-            expect(message).not.toBeUndefined();
-            expect(message.args).toStrictEqual(['exampleMessage']);
-          });
-        } else {
-          it(`should to not allow to initialize FramContext with context: ${frameContext}.`, async () => {
-            await framelessMock.initializeWithContext(frameContext);
-            expect(parentAppWindow.postMessage).toThrowError(
-              `This call is only allowed in following contexts: ${JSON.stringify(
-                allowedContexts,
-              )}. Current context: "${frameContext}".`,
-            );
-          });
-          it(`should to not allow to initialize FramContext with context: ${frameContext}.`, async () => {
-            await framedMock.initializeWithContext(frameContext);
-            expect(parentAppWindow.postMessage).toThrowError(
-              `This call is only allowed in following contexts: ${JSON.stringify(
-                allowedContexts,
-              )}. Current context: "${frameContext}".`,
-            );
-          });
-        }
+      describe('ParentAppWindow.addEventListener', () => {
+        Object.values(FrameContexts).forEach((frameContext) => {
+          if (allowedContexts.some((allowedContext) => allowedContext == frameContext)) {
+            it(`should initiate the registration call for 'messageForChild: ${frameContext}`, async () => {
+              await utils.initializeWithContext(frameContext);
+              expect(GlobalVars.isFramelessWindow).toBeTruthy();
+              parentAppWindow.addEventListener('message', emptyCallback);
+              const message = utils.findMessageByFunc('registerHandler');
+              expect(message).not.toBeUndefined();
+              expect(message.args).toStrictEqual(['messageForChild']);
+            });
+          } else {
+            it(`should to not allow to initialize FramContext with context: ${frameContext}.`, async () => {
+              await utils.initializeWithContext(frameContext);
+              expect(GlobalVars.isFramelessWindow).toBeTruthy();
+              expect(parentAppWindow.postMessage).toThrowError(
+                `This call is only allowed in following contexts: ${JSON.stringify(
+                  allowedContexts,
+                )}. Current context: "${frameContext}".`,
+              );
+            });
+          }
+        });
       });
     });
-    describe('ParentAppWindow.addEventListener', () => {
-      it('should not allow calls before initialization', () => {
-        expect.assertions(1);
-        expect(() => parentAppWindow.addEventListener('message', emptyCallback)).toThrowError(
-          new Error(errorLibraryNotInitialized),
-        );
+    describe('framed', () => {
+      let utils: Utils = new Utils();
+      beforeEach(() => {
+        utils = new Utils();
+        utils.messages = [];
       });
-
-      Object.values(FrameContexts).forEach((frameContext) => {
-        if (allowedContexts.some((allowedContext) => allowedContext == frameContext)) {
-          it(`FRAMED: should initiate the registration call for messageForChild: ${frameContext}`, async () => {
-            await framedMock.initializeWithContext(frameContext);
-            parentAppWindow.addEventListener('message', emptyCallback);
-            const message = framedMock.findMessageByFunc('registerHandler');
-            expect(message).not.toBeUndefined();
-            expect(message.args).toStrictEqual(['messageForChild']);
-          });
-
-          it(`FRAMELESS: should initiate the registration call for 'messageForChild: ${frameContext}`, async () => {
-            await framelessMock.initializeWithContext(frameContext);
-            parentAppWindow.addEventListener('message', emptyCallback);
-            const message = framelessMock.findMessageByFunc('registerHandler');
-            expect(message).not.toBeUndefined();
-            expect(message.args).toStrictEqual(['messageForChild']);
-          });
-        } else {
-          it(`should to not allow to initialize FramContext with context: ${frameContext}.`, async () => {
-            await framelessMock.initializeWithContext(frameContext);
-            expect(parentAppWindow.postMessage).toThrowError(
-              `This call is only allowed in following contexts: ${JSON.stringify(
-                allowedContexts,
-              )}. Current context: "${frameContext}".`,
-            );
-          });
-          it(`should to not allow to initialize FramContext with context: ${frameContext}.`, async () => {
-            await framedMock.initializeWithContext(frameContext);
-            expect(parentAppWindow.postMessage).toThrowError(
-              `This call is only allowed in following contexts: ${JSON.stringify(
-                allowedContexts,
-              )}. Current context: "${frameContext}".`,
-            );
-          });
-        }
+      afterEach(() => {
+        app._uninitialize();
+      });
+      describe('ParentAppWindow.postMessage', () => {
+        Object.values(FrameContexts).forEach((frameContext) => {
+          if (allowedContexts.some((allowedContext) => allowedContext == frameContext)) {
+            it(`should initiate the post message to parent: ${frameContext}`, async () => {
+              await utils.initializeWithContext(frameContext);
+              expect(GlobalVars.isFramelessWindow).toBeFalsy();
+              parentAppWindow.postMessage('exampleMessage');
+              const message = utils.findMessageByFunc('messageForParent');
+              expect(message).not.toBeUndefined();
+              expect(message.args).toStrictEqual(['exampleMessage']);
+            });
+          } else {
+            it(`should to not allow to initialize FramContext with context: ${frameContext}.`, async () => {
+              await utils.initializeWithContext(frameContext);
+              expect(GlobalVars.isFramelessWindow).toBeFalsy();
+              expect(parentAppWindow.postMessage).toThrowError(
+                `This call is only allowed in following contexts: ${JSON.stringify(
+                  allowedContexts,
+                )}. Current context: "${frameContext}".`,
+              );
+            });
+          }
+        });
+      });
+      describe('ParentAppWindow.addEventListener', () => {
+        Object.values(FrameContexts).forEach((frameContext) => {
+          if (allowedContexts.some((allowedContext) => allowedContext == frameContext)) {
+            it(`should initiate the registration call for messageForChild: ${frameContext}`, async () => {
+              await utils.initializeWithContext(frameContext);
+              expect(GlobalVars.isFramelessWindow).toBeFalsy();
+              parentAppWindow.addEventListener('message', emptyCallback);
+              const message = utils.findMessageByFunc('registerHandler');
+              expect(message).not.toBeUndefined();
+              expect(message.args).toStrictEqual(['messageForChild']);
+            });
+          } else {
+            it(`should to not allow to initialize FramContext with context: ${frameContext}.`, async () => {
+              await utils.initializeWithContext(frameContext);
+              expect(GlobalVars.isFramelessWindow).toBeFalsy();
+              expect(parentAppWindow.postMessage).toThrowError(
+                `This call is only allowed in following contexts: ${JSON.stringify(
+                  allowedContexts,
+                )}. Current context: "${frameContext}".`,
+              );
+            });
+          }
+        });
       });
     });
   });

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -163,7 +163,16 @@ export class Utils {
         `Cannot respond to message ${message.id} because processMessage function has not been set and is null`,
       );
     }
-
+    else if (this.processMessage === undefined) {
+      const domEvent = {
+        data: {
+          id: message.id,
+          args: args,
+        } as MessageResponse,
+      } as DOMMessageEvent;
+      (this.mockWindow as unknown as ExtendedWindow).onNativeMessage(domEvent);
+    }
+    else {
     this.processMessage({
       origin: this.validOrigin,
       source: this.mockWindow.parent,
@@ -172,6 +181,7 @@ export class Utils {
         args: args,
       } as MessageResponse,
     } as MessageEvent);
+  }
   };
 
   public respondToMessageAsOpener = (message: MessageRequest, ...args: unknown[]): void => {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

We now know that desktop has two existing implementations: 
``` 
 framed: Tabs are loaded inside iframe which is created inside electron webview.
```
``` 
frameless: Tabs are loaded directly inside webview. 
```
That means platform can be frameless or iframed based upon what implementation is being used. 
We know that web is always in iframe, and mobile is always frameless. We are going to use this information to name the mock windows correctly.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

Updated `appWindow.spec.ts` to uniformly use `Utils` class instead of `FramelessPostMock`.
Updated `utils.ts` file to adapt a way to respond to `frameless` window.

## Validation

### Validation performed:
N/A

### Unit Tests added:
Yes

### End-to-end tests added:
N/A
