### PR TITLE
Removed complicated regular expression that was breaking our CodeQL YAML file

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,8 +13,7 @@ name: 'CodeQL'
 
 on:
   push:
-    # We only have automation for release 1.13.*-and higher. The fourth entry is checking this
-    branches: ['main', archive/*, main*, release-1\.(1[3-9]|[2-9]\d|\d{3,})\.+.*, release/*]
+    branches: ['main', archive/*, main*, release-1.*, release/*]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: ['main']


### PR DESCRIPTION
## Description

The regular expression I was trying to use to only check pushes to 1.13.* or later for CodeQL issues was causing CodeQL to not run properly. I'm not sure what *exactly* the problem was, but I don't think there's any reason for a regex that complicated so I simplified it greatly. This change means that we'll now run codeql on any pushes to 1.* including branches earlier than 1.13, but that really shouldn't ever happen so I propose we do this for now and we can do something more complicated in the future if needed.

### Main changes in the PR:

1. Updated CodeQL yaml to now run on pushes to any 1.* release branches instead of just 1.13 or later

## Validation

### Validation performed:

1. Ran old yaml through yaml linter and verified there was a problem with that regular expression. Updated yaml as seen here and ran it through the same linter and verified that the linter no longer identified a yaml syntax problem.

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No, yaml workflow change only