### PR TITLE
Unit Test Case update people.spec.ts

### DIFF
--- a/change/@microsoft-teams-js-e88ee082-6fb3-4779-9727-777bd3b56814.json
+++ b/change/@microsoft-teams-js-e88ee082-6fb3-4779-9727-777bd3b56814.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix lint errors",
+  "packageName": "@microsoft/teams-js",
+  "email": "98348000+shrshindeMSFT@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/public/appInstallDialog.ts
+++ b/packages/teams-js/src/public/appInstallDialog.ts
@@ -15,7 +15,7 @@ export namespace appInstallDialog {
   /**
    * Displays a dialog box that allows users to install a specific app within the host environment.
    *
-   * @param openAPPInstallDialogParams - See {@link OpenAppInstallDialogParams | OpenAppInstallDialogParams} for more information. 
+   * @param openAPPInstallDialogParams - See {@link OpenAppInstallDialogParams | OpenAppInstallDialogParams} for more information.
    */
   export function openAppInstallDialog(openAPPInstallDialogParams: OpenAppInstallDialogParams): Promise<void> {
     return new Promise((resolve) => {

--- a/packages/teams-js/src/public/appWindow.ts
+++ b/packages/teams-js/src/public/appWindow.ts
@@ -34,7 +34,7 @@ export interface IAppWindow {
 }
 
 /**
- * An object that application can utilize to establish communication 
+ * An object that application can utilize to establish communication
  * with the child window it opened, which contains the corresponding task.
  */
 export class ChildAppWindow implements IAppWindow {
@@ -62,9 +62,9 @@ export class ChildAppWindow implements IAppWindow {
   }
 }
 
-/** 
- * An object that is utilized to facilitate communication with a parent window 
- * that initiated the opening of current window. For instance, a dialog or task 
+/**
+ * An object that is utilized to facilitate communication with a parent window
+ * that initiated the opening of current window. For instance, a dialog or task
  * module would utilize it to transmit messages to the application that launched it.
  */
 export class ParentAppWindow implements IAppWindow {
@@ -78,7 +78,7 @@ export class ParentAppWindow implements IAppWindow {
 
   /**
    * Send a message to the ParentAppWindow.
-   * 
+   *
    * @param message - The message to send
    * @param onComplete - The callback to know if the postMessage has been success/failed.
    */

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -65,11 +65,11 @@ export enum HostName {
  * FrameContexts provides information about the context in which the app is running within the host.
  * Developers can use FrameContexts to determine how their app should behave in different contexts,
  * and can use the information provided by the context to adapt the app to the user's needs.
- * 
- * @example 
- * If your app is running in the "settings" context, you should be displaying your apps configuration page. 
- * If the app is running in the content context, the developer may want to display information relevant to 
- * the content the user is currently viewing. 
+ *
+ * @example
+ * If your app is running in the "settings" context, you should be displaying your apps configuration page.
+ * If the app is running in the content context, the developer may want to display information relevant to
+ * the content the user is currently viewing.
  */
 export enum FrameContexts {
   /**

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -47,11 +47,7 @@ export { dialog } from './dialog';
 export { geoLocation } from './geoLocation';
 export { getAdaptiveCardSchemaVersion } from './adaptiveCards';
 export { pages } from './pages';
-export {
-  ChildAppWindow,
-  IAppWindow,
-  ParentAppWindow
-} from './appWindow';
+export { ChildAppWindow, IAppWindow, ParentAppWindow } from './appWindow';
 export { menus } from './menus';
 export { media } from './media';
 export { location } from './location';
@@ -92,12 +88,7 @@ export {
   setFrameContext,
   shareDeepLink,
 } from './publicAPIs';
-export {
-  returnFocus,
-  navigateBack,
-  navigateCrossDomain,
-  navigateToTab,
-} from './navigation';
+export { returnFocus, navigateBack, navigateCrossDomain, navigateToTab } from './navigation';
 export { settings } from './settings';
 export { tasks } from './tasks';
 export * from './liveShareHost';

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -156,28 +156,28 @@ export interface TeamInformation {
 export interface LocaleInfo {
   /** Represents the user's platform on which the app is running. */
   platform: HostClientType.android | HostClientType.ios | 'macos' | 'windows';
-  /** 
-   * Represents the regional format used by the user's locale. 
+  /**
+   * Represents the regional format used by the user's locale.
    * @example `en-us`.
    */
   regionalFormat: string;
-  /** 
+  /**
    * Displays date values, as specified by the short date format MM/DD/YYYY in user's regional settings.
-   * @example 4/21/2023 or 4-21-2023 
+   * @example 4/21/2023 or 4-21-2023
    */
   shortDate: string;
-  /** 
+  /**
    * Displays only date values, as specified by the Long Date format in user's regional settings.
-   * @example Friday, April 21, 2023 
+   * @example Friday, April 21, 2023
    */
   longDate: string;
   /**
-   * A string representing the short time format used by the user's locale. 
+   * A string representing the short time format used by the user's locale.
    * @example 10:10
    */
   shortTime: string;
-  /** 
-   * A string representing the long time format used by the user's locale. 
+  /**
+   * A string representing the long time format used by the user's locale.
    * @example 10:10:42 AM
    */
   longTime: string;

--- a/packages/teams-js/test/public/people.spec.ts
+++ b/packages/teams-js/test/public/people.spec.ts
@@ -5,8 +5,7 @@ import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { ErrorCode, SdkError } from '../../src/public/interfaces';
 import { people } from '../../src/public/people';
-import { _minRuntimeConfigToUninitialize, v1HostClientTypes } from '../../src/public/runtime';
-import { FramelessPostMocks } from '../framelessPostMocks';
+import { v1HostClientTypes } from '../../src/public/runtime';
 import { Utils } from '../utils';
 
 /* eslint-disable */

--- a/packages/teams-js/test/public/people.spec.ts
+++ b/packages/teams-js/test/public/people.spec.ts
@@ -156,6 +156,9 @@ describe('people', () => {
   });
 
   describe('Testing people.isSupported function', () => {
+    afterEach(() => {
+      app._uninitialize();
+    });
     it('people.isSupported should return false if the runtime says people is not supported', async () => {
       await utils.initializeWithContext(FrameContexts.content);
       utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
@@ -167,7 +170,6 @@ describe('people', () => {
       utils.setRuntimeConfig({ apiVersion: 1, supports: { people: {} } });
       expect(people.isSupported()).toBeTruthy();
     });
-
     it('people.isSupported should throw if called before initialization', () => {
       utils.uninitializeRuntimeConfig();
       expect(() => people.isSupported()).toThrowError(new Error(errorLibraryNotInitialized));
@@ -177,13 +179,6 @@ describe('people', () => {
   /* eslint-disable @typescript-eslint/no-empty-function */
   /* eslint-disable @typescript-eslint/no-unused-vars */
   describe('peoplePicker_V1', () => {
-    /**
-     * People Picker tests
-     */
-    it('should not allow selectPeople calls before initialization', () => {
-      expect(() => people.selectPeople(() => {})).toThrowError(new Error(errorLibraryNotInitialized));
-    });
-
     let utils: Utils = new Utils();
     beforeEach(() => {
       utils = new Utils();
@@ -195,6 +190,14 @@ describe('people', () => {
       app._uninitialize();
       GlobalVars.isFramelessWindow = false;
     });
+
+    /**
+     * People Picker tests
+     */
+    it('should not allow selectPeople calls before initialization', () => {
+      expect(() => people.selectPeople(() => {})).toThrowError(new Error(errorLibraryNotInitialized));
+    });
+
     Object.values(FrameContexts).forEach((context) => {
       if (allowedContexts.some((allowedContext) => allowedContext === context)) {
         Object.values(v1HostClientTypes).forEach((hostClientType) => {

--- a/packages/teams-js/test/public/people.spec.ts
+++ b/packages/teams-js/test/public/people.spec.ts
@@ -1,4 +1,5 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
+import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
@@ -16,25 +17,9 @@ import { Utils } from '../utils';
  * Test cases for selectPeople API
  */
 describe('people', () => {
-  const framelessPlatformMock = new FramelessPostMocks();
-  const framedMock = new Utils();
+  const utils = new Utils();
   const minVersionForSelectPeople = '2.0.0';
   const originalDefaultPlatformVersion = '1.6.0';
-
-  beforeEach(() => {
-    framelessPlatformMock.messages = [];
-
-    // Set a mock window for testing
-    app._initialize(framelessPlatformMock.mockWindow);
-  });
-
-  afterEach(() => {
-    // Reset the object since it's a singleton
-    if (app._uninitialize) {
-      framedMock.setRuntimeConfig(_minRuntimeConfigToUninitialize);
-      app._uninitialize();
-    }
-  });
   const allowedContexts = [FrameContexts.content, FrameContexts.task, FrameContexts.settings];
   const result = [
     {
@@ -47,6 +32,7 @@ describe('people', () => {
     title: 'Title',
     openOrgWideSearchInChatOrChannel: true,
   };
+
   describe('peoplePicker', () => {
     /**
      * People Picker tests
@@ -55,121 +41,135 @@ describe('people', () => {
       expect(() => people.selectPeople()).toThrowError(new Error(errorLibraryNotInitialized));
     });
 
-    Object.values(FrameContexts).forEach((context) => {
-      if (allowedContexts.some((allowedContext) => allowedContext === context)) {
-        Object.values(v1HostClientTypes).forEach((hostClientType) => {
-          it(`should throw error when people is not supported in runtime config. context: ${context}`, async () => {
-            await framelessPlatformMock.initializeWithContext(context, hostClientType);
-            framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-            expect(people.selectPeople()).rejects.toEqual(errorNotSupportedOnPlatform);
+    describe('frameless', () => {
+      let utils: Utils = new Utils();
+      beforeEach(() => {
+        utils = new Utils();
+        utils.mockWindow.parent = undefined;
+        utils.messages = [];
+        GlobalVars.isFramelessWindow = false;
+      });
+      afterEach(() => {
+        app._uninitialize();
+        GlobalVars.isFramelessWindow = false;
+      });
+
+      Object.values(FrameContexts).forEach((context) => {
+        if (allowedContexts.some((allowedContext) => allowedContext === context)) {
+          Object.values(v1HostClientTypes).forEach((hostClientType) => {
+            it(`should throw error when people is not supported in runtime config. context: ${context}`, async () => {
+              await utils.initializeWithContext(context, hostClientType);
+              utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+              expect(people.selectPeople()).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it(`should allow selectPeople calls with null peoplePickerInputs. context: ${context}`, async () => {
+              await utils.initializeWithContext(context, hostClientType);
+              utils.setClientSupportedSDKVersion(minVersionForSelectPeople);
+              people.selectPeople(null);
+              const selectPeopleMessage = utils.findMessageByFunc('people.selectPeople');
+              expect(selectPeopleMessage).not.toBeNull();
+              expect(selectPeopleMessage.args[0]).toEqual(null);
+            });
+
+            it(`should allow selectPeople calls with no peoplePickerInputs. context: ${context}`, async () => {
+              await utils.initializeWithContext(context, hostClientType);
+              utils.setClientSupportedSDKVersion(minVersionForSelectPeople);
+              people.selectPeople();
+              const selectPeopleMessage = utils.findMessageByFunc('people.selectPeople');
+              expect(selectPeopleMessage).not.toBeNull();
+              expect(selectPeopleMessage.args[0]).toEqual(null);
+            });
+
+            it(`should allow selectPeople calls with undefined peoplePickerInputs. context: ${context}`, async () => {
+              await utils.initializeWithContext(context, hostClientType);
+              utils.setClientSupportedSDKVersion(minVersionForSelectPeople);
+              people.selectPeople(undefined);
+              const selectPeopleMessage = utils.findMessageByFunc('people.selectPeople');
+              expect(selectPeopleMessage).not.toBeNull();
+              expect(selectPeopleMessage.args[0]).toEqual(null);
+            });
+
+            it(`selectPeople call in default version of platform support fails. context: ${context}`, async () => {
+              await utils.initializeWithContext(context, hostClientType);
+              utils.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+              await expect(people.selectPeople()).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
+            });
+
+            it(`selectPeople calls with peoplePickerInput. context: ${context}`, async () => {
+              await utils.initializeWithContext(context, hostClientType);
+              utils.setClientSupportedSDKVersion(minVersionForSelectPeople);
+              const promise = people.selectPeople(input);
+
+              const message = utils.findMessageByFunc('people.selectPeople');
+
+              const callbackId = message.id;
+              utils.respondToFramelessMessage({
+                data: {
+                  id: callbackId,
+                  args: [undefined, result],
+                },
+              } as DOMMessageEvent);
+
+              await expect(promise).resolves.toBe(result);
+            });
+
+            it(`selectPeople calls with error. context: ${context}`, async () => {
+              await utils.initializeWithContext(context, hostClientType);
+              utils.setClientSupportedSDKVersion(minVersionForSelectPeople);
+              const peoplePickerInput: people.PeoplePickerInputs = {
+                title: 'Hello World',
+                setSelected: null,
+                openOrgWideSearchInChatOrChannel: true,
+                singleSelect: true,
+              };
+              const promise = people.selectPeople(peoplePickerInput);
+
+              const message = utils.findMessageByFunc('people.selectPeople');
+              expect(message).not.toBeNull();
+              expect(message.args.length).toBe(1);
+
+              const callbackId = message.id;
+              utils.respondToFramelessMessage({
+                data: {
+                  id: callbackId,
+                  args: [{ errorCode: ErrorCode.INTERNAL_ERROR }],
+                },
+              } as DOMMessageEvent);
+
+              expect(promise).rejects.toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
+            });
           });
+        } else {
+          it(`should not allow selectPeople calls from the wrong context. context: ${context}`, async () => {
+            await utils.initializeWithContext(context);
 
-          it(`should allow selectPeople calls with null peoplePickerInputs. context: ${context}`, async () => {
-            await framelessPlatformMock.initializeWithContext(context, hostClientType);
-            framelessPlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
-            people.selectPeople(null);
-            const selectPeopleMessage = framelessPlatformMock.findMessageByFunc('people.selectPeople');
-            expect(selectPeopleMessage).not.toBeNull();
-            expect(selectPeopleMessage.args[0]).toEqual(null);
+            expect(() => people.selectPeople()).toThrowError(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${context}".`,
+            );
           });
-
-          it(`should allow selectPeople calls with no peoplePickerInputs. context: ${context}`, async () => {
-            await framelessPlatformMock.initializeWithContext(context, hostClientType);
-            framelessPlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
-            people.selectPeople();
-            const selectPeopleMessage = framelessPlatformMock.findMessageByFunc('people.selectPeople');
-            expect(selectPeopleMessage).not.toBeNull();
-            expect(selectPeopleMessage.args[0]).toEqual(null);
-          });
-
-          it(`should allow selectPeople calls with undefined peoplePickerInputs. context: ${context}`, async () => {
-            await framelessPlatformMock.initializeWithContext(context, hostClientType);
-            framelessPlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
-            people.selectPeople(undefined);
-            const selectPeopleMessage = framelessPlatformMock.findMessageByFunc('people.selectPeople');
-            expect(selectPeopleMessage).not.toBeNull();
-            expect(selectPeopleMessage.args[0]).toEqual(null);
-          });
-
-          it(`selectPeople call in default version of platform support fails. context: ${context}`, async () => {
-            await framelessPlatformMock.initializeWithContext(context, hostClientType);
-            framelessPlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
-            await expect(people.selectPeople()).rejects.toEqual({ errorCode: ErrorCode.OLD_PLATFORM });
-          });
-
-          it(`selectPeople calls with peoplePickerInput. context: ${context}`, async () => {
-            await framelessPlatformMock.initializeWithContext(context, hostClientType);
-            framelessPlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
-            const promise = people.selectPeople(input);
-
-            const message = framelessPlatformMock.findMessageByFunc('people.selectPeople');
-
-            const callbackId = message.id;
-            framelessPlatformMock.respondToMessage({
-              data: {
-                id: callbackId,
-                args: [undefined, result],
-              },
-            } as DOMMessageEvent);
-
-            await expect(promise).resolves.toBe(result);
-          });
-
-          it(`selectPeople calls with error. context: ${context}`, async () => {
-            await framelessPlatformMock.initializeWithContext(context, hostClientType);
-            framelessPlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
-            const peoplePickerInput: people.PeoplePickerInputs = {
-              title: 'Hello World',
-              setSelected: null,
-              openOrgWideSearchInChatOrChannel: true,
-              singleSelect: true,
-            };
-            const promise = people.selectPeople(peoplePickerInput);
-
-            const message = framelessPlatformMock.findMessageByFunc('people.selectPeople');
-            expect(message).not.toBeNull();
-            expect(message.args.length).toBe(1);
-
-            const callbackId = message.id;
-            framelessPlatformMock.respondToMessage({
-              data: {
-                id: callbackId,
-                args: [{ errorCode: ErrorCode.INTERNAL_ERROR }],
-              },
-            } as DOMMessageEvent);
-
-            expect(promise).rejects.toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
-          });
-        });
-      } else {
-        it(`should not allow selectPeople calls from the wrong context. context: ${context}`, async () => {
-          await framelessPlatformMock.initializeWithContext(context);
-
-          expect(() => people.selectPeople()).toThrowError(
-            `This call is only allowed in following contexts: ${JSON.stringify(
-              allowedContexts,
-            )}. Current context: "${context}".`,
-          );
-        });
-      }
+        }
+      });
     });
   });
 
   describe('Testing people.isSupported function', () => {
     it('people.isSupported should return false if the runtime says people is not supported', async () => {
-      await framedMock.initializeWithContext(FrameContexts.content);
-      framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
+      await utils.initializeWithContext(FrameContexts.content);
+      utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
       expect(people.isSupported()).not.toBeTruthy();
     });
 
     it('people.isSupported should return true if the runtime says people is supported', async () => {
-      await framedMock.initializeWithContext(FrameContexts.content);
-      framedMock.setRuntimeConfig({ apiVersion: 1, supports: { people: {} } });
+      await utils.initializeWithContext(FrameContexts.content);
+      utils.setRuntimeConfig({ apiVersion: 1, supports: { people: {} } });
       expect(people.isSupported()).toBeTruthy();
     });
 
     it('people.isSupported should throw if called before initialization', () => {
-      framedMock.uninitializeRuntimeConfig();
+      utils.uninitializeRuntimeConfig();
       expect(() => people.isSupported()).toThrowError(new Error(errorLibraryNotInitialized));
     });
   });
@@ -184,48 +184,59 @@ describe('people', () => {
       expect(() => people.selectPeople(() => {})).toThrowError(new Error(errorLibraryNotInitialized));
     });
 
+    let utils: Utils = new Utils();
+    beforeEach(() => {
+      utils = new Utils();
+      utils.mockWindow.parent = undefined;
+      utils.messages = [];
+      GlobalVars.isFramelessWindow = false;
+    });
+    afterEach(() => {
+      app._uninitialize();
+      GlobalVars.isFramelessWindow = false;
+    });
     Object.values(FrameContexts).forEach((context) => {
       if (allowedContexts.some((allowedContext) => allowedContext === context)) {
         Object.values(v1HostClientTypes).forEach((hostClientType) => {
           it(`should throw error when people is not supported in runtime config. context: ${context}`, async () => {
-            await framelessPlatformMock.initializeWithContext(context, hostClientType);
-            framedMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
+            await utils.initializeWithContext(context, hostClientType);
+            utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
             expect(people.selectPeople(() => {})).rejects.toEqual(errorNotSupportedOnPlatform);
           });
 
           it(`should allow selectPeople calls with null peoplePickerInputs context: ${context}`, async () => {
-            await framelessPlatformMock.initializeWithContext(context, hostClientType);
-            framelessPlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
+            await utils.initializeWithContext(context, hostClientType);
+            utils.setClientSupportedSDKVersion(minVersionForSelectPeople);
             people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {}, null);
-            const message = framelessPlatformMock.findMessageByFunc('people.selectPeople');
+            const message = utils.findMessageByFunc('people.selectPeople');
             expect(message).not.toBeNull();
             expect(message.args.length).toBe(1);
             expect(message.args[0]).toEqual(null);
           });
 
           it(`should allow selectPeople calls with no peoplePickerInputs. context: ${context}`, async () => {
-            await framelessPlatformMock.initializeWithContext(context, hostClientType);
-            framelessPlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
+            await utils.initializeWithContext(context, hostClientType);
+            utils.setClientSupportedSDKVersion(minVersionForSelectPeople);
             people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {});
-            const message = framelessPlatformMock.findMessageByFunc('people.selectPeople');
+            const message = utils.findMessageByFunc('people.selectPeople');
             expect(message).not.toBeNull();
             expect(message.args.length).toBe(1);
             expect(message.args[0]).toEqual(null);
           });
 
           it(`should allow selectPeople calls with undefined peoplePickerInputs. context: ${context}`, async () => {
-            await framelessPlatformMock.initializeWithContext(context, hostClientType);
-            framelessPlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
+            await utils.initializeWithContext(context, hostClientType);
+            utils.setClientSupportedSDKVersion(minVersionForSelectPeople);
             people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {}, undefined);
-            const message = framelessPlatformMock.findMessageByFunc('people.selectPeople');
+            const message = utils.findMessageByFunc('people.selectPeople');
             expect(message).not.toBeNull();
             expect(message.args.length).toBe(1);
             expect(message.args[0]).toEqual(null);
           });
 
           it(`selectPeople call in default version of platform support fails. context: ${context}`, (done) => {
-            framelessPlatformMock.initializeWithContext(context, hostClientType).then(() => {
-              framelessPlatformMock.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+            utils.initializeWithContext(context, hostClientType).then(() => {
+              utils.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
               people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {
                 expect(error).not.toBeNull();
                 expect(error.errorCode).toBe(ErrorCode.OLD_PLATFORM);
@@ -235,8 +246,8 @@ describe('people', () => {
           });
 
           it(`selectPeople calls with valid peoplePickerInput. context: ${context}`, (done) => {
-            framelessPlatformMock.initializeWithContext(context, hostClientType).then(() => {
-              framelessPlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
+            utils.initializeWithContext(context, hostClientType).then(() => {
+              utils.setClientSupportedSDKVersion(minVersionForSelectPeople);
 
               people.selectPeople((e: SdkError, m: people.PeoplePickerResult[]) => {
                 expect(e).toBeFalsy();
@@ -244,10 +255,10 @@ describe('people', () => {
                 done();
               }, input);
 
-              const message = framelessPlatformMock.findMessageByFunc('people.selectPeople');
+              const message = utils.findMessageByFunc('people.selectPeople');
 
               const callbackId = message.id;
-              framelessPlatformMock.respondToMessage({
+              utils.respondToFramelessMessage({
                 data: {
                   id: callbackId,
                   args: [undefined, result],
@@ -257,8 +268,8 @@ describe('people', () => {
           });
 
           it(`selectPeople calls with error. context: ${context}`, (done) => {
-            framelessPlatformMock.initializeWithContext(context, hostClientType).then(() => {
-              framelessPlatformMock.setClientSupportedSDKVersion(minVersionForSelectPeople);
+            utils.initializeWithContext(context, hostClientType).then(() => {
+              utils.setClientSupportedSDKVersion(minVersionForSelectPeople);
 
               const peoplePickerInput: people.PeoplePickerInputs = {
                 title: 'Hello World',
@@ -272,10 +283,10 @@ describe('people', () => {
                 done();
               }, peoplePickerInput);
 
-              const message = framelessPlatformMock.findMessageByFunc('people.selectPeople');
+              const message = utils.findMessageByFunc('people.selectPeople');
 
               const callbackId = message.id;
-              framelessPlatformMock.respondToMessage({
+              utils.respondToFramelessMessage({
                 data: {
                   id: callbackId,
                   args: [{ errorCode: ErrorCode.INTERNAL_ERROR }],
@@ -286,7 +297,7 @@ describe('people', () => {
         });
       } else {
         it(`should not allow selectPeople calls from the wrong context. context: ${context}`, async () => {
-          await framelessPlatformMock.initializeWithContext(context);
+          await utils.initializeWithContext(context);
 
           expect(() =>
             people.selectPeople((error: SdkError, people: people.PeoplePickerResult[]) => {}, null),


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

We now know that desktop has two existing implementations: 
``` 
 framed: Tabs are loaded inside iframe which is created inside electron webview.
```
``` 
frameless: Tabs are loaded directly inside webview. 
```
That means platform can be frameless or iframed based upon what implementation is being used. 
We know that web is always in iframe, and mobile is always frameless. We are going to use this information to name the mock windows correctly.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

Updated `people.spec.ts` to uniformly use `Utils` class instead of `FramelessPostMock`.


## Validation

### Validation performed:
N/A

### Unit Tests added:
Yes

### End-to-end tests added:
N/A
