### PR TITLE
Unit Test Case update: barcode.spec.ts

### DIFF
--- a/apps/teams-test-app/src/components/GeoLocationAPIs.tsx
+++ b/apps/teams-test-app/src/components/GeoLocationAPIs.tsx
@@ -107,5 +107,4 @@ const GeoLocationAPIs = (): ReactElement => (
   </ModuleWrapper>
 );
 
-
 export default GeoLocationAPIs;


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

We now know that desktop has two existing implementations: 
``` 
 framed: Tabs are loaded inside iframe which is created inside electron webview.
```
``` 
frameless: Tabs are loaded directly inside webview. 
```
That means platform can be frameless or iframed based upon what implementation is being used. 
We know that web is always in iframe, and mobile is always frameless. We are going to use this information to name the mock windows correctly.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

Updated `barcode.spec.ts` to uniformly use `Utils` class instead of `FramelessPostMock`.


## Validation

### Validation performed:
N/A

### Unit Tests added:
Yes

### End-to-end tests added:
N/A
