### PR TITLE
Unit Test Case Update: videoEx.spec.ts

### DIFF
--- a/packages/teams-js/test/private/videoEx.spec.ts
+++ b/packages/teams-js/test/private/videoEx.spec.ts
@@ -1,5 +1,5 @@
 import { GlobalVars } from '../../src/internal/globalVars';
-import { DOMMessageEvent } from '../../src/internal/interfaces';
+import { DOMMessageEvent, MessageRequest } from '../../src/internal/interfaces';
 import { videoEx } from '../../src/private/videoEx';
 import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
@@ -69,9 +69,8 @@ describe('videoEx', () => {
       it('should successfully send registerForVideoFrame message', async () => {
         await utils.initializeWithContext(FrameContexts.sidePanel);
         videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig);
-        const message = utils.findMessageByFunc('video.registerForVideoFrame');
+        const message = utils.findMessageByFunc('video.registerForVideoFrame') as MessageRequest;
         expect(message).not.toBeNull();
-        console.log(message.args);
         expect(message.args[0]).toHaveProperty('audioInferenceModel');
         expect(message.args[0].format).toBe(video.VideoFrameFormat.NV12);
         expect(message.args[0].requireCameraStream).toBe(false);

--- a/packages/teams-js/test/private/videoEx.spec.ts
+++ b/packages/teams-js/test/private/videoEx.spec.ts
@@ -1,10 +1,9 @@
+import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { videoEx } from '../../src/private/videoEx';
 import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
-import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { video } from '../../src/public/video';
-import { FramelessPostMocks } from '../framelessPostMocks';
 import { Utils } from '../utils';
 
 /* eslint-disable */
@@ -15,657 +14,709 @@ import { Utils } from '../utils';
  * Test cases for selectPeople API
  */
 describe('videoEx', () => {
-  const framelessPlatformMock = new FramelessPostMocks();
-  const framedPlatformMock = new Utils();
-
-  beforeEach(() => {
-    framelessPlatformMock.messages = [];
-    framedPlatformMock.messages = [];
-  });
-
-  afterEach(() => {
-    // Reset the object since it's a singleton
-    if (app._uninitialize) {
-      framedPlatformMock.setRuntimeConfig(_minRuntimeConfigToUninitialize);
+  describe('frameless', () => {
+    let utils: Utils = new Utils();
+    beforeEach(() => {
+      utils = new Utils();
+      utils.mockWindow.parent = undefined;
+      app._initialize(utils.mockWindow);
+      utils.messages = [];
+      GlobalVars.isFramelessWindow = false;
+    });
+    afterEach(() => {
       app._uninitialize();
-    }
-  });
-  describe('registerForVideoFrame', () => {
-    const emptyVideoFrameCallback = (
-      _frame: videoEx.VideoFrame,
-      _notifyVideoFrameProcessed: () => void,
-      _notifyError: (errorMessage: string) => void,
-    ): void => {};
-    const videoFrameConfig: videoEx.VideoFrameConfig = {
-      format: video.VideoFrameFormat.NV12,
-      requireCameraStream: false,
-      audioInferenceModel: new ArrayBuffer(100),
-    };
-
-    const allowedContexts = [FrameContexts.sidePanel];
-    Object.values(FrameContexts).forEach((context) => {
-      if (!allowedContexts.some((allowedContext) => allowedContext === context)) {
-        it('FRAMED - should not allow registerForVideoFrame calls from the wrong context', async () => {
-          await framedPlatformMock.initializeWithContext(context);
-
-          expect(() => videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig)).toThrowError(
-            `This call is only allowed in following contexts: ${JSON.stringify(
-              allowedContexts,
-            )}. Current context: "${context}".`,
-          );
-        });
-
-        it('FRAMELESS - should not allow registerForVideoFrame calls from the wrong context', async () => {
-          await framelessPlatformMock.initializeWithContext(context);
-
-          expect(() => videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig)).toThrowError(
-            `This call is only allowed in following contexts: ${JSON.stringify(
-              allowedContexts,
-            )}. Current context: "${context}".`,
-          );
-        });
-      }
+      GlobalVars.isFramelessWindow = false;
     });
 
-    it('FRAMED - should throw error when video is not supported in runtime config', async () => {
-      await framedPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      framedPlatformMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-      expect.assertions(1);
-      try {
+    describe('registerForVideoFrame', () => {
+      const emptyVideoFrameCallback = (
+        _frame: videoEx.VideoFrame,
+        _notifyVideoFrameProcessed: () => void,
+        _notifyError: (errorMessage: string) => void,
+      ): void => {};
+      const videoFrameConfig: videoEx.VideoFrameConfig = {
+        format: video.VideoFrameFormat.NV12,
+        requireCameraStream: false,
+        audioInferenceModel: new ArrayBuffer(100),
+      };
+
+      const allowedContexts = [FrameContexts.sidePanel];
+      Object.values(FrameContexts).forEach((context) => {
+        if (!allowedContexts.some((allowedContext) => allowedContext === context)) {
+          it('should not allow registerForVideoFrame calls from the wrong context', async () => {
+            await utils.initializeWithContext(context);
+
+            expect(() => videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig)).toThrowError(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${context}".`,
+            );
+          });
+        }
+      });
+
+      it('should throw error when video is not supported in runtime config', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+        expect.assertions(1);
+        try {
+          videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig);
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
+
+      it('should successfully send registerForVideoFrame message', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
         videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig);
-      } catch (e) {
-        expect(e).toEqual(errorNotSupportedOnPlatform);
-      }
-    });
+        const message = utils.findMessageByFunc('video.registerForVideoFrame');
+        expect(message).not.toBeNull();
+        console.log(message.args);
+        expect(message.args[0]).toHaveProperty('audioInferenceModel');
+        expect(message.args[0].format).toBe(video.VideoFrameFormat.NV12);
+        expect(message.args[0].requireCameraStream).toBe(false);
+      });
 
-    it('FRAMELESS - should throw error when video is not supported in runtime config', async () => {
-      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      framelessPlatformMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-      expect.assertions(4);
-      try {
+      it('should not send default message when register video frame handler', async () => {
+        await utils.initializeWithContext('sidePanel');
         videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig);
-      } catch (e) {
-        expect(e).toEqual(errorNotSupportedOnPlatform);
-      }
+        const messageForRegister = utils.findMessageByFunc('registerHandler');
+        expect(messageForRegister).toBeNull();
+      });
+
+      it('should successfully invoke video frame event handler', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        let returnedVideoFrame: videoEx.VideoFrame;
+        let handlerInvoked = false;
+        //callback
+        const videoFrameCallback = (
+          _frame: videoEx.VideoFrame,
+          _notifyVideoFrameProcessed: () => void,
+          _notifyError: (errorMessage: string) => void,
+        ): void => {
+          handlerInvoked = true;
+          returnedVideoFrame = _frame;
+        };
+        videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
+        const videoFrameMock = {
+          width: 30,
+          height: 40,
+          data: 101,
+        };
+        utils.respondToFramelessMessage({
+          data: {
+            func: 'video.newVideoFrame',
+            args: [videoFrameMock],
+          },
+        } as DOMMessageEvent);
+        expect(handlerInvoked).toBeTruthy();
+        expect(returnedVideoFrame).toEqual(videoFrameMock);
+      });
+
+      it('should invoke video frame event handler and successfully send videoFrameProcessed', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        const videoFrameCallback = (
+          _frame: videoEx.VideoFrame,
+          _notifyVideoFrameProcessed: () => void,
+          _notifyError: (errorMessage: string) => void,
+        ): void => {
+          _notifyVideoFrameProcessed();
+        };
+
+        videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
+        const videoFrameMock = {
+          width: 30,
+          height: 40,
+          data: 101,
+        };
+        utils.respondToFramelessMessage({
+          data: {
+            func: 'video.newVideoFrame',
+            args: [videoFrameMock],
+          },
+        } as DOMMessageEvent);
+        const message = utils.findMessageByFunc('video.videoFrameProcessed');
+
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+      });
+
+      it('should invoke video frame event handler and successfully send videoFrameProcessed with timestamp', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        const videoFrameCallback = (
+          _frame: video.VideoFrame,
+          _notifyVideoFrameProcessed: () => void,
+          _notifyError: (errorMessage: string) => void,
+        ): void => {
+          _notifyVideoFrameProcessed();
+        };
+
+        video.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
+        const videoFrameMock = {
+          width: 30,
+          height: 40,
+          data: 101,
+          timestamp: 200,
+        };
+        utils.respondToFramelessMessage({
+          data: {
+            func: 'video.newVideoFrame',
+            args: [videoFrameMock],
+          },
+        } as DOMMessageEvent);
+        const message = utils.findMessageByFunc('video.videoFrameProcessed');
+
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+        expect(message.args[0]).toBe(200);
+      });
+
+      it('should invoke video frame event handler and successfully send notifyError', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        const errorMessage = 'Error occurs when processing the video frame';
+        const videoFrameCallback = (
+          _frame: videoEx.VideoFrame,
+          _notifyVideoFrameProcessed: () => void,
+          _notifyError: (errorMessage: string) => void,
+        ): void => {
+          _notifyError(errorMessage);
+        };
+
+        videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
+        const videoFrameMock = {
+          width: 30,
+          height: 40,
+          data: 101,
+        };
+        utils.respondToFramelessMessage({
+          data: {
+            func: 'video.newVideoFrame',
+            args: [videoFrameMock],
+          },
+        } as DOMMessageEvent);
+        const message = utils.findMessageByFunc('video.notifyError');
+
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(2);
+        expect(message.args[0]).toEqual(errorMessage);
+        expect(message.args[1]).toEqual(videoEx.ErrorLevel.Warn);
+      });
+
+      it('should not invoke video frame event handler when videoFrame is undefined', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        let handlerInvoked = false;
+        const videoFrameCallback = (
+          _frame: videoEx.VideoFrame,
+          _notifyVideoFrameProcessed: () => void,
+          _notifyError: (errorMessage: string) => void,
+        ): void => {
+          handlerInvoked = true;
+        };
+        videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
+        utils.respondToFramelessMessage({
+          data: {
+            func: 'video.newVideoFrame',
+            args: [undefined],
+          },
+        } as DOMMessageEvent);
+        expect(handlerInvoked).toBe(false);
+      });
     });
 
-    it('FRAMED - should successfully send registerForVideoFrame message', async () => {
-      await framedPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig);
-      const message = framedPlatformMock.findMessageByFunc('video.registerForVideoFrame');
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
-      expect(message.args[0]).toEqual(videoFrameConfig);
-    });
+    describe('notifySelectedVideoEffectChanged', () => {
+      const effectChangeType = video.EffectChangeType.EffectChanged;
+      const effectId = 'effectId';
 
-    it('FRAMELESS - should successfully send registerForVideoFrame message', async () => {
-      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig);
-      const message = framelessPlatformMock.findMessageByFunc('video.registerForVideoFrame');
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
-      expect(message.args[0]).toHaveProperty('audioInferenceModel');
-      expect(message.args[0].format).toBe(video.VideoFrameFormat.NV12);
-      expect(message.args[0].requireCameraStream).toBe(false);
-    });
+      const allowedContexts = [FrameContexts.sidePanel];
+      Object.values(FrameContexts).forEach((context) => {
+        if (!allowedContexts.some((allowedContext) => allowedContext === context)) {
+          it('should not allow notifySelectedVideoEffectChanged calls from the wrong context', async () => {
+            await utils.initializeWithContext(context);
 
-    it('FRAMED - should not send default message when register video frame handler', async () => {
-      await framedPlatformMock.initializeWithContext('sidePanel');
-      videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig);
-      const messageForRegister = framedPlatformMock.findMessageByFunc('registerHandler');
-      expect(messageForRegister).toBeNull();
-    });
+            expect(() => videoEx.notifySelectedVideoEffectChanged(effectChangeType, effectId)).toThrowError(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${context}".`,
+            );
+          });
+        }
+      });
 
-    it('FRAMELESS - should not send default message when register video frame handler', async () => {
-      await framelessPlatformMock.initializeWithContext('sidePanel');
-      videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig);
-      const messageForRegister = framelessPlatformMock.findMessageByFunc('registerHandler');
-      expect(messageForRegister).toBeNull();
-    });
+      it('should throw error when video is not supported in runtime config', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
 
-    it('FRAMED - should successfully invoke video frame event handler', async () => {
-      await framedPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      let returnedVideoFrame: videoEx.VideoFrame;
-      let handlerInvoked = false;
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+        expect.assertions(1);
+        try {
+          videoEx.notifySelectedVideoEffectChanged(effectChangeType, effectId);
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
 
-      const videoFrameCallback = (
-        _frame: videoEx.VideoFrame,
-        _notifyVideoFrameProcessed: () => void,
-        _notifyError: (errorMessage: string) => void,
-      ): void => {
-        handlerInvoked = true;
-        returnedVideoFrame = _frame;
-      };
-
-      videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
-      const videoFrameMock = {
-        width: 30,
-        height: 40,
-        data: 101,
-      };
-      framedPlatformMock.sendMessage('video.newVideoFrame', videoFrameMock);
-      expect(returnedVideoFrame).toEqual(videoFrameMock);
-      expect(handlerInvoked).toBeTruthy();
-    });
-
-    it('FRAMELESS - should successfully invoke video frame event handler', async () => {
-      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      let returnedVideoFrame: videoEx.VideoFrame;
-      let handlerInvoked = false;
-      //callback
-      const videoFrameCallback = (
-        _frame: videoEx.VideoFrame,
-        _notifyVideoFrameProcessed: () => void,
-        _notifyError: (errorMessage: string) => void,
-      ): void => {
-        handlerInvoked = true;
-        returnedVideoFrame = _frame;
-      };
-      videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
-      const videoFrameMock = {
-        width: 30,
-        height: 40,
-        data: 101,
-      };
-      framelessPlatformMock.respondToMessage({
-        data: {
-          func: 'video.newVideoFrame',
-          args: [videoFrameMock],
-        },
-      } as DOMMessageEvent);
-      expect(handlerInvoked).toBeTruthy();
-      expect(returnedVideoFrame).toEqual(videoFrameMock);
-    });
-
-    it('FRAMED - should invoke video frame event handler and successfully send videoFrameProcessed', async () => {
-      await framedPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      const videoFrameCallback = (
-        _frame: videoEx.VideoFrame,
-        _notifyVideoFrameProcessed: () => void,
-        _notifyError: (errorMessage: string) => void,
-      ): void => {
-        _notifyVideoFrameProcessed();
-      };
-
-      videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
-      const videoFrameMock = {
-        width: 30,
-        height: 40,
-        data: 101,
-      };
-      framedPlatformMock.sendMessage('video.newVideoFrame', videoFrameMock);
-      const message = framedPlatformMock.findMessageByFunc('video.videoFrameProcessed');
-
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
-      expect(message.args[0]).toBeUndefined();
-    });
-
-    it('FRAMED - should invoke video frame event handler and successfully send videoFrameProcessed with timestamp', async () => {
-      await framedPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      const videoFrameCallback = (
-        _frame: video.VideoFrame,
-        _notifyVideoFrameProcessed: () => void,
-        _notifyError: (errorMessage: string) => void,
-      ): void => {
-        _notifyVideoFrameProcessed();
-      };
-
-      video.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
-      const videoFrameMock = {
-        width: 30,
-        height: 40,
-        data: 101,
-        timestamp: 200,
-      };
-      framedPlatformMock.sendMessage('video.newVideoFrame', videoFrameMock);
-      const message = framedPlatformMock.findMessageByFunc('video.videoFrameProcessed');
-
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
-      expect(message.args[0]).toBe(200);
-    });
-
-    it('FRAMELESS - should invoke video frame event handler and successfully send videoFrameProcessed', async () => {
-      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      const videoFrameCallback = (
-        _frame: videoEx.VideoFrame,
-        _notifyVideoFrameProcessed: () => void,
-        _notifyError: (errorMessage: string) => void,
-      ): void => {
-        _notifyVideoFrameProcessed();
-      };
-
-      videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
-      const videoFrameMock = {
-        width: 30,
-        height: 40,
-        data: 101,
-      };
-      framelessPlatformMock.respondToMessage({
-        data: {
-          func: 'video.newVideoFrame',
-          args: [videoFrameMock],
-        },
-      } as DOMMessageEvent);
-      const message = framelessPlatformMock.findMessageByFunc('video.videoFrameProcessed');
-
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
-    });
-
-    it('FRAMELESS - should invoke video frame event handler and successfully send videoFrameProcessed with timestamp', async () => {
-      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      const videoFrameCallback = (
-        _frame: video.VideoFrame,
-        _notifyVideoFrameProcessed: () => void,
-        _notifyError: (errorMessage: string) => void,
-      ): void => {
-        _notifyVideoFrameProcessed();
-      };
-
-      video.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
-      const videoFrameMock = {
-        width: 30,
-        height: 40,
-        data: 101,
-        timestamp: 200,
-      };
-      framelessPlatformMock.respondToMessage({
-        data: {
-          func: 'video.newVideoFrame',
-          args: [videoFrameMock],
-        },
-      } as DOMMessageEvent);
-      const message = framelessPlatformMock.findMessageByFunc('video.videoFrameProcessed');
-
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(1);
-      expect(message.args[0]).toBe(200);
-    });
-
-    it('FRAMED - should invoke video frame event handler and successfully send notifyError', async () => {
-      await framedPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      const errorMessage = 'Error occurs when processing the video frame';
-      const videoFrameCallback = (
-        _frame: videoEx.VideoFrame,
-        _notifyVideoFrameProcessed: () => void,
-        _notifyError: (errorMessage: string) => void,
-      ): void => {
-        _notifyError(errorMessage);
-      };
-
-      videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
-      const videoFrameMock = {
-        width: 30,
-        height: 40,
-        data: 101,
-      };
-      framedPlatformMock.sendMessage('video.newVideoFrame', videoFrameMock);
-      const message = framedPlatformMock.findMessageByFunc('video.notifyError');
-
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(2);
-      expect(message.args[0]).toEqual(errorMessage);
-      expect(message.args[1]).toEqual(videoEx.ErrorLevel.Warn);
-    });
-
-    it('FRAMELESS - should invoke video frame event handler and successfully send notifyError', async () => {
-      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      const errorMessage = 'Error occurs when processing the video frame';
-      const videoFrameCallback = (
-        _frame: videoEx.VideoFrame,
-        _notifyVideoFrameProcessed: () => void,
-        _notifyError: (errorMessage: string) => void,
-      ): void => {
-        _notifyError(errorMessage);
-      };
-
-      videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
-      const videoFrameMock = {
-        width: 30,
-        height: 40,
-        data: 101,
-      };
-      framelessPlatformMock.respondToMessage({
-        data: {
-          func: 'video.newVideoFrame',
-          args: [videoFrameMock],
-        },
-      } as DOMMessageEvent);
-      const message = framelessPlatformMock.findMessageByFunc('video.notifyError');
-
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(2);
-      expect(message.args[0]).toEqual(errorMessage);
-      expect(message.args[1]).toEqual(videoEx.ErrorLevel.Warn);
-    });
-
-    it('FRAMED - should not invoke video frame event handler when videoFrame is undefined', async () => {
-      await framedPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      let handlerInvoked = false;
-      const videoFrameCallback = (
-        _frame: videoEx.VideoFrame,
-        _notifyVideoFrameProcessed: () => void,
-        _notifyError: (errorMessage: string) => void,
-      ): void => {
-        handlerInvoked = true;
-      };
-      videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
-      framedPlatformMock.sendMessage('video.newVideoFrame', undefined);
-      expect(handlerInvoked).toBe(false);
-    });
-
-    it('FRAMELESS - should not invoke video frame event handler when videoFrame is undefined', async () => {
-      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      let handlerInvoked = false;
-      const videoFrameCallback = (
-        _frame: videoEx.VideoFrame,
-        _notifyVideoFrameProcessed: () => void,
-        _notifyError: (errorMessage: string) => void,
-      ): void => {
-        handlerInvoked = true;
-      };
-      videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
-      framelessPlatformMock.respondToMessage({
-        data: {
-          func: 'video.newVideoFrame',
-          args: [undefined],
-        },
-      } as DOMMessageEvent);
-      expect(handlerInvoked).toBe(false);
-    });
-  });
-
-  describe('notifySelectedVideoEffectChanged', () => {
-    const effectChangeType = video.EffectChangeType.EffectChanged;
-    const effectId = 'effectId';
-
-    const allowedContexts = [FrameContexts.sidePanel];
-    Object.values(FrameContexts).forEach((context) => {
-      if (!allowedContexts.some((allowedContext) => allowedContext === context)) {
-        it('FRAMED - should not allow notifySelectedVideoEffectChanged calls from the wrong context', async () => {
-          await framedPlatformMock.initializeWithContext(context);
-
-          expect(() => videoEx.notifySelectedVideoEffectChanged(effectChangeType, effectId)).toThrowError(
-            `This call is only allowed in following contexts: ${JSON.stringify(
-              allowedContexts,
-            )}. Current context: "${context}".`,
-          );
-        });
-
-        it('FRAMELESS - should not allow notifySelectedVideoEffectChanged calls from the wrong context', async () => {
-          await framelessPlatformMock.initializeWithContext(context);
-
-          expect(() => videoEx.notifySelectedVideoEffectChanged(effectChangeType, effectId)).toThrowError(
-            `This call is only allowed in following contexts: ${JSON.stringify(
-              allowedContexts,
-            )}. Current context: "${context}".`,
-          );
-        });
-      }
-    });
-
-    it('FRAMED - should throw error when video is not supported in runtime config', async () => {
-      await framedPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      framedPlatformMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-      expect.assertions(1);
-      try {
+      it('should successfully send notifySelectedVideoEffectChanged message', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
         videoEx.notifySelectedVideoEffectChanged(effectChangeType, effectId);
-      } catch (e) {
-        expect(e).toEqual(errorNotSupportedOnPlatform);
-      }
+        const message = utils.findMessageByFunc('video.videoEffectChanged');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(3);
+        expect(message.args).toStrictEqual([effectChangeType, effectId, null]);
+      });
     });
 
-    it('FRAMELESS - should throw error when video is not supported in runtime config', async () => {
-      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
+    describe('registerForVideoEffect', () => {
+      const allowedContexts = [FrameContexts.sidePanel];
+      Object.values(FrameContexts).forEach((context) => {
+        if (!allowedContexts.some((allowedContext) => allowedContext === context)) {
+          it('should not allow registerForVideoEffect calls from the wrong context', async () => {
+            await utils.initializeWithContext(context);
 
-      framedPlatformMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-      expect.assertions(4);
-      try {
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            expect(() => videoEx.registerForVideoEffect(() => {})).toThrowError(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${context}".`,
+            );
+          });
+        }
+      });
+
+      it('should throw error when video is not supported in runtime config', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+        expect.assertions(1);
+        try {
+          videoEx.registerForVideoEffect(() => {});
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
+
+      it('should successfully register effectParameterChange', async () => {
+        await utils.initializeWithContext('sidePanel');
+
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        videoEx.registerForVideoEffect(() => {});
+
+        expect(utils.findMessageByFunc('registerHandler')).toBeNull();
+        const messageForRegister = utils.findMessageByFunc('video.registerForVideoEffect');
+        expect(messageForRegister.args.length).toBe(0);
+      });
+
+      it('should successfully invoke effectParameterChange handler', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        let returnedEffectId: string;
+        let handlerInvoked = false;
+        const videoEffectCallBack = (effectId: string): void => {
+          handlerInvoked = true;
+          returnedEffectId = effectId;
+        };
+
+        videoEx.registerForVideoEffect(videoEffectCallBack);
+        const effectId = 'sampleEffectId';
+        utils.respondToFramelessMessage({
+          data: {
+            func: 'video.effectParameterChange',
+            args: [effectId],
+          },
+        } as DOMMessageEvent);
+        expect(returnedEffectId).toEqual(effectId);
+        expect(handlerInvoked).toBeTruthy();
+      });
+    });
+
+    describe('updatePersonalizedEffects', () => {
+      const allowedContexts = [FrameContexts.sidePanel];
+      const personalizedEffects: videoEx.PersonalizedEffect[] = [
+        { name: 'e1', id: '1', type: 'background', thumbnail: 'mockthumbnail' },
+      ];
+      Object.values(FrameContexts).forEach((context) => {
+        if (!allowedContexts.some((allowedContext) => allowedContext === context)) {
+          it('should not allow updatePersonalizedEffects calls from the wrong context', async () => {
+            await utils.initializeWithContext(context);
+            expect(() => videoEx.updatePersonalizedEffects(personalizedEffects)).toThrowError(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${context}".`,
+            );
+          });
+        }
+      });
+
+      it('should throw error when video is not supported in runtime config', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+        expect.assertions(1);
+        try {
+          videoEx.updatePersonalizedEffects(personalizedEffects);
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
+
+      it('should successfully send PersonalizedEffects', async () => {
+        await utils.initializeWithContext('sidePanel');
+        videoEx.updatePersonalizedEffects(personalizedEffects);
+        const message = utils.findMessageByFunc('video.personalizedEffectsChanged');
+        expect(message.args.length).toBe(1);
+        expect(message.args[0]).toEqual(personalizedEffects);
+      });
+    });
+
+    describe('isSupported', () => {
+      it('should not be supported before initialization', () => {
+        utils.uninitializeRuntimeConfig();
+        expect(() => videoEx.isSupported()).toThrowError('The library has not yet been initialized');
+      });
+    });
+
+    describe('notifyFatalError', () => {
+      it('should not be supported before initialization', () => {
+        utils.uninitializeRuntimeConfig();
+        expect(() => videoEx.notifyFatalError('')).toThrowError('The library has not yet been initialized');
+      });
+
+      it('should send error to host successfully', async () => {
+        await utils.initializeWithContext('sidePanel');
+        const fakeErrorMsg = 'fake error';
+        videoEx.notifyFatalError(fakeErrorMsg);
+        const message = utils.findMessageByFunc('video.notifyError');
+        expect(message.args.length).toBe(2);
+        expect(message.args[0]).toEqual(fakeErrorMsg);
+        expect(message.args[1]).toEqual(videoEx.ErrorLevel.Fatal);
+      });
+    });
+  });
+
+  describe('framed', () => {
+    let utils: Utils = new Utils();
+    beforeEach(() => {
+      utils = new Utils();
+      utils.messages = [];
+    });
+    afterEach(() => {
+      app._uninitialize();
+    });
+
+    describe('registerForVideoFrame', () => {
+      const emptyVideoFrameCallback = (
+        _frame: videoEx.VideoFrame,
+        _notifyVideoFrameProcessed: () => void,
+        _notifyError: (errorMessage: string) => void,
+      ): void => {};
+      const videoFrameConfig: videoEx.VideoFrameConfig = {
+        format: video.VideoFrameFormat.NV12,
+        requireCameraStream: false,
+        audioInferenceModel: new ArrayBuffer(100),
+      };
+
+      const allowedContexts = [FrameContexts.sidePanel];
+      Object.values(FrameContexts).forEach((context) => {
+        if (!allowedContexts.some((allowedContext) => allowedContext === context)) {
+          it('should not allow registerForVideoFrame calls from the wrong context', async () => {
+            await utils.initializeWithContext(context);
+
+            expect(() => videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig)).toThrowError(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${context}".`,
+            );
+          });
+        }
+      });
+
+      it('should throw error when video is not supported in runtime config', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+        expect.assertions(1);
+        try {
+          videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig);
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
+
+      it('should successfully send registerForVideoFrame message', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig);
+        const message = utils.findMessageByFunc('video.registerForVideoFrame');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+        expect(message.args[0]).toEqual(videoFrameConfig);
+      });
+
+      it('should not send default message when register video frame handler', async () => {
+        await utils.initializeWithContext('sidePanel');
+        videoEx.registerForVideoFrame(emptyVideoFrameCallback, videoFrameConfig);
+        const messageForRegister = utils.findMessageByFunc('registerHandler');
+        expect(messageForRegister).toBeNull();
+      });
+
+      it('should successfully invoke video frame event handler', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        let returnedVideoFrame: videoEx.VideoFrame;
+        let handlerInvoked = false;
+
+        const videoFrameCallback = (
+          _frame: videoEx.VideoFrame,
+          _notifyVideoFrameProcessed: () => void,
+          _notifyError: (errorMessage: string) => void,
+        ): void => {
+          handlerInvoked = true;
+          returnedVideoFrame = _frame;
+        };
+
+        videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
+        const videoFrameMock = {
+          width: 30,
+          height: 40,
+          data: 101,
+        };
+        utils.sendMessage('video.newVideoFrame', videoFrameMock);
+        expect(returnedVideoFrame).toEqual(videoFrameMock);
+        expect(handlerInvoked).toBeTruthy();
+      });
+
+      it('should invoke video frame event handler and successfully send videoFrameProcessed', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        const videoFrameCallback = (
+          _frame: videoEx.VideoFrame,
+          _notifyVideoFrameProcessed: () => void,
+          _notifyError: (errorMessage: string) => void,
+        ): void => {
+          _notifyVideoFrameProcessed();
+        };
+
+        videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
+        const videoFrameMock = {
+          width: 30,
+          height: 40,
+          data: 101,
+        };
+        utils.sendMessage('video.newVideoFrame', videoFrameMock);
+        const message = utils.findMessageByFunc('video.videoFrameProcessed');
+
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+        expect(message.args[0]).toBeUndefined();
+      });
+
+      it('should invoke video frame event handler and successfully send videoFrameProcessed with timestamp', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        const videoFrameCallback = (
+          _frame: video.VideoFrame,
+          _notifyVideoFrameProcessed: () => void,
+          _notifyError: (errorMessage: string) => void,
+        ): void => {
+          _notifyVideoFrameProcessed();
+        };
+
+        video.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
+        const videoFrameMock = {
+          width: 30,
+          height: 40,
+          data: 101,
+          timestamp: 200,
+        };
+        utils.sendMessage('video.newVideoFrame', videoFrameMock);
+        const message = utils.findMessageByFunc('video.videoFrameProcessed');
+
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(1);
+        expect(message.args[0]).toBe(200);
+      });
+
+      it('should invoke video frame event handler and successfully send notifyError', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        const errorMessage = 'Error occurs when processing the video frame';
+        const videoFrameCallback = (
+          _frame: videoEx.VideoFrame,
+          _notifyVideoFrameProcessed: () => void,
+          _notifyError: (errorMessage: string) => void,
+        ): void => {
+          _notifyError(errorMessage);
+        };
+
+        videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
+        const videoFrameMock = {
+          width: 30,
+          height: 40,
+          data: 101,
+        };
+        utils.sendMessage('video.newVideoFrame', videoFrameMock);
+        const message = utils.findMessageByFunc('video.notifyError');
+
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(2);
+        expect(message.args[0]).toEqual(errorMessage);
+        expect(message.args[1]).toEqual(videoEx.ErrorLevel.Warn);
+      });
+
+      it('should not invoke video frame event handler when videoFrame is undefined', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        let handlerInvoked = false;
+        const videoFrameCallback = (
+          _frame: videoEx.VideoFrame,
+          _notifyVideoFrameProcessed: () => void,
+          _notifyError: (errorMessage: string) => void,
+        ): void => {
+          handlerInvoked = true;
+        };
+        videoEx.registerForVideoFrame(videoFrameCallback, videoFrameConfig);
+        utils.sendMessage('video.newVideoFrame', undefined);
+        expect(handlerInvoked).toBe(false);
+      });
+    });
+
+    describe('notifySelectedVideoEffectChanged', () => {
+      const effectChangeType = video.EffectChangeType.EffectChanged;
+      const effectId = 'effectId';
+
+      const allowedContexts = [FrameContexts.sidePanel];
+      Object.values(FrameContexts).forEach((context) => {
+        if (!allowedContexts.some((allowedContext) => allowedContext === context)) {
+          it('should not allow notifySelectedVideoEffectChanged calls from the wrong context', async () => {
+            await utils.initializeWithContext(context);
+
+            expect(() => videoEx.notifySelectedVideoEffectChanged(effectChangeType, effectId)).toThrowError(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${context}".`,
+            );
+          });
+        }
+      });
+
+      it('should throw error when video is not supported in runtime config', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+        expect.assertions(1);
+        try {
+          videoEx.notifySelectedVideoEffectChanged(effectChangeType, effectId);
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
+
+      it('should successfully send notifySelectedVideoEffectChanged message', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
         videoEx.notifySelectedVideoEffectChanged(effectChangeType, effectId);
-      } catch (e) {
-        expect(e).toEqual(errorNotSupportedOnPlatform);
-      }
+        const message = utils.findMessageByFunc('video.videoEffectChanged');
+        expect(message).not.toBeNull();
+        expect(message.args.length).toBe(3);
+        expect(message.args).toStrictEqual([effectChangeType, effectId, undefined]);
+      });
     });
 
-    it('FRAMED - should successfully send notifySelectedVideoEffectChanged message', async () => {
-      await framedPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      videoEx.notifySelectedVideoEffectChanged(effectChangeType, effectId);
-      const message = framedPlatformMock.findMessageByFunc('video.videoEffectChanged');
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(3);
-      expect(message.args).toStrictEqual([effectChangeType, effectId, undefined]);
-    });
+    describe('registerForVideoEffect', () => {
+      const allowedContexts = [FrameContexts.sidePanel];
+      Object.values(FrameContexts).forEach((context) => {
+        if (!allowedContexts.some((allowedContext) => allowedContext === context)) {
+          it('should not allow registerForVideoEffect calls from the wrong context', async () => {
+            await utils.initializeWithContext(context);
 
-    it('FRAMELESS - should successfully send notifySelectedVideoEffectChanged message', async () => {
-      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      videoEx.notifySelectedVideoEffectChanged(effectChangeType, effectId);
-      const message = framelessPlatformMock.findMessageByFunc('video.videoEffectChanged');
-      expect(message).not.toBeNull();
-      expect(message.args.length).toBe(3);
-      expect(message.args).toStrictEqual([effectChangeType, effectId, null]);
-    });
-  });
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            expect(() => videoEx.registerForVideoEffect(() => {})).toThrowError(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${context}".`,
+            );
+          });
+        }
+      });
 
-  describe('registerForVideoEffect', () => {
-    const allowedContexts = [FrameContexts.sidePanel];
-    Object.values(FrameContexts).forEach((context) => {
-      if (!allowedContexts.some((allowedContext) => allowedContext === context)) {
-        it('FRAMED - should not allow registerForVideoEffect calls from the wrong context', async () => {
-          await framedPlatformMock.initializeWithContext(context);
+      it('should throw error when video is not supported in runtime config', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+        expect.assertions(1);
+        try {
+          videoEx.registerForVideoEffect(() => {});
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
 
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          expect(() => videoEx.registerForVideoEffect(() => {})).toThrowError(
-            `This call is only allowed in following contexts: ${JSON.stringify(
-              allowedContexts,
-            )}. Current context: "${context}".`,
-          );
-        });
+      it('should successfully register effectParameterChange', async () => {
+        await utils.initializeWithContext('sidePanel');
 
-        it('FRAMELESS - should not allow registerForVideoEffect calls from the wrong context', async () => {
-          await framelessPlatformMock.initializeWithContext(context);
-
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          expect(() => videoEx.registerForVideoEffect(() => {})).toThrowError(
-            `This call is only allowed in following contexts: ${JSON.stringify(
-              allowedContexts,
-            )}. Current context: "${context}".`,
-          );
-        });
-      }
-    });
-
-    it('FRAMED - should throw error when video is not supported in runtime config', async () => {
-      await framedPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      framedPlatformMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-      expect.assertions(1);
-      try {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         videoEx.registerForVideoEffect(() => {});
-      } catch (e) {
-        expect(e).toEqual(errorNotSupportedOnPlatform);
-      }
+
+        expect(utils.findMessageByFunc('registerHandler')).toBeNull();
+        const messageForRegister = utils.findMessageByFunc('video.registerForVideoEffect');
+        expect(messageForRegister.args.length).toBe(0);
+      });
+
+      it('should successfully invoke effectParameterChange handler', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        let returnedEffectId: string;
+        let handlerInvoked = false;
+        const videoEffectCallBack = (effectId: string): void => {
+          handlerInvoked = true;
+          returnedEffectId = effectId;
+        };
+
+        videoEx.registerForVideoEffect(videoEffectCallBack);
+        const effectId = 'sampleEffectId';
+        utils.sendMessage('video.effectParameterChange', effectId);
+        expect(returnedEffectId).toEqual(effectId);
+        expect(handlerInvoked).toBeTruthy();
+      });
     });
 
-    it('FRAMELESS - should throw error when video is not supported in runtime config', async () => {
-      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
+    describe('updatePersonalizedEffects', () => {
+      const allowedContexts = [FrameContexts.sidePanel];
+      const personalizedEffects: videoEx.PersonalizedEffect[] = [
+        { name: 'e1', id: '1', type: 'background', thumbnail: 'mockthumbnail' },
+      ];
+      Object.values(FrameContexts).forEach((context) => {
+        if (!allowedContexts.some((allowedContext) => allowedContext === context)) {
+          it('should not allow updatePersonalizedEffects calls from the wrong context', async () => {
+            await utils.initializeWithContext(context);
+            expect(() => videoEx.updatePersonalizedEffects(personalizedEffects)).toThrowError(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${context}".`,
+            );
+          });
+        }
+      });
 
-      framelessPlatformMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-      expect.assertions(4);
-      try {
-        videoEx.registerForVideoEffect(() => {});
-      } catch (e) {
-        expect(e).toEqual(errorNotSupportedOnPlatform);
-      }
-    });
+      it('should throw error when video is not supported in runtime config', async () => {
+        await utils.initializeWithContext(FrameContexts.sidePanel);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+        expect.assertions(1);
+        try {
+          videoEx.updatePersonalizedEffects(personalizedEffects);
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
 
-    it('FRAMED - should successfully register effectParameterChange', async () => {
-      await framedPlatformMock.initializeWithContext('sidePanel');
-
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      videoEx.registerForVideoEffect(() => {});
-
-      expect(framedPlatformMock.findMessageByFunc('registerHandler')).toBeNull();
-      const messageForRegister = framedPlatformMock.findMessageByFunc('video.registerForVideoEffect');
-      expect(messageForRegister.args.length).toBe(0);
-    });
-
-    it('FRAMELESS - should successfully register effectParameterChange', async () => {
-      await framelessPlatformMock.initializeWithContext('sidePanel');
-
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      videoEx.registerForVideoEffect(() => {});
-
-      expect(framelessPlatformMock.findMessageByFunc('registerHandler')).toBeNull();
-      const messageForRegister = framelessPlatformMock.findMessageByFunc('video.registerForVideoEffect');
-      expect(messageForRegister.args.length).toBe(0);
-    });
-
-    it('FRAMED - should successfully invoke effectParameterChange handler', async () => {
-      await framedPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      let returnedEffectId: string;
-      let handlerInvoked = false;
-      const videoEffectCallBack = (effectId: string): void => {
-        handlerInvoked = true;
-        returnedEffectId = effectId;
-      };
-
-      videoEx.registerForVideoEffect(videoEffectCallBack);
-      const effectId = 'sampleEffectId';
-      framedPlatformMock.sendMessage('video.effectParameterChange', effectId);
-      expect(returnedEffectId).toEqual(effectId);
-      expect(handlerInvoked).toBeTruthy();
-    });
-
-    it('FRAMELESS - should successfully invoke effectParameterChange handler', async () => {
-      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      let returnedEffectId: string;
-      let handlerInvoked = false;
-      const videoEffectCallBack = (effectId: string): void => {
-        handlerInvoked = true;
-        returnedEffectId = effectId;
-      };
-
-      videoEx.registerForVideoEffect(videoEffectCallBack);
-      const effectId = 'sampleEffectId';
-      framelessPlatformMock.respondToMessage({
-        data: {
-          func: 'video.effectParameterChange',
-          args: [effectId],
-        },
-      } as DOMMessageEvent);
-      expect(returnedEffectId).toEqual(effectId);
-      expect(handlerInvoked).toBeTruthy();
-    });
-  });
-
-  describe('updatePersonalizedEffects', () => {
-    const allowedContexts = [FrameContexts.sidePanel];
-    const personalizedEffects: videoEx.PersonalizedEffect[] = [
-      { name: 'e1', id: '1', type: 'background', thumbnail: 'mockthumbnail' },
-    ];
-    Object.values(FrameContexts).forEach((context) => {
-      if (!allowedContexts.some((allowedContext) => allowedContext === context)) {
-        it('FRAMED - should not allow updatePersonalizedEffects calls from the wrong context', async () => {
-          await framedPlatformMock.initializeWithContext(context);
-          expect(() => videoEx.updatePersonalizedEffects(personalizedEffects)).toThrowError(
-            `This call is only allowed in following contexts: ${JSON.stringify(
-              allowedContexts,
-            )}. Current context: "${context}".`,
-          );
-        });
-
-        it('FRAMELESS - should not allow updatePersonalizedEffects calls from the wrong context', async () => {
-          await framelessPlatformMock.initializeWithContext(context);
-          expect(() => videoEx.updatePersonalizedEffects(personalizedEffects)).toThrowError(
-            `This call is only allowed in following contexts: ${JSON.stringify(
-              allowedContexts,
-            )}. Current context: "${context}".`,
-          );
-        });
-      }
-    });
-
-    it('FRAMED - should throw error when video is not supported in runtime config', async () => {
-      await framedPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      framedPlatformMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-      expect.assertions(1);
-      try {
+      it('should successfully send PersonalizedEffects', async () => {
+        await utils.initializeWithContext('sidePanel');
         videoEx.updatePersonalizedEffects(personalizedEffects);
-      } catch (e) {
-        expect(e).toEqual(errorNotSupportedOnPlatform);
-      }
+        const message = utils.findMessageByFunc('video.personalizedEffectsChanged');
+        expect(message.args.length).toBe(1);
+        expect(message.args[0]).toEqual(personalizedEffects);
+      });
     });
+    describe('notifyFatalError', () => {
+      it('should not be supported before initialization', () => {
+        utils.uninitializeRuntimeConfig();
+        expect(() => videoEx.notifyFatalError('')).toThrowError('The library has not yet been initialized');
+      });
 
-    it('FRAMELESS - should throw error when video is not supported in runtime config', async () => {
-      await framelessPlatformMock.initializeWithContext(FrameContexts.sidePanel);
-      framelessPlatformMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
-      expect.assertions(4);
-      try {
-        videoEx.updatePersonalizedEffects(personalizedEffects);
-      } catch (e) {
-        expect(e).toEqual(errorNotSupportedOnPlatform);
-      }
-    });
-
-    it('FRAMED - should successfully send PersonalizedEffects', async () => {
-      await framedPlatformMock.initializeWithContext('sidePanel');
-      videoEx.updatePersonalizedEffects(personalizedEffects);
-      const message = framedPlatformMock.findMessageByFunc('video.personalizedEffectsChanged');
-      expect(message.args.length).toBe(1);
-      expect(message.args[0]).toEqual(personalizedEffects);
-    });
-
-    it('FRAMELESS - should successfully send PersonalizedEffects', async () => {
-      await framelessPlatformMock.initializeWithContext('sidePanel');
-      videoEx.updatePersonalizedEffects(personalizedEffects);
-      const message = framelessPlatformMock.findMessageByFunc('video.personalizedEffectsChanged');
-      expect(message.args.length).toBe(1);
-      expect(message.args[0]).toEqual(personalizedEffects);
-    });
-  });
-
-  describe('isSupported', () => {
-    it('FRAMED - should not be supported before initialization', () => {
-      framedPlatformMock.uninitializeRuntimeConfig();
-      expect(() => videoEx.isSupported()).toThrowError('The library has not yet been initialized');
-    });
-
-    it('FRAMELESS - should not be supported before initialization', () => {
-      framelessPlatformMock.uninitializeRuntimeConfig();
-      expect(() => videoEx.isSupported()).toThrowError('The library has not yet been initialized');
-    });
-  });
-
-  describe('notifyFatalError', () => {
-    it('FRAMED - should not be supported before initialization', () => {
-      framedPlatformMock.uninitializeRuntimeConfig();
-      expect(() => videoEx.notifyFatalError('')).toThrowError('The library has not yet been initialized');
-    });
-
-    it('FRAMELESS - should not be supported before initialization', () => {
-      framelessPlatformMock.uninitializeRuntimeConfig();
-      expect(() => videoEx.notifyFatalError('')).toThrowError('The library has not yet been initialized');
-    });
-
-    it('FRAMED - should send error to host successfully', async () => {
-      await framedPlatformMock.initializeWithContext('sidePanel');
-      const fakeErrorMsg = 'fake error';
-      videoEx.notifyFatalError(fakeErrorMsg);
-      const message = framedPlatformMock.findMessageByFunc('video.notifyError');
-      expect(message.args.length).toBe(2);
-      expect(message.args[0]).toEqual(fakeErrorMsg);
-      expect(message.args[1]).toEqual(videoEx.ErrorLevel.Fatal);
-    });
-
-    it('FRAMELESS - should send error to host successfully', async () => {
-      await framelessPlatformMock.initializeWithContext('sidePanel');
-      const fakeErrorMsg = 'fake error';
-      videoEx.notifyFatalError(fakeErrorMsg);
-      const message = framelessPlatformMock.findMessageByFunc('video.notifyError');
-      expect(message.args.length).toBe(2);
-      expect(message.args[0]).toEqual(fakeErrorMsg);
-      expect(message.args[1]).toEqual(videoEx.ErrorLevel.Fatal);
+      it('should send error to host successfully', async () => {
+        await utils.initializeWithContext('sidePanel');
+        const fakeErrorMsg = 'fake error';
+        videoEx.notifyFatalError(fakeErrorMsg);
+        const message = utils.findMessageByFunc('video.notifyError');
+        expect(message.args.length).toBe(2);
+        expect(message.args[0]).toEqual(fakeErrorMsg);
+        expect(message.args[1]).toEqual(videoEx.ErrorLevel.Fatal);
+      });
     });
   });
 });

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -7,7 +7,7 @@ import { applyRuntimeConfig, IBaseRuntime, setUnitializedRuntime } from '../src/
 export interface MessageRequest {
   id: number;
   func: string;
-  args?: unknown[];
+  args?: any[];
   timestamp?: number;
   isPartialResponse?: boolean;
 }

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -7,7 +7,7 @@ import { applyRuntimeConfig, IBaseRuntime, setUnitializedRuntime } from '../src/
 export interface MessageRequest {
   id: number;
   func: string;
-  args?: any[];
+  args?: unknown[];
   timestamp?: number;
   isPartialResponse?: boolean;
 }


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

We now know that desktop has two existing implementations: 
``` 
 framed: Tabs are loaded inside iframe which is created inside electron webview.
```
``` 
frameless: Tabs are loaded directly inside webview. 
```
That means platform can be frameless or iframed based upon what implementation is being used. 
We know that web is always in iframe, and mobile is always frameless. We are going to use this information to name the mock windows correctly.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

Updated `videoEx.spec.ts` to uniformly use `Utils` class instead of `FramelessPostMock`.


## Validation

### Validation performed:
N/A

### Unit Tests added:
Yes

### End-to-end tests added:
N/A
