### PR TITLE
Unit Test Case update: monetization.spec.ts

### DIFF
--- a/packages/teams-js/test/public/monetization.spec.ts
+++ b/packages/teams-js/test/public/monetization.spec.ts
@@ -1,12 +1,11 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
+import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { FrameContexts } from '../../src/public';
 import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform } from '../../src/public/constants';
 import { SdkError } from '../../src/public/interfaces';
 import { monetization } from '../../src/public/monetization';
-import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
-import { FramelessPostMocks } from '../framelessPostMocks';
 import { Utils } from '../utils';
 
 /* eslint-disable */
@@ -17,22 +16,15 @@ const allowedContexts = [FrameContexts.content];
 
 describe('Testing monetization capability', () => {
   describe('Framed - monetization test', () => {
+    let utils: Utils = new Utils();
+    beforeEach(() => {
+      utils = new Utils();
+      utils.messages = [];
+    });
+    afterEach(() => {
+      app._uninitialize();
+    });
     describe('monetization_v1', () => {
-      const framedPlatformMock = new Utils();
-
-      beforeEach(() => {
-        framedPlatformMock.messages = [];
-        app._initialize(framedPlatformMock.mockWindow);
-      });
-
-      afterEach(() => {
-        // Reset the object since it's a singleton
-        if (app._uninitialize) {
-          framedPlatformMock.setRuntimeConfig(_minRuntimeConfigToUninitialize);
-          app._uninitialize();
-        }
-      });
-
       describe('openPurchaseExperience', () => {
         it('should not allow calls before initialization', () => {
           expect(() =>
@@ -45,7 +37,7 @@ describe('Testing monetization capability', () => {
         Object.values(FrameContexts).forEach((context) => {
           if (!allowedContexts.some((allowedContext) => allowedContext == context)) {
             it(`should to not allow to initialize FramContext with context: ${context}.`, async () => {
-              await framedPlatformMock.initializeWithContext(context);
+              await utils.initializeWithContext(context);
               expect(() => {
                 monetization.openPurchaseExperience((error: SdkError | null) => {
                   expect(error).toBeNull();
@@ -59,41 +51,24 @@ describe('Testing monetization capability', () => {
           }
         });
         it('openPurchaseExperience should throw error when monetization is not supported. context: content', async () => {
-          await framedPlatformMock.initializeWithContext('content');
-          framedPlatformMock.setRuntimeConfig({ apiVersion: 1, supports: {} });
+          await utils.initializeWithContext('content');
+          utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
           expect(() => monetization.openPurchaseExperience(() => {})).rejects.toEqual(errorNotSupportedOnPlatform);
         });
 
         it('should successfully execute callback and sdkError should be null', async () => {
-          await framedPlatformMock.initializeWithContext(FrameContexts.content);
+          await utils.initializeWithContext(FrameContexts.content);
           monetization.openPurchaseExperience((error: SdkError | null) => {
             expect(error).toBeNull();
           });
-          const message = framedPlatformMock.findMessageByFunc('monetization.openPurchaseExperience');
+          const message = utils.findMessageByFunc('monetization.openPurchaseExperience');
           expect(message).not.toBeNull();
-          framedPlatformMock.respondToMessage(message);
+          utils.respondToMessage(message);
         });
       });
     });
 
     describe('monetization_v2', () => {
-      const framelessPlatformMock = new FramelessPostMocks();
-      const utils = new Utils();
-
-      beforeEach(() => {
-        framelessPlatformMock.messages = [];
-        // Set a mock window for testing
-        app._initialize(framelessPlatformMock.mockWindow);
-      });
-
-      afterEach(() => {
-        // Reset the object since it's a singleton
-        if (app._uninitialize) {
-          utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
-          app._uninitialize();
-        }
-      });
-
       describe('isSupported', () => {
         it('should throw if called before initialization', () => {
           utils.uninitializeRuntimeConfig();
@@ -111,7 +86,7 @@ describe('Testing monetization capability', () => {
         Object.values(FrameContexts).forEach((context) => {
           if (!allowedContexts.some((allowedContext) => allowedContext == context)) {
             it(`should to not allow to initialize FramContext with context: ${context}.`, async () => {
-              await framelessPlatformMock.initializeWithContext(context);
+              await utils.initializeWithContext(context);
               expect(() => monetization.openPurchaseExperience()).toThrowError(
                 `This call is only allowed in following contexts: ${JSON.stringify(
                   allowedContexts,
@@ -122,54 +97,30 @@ describe('Testing monetization capability', () => {
         });
 
         it('openPurchaseExperience should throw error when monetization is not supported. context: content', async () => {
-          await framelessPlatformMock.initializeWithContext('content');
+          await utils.initializeWithContext('content');
           utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
-          expect.assertions(3);
           try {
             monetization.openPurchaseExperience();
           } catch (e) {
             expect(e).toEqual(errorNotSupportedOnPlatform);
           }
         });
-
-        it('should successfully execute and not throw any error', async () => {
-          await framelessPlatformMock.initializeWithContext(FrameContexts.content);
-          const promise = monetization.openPurchaseExperience();
-          const message = framelessPlatformMock.findMessageByFunc('monetization.openPurchaseExperience');
-          expect(message).not.toBeNull();
-
-          const callbackId = message.id;
-          framelessPlatformMock.respondToMessage({
-            data: {
-              id: callbackId,
-              args: [null, true],
-            },
-          } as DOMMessageEvent);
-          await expect(promise).resolves.not.toThrow();
-          await expect(promise).resolves.toBe(true);
-        });
       });
     });
   });
 
   describe('Frameless - monetization test', () => {
+    let utils: Utils = new Utils();
+    beforeEach(() => {
+      utils = new Utils();
+      utils.mockWindow.parent = undefined;
+      utils.messages = [];
+    });
+    afterEach(() => {
+      app._uninitialize();
+      GlobalVars.isFramelessWindow = false;
+    });
     describe('monetization_v1', () => {
-      const framelessPlatformMock = new FramelessPostMocks();
-      const utils = new Utils();
-
-      beforeEach(() => {
-        framelessPlatformMock.messages = [];
-        app._initialize(framelessPlatformMock.mockWindow);
-      });
-
-      afterEach(() => {
-        // Reset the object since it's a singleton
-        if (app._uninitialize) {
-          utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
-          app._uninitialize();
-        }
-      });
-
       describe('openPurchaseExperience', () => {
         it('should not allow calls before initialization', () => {
           expect(() =>
@@ -182,7 +133,7 @@ describe('Testing monetization capability', () => {
         Object.values(FrameContexts).forEach((context) => {
           if (!allowedContexts.some((allowedContext) => allowedContext == context)) {
             it(`should to not allow to initialize FramContext with context: ${context}.`, async () => {
-              await framelessPlatformMock.initializeWithContext(context);
+              await utils.initializeWithContext(context);
               expect(() => {
                 monetization.openPurchaseExperience((error: SdkError | null) => {
                   expect(error).toBeNull();
@@ -196,21 +147,21 @@ describe('Testing monetization capability', () => {
           }
         });
         it('openPurchaseExperience should throw error when monetization is not supported. context: content', async () => {
-          await framelessPlatformMock.initializeWithContext('content');
+          await utils.initializeWithContext('content');
           utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
           expect(() => monetization.openPurchaseExperience(() => {})).rejects.toEqual(errorNotSupportedOnPlatform);
         });
 
         it('should successfully execute callback and sdkError should be null', async () => {
-          await framelessPlatformMock.initializeWithContext(FrameContexts.content);
+          await utils.initializeWithContext(FrameContexts.content);
           monetization.openPurchaseExperience((error: SdkError | null) => {
             expect(error).toBeNull();
           });
-          const message = framelessPlatformMock.findMessageByFunc('monetization.openPurchaseExperience');
+          const message = utils.findMessageByFunc('monetization.openPurchaseExperience');
           expect(message).not.toBeNull();
 
           const callbackId = message.id;
-          framelessPlatformMock.respondToMessage({
+          utils.respondToFramelessMessage({
             data: {
               id: callbackId,
               args: [null, undefined],
@@ -221,23 +172,6 @@ describe('Testing monetization capability', () => {
     });
 
     describe('monetization_v2', () => {
-      const framelessPlatformMock = new FramelessPostMocks();
-      const utils = new Utils();
-
-      beforeEach(() => {
-        framelessPlatformMock.messages = [];
-        // Set a mock window for testing
-        app._initialize(framelessPlatformMock.mockWindow);
-      });
-
-      afterEach(() => {
-        // Reset the object since it's a singleton
-        if (app._uninitialize) {
-          utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
-          app._uninitialize();
-        }
-      });
-
       describe('openPurchaseExperience', () => {
         it('should not allow calls before initialization', () => {
           expect(() => monetization.openPurchaseExperience(undefined)).toThrowError(
@@ -248,7 +182,7 @@ describe('Testing monetization capability', () => {
         Object.values(FrameContexts).forEach((context) => {
           if (!allowedContexts.some((allowedContext) => allowedContext == context)) {
             it(`should to not allow to initialize FramContext with context: ${context}.`, async () => {
-              await framelessPlatformMock.initializeWithContext(context);
+              await utils.initializeWithContext(context);
               expect(() => monetization.openPurchaseExperience()).toThrowError(
                 `This call is only allowed in following contexts: ${JSON.stringify(
                   allowedContexts,
@@ -259,9 +193,8 @@ describe('Testing monetization capability', () => {
         });
 
         it('openPurchaseExperience should throw error when monetization is not supported. context: content', async () => {
-          await framelessPlatformMock.initializeWithContext('content');
+          await utils.initializeWithContext('content');
           utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
-          expect.assertions(3);
           try {
             monetization.openPurchaseExperience();
           } catch (e) {
@@ -270,13 +203,13 @@ describe('Testing monetization capability', () => {
         });
 
         it('should successfully execute and not throw any error', async () => {
-          await framelessPlatformMock.initializeWithContext(FrameContexts.content);
+          await utils.initializeWithContext(FrameContexts.content);
           const promise = monetization.openPurchaseExperience();
-          const message = framelessPlatformMock.findMessageByFunc('monetization.openPurchaseExperience');
+          const message = utils.findMessageByFunc('monetization.openPurchaseExperience');
           expect(message).not.toBeNull();
 
           const callbackId = message.id;
-          framelessPlatformMock.respondToMessage({
+          utils.respondToFramelessMessage({
             data: {
               id: callbackId,
               args: [null, true],


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

We now know that desktop has two existing implementations: 
``` 
 framed: Tabs are loaded inside iframe which is created inside electron webview.
```
``` 
frameless: Tabs are loaded directly inside webview. 
```
That means platform can be frameless or iframed based upon what implementation is being used. 
We know that web is always in iframe, and mobile is always frameless. We are going to use this information to name the mock windows correctly.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

Updated `monetization.spec.ts` to uniformly use `Utils` class instead of `FramelessPostMock`.


## Validation

### Validation performed:
N/A

### Unit Tests added:
Yes

### End-to-end tests added:
N/A
