### PR TITLE
Adding Dependent Types Tester Package

### DIFF
--- a/apps/teams-types-tester/package.json
+++ b/apps/teams-types-tester/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "teams-type-tester",
+  "private": true,
+  "author": "Microsoft Teams",
+  "description": "A tester to check if types in the dependency array will cause errors",
+  "version": "0.0.1",
+  "scripts": {
+    "build": "pnpm i && pnpm copy && pnpm tsc && pnpm clean",
+    "copy": "cp ./node_modules/@microsoft/teams-js/dist/MicrosoftTeams.d.ts ./ || xcopy \"./node_modules\\@microsoft\\teams-js\\dist\\MicrosoftTeams.d.ts\" \".\\\" /Y",
+    "clean": "rimraf node_modules && rimraf MicrosoftTeams.d.ts"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@microsoft/teams-js": "workspace:*"
+  }
+}

--- a/apps/teams-types-tester/tsconfig.json
+++ b/apps/teams-types-tester/tsconfig.json
@@ -1,104 +1,13 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
-    /* Modules */
-    "module": "commonjs" /* Specify what module code is generated. */,
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-
-    /* Type Checking */
-    //"strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-    /* Completeness */
-    "skipDefaultLibCheck": true /* Skip type checking .d.ts files that are included with TypeScript. */,
-    "skipLibCheck": false /* Skip type checking all .d.ts files. */
-  },
-  "include": ["./"]
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es5",
+    "noResolve": false,
+    "noImplicitAny": false,
+    "noEmitOnError": false,
+    "noImplicitReturns": true,
+    "sourceMap": true,
+    "skipDefaultLibCheck": true /* Skip type checking .d.ts files that are included with TypeScript. */
+  }
 }

--- a/apps/teams-types-tester/tsconfig.json
+++ b/apps/teams-types-tester/tsconfig.json
@@ -1,0 +1,104 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs" /* Specify what module code is generated. */,
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    //"strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    "skipDefaultLibCheck": true /* Skip type checking .d.ts files that are included with TypeScript. */,
+    "skipLibCheck": false /* Skip type checking all .d.ts files. */
+  },
+  "include": ["./"]
+}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/jscodeshift": "^0.11.0",
     "@types/jszip": "^3.4.1",
     "@types/msgpack-lite": "^0.1.7",
-    "@types/node": "^15.6.1",
+    "@types/node": "^20.1.5",
     "@types/pako": "^1.0.1",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,9 +234,9 @@ importers:
 
   apps/teams-types-tester:
     specifiers:
-      '@microsoft/teams-js': 2.10.0
+      '@microsoft/teams-js': workspace:*
     devDependencies:
-      '@microsoft/teams-js': 2.10.0
+      '@microsoft/teams-js': link:../../packages/teams-js
 
   packages/teams-js:
     specifiers:
@@ -3126,15 +3126,6 @@ packages:
     resolution: {integrity: sha1-EUNtEG20PQlzeD2djgmepYma7ng=}
     dev: true
 
-  /@microsoft/teams-js/2.10.0:
-    resolution: {integrity: sha512-vy4flhocAlwbo0bN9jPHT16Cnh0l49FD0miLOfPEkB95OdP/jtqXZ+PLdBAwGA64kuZkoqnPWgZSyUJWiKHFgQ==}
-    dependencies:
-      '@types/dom-webcodecs': 0.1.3
-      debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@mixer/webpack-bundle-compare/0.1.1:
     resolution: {integrity: sha1-p1Tz64IqIqhjTAm5LFNNv21CC44=}
     dependencies:
@@ -3892,10 +3883,6 @@ packages:
 
   /@types/detect-indent/0.1.30:
     resolution: {integrity: sha1-3GgrtBK05lugmOcO2tc7SDP7kQ0=}
-    dev: true
-
-  /@types/dom-webcodecs/0.1.3:
-    resolution: {integrity: sha512-MEUfHAnXifFqUbY51WK1f9y3NyupMqBhcRwCpl+UtHcl40Au3ijhahI37bblMoNmAOlU/33KMCkN4usdE1kJjg==}
     dev: true
 
   /@types/eslint-scope/3.7.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
       '@types/jscodeshift': ^0.11.0
       '@types/jszip': ^3.4.1
       '@types/msgpack-lite': ^0.1.7
-      '@types/node': ^15.6.1
+      '@types/node': ^20.1.5
       '@types/pako': ^1.0.1
       '@types/react': ^17.0.0
       '@types/react-dom': ^17.0.0
@@ -105,7 +105,7 @@ importers:
       '@types/jscodeshift': 0.11.6
       '@types/jszip': 3.4.1
       '@types/msgpack-lite': 0.1.8
-      '@types/node': 15.14.9
+      '@types/node': 20.1.5
       '@types/pako': 1.0.4
       '@types/react': 17.0.53
       '@types/react-dom': 17.0.19
@@ -136,7 +136,7 @@ importers:
       fs-extra: 9.1.0
       fs-jetpack: 2.4.0
       html-webpack-plugin: 5.5.0_webpack@5.75.0
-      jest: 29.4.3_2x2lj646cbu4dgvxdtgak5ih3i
+      jest: 29.4.3_axddsh2a43szblavus5m5ahe4u
       jest-environment-jsdom: 29.4.3
       jest-junit: 15.0.0
       lerna: 6.5.1
@@ -148,7 +148,7 @@ importers:
       style-loader: 3.3.1_webpack@5.75.0
       ts-jest: 29.0.5_kv2fdk7yz6jlbcjfldgcwh5vp4
       ts-loader: 9.4.2_hhrrucqyg4eysmfpujvov2ym5u
-      ts-node: 10.9.1_zlol4fzmmjgb3bdeviopae4asm
+      ts-node: 10.9.1_wh5cciuul2ivno4sebepep4pie
       typedoc: 0.24.4_typescript@4.9.5
       typescript: 4.9.5
       webpack: 5.75.0_webpack-cli@5.0.1
@@ -231,6 +231,12 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@microsoft/teams-js': link:../../packages/teams-js
+
+  apps/teams-types-tester:
+    specifiers:
+      '@microsoft/teams-js': 2.10.0
+    devDependencies:
+      '@microsoft/teams-js': 2.10.0
 
   packages/teams-js:
     specifiers:
@@ -2787,7 +2793,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.3
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       chalk: 4.1.2
       jest-message-util: 29.4.3
       jest-util: 29.4.3
@@ -2808,14 +2814,14 @@ packages:
       '@jest/test-result': 29.4.3
       '@jest/transform': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.4.3
-      jest-config: 29.4.3_2263m44mchjafa7bz7l52hbcpa
+      jest-config: 29.4.3_axddsh2a43szblavus5m5ahe4u
       jest-haste-map: 29.4.3
       jest-message-util: 29.4.3
       jest-regex-util: 29.4.3
@@ -2842,7 +2848,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       jest-mock: 29.4.3
     dev: true
 
@@ -2869,7 +2875,7 @@ packages:
     dependencies:
       '@jest/types': 29.4.3
       '@sinonjs/fake-timers': 10.0.2
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       jest-message-util: 29.4.3
       jest-mock: 29.4.3
       jest-util: 29.4.3
@@ -2902,7 +2908,7 @@ packages:
       '@jest/transform': 29.4.3
       '@jest/types': 29.4.3
       '@jridgewell/trace-mapping': 0.3.17
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -2990,7 +2996,7 @@ packages:
       '@jest/schemas': 29.4.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       '@types/yargs': 17.0.22
       chalk: 4.1.2
     dev: true
@@ -3118,6 +3124,15 @@ packages:
 
   /@microsoft/microsoft-graph-types/2.26.0:
     resolution: {integrity: sha1-EUNtEG20PQlzeD2djgmepYma7ng=}
+    dev: true
+
+  /@microsoft/teams-js/2.10.0:
+    resolution: {integrity: sha512-vy4flhocAlwbo0bN9jPHT16Cnh0l49FD0miLOfPEkB95OdP/jtqXZ+PLdBAwGA64kuZkoqnPWgZSyUJWiKHFgQ==}
+    dependencies:
+      '@types/dom-webcodecs': 0.1.3
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@mixer/webpack-bundle-compare/0.1.1:
@@ -3847,26 +3862,26 @@ packages:
     resolution: {integrity: sha1-rqIFnii3ZYY5CBNHrE+rPeFm5vA=}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
     dev: true
 
   /@types/bonjour/3.5.10:
     resolution: {integrity: sha1-D2qt/gDqQU7chvXRBjV82pcB4nU=}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
     dev: true
 
   /@types/connect-history-api-fallback/1.3.5:
     resolution: {integrity: sha1-0feooJ0O1aV67lrpwYq5uAMgXa4=}
     dependencies:
       '@types/express-serve-static-core': 4.17.33
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
     dev: true
 
   /@types/connect/3.4.35:
     resolution: {integrity: sha1-X89q5EXkAh0fwiGaSHPMc6O7KtE=}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
     dev: true
 
   /@types/debug/4.1.7:
@@ -3877,6 +3892,10 @@ packages:
 
   /@types/detect-indent/0.1.30:
     resolution: {integrity: sha1-3GgrtBK05lugmOcO2tc7SDP7kQ0=}
+    dev: true
+
+  /@types/dom-webcodecs/0.1.3:
+    resolution: {integrity: sha512-MEUfHAnXifFqUbY51WK1f9y3NyupMqBhcRwCpl+UtHcl40Au3ijhahI37bblMoNmAOlU/33KMCkN4usdE1kJjg==}
     dev: true
 
   /@types/eslint-scope/3.7.4:
@@ -3900,7 +3919,7 @@ packages:
   /@types/express-serve-static-core/4.17.33:
     resolution: {integrity: sha1-3jXTCp1jfcFFCtGN1YPXXVcz1UM=}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: true
@@ -3917,27 +3936,27 @@ packages:
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha1-dZT7rgT+fxkYzos9IT90/0SsH0U=}
     dependencies:
-      '@types/node': 15.14.9
+      '@types/node': 20.1.5
     dev: true
 
   /@types/glob/5.0.30:
     resolution: {integrity: sha1-ECZAnFYlqGiQdGAoCNCCsoZ7ilE=}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
     dev: true
 
   /@types/glob/8.1.0:
     resolution: {integrity: sha1-tj5wFVORsFhNzkTn6iUZC7w48vw=}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
     dev: true
 
   /@types/graceful-fs/4.1.6:
     resolution: {integrity: sha1-4UsldqHCUCa38C7eHeO4TDoe/q4=}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
     dev: true
 
   /@types/html-minifier-terser/6.1.0:
@@ -3947,7 +3966,7 @@ packages:
   /@types/http-proxy/1.17.10:
     resolution: {integrity: sha1-5XbI5KDMXGoTiBkCWojhZ+uzjWw=}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
     dev: true
 
   /@types/istanbul-lib-coverage/2.0.4:
@@ -3983,7 +4002,7 @@ packages:
   /@types/jsdom/20.0.1:
     resolution: {integrity: sha1-B8FLwZvS+RjBkpVBzarK6JR0SAg=}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       '@types/tough-cookie': 4.0.2
       parse5: 7.1.2
     dev: true
@@ -4025,15 +4044,15 @@ packages:
   /@types/msgpack-lite/0.1.8:
     resolution: {integrity: sha1-Ay8ZYJ5jU7ZfKJjRNeH2HjqosQI=}
     dependencies:
-      '@types/node': 15.14.9
-    dev: true
-
-  /@types/node/15.14.9:
-    resolution: {integrity: sha1-vEPJkMPJvnKBhou8e4/dbitXrfo=}
+      '@types/node': 20.1.5
     dev: true
 
   /@types/node/17.0.45:
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+    dev: true
+
+  /@types/node/20.1.5:
+    resolution: {integrity: sha512-IvGD1CD/nego63ySR7vrAKEX3AJTcmrAN2kn+/sDNLi1Ff5kBzDeEdqWDplK+0HAEoLYej137Sk0cUU8OLOlMg==}
     dev: true
 
   /@types/node/8.0.0:
@@ -4118,13 +4137,13 @@ packages:
     resolution: {integrity: sha1-hrF1Pwvk+aG+5o1Fn82lvk6lK10=}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
     dev: true
 
   /@types/sockjs/0.3.33:
     resolution: {integrity: sha1-Vw06C5msmVNg4xNv1gRRE7G9I28=}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
     dev: true
 
   /@types/stack-utils/2.0.1:
@@ -4151,7 +4170,7 @@ packages:
   /@types/webpack/5.28.0_webpack-cli@5.0.1:
     resolution: {integrity: sha1-eN3gYhLwONd+VBFs/mnoiuntLAM=}
     dependencies:
-      '@types/node': 15.14.9
+      '@types/node': 20.1.5
       tapable: 2.2.1
       webpack: 5.75.0_webpack-cli@5.0.1
     transitivePeerDependencies:
@@ -4164,7 +4183,7 @@ packages:
   /@types/ws/8.5.4:
     resolution: {integrity: sha1-uxDjYRbW5XDdlDc1+GyTPBWHuKU=}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
     dev: true
 
   /@types/yargs-parser/21.0.0:
@@ -6075,7 +6094,7 @@ packages:
     dev: true
 
   /debug/2.6.9:
-    resolution: {integrity: sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=}
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -8409,7 +8428,7 @@ packages:
       '@jest/expect': 29.4.3
       '@jest/test-result': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -8428,7 +8447,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/29.4.3_2x2lj646cbu4dgvxdtgak5ih3i:
+  /jest-cli/29.4.3_axddsh2a43szblavus5m5ahe4u:
     resolution: {integrity: sha1-/jH90MkMdl85K4t8l+SEUHHNIWM=}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -8445,7 +8464,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 29.4.3_2x2lj646cbu4dgvxdtgak5ih3i
+      jest-config: 29.4.3_axddsh2a43szblavus5m5ahe4u
       jest-util: 29.4.3
       jest-validate: 29.4.3
       prompts: 2.4.2
@@ -8456,7 +8475,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config/29.4.3_2263m44mchjafa7bz7l52hbcpa:
+  /jest-config/29.4.3_axddsh2a43szblavus5m5ahe4u:
     resolution: {integrity: sha1-/KnN/mKYrm0Evu8WJAZNRVNHyXg=}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -8471,7 +8490,7 @@ packages:
       '@babel/core': 7.21.0
       '@jest/test-sequencer': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       babel-jest: 29.4.3_@babel+core@7.21.0
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -8491,47 +8510,7 @@ packages:
       pretty-format: 29.4.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_zlol4fzmmjgb3bdeviopae4asm
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /jest-config/29.4.3_2x2lj646cbu4dgvxdtgak5ih3i:
-    resolution: {integrity: sha1-/KnN/mKYrm0Evu8WJAZNRVNHyXg=}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.0
-      '@jest/test-sequencer': 29.4.3
-      '@jest/types': 29.4.3
-      '@types/node': 15.14.9
-      babel-jest: 29.4.3_@babel+core@7.21.0
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.0
-      glob: 7.2.3
-      graceful-fs: 4.2.10
-      jest-circus: 29.4.3
-      jest-environment-node: 29.4.3
-      jest-get-type: 29.4.3
-      jest-regex-util: 29.4.3
-      jest-resolve: 29.4.3
-      jest-runner: 29.4.3
-      jest-util: 29.4.3
-      jest-validate: 29.4.3
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.4.3
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-      ts-node: 10.9.1_zlol4fzmmjgb3bdeviopae4asm
+      ts-node: 10.9.1_wh5cciuul2ivno4sebepep4pie
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8587,7 +8566,7 @@ packages:
       '@jest/fake-timers': 29.4.3
       '@jest/types': 29.4.3
       '@types/jsdom': 20.0.1
-      '@types/node': 15.14.9
+      '@types/node': 20.1.5
       jest-mock: 29.4.3
       jest-util: 29.4.3
       jsdom: 20.0.3
@@ -8604,7 +8583,7 @@ packages:
       '@jest/environment': 29.4.3
       '@jest/fake-timers': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       jest-mock: 29.4.3
       jest-util: 29.4.3
     dev: true
@@ -8625,7 +8604,7 @@ packages:
     dependencies:
       '@jest/types': 29.4.3
       '@types/graceful-fs': 4.1.6
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -8696,7 +8675,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.3
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       jest-util: 29.4.3
     dev: true
 
@@ -8751,7 +8730,7 @@ packages:
       '@jest/test-result': 29.4.3
       '@jest/transform': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.10
@@ -8782,7 +8761,7 @@ packages:
       '@jest/test-result': 29.4.3
       '@jest/transform': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -8838,7 +8817,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.3
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.10
@@ -8863,7 +8842,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.4.3
       '@jest/types': 29.4.3
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -8875,7 +8854,7 @@ packages:
     resolution: {integrity: sha1-jRRvCQDolzsQa29zzB6ajLhvjbA=}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -8884,13 +8863,13 @@ packages:
     resolution: {integrity: sha1-mkAj4eodMGA0I3xxM9faQkDok04=}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.1.5
       jest-util: 29.4.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest/29.4.3_2x2lj646cbu4dgvxdtgak5ih3i:
+  /jest/29.4.3_axddsh2a43szblavus5m5ahe4u:
     resolution: {integrity: sha1-G4vlQWZsb+uZmQ/ZitrEc35uY4Y=}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -8903,7 +8882,7 @@ packages:
       '@jest/core': 29.4.3_ts-node@10.9.1
       '@jest/types': 29.4.3
       import-local: 3.1.0
-      jest-cli: 29.4.3_2x2lj646cbu4dgvxdtgak5ih3i
+      jest-cli: 29.4.3_axddsh2a43szblavus5m5ahe4u
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -11747,7 +11726,7 @@ packages:
     dev: true
 
   /source-map/0.6.1:
-    resolution: {integrity: sha1-dHIq8y6WFOnCh6jQu95IteLxomM=}
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -12287,7 +12266,7 @@ packages:
       '@babel/core': 7.21.0
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.4.3_2x2lj646cbu4dgvxdtgak5ih3i
+      jest: 29.4.3_axddsh2a43szblavus5m5ahe4u
       jest-util: 29.4.3
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -12312,7 +12291,7 @@ packages:
       webpack: 5.75.0_webpack-cli@5.0.1
     dev: true
 
-  /ts-node/10.9.1_zlol4fzmmjgb3bdeviopae4asm:
+  /ts-node/10.9.1_wh5cciuul2ivno4sebepep4pie:
     resolution: {integrity: sha1-5z3pEClYr54fCxaKb/Mg4lrc/0s=}
     hasBin: true
     peerDependencies:
@@ -12331,7 +12310,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 15.14.9
+      '@types/node': 20.1.5
       acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1.  Created a new package `teams-types-tester` that copies the built Types definitions and runs the Typescript Compiler on them to detect any errors with dependencies.
2. Upgraded `@types/nodes` package to remove duplicate types with Typescript