### PR TITLE
Mark our pipeline as something that generates prod assets

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,8 @@ variables:
   - group: InfoSec-SecurityResults
   - name: products
     value: 6eff390d-80c0-4456-81b6-6abafa71e768
+  - name: tags
+    value: production
 
 trigger:
   branches:


### PR DESCRIPTION
## Description

Adding another variable to our azure pipeline yaml that will mark pipelines driven by that yaml as being ones that generate production assets. This is needed to correctly tag our pipeline.

### Main changes in the PR:

1. Added new tags variable to pipeline following internal guidance

## Validation

### Validation performed:

1. Ran pipeline and made sure it worked

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No, none needed for yaml update
