### PR TITLE
E2E Testing Json Data Migration

### DIFF
--- a/apps/teams-test-app/capabilities.schema.json
+++ b/apps/teams-test-app/capabilities.schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "version": { "type": "string" },
+    "only": { "type": "boolean" },
+    "checkIsSupported": {
+      "type": "object",
+      "properties": {
+        "capabilityName": { "type": "string" },
+        "domElementName": { "type": "string" },
+        "expectedOutput": { "type": "string" },
+        "toggleId": { "type": "string" },
+        "version": { "type": "string" },
+        "testUrlParams": { "$ref": "#/$defs/testUrlParams" }
+      },
+      "additionalProperties": false
+    },
+    "platforms": {
+      "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+    },
+    "testUrlParams": { "$ref": "#/$defs/testUrlParams" },
+    "testCases": {
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "title": { "type": "string" },
+              "version": { "type": "string" },
+              "platformsExcluded": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "only": { "type": "boolean" },
+              "testUrlParams": { "$ref": "#/$defs/testUrlParams" },
+              "expectedAlertValue": {
+                "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+              },
+              "expectedWindowOpenTarget": { "type": "string" },
+              "expectedIFrameTarget": { "type": "string" },
+              "modulesToDisable": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "skipForCallbackBasedRuns": { "type": "boolean" }
+            },
+            "required": ["title"]
+          },
+          {
+            "type": "object",
+            "oneOf": [
+              {
+                "properties": {
+                  "type": { "const": "callResponse" },
+                  "boxSelector": { "type": "string" },
+                  "inputValue": {},
+                  "skipJsonStringifyOnInputValue": { "type": "boolean" },
+                  "checkboxState": { "type": "boolean" },
+                  "expectedTestAppValue": { "type": "string" },
+                  "requestPermissionBeforeThisCall": {
+                    "type": "object",
+                    "properties": {
+                      "boxSelector": { "type": "string" },
+                      "consentPermission": { "type": "boolean" }
+                    }
+                  }
+                },
+                "required": ["boxSelector"]
+              },
+              {
+                "properties": {
+                  "type": { "const": "raiseEvent" },
+                  "eventName": { "type": "string" },
+                  "eventData": {}
+                },
+                "required": ["eventName"]
+              },
+              {
+                "properties": {
+                  "type": { "const": "registerAndRaiseEvent" },
+                  "boxSelector": { "type": "string" },
+                  "inputValue": {},
+                  "eventName": { "type": "string" },
+                  "eventData": {},
+                  "expectedAlertValueOnRegistration": {
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                  },
+                  "expectedTestAppValue": { "type": "string" }
+                },
+                "required": ["boxSelector", "eventName"]
+              }
+            ]
+          }
+        ],
+        "unevaluatedProperties": false,
+        "required": ["type"]
+      }
+    }
+  },
+  "required": ["name", "testCases"],
+  "additionalProperties": false,
+  "$defs": {
+    "testUrlParams": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "prefixItems": [
+          { "enum": ["env", "appDefOverrides", "sessionId", "frameContext", "hostClientType", "hostView"] },
+          { "type": "string" }
+        ]
+      }
+    },
+    "appInteractionValidationProperties": {
+      "type": "object",
+      "properties": {
+        "expectedAlertValue": {
+          "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+        },
+        "expectedTestAppValue": { "type": "string" },
+        "expectedWindowOpenTarget": { "type": "string" },
+        "expectedIFrameTarget": { "type": "string" }
+      }
+    }
+  }
+}

--- a/apps/teams-test-app/e2e-test-data/app.json
+++ b/apps/teams-test-app/e2e-test-data/app.json
@@ -1,0 +1,92 @@
+{
+  "name": "App",
+  "platforms": "*",
+  "testCases": [
+    {
+      "title": "openLink API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_executeDeepLink2",
+      "platformsExcluded": ["iOS"],
+      "inputValue": "https://bing.com",
+      "expectedWindowOpenTarget": "https://bing.com"
+    },
+    {
+      "title": "openLink startCall API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_executeDeepLink2",
+      "platformsExcluded": ["iOS"],
+      "inputValue": "https://teams.microsoft.com/l/call/0/0?users=joe@contoso.com,bob@contoso.com&withVideo=true&source=test",
+      "expectedAlertValue": "startCall called with {\"targets\":[\"joe@contoso.com\",\"bob@contoso.com\"],\"requestedModalities\":[\"audio\",\"video\"],\"source\":\"test\"}",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "openLink openAppInstallDialog API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_executeDeepLink2",
+      "platformsExcluded": ["iOS"],
+      "inputValue": "https://teams.microsoft.com/l/app/957f8a7e-fbcd-411d-b69f-acb7eb58b515",
+      "expectedAlertValue": "openAppInstallDialog called with {\"appId\":\"957f8a7e-fbcd-411d-b69f-acb7eb58b515\"}",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "openLink navigateToApp API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_executeDeepLink2",
+      "inputValue": "https://teams.microsoft.com/l/entity/fe4a8eba-2a31-4737-8e33-e5fae6fee194/tasklist123?webUrl=https%3A%2F%2Ftasklist.example.com%2F123&context=%7B%22subEntityId%22%3A%20%22task456%22%2C%20%22channelId%22%3A%20%2219%3Acbe3683f25094106b826c9cada3afbe0%40thread.skype%22%7D",
+      "expectedAlertValue": "navigateToApp called with {\"appId\":\"fe4a8eba-2a31-4737-8e33-e5fae6fee194\",\"pageId\":\"tasklist123\",\"webUrl\":\"https://tasklist.example.com/123\",\"subPageId\":\"task456\",\"channelId\":\"19:cbe3683f25094106b826c9cada3afbe0@thread.skype\"}",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "openLink composeMeeting API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_executeDeepLink2",
+      "inputValue": "https://teams.microsoft.com/l/meeting/new?subject=test%20subject&attendees=joe@contoso.com,bob@contoso.com&startTime=10%2F24%2F2018%2010%3A30%3A00&endTime=10%2F24%2F2018%2010%3A30%3A00&content=test%3Acontent",
+      "expectedAlertValue": "composeMeeting called with {\"attendees\":[\"joe@contoso.com\",\"bob@contoso.com\"],\"startTime\":\"10/24/2018 10:30:00\",\"endTime\":\"10/24/2018 10:30:00\",\"subject\":\"test subject\",\"content\":\"test:content\"}",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "openLink openChat API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_executeDeepLink2",
+      "platformsExcluded": ["Web"],
+      "inputValue": "https://teams.microsoft.com/l/chat/0/0?users=joe@contoso.com,bob@contoso.com&topicName=Prep%20For%20Meeting%20Tomorrow&message=Hi%20folks%2C%20kicking%20off%20a%20chat%20about%20our%20meeting%20tomorrow",
+      "expectedAlertValue": "openChat called with {\"members\":[\"joe@contoso.com\",\"bob@contoso.com\"],\"message\":\"Hi folks, kicking off a chat about our meeting tomorrow\",\"topic\":\"Prep For Meeting Tomorrow\"}",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "openLink openFilePreview API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_executeDeepLink2",
+      "platformsExcluded": ["Web"],
+      "inputValue": "https://teams.microsoft.com/l/file/5E0154FC-F2B4-4DA5-8CDA-F096E72C0A80?tenantId=0d9b645f-597b-41f0-a2a3-ef103fbd91bb&fileType=pptx&objectUrl=https%3A%2F%2Fmicrosoft.sharepoint.com%2Fteams%2FActionPlatform%2FShared%20Documents%2FFC7-%20Bot%20and%20Action%20Infra%2FKaizala%20Actions%20in%20Adaptive%20Cards%20-%20Deck.pptx&baseUrl=https%3A%2F%2Fmicrosoft.sharepoint.com%2Fteams%2FActionPlatform&serviceName=teams&threadId=19:f8fbfc4d89e24ef5b3b8692538cebeb7@thread.skype&groupId=ae063b79-5315-4ddb-ba70-27328ba6c31e",
+      "expectedAlertValue": "openFilePreview called with {\"baseUrl\":\"https://microsoft.sharepoint.com/teams/ActionPlatform\",\"entityId\":\"5E0154FC-F2B4-4DA5-8CDA-F096E72C0A80\",\"objectUrl\":\"https://microsoft.sharepoint.com/teams/ActionPlatform/Shared Documents/FC7- Bot and Action Infra/Kaizala Actions in Adaptive Cards - Deck.pptx\",\"title\":\"Kaizala Actions in Adaptive Cards - Deck.pptx\",\"type\":\"pptx\"}",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "openLink stageView.open API Call with thread id - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_executeDeepLink2",
+      "platformsExcluded": ["iOS"],
+      "inputValue": "https://teams.microsoft.com/l/stage/app-id/0?context=%7B%22contentUrl%22%3A%22https%3A%2F%2Fteams-alb.wakelet.com%22%2C%22websiteUrl%22%3A%22https%3A%2F%2Fteams-alb.wakelet.com%22%2C%22title%22%3A%22TestTitle%22%2C%22threadId%22%3A%22TestThreadId%22%7D",
+      "expectedAlertValue": "stageView.open called with {\"appId\":\"app-id\",\"contentUrl\":\"https://teams-alb.wakelet.com\",\"threadId\":\"TestThreadId\",\"title\":\"TestTitle\",\"websiteUrl\":\"https://teams-alb.wakelet.com\"}",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "openLink stageView.open API Call without thread id - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_executeDeepLink2",
+      "platformsExcluded": ["iOS"],
+      "inputValue": "https://teams.microsoft.com/l/stage/app-id/0?context=%7B%22contentUrl%22%3A%22https%3A%2F%2Fteams-alb.wakelet.com%22%2C%22websiteUrl%22%3A%22https%3A%2F%2Fteams-alb.wakelet.com%22%2C%22title%22%3A%22TestTitle%22%7D",
+      "expectedAlertValue": "stageView.open called with {\"appId\":\"app-id\",\"contentUrl\":\"https://teams-alb.wakelet.com\",\"title\":\"TestTitle\",\"websiteUrl\":\"https://teams-alb.wakelet.com\"}",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "openLink appLink domain doesn't match API Call - executeDeepLink called",
+      "type": "callResponse",
+      "boxSelector": "#box_executeDeepLink2",
+      "inputValue": "https://contoso.com/l/entity/fe4a8eba-2a31-4737-8e33-e5fae6fee194/tasklist123",
+      "expectedWindowOpenTarget": "https://contoso.com/l/entity/fe4a8eba-2a31-4737-8e33-e5fae6fee194/tasklist123",
+      "expectedTestAppValue": "Completed"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/appEntity.json
+++ b/apps/teams-test-app/e2e-test-data/appEntity.json
@@ -1,0 +1,35 @@
+{
+  "name": "AppEntity",
+  "platforms": "Web",
+  "version": ">=2.0.1",
+  "checkIsSupported": {
+    "expectedOutput": "AppEntity is not supported"
+  },
+  "testCases": [
+    {
+      "title": "SelectAppEntity API Call - Success",
+      "version": ">2.0.0",
+      "type": "callResponse",
+      "boxSelector": "#box_select_appEntity",
+      "inputValue": {
+        "threadId": "123",
+        "categories": ["books", "animals"],
+        "subEntityId": "abc"
+      },
+      "expectedAlertValue": "appEntity.selectAppEntity called with 123 + books,animals + abc",
+      "expectedTestAppValue": "{\"appId\":\"007\",\"appIconUrl\":\"appIncon_pengiun.com\",\"contentUrl\":\"contentUrl.com\",\"displayName\":\"penguin\",\"websiteUrl\":\"penguin.com\"}"
+    },
+    {
+      "title": "SelectAppEntity API Call - Success",
+      "version": "2.0.0",
+      "type": "callResponse",
+      "boxSelector": "#box_select_appEntity",
+      "inputValue": {
+        "threadId": "123",
+        "categories": ["books", "animals"]
+      },
+      "expectedAlertValue": "appEntity.selectAppEntity called with 123 + books,animals",
+      "expectedTestAppValue": "{\"appId\":\"007\",\"appIconUrl\":\"appIncon_pengiun.com\",\"contentUrl\":\"contentUrl.com\",\"displayName\":\"penguin\",\"websiteUrl\":\"penguin.com\"}"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/appInstallDialog.json
+++ b/apps/teams-test-app/e2e-test-data/appInstallDialog.json
@@ -1,0 +1,20 @@
+{
+  "name": "AppInstallDialog",
+  "platforms": "Web",
+  "version": ">2.0.0",
+  "checkIsSupported": {
+    "domElementName": "checkCapabilityAppInstallDialog"
+  },
+  "testCases": [
+    {
+      "title": "openAppInstallDialog API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_openAppInstallDialog",
+      "inputValue": {
+        "appId": "957f8a7e-fbcd-411d-b69f-acb7eb58b515"
+      },
+      "expectedAlertValue": "openAppInstallDialog called with {\"appId\":\"957f8a7e-fbcd-411d-b69f-acb7eb58b515\"}",
+      "expectedTestAppValue": "called"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/authentication.json
+++ b/apps/teams-test-app/e2e-test-data/authentication.json
@@ -1,0 +1,22 @@
+{
+  "name": "Authentication",
+  "platforms": "*",
+  "testCases": [
+    {
+      "title": "getUser API Call - Success",
+      "version": "1.x || >2.0.0-beta.2",
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_getUser",
+      "expectedTestAppValue": "{\"oid\":\"mockoid\",\"tid\":\"mocktid\",\"upn\":\"mockupn\",\"loginHint\":\"mockLoginHint\",\"displayName\":\"mockName\",\"dataResidency\":\"public\"}"
+    },
+    {
+      "title": "getUser API Call - Success",
+      "version": "2.0.0-beta.2",
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_getUser",
+      "expectedTestAppValue": "Success: {\"oid\":\"mockoid\",\"tid\":\"mocktid\",\"upn\":\"mockupn\",\"loginHint\":\"mockLoginHint\",\"displayName\":\"mockName\",\"dataResidency\":\"public\"}"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/barCode.json
+++ b/apps/teams-test-app/e2e-test-data/barCode.json
@@ -1,0 +1,54 @@
+{
+  "name": "BarCode",
+  "platforms": "Web",
+  "version": ">=2.1.0",
+  "checkIsSupported": {
+    "domElementName": "checkBarCodeCapability",
+    "expectedOutput": "BarCode is not supported"
+  },
+  "testCases": [
+    {
+      "title": "requestBarCodePermission API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_requestBarCodePermission",
+      "isRequestPermissionCall": { "repeatRequestPermissionCall": false },
+      "expectedTestAppValue": "true"
+    },
+    {
+      "title": "repeated requestBarCodePermission API Call with no dialog- Success",
+      "type": "callResponse",
+      "boxSelector": "#box_requestBarCodePermission",
+      "isRequestPermissionCall": { "repeatRequestPermissionCall": true },
+      "expectedTestAppValue": "true"
+    },
+    {
+      "title": "hasBarCodePermission API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_hasBarCodePermission",
+      "expectedTestAppValue": "false"
+    },
+    {
+      "title": "scanBarCode API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_scanBarCode",
+      "requestPermissionBeforeThisCall": {
+        "boxSelector": "#box_requestBarCodePermission",
+        "consentPermission": true
+      },
+      "inputValue": {},
+      "expectedTestAppValue": "\"scannedCode\"",
+      "expectedAlertValue": ["scanBarCode called with {}"]
+    },
+    {
+      "title": "scanBarCode API Call - Failure",
+      "type": "callResponse",
+      "boxSelector": "#box_scanBarCode",
+      "requestPermissionBeforeThisCall": {
+        "boxSelector": "#box_requestBarCodePermission",
+        "consentPermission": "false"
+      },
+      "inputValue": {},
+      "expectedTestAppValue": "Error: [object Object]"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/calendar.json
+++ b/apps/teams-test-app/e2e-test-data/calendar.json
@@ -1,0 +1,32 @@
+{
+  "name": "Calendar",
+  "version": ">=2.0.0",
+  "checkIsSupported": {},
+  "platforms": "*",
+  "testCases": [
+    {
+      "title": "openCalendarItem API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_openCalendarItem",
+      "inputValue": {
+        "itemId": "123"
+      },
+      "expectedAlertValue": "openCalendarItem called with itemId: 123",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "composeMeeting API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_composeMeeting",
+      "inputValue": {
+        "attendees": ["attendees"],
+        "startTime": "startTime",
+        "endTime": "endTime",
+        "subject": "subject",
+        "content": "content"
+      },
+      "expectedAlertValue": "composeMeeting called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "Completed"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/call.json
+++ b/apps/teams-test-app/e2e-test-data/call.json
@@ -1,0 +1,22 @@
+{
+  "name": "Call",
+  "platforms": "Web",
+  "version": ">=2.0.0",
+  "checkIsSupported": {
+    "domElementName": "checkCapabilityCall"
+  },
+  "testCases": [
+    {
+      "title": "startCall API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_startCall",
+      "inputValue": {
+        "targets": ["user1", "user2"],
+        "requestedModalities": ["video"],
+        "source": "source"
+      },
+      "expectedAlertValue": "startCall called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "result: true"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/chat.json
+++ b/apps/teams-test-app/e2e-test-data/chat.json
@@ -1,0 +1,58 @@
+{
+  "name": "Chat",
+  "version": ">2.0.0-beta.0",
+  "platforms": "*",
+  "checkIsSupported": {
+    "version": ">2.0.0-beta.3"
+  },
+  "testCases": [
+    {
+      "title": "openChat API Call - Success",
+      "type": "callResponse",
+      "version": ">2.0.0-beta.3",
+      "boxSelector": "#box_openChat",
+      "inputValue": {
+        "user": ["testUpn"],
+        "message": "testMessage"
+      },
+      "expectedAlertValue": "openChat called with {\"members\":[\"testUpn\"],\"message\":\"testMessage\"}",
+      "expectedTestAppValue": "chat.openChat() was called, but there was no response from the Host SDK."
+    },
+    {
+      "title": "openGroupChat API Call - Success",
+      "type": "callResponse",
+      "version": ">2.0.0-beta.3",
+      "boxSelector": "#box_openGroupChat",
+      "inputValue": {
+        "users": ["testUpn1", "testUpn2"],
+        "message": "testMessage"
+      },
+      "expectedAlertValue": "openChat called with {\"members\":[\"testUpn1\",\"testUpn2\"],\"message\":\"testMessage\"}",
+      "expectedTestAppValue": "chat.openChat() was called, but there was no response from the Host SDK."
+    },
+    {
+      "title": "openChat2 API Call - Success",
+      "type": "callResponse",
+      "version": ">2.2.0",
+      "boxSelector": "#box_openChat2",
+      "inputValue": {
+        "user": ["testUpn"],
+        "message": "testMessage"
+      },
+      "expectedAlertValue": "openChat called with {\"members\":[\"testUpn\"],\"message\":\"testMessage\"}",
+      "expectedTestAppValue": "chat.openChat() was called"
+    },
+    {
+      "title": "openGroupChat2 API Call - Success",
+      "type": "callResponse",
+      "version": ">2.2.0",
+      "boxSelector": "#box_openGroupChat2",
+      "inputValue": {
+        "users": ["testUpn1", "testUpn2"],
+        "message": "testMessage"
+      },
+      "expectedAlertValue": "openChat called with {\"members\":[\"testUpn1\",\"testUpn2\"],\"message\":\"testMessage\"}",
+      "expectedTestAppValue": "chat.openGroupChat() was called"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/conversation.json
+++ b/apps/teams-test-app/e2e-test-data/conversation.json
@@ -1,0 +1,124 @@
+{
+  "name": "Conversation",
+  "platforms": "*",
+  "testCases": [
+    {
+      "title": "closeConversation API Call - Success",
+      "type": "callResponse",
+      "version": ">2.0.0-beta.3",
+      "boxSelector": "#box_closeConversation",
+      "expectedAlertValue": "closeConversation called",
+      "expectedTestAppValue": "Conversation Closed!"
+    },
+    {
+      "title": "getChatMembers API Call - Success",
+      "type": "callResponse",
+      "version": ">2.0.0-beta.3",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_getChatMembers",
+      "expectedAlertValue": "getChatMembers called",
+      "expectedTestAppValue": "{\"members\":[{\"upn\":\"testUpn\"}]}"
+    },
+    {
+      "title": "getChatMembers API Call - Success",
+      "type": "callResponse",
+      "version": ">2.0.0-beta.3",
+      "platformsExcluded": ["Web"],
+      "boxSelector": "#box_getChatMembers",
+      "expectedAlertValue": "getChatMembers called",
+      "expectedTestAppValue": "{\"members\":[{\"principalName\":\"TestUser\"}]}"
+    },
+    {
+      "title": "openConversation API Call - with startConversation",
+      "version": ">2.0.0-beta.2",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_openConversation2",
+      "type": "registerAndRaiseEvent",
+      "inputValue": {
+        "title": "testTitle",
+        "subEntityId": "testSubEntityId",
+        "conversationId": "testConversationId",
+        "channelId": "testChannelId",
+        "entityId": "testEntityId"
+      },
+      "expectedAlertValueOnRegistration": "openConversation called with ##JSON_INPUT_VALUE##",
+      "eventName": "startConversation",
+      "eventData": {
+        "subEntityId": "testSubEntityId",
+        "conversationId": "testConversationId",
+        "channelId": "testChannelId",
+        "entityId": "testEntityId"
+      },
+      "expectedTestAppValue": "Start Conversation Subentity Id testSubEntityId Conversation Id: testConversationId Entity Id: testEntityId Channel Id: testChannelId"
+    },
+    {
+      "title": "openConversation API Call - with startConversation",
+      "version": "2.0.0-beta.2",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_openConversation",
+      "type": "registerAndRaiseEvent",
+      "inputValue": {
+        "title": "testTitle",
+        "subEntityId": "testSubEntityId",
+        "conversationId": "testConversationId",
+        "channelId": "testChannelId",
+        "entityId": "testEntityId"
+      },
+      "expectedAlertValueOnRegistration": "openConversation called with ##JSON_INPUT_VALUE##",
+      "eventName": "startConversation",
+      "eventData": {
+        "subEntityId": "testSubEntityId",
+        "conversationId": "testConversationId",
+        "channelId": "testChannelId",
+        "entityId": "testEntityId"
+      },
+      "expectedTestAppValue": "Start Conversation Subentity Id testSubEntityId Conversation Id: testConversationId Entity Id: testEntityId Channel Id: testChannelId"
+    },
+    {
+      "title": "openConversation API Call - with closeConversation",
+      "version": ">2.0.0-beta.2",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_openConversation2",
+      "type": "registerAndRaiseEvent",
+      "inputValue": {
+        "title": "testTitle",
+        "subEntityId": "testSubEntityId",
+        "conversationId": "testConversationId",
+        "channelId": "testChannelId",
+        "entityId": "testEntityId"
+      },
+      "expectedAlertValueOnRegistration": "openConversation called with ##JSON_INPUT_VALUE##",
+      "eventName": "closeConversation",
+      "eventData": {
+        "subEntityId": "closeConversationSubEntityId",
+        "conversationId": "closeConversationConversationId",
+        "channelId": "closeConversationChannelId",
+        "entityId": "closeConversationEntityId"
+      },
+      "expectedTestAppValue": "Close Conversation Subentity Id closeConversationSubEntityId Conversation Id: closeConversationConversationId Entity Id: closeConversationEntityId Channel Id: closeConversationChannelId"
+    },
+    {
+      "title": "openConversation API Call - with closeConversation",
+      "version": "2.0.0-beta.2",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_openConversation",
+      "type": "registerAndRaiseEvent",
+      "inputValue": {
+        "title": "testTitle",
+        "subEntityId": "testSubEntityId",
+        "conversationId": "testConversationId",
+        "channelId": "testChannelId",
+        "entityId": "testEntityId"
+      },
+      "expectedAlertValueOnRegistration": "openConversation called with ##JSON_INPUT_VALUE##",
+      "eventName": "closeConversation",
+      "eventData": {
+        "subEntityId": "closeConversationSubEntityId",
+        "conversationId": "closeConversationConversationId",
+        "channelId": "closeConversationChannelId",
+        "entityId": "closeConversationEntityId"
+      },
+      "expectedTestAppValue": "Start Conversation Subentity Id closeConversationSubEntityId Conversation Id: closeConversationConversationId Entity Id: closeConversationEntityId Channel Id: closeConversationChannelId"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/dialog.json
+++ b/apps/teams-test-app/e2e-test-data/dialog.json
@@ -1,0 +1,30 @@
+{
+  "name": "Dialog",
+  "platforms": "Web",
+  "checkIsSupported": {
+    "domElementName": "checkCapabilityDialog"
+  },
+  "testCases": [
+    {
+      "title": "dialogResize API Call - Success",
+      "type": "callResponse",
+      "testUrlParams": [["frameContext", "task"]],
+      "boxSelector": "#box_dialogResize",
+      "inputValue": {
+        "height": "large",
+        "width": "large"
+      },
+      "expectedAlertValue": "dialog.resize() called with ##JSON_INPUT_VALUE##"
+    },
+    {
+      "title": "dialogSubmit API Call - Success",
+      "type": "callResponse",
+      "testUrlParams": [["frameContext", "task"]],
+      "boxSelector": "#box_dialogSubmitWithInput",
+      "inputValue": {
+        "result": "testResult"
+      },
+      "expectedAlertValue": "dialog.submit() called with \"testResult\""
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/files.json
+++ b/apps/teams-test-app/e2e-test-data/files.json
@@ -1,0 +1,188 @@
+{
+  "name": "Files",
+  "version": ">2.0.0-beta.0",
+  "platforms": "*",
+  "testCases": [
+    {
+      "title": "openFilePreview API Call - Success",
+      "type": "callResponse",
+      "version": ">2.0.0-beta.2",
+      "boxSelector": "#box_openFilePreview",
+      "inputValue": {
+        "entityId": "testEntityId",
+        "title": "testTitle",
+        "description": "testDescription",
+        "type": "testType",
+        "objectUrl": "testObjectUrl",
+        "downloadUrl": "testDownloadUrl",
+        "webPreviewUrl": "testWebPreviewUrl",
+        "baseUrl": "testBaseUrl",
+        "editFile": true,
+        "subEntityId": "testSubEntityId",
+        "viewerAction": "edit",
+        "fileOpenPreference": "web"
+      },
+      "expectedAlertValue": "openFilePreview called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "Called"
+    },
+    {
+      "title": "openFilePreview API Call - Success",
+      "type": "callResponse",
+      "version": "2.0.0-beta.2",
+      "boxSelector": "#box_openFilePreview",
+      "inputValue": {
+        "entityId": "testEntityId",
+        "title": "testTitle",
+        "description": "testDescription",
+        "type": "testType",
+        "objectUrl": "testObjectUrl",
+        "downloadUrl": "testDownloadUrl",
+        "webPreviewUrl": "testWebPreviewUrl",
+        "baseUrl": "testBaseUrl",
+        "editFile": true,
+        "subEntityId": "testSubEntityId",
+        "viewerAction": "edit",
+        "fileOpenPreference": "web"
+      },
+      "expectedAlertValue": "openFilePreview called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "openFilePreview() was called, but there was no response from the Host SDK."
+    },
+    {
+      "title": "getCloudStorageFolders API Call - Success",
+      "type": "callResponse",
+      "version": ">2.0.0-beta.2",
+      "boxSelector": "#box_getCloudStorageFolders2",
+      "inputValue": "testChannelId",
+      "expectedAlertValue": "getCloudStorageFolders called with channelId: testChannelId",
+      "expectedTestAppValue": "[{\"id\":\"testId\",\"title\":\"testTitle\",\"folderId\":\"testFolderId\",\"providerType\":2,\"providerCode\":\"GOOGLEDRIVE\",\"ownerDisplayName\":\"testOwnerDisplayName\"}]"
+    },
+    {
+      "title": "getCloudStorageFolders API Call - Success",
+      "type": "callResponse",
+      "version": "2.0.0-beta.2",
+      "boxSelector": "#box_getCloudStorageFolders",
+      "inputValue": "testChannelId",
+      "expectedAlertValue": "getCloudStorageFolders called with channelId: \"testChannelId\"",
+      "expectedTestAppValue": "[{\"id\":\"testId\",\"title\":\"testTitle\",\"folderId\":\"testFolderId\",\"providerType\":2,\"providerCode\":\"GOOGLEDRIVE\",\"ownerDisplayName\":\"testOwnerDisplayName\"}]"
+    },
+    {
+      "title": "addCloudStorageFolder API Call - Success",
+      "type": "callResponse",
+      "version": ">2.0.0-beta.2",
+      "boxSelector": "#box_addCloudStorageFolder2",
+      "inputValue": "testChannelId",
+      "expectedAlertValue": "addCloudStorageFolder called with channelId: testChannelId",
+      "expectedTestAppValue": "{\"isFolderAdded\":true,\"folders\":[{\"id\":\"testId\",\"title\":\"testTitle\",\"folderId\":\"testFolderId\",\"providerType\":2,\"providerCode\":\"GOOGLEDRIVE\",\"ownerDisplayName\":\"testOwnerDisplayName\"}]}"
+    },
+    {
+      "title": "addCloudStorageFolder API Call - Success",
+      "type": "callResponse",
+      "version": "2.0.0-beta.2",
+      "boxSelector": "#box_addCloudStorageFolder",
+      "inputValue": "testChannelId",
+      "expectedAlertValue": "addCloudStorageFolder called with channelId: \"testChannelId\"",
+      "expectedTestAppValue": "{\"isFolderAdded\":true,\"folders\":[{\"id\":\"testId\",\"title\":\"testTitle\",\"folderId\":\"testFolderId\",\"providerType\":2,\"providerCode\":\"GOOGLEDRIVE\",\"ownerDisplayName\":\"testOwnerDisplayName\"}]}"
+    },
+    {
+      "title": "deleteCloudStorageFolder API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_deleteCloudStorageFolder",
+      "inputValue": {
+        "channelId": "testChannelId",
+        "folderToDelete": {
+          "id": "testId",
+          "title": "testTitle",
+          "folderId": "testFolderId",
+          "providerType": 2,
+          "providerCode": "GOOGLEDRIVE",
+          "ownerDisplayName": "testOwnerDisplayName"
+        }
+      },
+      "expectedAlertValue": "deleteCloudStorageFolder called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "true"
+    },
+    {
+      "title": "copyMoveFiles API Call - Success",
+      "version": ">2.0.0-beta.2",
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_copyMoveFiles",
+      "inputValue": {
+        "selectedFiles": [
+          {
+            "id": "123",
+            "lastModifiedTime": "2021-04-14T15:08:35Z",
+            "size": 32,
+            "objectUrl": "abc.com",
+            "title": "file",
+            "isSubdirectory": false,
+            "type": "type"
+          }
+        ],
+        "providerCode": "DROPBOX",
+        "destinationFolder": {
+          "id": "123",
+          "lastModifiedTime": "2021-04-14T15:08:35Z",
+          "size": 32,
+          "objectUrl": "abc.com",
+          "title": "file",
+          "isSubdirectory": false,
+          "type": "type"
+        },
+        "destinationProviderCode": "GOOGLEDRIVE",
+        "isMove": false
+      },
+      "expectedAlertValue": "copyMoveFiles called with ##JSON_INPUT_VALUE##"
+    },
+    {
+      "title": "openCloudStorageFile API Call - Success",
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_openCloudStorageFile",
+      "inputValue": {
+        "file": {
+          "id": "test1",
+          "title": "test.pptx",
+          "isSubdirectory": false,
+          "type": ".pptx",
+          "size": 100,
+          "objectUrl": "https://api.com/test.pptx",
+          "lastModifiedTime": "2021-04-14T15:08:35Z"
+        },
+        "providerCode": "BOX"
+      },
+      "expectedAlertValue": "openCloudStorageFile called with ##JSON_INPUT_VALUE##"
+    },
+    {
+      "title": "getExternalProviders API Call - Success",
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "version": ">2.0.0",
+      "boxSelector": "#box_getExternalProviders",
+      "checkboxState": true,
+      "expectedAlertValue": "getExternalProviders called",
+      "expectedTestAppValue": "[{\"name\":\"firstProvider\",\"description\":\"dDesc\",\"thumbnails\":[],\"providerCode\":\"GOOGLEDRIVE\",\"providerType\":2}]"
+    },
+    {
+      "title": "getCloudStorageFolderContents API Call - Success",
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "version": ">2.0.0-beta.2",
+      "boxSelector": "#box_getCloudStorageFolderContents",
+      "inputValue": {
+        "folder": {
+          "id": "test1",
+          "title": "test.pptx",
+          "isSubdirectory": true,
+          "type": ".pptx",
+          "size": 100,
+          "objectUrl": "https://api.com/test.pptx",
+          "lastModifiedTime": "2021-04-14T15:08:35Z"
+        },
+        "providerCode": "BOX"
+      },
+      "expectedAlertValue": "getCloudStorageFolderContents called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "[{\"id\":\"test\",\"isSubdirectory\":false,\"lastModifiedTime\":\"23/06\",\"type\":\"ext\",\"size\":50,\"objectUrl\":\"object\",\"title\":\"testtitle\"}]"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/files.json
+++ b/apps/teams-test-app/e2e-test-data/files.json
@@ -57,6 +57,16 @@
       "expectedTestAppValue": "[{\"id\":\"testId\",\"title\":\"testTitle\",\"folderId\":\"testFolderId\",\"providerType\":2,\"providerCode\":\"GOOGLEDRIVE\",\"ownerDisplayName\":\"testOwnerDisplayName\"}]"
     },
     {
+      "title": "getCloudStorageFolders API Call - Failure (Not Full Trust)",
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "version": ">2.0.0-beta.5",
+      "boxSelector": "#box_getCloudStorageFolders2",
+      "inputValue": "testChannelId",
+      "testUrlParams": [["appDefOverrides", "{\"isFullTrustApp\": false}"]],
+      "expectedTestAppValue": "{\"errorCode\":500,\"message\":\"App does not have the required permissions for this operation\"}"
+    },
+    {
       "title": "getCloudStorageFolders API Call - Success",
       "type": "callResponse",
       "version": "2.0.0-beta.2",

--- a/apps/teams-test-app/e2e-test-data/geoLocation.json
+++ b/apps/teams-test-app/e2e-test-data/geoLocation.json
@@ -1,0 +1,53 @@
+{
+  "name": "GeoLocation",
+  "platforms": "Web",
+  "version": ">=2.1.0",
+  "checkIsSupported": {
+    "capabilityName": "GeoLocation",
+    "toggleId": "locationToggle",
+    "expectedOutput": "geoLocation module is not supported"
+  },
+  "testCases": [
+    {
+      "title": "hasGeoLocationPermission API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_hasGeoLocationPermission",
+      "expectedTestAppValue": "false"
+    },
+    {
+      "title": "requestGeoLocationPermission API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_requestGeoLocationPermission",
+      "isRequestPermissionCall": { "repeatRequestPermissionCall": false },
+      "expectedTestAppValue": "true"
+    },
+    {
+      "title": "repeat requestGeoLocationPermission API Call with no dialog - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_requestGeoLocationPermission",
+      "isRequestPermissionCall": { "repeatRequestPermissionCall": true },
+      "expectedTestAppValue": "true"
+    },
+    {
+      "title": "getCurrentLocation API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getCurrentLocation",
+      "requestPermissionBeforeThisCall": {
+        "boxSelector": "#box_requestGeoLocationPermission",
+        "consentPermission": true
+      },
+      "expectedAlertValue": ["getCurrentLocation is called"],
+      "expectedTestAppValue": "{\"latitude\":51.50735,\"longitude\":-0.127758,\"accuracy\":2,\"timestamp\":200}"
+    },
+    {
+      "title": "getCurrentLocation API Call - Failure",
+      "type": "callResponse",
+      "boxSelector": "#box_getCurrentLocation",
+      "requestPermissionBeforeThisCall": {
+        "boxSelector": "#box_requestGeoLocationPermission",
+        "consentPermission": false
+      },
+      "expectedTestAppValue": "Error: [object Object]"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/geoLocation.map.json
+++ b/apps/teams-test-app/e2e-test-data/geoLocation.map.json
@@ -1,0 +1,48 @@
+{
+  "name": "GeoLocation Map",
+  "platforms": "Web",
+  "version": ">=2.1.0",
+  "checkIsSupported": {
+    "capabilityName": "LocationMap"
+  },
+  "testCases": [
+    {
+      "title": "chooseLocationOnMap API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_chooseLocationOnMap",
+      "requestPermissionBeforeThisCall": {
+        "boxSelector": "#box_requestGeoLocationPermission",
+        "consentPermission": true
+      },
+      "expectedAlertValue": "location.map.chooseLocation is called.",
+      "expectedTestAppValue": "{\"latitude\":51.50735,\"longitude\":-0.127758,\"accuracy\":2,\"timestamp\":200}"
+    },
+    {
+      "title": "chooseLocationOnMap API Call - Failure",
+      "type": "callResponse",
+      "boxSelector": "#box_chooseLocationOnMap",
+      "requestPermissionBeforeThisCall": {
+        "boxSelector": "#box_requestGeoLocationPermission",
+        "consentPermission": "false"
+      },
+      "expectedTestAppValue": "Error: [object Object]"
+    },
+    {
+      "title": "showLocationOnMap API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_showLocationOnMap",
+      "requestPermissionBeforeThisCall": {
+        "boxSelector": "#box_requestGeoLocationPermission",
+        "consentPermission": true
+      },
+      "inputValue": {
+        "latitude": 51.507351,
+        "longitude": -0.127758,
+        "accuracy": 2,
+        "timestamp": 200
+      },
+      "expectedAlertValue": "location.map.showLocation called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "Completed"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/interactive.json
+++ b/apps/teams-test-app/e2e-test-data/interactive.json
@@ -1,6 +1,5 @@
 {
   "name": "Interactive",
-  "platforms": "Web",
   "version": "experimental/interactive",
   "testUrlParams": [["frameContext", "sidePanel"]],
   "testCases": [
@@ -12,7 +11,7 @@
         "origin": "https://localhost:4000"
       },
       "expectedAlertValue": "getFluidTenantInfo called with ##JSON_INPUT_VALUE##",
-      "expectedTestAppValue": "{\"tenantId\":\"mockTenantId\",\"ordererEndpoint\":\"mockOrdererEndpoint\",\"storageEndpoint\":\"mockStorageEndpoint\",\"serviceEndpoint\":\"mockServiceEndpoint\"}"
+      "expectedTestAppValue": "{\"tenantId\":\"mockTenantId\",\"serviceEndpoint\":\"mockServiceEndpoint\"}"
     },
     {
       "title": "getFluidToken API Call - Success",

--- a/apps/teams-test-app/e2e-test-data/interactive.json
+++ b/apps/teams-test-app/e2e-test-data/interactive.json
@@ -1,0 +1,74 @@
+{
+  "name": "Interactive",
+  "platforms": "Web",
+  "version": "experimental/interactive",
+  "testUrlParams": [["frameContext", "sidePanel"]],
+  "testCases": [
+    {
+      "title": "getFluidTenantInfo API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getFluidTenantInfo",
+      "inputValue": {
+        "origin": "https://localhost:4000"
+      },
+      "expectedAlertValue": "getFluidTenantInfo called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "{\"tenantId\":\"mockTenantId\",\"ordererEndpoint\":\"mockOrdererEndpoint\",\"storageEndpoint\":\"mockStorageEndpoint\",\"serviceEndpoint\":\"mockServiceEndpoint\"}"
+    },
+    {
+      "title": "getFluidToken API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getFluidToken",
+      "inputValue": {
+        "containerId": "mockContainerId",
+        "origin": "https://localhost:4000"
+      },
+      "expectedAlertValue": "getFluidToken called with ##JSON_INPUT_VALUE##"
+    },
+    {
+      "title": "getFluidContainerId API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getFluidContainerId",
+      "inputValue": {
+        "origin": "https://localhost:4000"
+      },
+      "expectedAlertValue": "getFluidContainerId called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "{\"containerState\":\"Added\",\"containerId\":\"mockContainerId\",\"shouldCreate\":false,\"retryAfter\":0}"
+    },
+    {
+      "title": "setFluidContainerId API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_setFluidContainerId",
+      "inputValue": {
+        "containerId": "mockContainerId",
+        "origin": "https://localhost:4000"
+      },
+      "expectedAlertValue": "setFluidContainerId called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "{\"containerState\":\"Added\",\"containerId\":\"mockContainerId\",\"shouldCreate\":false,\"retryAfter\":0}"
+    },
+    {
+      "title": "getNtpTime API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getNtpTime",
+      "expectedAlertValue": "getNtpTime called",
+      "expectedTestAppValue": "{\"ntpTime\":\"mockNtpTime\",\"ntpTimeInUTC\":0}"
+    },
+    {
+      "title": "registerClientId API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_registerClientId",
+      "expectedAlertValue": "registerClientId called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "[\"Attendee\",\"Presenter\"]"
+    },
+    {
+      "title": "getClientRoles API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getClientRoles",
+      "inputValue": {
+        "clientId": "mockClientId",
+        "origin": "https://localhost:4000"
+      },
+      "expectedAlertValue": "getClientRoles called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "[\"Attendee\",\"Presenter\"]"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/location.json
+++ b/apps/teams-test-app/e2e-test-data/location.json
@@ -1,0 +1,37 @@
+{
+  "name": "Location",
+  "version": ">=2.1.0",
+  "platforms": "*",
+  "checkIsSupported": {},
+  "testCases": [
+    {
+      "title": "getLocation API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getLocation",
+      "requestPermissionBeforeThisCall": {
+        "boxSelector": "#box_requestGeoLocationPermission",
+        "consentPermission": true
+      },
+      "inputValue": { "allowChooseLocation": true },
+      "expectedAlertValue": "location.map.chooseLocation is called.",
+      "expectedTestAppValue": "{\"latitude\":51.50735,\"longitude\":-0.127758,\"accuracy\":2,\"timestamp\":200}"
+    },
+    {
+      "title": "showLocation API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_showLocation",
+      "requestPermissionBeforeThisCall": {
+        "boxSelector": "#box_requestGeoLocationPermission",
+        "consentPermission": true
+      },
+      "inputValue": {
+        "latitude": 51.50735,
+        "longitude": -0.127758,
+        "accuracy": 2,
+        "timestamp": 200
+      },
+      "expectedAlertValue": "location.map.showLocation called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "Completed"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/log.json
+++ b/apps/teams-test-app/e2e-test-data/log.json
@@ -1,0 +1,14 @@
+{
+  "name": "Log",
+  "platforms": "Web",
+  "testCases": [
+    {
+      "title": "registerGetLogHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerGetLogHandler",
+      "eventName": "log.request",
+      "expectedAlertValue": "handleAppLog called with appLog: App log string",
+      "expectedTestAppValue": "Success"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/mail.json
+++ b/apps/teams-test-app/e2e-test-data/mail.json
@@ -1,0 +1,35 @@
+{
+  "name": "Mail",
+  "version": ">2.0.0-beta.0",
+  "platforms": "*",
+  "checkIsSupported": {
+    "domElementName": "checkCapabilityMail"
+  },
+  "testCases": [
+    {
+      "title": "openMailItem API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_openMailItem",
+      "inputValue": {
+        "itemId": "123"
+      },
+      "expectedAlertValue": "openMailItem called with itemId: 123",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "composeMail API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_composeMail",
+      "inputValue": {
+        "type": "new",
+        "toRecipients": ["toRecipients"],
+        "ccRecipients": ["ccRecipients"],
+        "bccRecipients": ["bccRecipients"],
+        "subject": "subject",
+        "message": "message"
+      },
+      "expectedAlertValue": "composeMail called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "Completed"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/media.json
+++ b/apps/teams-test-app/e2e-test-data/media.json
@@ -1,0 +1,71 @@
+{
+  "name": "Media",
+  "platforms": "Web",
+  "testCases": [
+    {
+      "title": "selectMedia API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_selectMedia",
+      "inputValue": {
+        "mediaType": 1,
+        "maxMediaCount": 1,
+        "imageProps": {
+          "sources": [1, 2],
+          "startMode": 1,
+          "ink": true,
+          "cameraSwitcher": true,
+          "textSticker": true,
+          "enableFilter": false
+        }
+      },
+      "expectedAlertValue": "selectMedia called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "[format: id, size: 2, mimeType: text/plain, content: ABCDEFGHIJKL, preview: ABC],[format: base64, size: 2, mimeType: .bin, content: ABCDEFGHIJKL2, preview: ABC],"
+    },
+    {
+      "title": "getMedia API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getMedia",
+      "inputValue": {},
+      "expectedAlertValue": ["selectMedia called with ##JSON_INPUT_VALUE##", "getMedia called with \"ABCDEFGHIJKL\""],
+      "expectedTestAppValue": "Received Blob (length: 74163)"
+    },
+    {
+      "title": "viewImagesWithIds API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_viewImagesWithId",
+      "inputValue": {
+        "mediaType": 1,
+        "maxMediaCount": 1,
+        "imageProps": {
+          "sources": [1, 2],
+          "startMode": 1,
+          "ink": true,
+          "cameraSwitcher": true,
+          "textSticker": true,
+          "enableFilter": false
+        }
+      },
+      "expectedAlertValue": [
+        "selectMedia called with ##JSON_INPUT_VALUE##",
+        "viewImages called with [{\"value\":\"ABCDEFGHIJKL\",\"type\":1},{\"value\":\"ABCDEFGHIJKL2\",\"type\":1}]"
+      ]
+    },
+    {
+      "title": "viewImagesWithUrls API Call - Success",
+      "type": "callResponse",
+      "version": "1.x || >2.0.0-beta.2",
+      "boxSelector": "#box_viewImagesWithUrls",
+      "inputValue": ["first", "second"],
+      "expectedAlertValue": "viewImages called with [{\"value\":\"first\",\"type\":2},{\"value\":\"second\",\"type\":2}]"
+    },
+    {
+      "title": "viewImagesWithUrls API Call - Success",
+      "type": "callResponse",
+      "version": "2.0.0-beta.2",
+      "boxSelector": "#box_viewImagesWithUrls",
+      "inputValue": "first, second",
+      "skipJsonStringifyOnInputValue": true,
+      "expectedAlertValue": "viewImages called with [{\"value\":\"first\",\"type\":2},{\"value\":\"second\",\"type\":2}]"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/meeting.appShareButton.json
+++ b/apps/teams-test-app/e2e-test-data/meeting.appShareButton.json
@@ -1,0 +1,18 @@
+{
+  "name": "Meeting",
+  "platforms": "Web",
+  "testUrlParams": [["sidePanel"]],
+  "testCases": [
+    {
+      "title": "setOptions API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_setOptions",
+      "inputValue": {
+        "contentUrl": "https://www.someUrl.com",
+        "isVisible": true
+      },
+      "expectedAlertValue": "setOptions called",
+      "expectedTestAppValue": "setOptions() succeeded"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/meeting.json
+++ b/apps/teams-test-app/e2e-test-data/meeting.json
@@ -1,0 +1,217 @@
+{
+  "name": "Meeting",
+  "platforms": "Web",
+  "testUrlParams": [["frameContext", "sidePanel"]],
+  "testCases": [
+    {
+      "title": "getIncomingClientAudioState API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getIncomingClientAudioState",
+      "expectedAlertValue": "getIncomingClientAudioState called",
+      "expectedTestAppValue": "true"
+    },
+    {
+      "title": "toggleIncomingClientAudio API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_toggleIncomingClientAudio",
+      "expectedAlertValue": "toggleIncomingClientAudio called",
+      "expectedTestAppValue": "false"
+    },
+    {
+      "title": "getMeetingDetails API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getMeetingDetails",
+      "expectedAlertValue": "getMeetingDetails called",
+      "expectedTestAppValue": "{\"details\":{\"id\":\"testDetailsId\",\"scheduledStartTime\":\"testStartTime\",\"scheduledEndTime\":\"testEndTime\",\"joinUrl\":\"testJoinUrl\",\"title\":\"testTitle\",\"type\":\"Unknown\"},\"conversation\":{\"id\":\"testConversationId\"},\"organizer\":{\"id\":\"testOrganizerId\",\"tenantId\":\"testTenantId\"}}"
+    },
+    {
+      "title": "getAuthenticationTokenForAnonymousUser API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getAuthTokenForAnonymousUser",
+      "expectedAlertValue": "getAuthenticationTokenForAnonymousUser called",
+      "expectedTestAppValue": "testAuthToken"
+    },
+    {
+      "title": "getLiveStreamState API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getLiveStreamState",
+      "expectedAlertValue": "getLiveStreamState called",
+      "expectedTestAppValue": "true"
+    },
+    {
+      "title": "requestStartLiveStreaming API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_requestStartLiveStreaming",
+      "inputValue": {
+        "streamUrl": "https://www.bing.com",
+        "streamKey": "testStreamKey"
+      },
+      "expectedAlertValue": "requestStartLiveStreaming called with https://www.bing.com + testStreamKey"
+    },
+    {
+      "title": "requestStopLiveStreaming API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_requestStopLiveStreaming",
+      "expectedAlertValue": "requestStopLiveStreaming called"
+    },
+    {
+      "title": "registerLiveStreamChangedHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "version": ">2.0.0-beta.2",
+      "boxSelector": "#box_registerLiveStreamChangedHandler",
+      "eventName": "liveStreamChanged",
+      "eventData": {
+        "isStreaming": true,
+        "error": {
+          "code": "ServerError404",
+          "message": "Server failed to respond"
+        }
+      },
+      "expectedTestAppValue": "Live StreamState changed to true with error {\"code\":\"ServerError404\",\"message\":\"Server failed to respond\"}"
+    },
+    {
+      "title": "registerLiveStreamChangedHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "version": "2.0.0-beta.2",
+      "boxSelector": "#box_registerLiveStreamChangedHandler",
+      "eventName": "liveStreamChanged",
+      "eventData": {
+        "isStreaming": true,
+        "error": {
+          "code": "ServerError404",
+          "message": "Server failed to respond"
+        }
+      },
+      "expectedTestAppValue": "Live StreamState changed to true"
+    },
+    {
+      "title": "registerRaiseHandStateChangedHandler API Call - Handler - Success",
+      "type": "registerAndRaiseEvent",
+      "version": ">2.0.0",
+      "boxSelector": "#box_registerRaiseHandStateChangedHandler",
+      "eventName": "raiseHandStateChanged",
+      "eventData": {
+        "raiseHandState": { "isHandRaised": true }
+      },
+      "expectedTestAppValue": "RaiseHand state changed to {\"isHandRaised\":true}"
+    },
+    {
+      "title": "registerRaiseHandStateChangedHandler API Call - Handler - Error",
+      "type": "registerAndRaiseEvent",
+      "version": ">2.0.0",
+      "boxSelector": "#box_registerRaiseHandStateChangedHandler",
+      "eventName": "raiseHandStateChanged",
+      "eventData": {
+        "raiseHandState": { "isHandRaised": false },
+        "error": {
+          "errorCode": 1000,
+          "message": "Encountered an error"
+        }
+      },
+      "expectedTestAppValue": "Receieved error {\"errorCode\":1000,\"message\":\"Encountered an error\"}"
+    },
+    {
+      "title": "registerMeetingReactionReceivedHandler API Call - Handler - Success",
+      "type": "registerAndRaiseEvent",
+      "version": ">2.0.0",
+      "boxSelector": "#box_registerMeetingReactionReceivedHandler",
+      "eventName": "meetingReactionReceived",
+      "eventData": {
+        "meetingReactionType": "like"
+      },
+      "expectedTestAppValue": "Received \"like\""
+    },
+    {
+      "title": "registerMeetingReactionReceivedHandler API Call - Handler - Error",
+      "type": "registerAndRaiseEvent",
+      "version": ">2.0.0",
+      "boxSelector": "#box_registerMeetingReactionReceivedHandler",
+      "eventName": "meetingReactionReceived",
+      "eventData": {
+        "error": {
+          "errorCode": 1000,
+          "message": "Encountered an error"
+        }
+      },
+      "expectedTestAppValue": "Receieved error {\"errorCode\":1000,\"message\":\"Encountered an error\"}"
+    },
+    {
+      "title": "registerSpeakingStateChangedHandler API Call - Handler - Success",
+      "type": "registerAndRaiseEvent",
+      "version": ">2.0.0",
+      "boxSelector": "#box_registerSpeakingStateChangedHandler",
+      "eventName": "speakingStateChanged",
+      "eventData": {
+        "isSpeakingDetected": true
+      },
+      "expectedTestAppValue": "Speaking state changed to true"
+    },
+    {
+      "title": "registerSpeakingStateChangedHandler API Call - Handler - Error",
+      "type": "registerAndRaiseEvent",
+      "version": ">2.1.0",
+      "boxSelector": "#box_registerSpeakingStateChangedHandler",
+      "eventName": "speakingStateChanged",
+      "eventData": {
+        "isSpeakingDetected": false,
+        "error": {
+          "errorCode": 1000,
+          "message": "Encountered an error"
+        }
+      },
+      "expectedTestAppValue": "Receieved error {\"errorCode\":1000,\"message\":\"Encountered an error\"}"
+    },
+    {
+      "title": "shareAppContentToStage API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_shareAppContentToStage",
+      "inputValue": {
+        "appContentUrl": "www.someUrl.com"
+      },
+      "expectedAlertValue": "shareAppContentToStage called",
+      "expectedTestAppValue": "shareAppContentToStage() succeeded"
+    },
+    {
+      "title": "getAppContentStageSharingCapabilities API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getAppContentStageSharingCapabilities",
+      "expectedAlertValue": "getAppContentStageSharingCapabilities called",
+      "expectedTestAppValue": "getAppContentStageSharingCapabilities() succeeded: {\"doesAppHaveSharePermission\":true}"
+    },
+    {
+      "title": "stopSharingAppContentToStage API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_stopSharingAppContentToStage",
+      "expectedAlertValue": "stopSharingAppContentToStage called",
+      "expectedTestAppValue": "stopSharingAppContentToStage() succeeded: true"
+    },
+    {
+      "title": "getAppContentStageSharingState API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getAppContentStageSharingState",
+      "expectedAlertValue": "getAppContentStageSharingState called",
+      "expectedTestAppValue": "getAppContentStageSharingState() succeeded: {\"isAppSharing\":true}"
+    },
+    {
+      "title": "requestAppAudioHandling API Call - Success",
+      "type": "callResponse",
+      "version": ">2.7.1",
+      "boxSelector": "#box_requestAppAudioHandling",
+      "inputValue": {
+        "isMicMuted": true
+      },
+      "expectedAlertValue": "requestAppAudioHandling called",
+      "expectedTestAppValue": "requestAppAudioHandling() succeeded: isHostAudioless=true"
+    },
+    {
+      "title": "updateMicState API Call - Success",
+      "type": "callResponse",
+      "version": ">2.7.1",
+      "boxSelector": "#box_updateMicState",
+      "inputValue": {
+        "isMicMuted": true
+      },
+      "expectedAlertValue": "updateMicState called"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/meetingRoom.json
+++ b/apps/teams-test-app/e2e-test-data/meetingRoom.json
@@ -1,0 +1,63 @@
+{
+  "name": "MeetingRoom",
+  "platforms": "Web",
+  "version": ">2.0.0-beta.0",
+  "checkIsSupported": {
+    "expectedOutput": "MeetingRoom is not supported"
+  },
+  "testCases": [
+    {
+      "title": "getPairedMeetingRoomInfo API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getPairedMeetingRoomInfo",
+      "expectedAlertValue": "getPairedMeetingRoomInfo is called",
+      "expectedTestAppValue": "{\"endpointId\":\"someEndpointId\",\"deviceName\":\"someDeviceName\",\"clientType\":\"clientType\",\"clientVersion\":\"clientVersion\"}"
+    },
+    {
+      "title": "sendCommandToPairedMeetingRoom API Call - Success",
+      "type": "callResponse",
+      "version": ">2.0.0-beta.2",
+      "boxSelector": "#box_sendCommandToPairedMeetingRoom",
+      "inputValue": {
+        "commandName": "someCommandName"
+      },
+      "expectedAlertValue": "sendCommandToPairedMeetingRoom is called with ##JSON_INPUT_VALUE##"
+    },
+    {
+      "title": "sendCommandToPairedMeetingRoom API Call - Success",
+      "type": "callResponse",
+      "version": "2.0.0-beta.2",
+      "boxSelector": "#box_sendCommandToPairedMeetingRoom",
+      "inputValue": {
+        "commandName": "someCommandName"
+      },
+      "expectedAlertValue": "sendCommandToPairedMeetingRoom is called with \"{\\\"commandName\\\":\\\"someCommandName\\\"}\""
+    },
+    {
+      "title": "registerMeetingRoomCapabilitiesUpdateHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerMeetingRoomCapabilitiesUpdateHandler",
+      "eventName": "meetingRoomCapabilitiesUpdate",
+      "eventData": {
+        "mediaControls": ["toggleMute", "toggleMute"],
+        "stageLayoutControls": ["showContent", "showVideoGalleryAndContent"],
+        "meetingControls": ["leaveMeeting"]
+      },
+      "expectedTestAppValue": "Capabilities of meeting room update ##JSON_EVENT_DATA##"
+    },
+    {
+      "title": "registerMeetingRoomStatesUpdateHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerMeetingRoomStatesUpdateHandler",
+      "eventName": "meetingRoomStatesUpdate",
+      "eventData": {
+        "toggleMute": true,
+        "toggleCamera": true,
+        "toggleCaptions": true,
+        "stageLayout": ["Gallery"],
+        "leaveMeeting": true
+      },
+      "expectedTestAppValue": "States of meeting room update ##JSON_EVENT_DATA##"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/monetization.json
+++ b/apps/teams-test-app/e2e-test-data/monetization.json
@@ -1,0 +1,29 @@
+{
+  "name": "Monetization",
+  "platforms": "Web",
+  "checkIsSupported": {
+    "domElementName": "checkCapabilityMonetization",
+    "version": "1.x || >2.0.0-beta.2"
+  },
+  "testCases": [
+    {
+      "title": "openPurchaseExperience API Call - Success",
+      "type": "callResponse",
+      "version": "1.x || >2.0.0-beta.2",
+      "boxSelector": "#box_monetization_openPurchaseExperience",
+      "inputValue": {
+        "planId": "abc",
+        "term": "001"
+      },
+      "expectedAlertValue": "openPurchaseExperience called with ##JSON_INPUT_VALUE##"
+    },
+
+    {
+      "title": "openPurchaseExperience API Call - Success",
+      "type": "callResponse",
+      "version": "2.0.0-beta.2",
+      "boxSelector": "#box_monetization_openPurchaseExperience",
+      "expectedAlertValue": "openPurchaseExperience called with undefined"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/notifications.json
+++ b/apps/teams-test-app/e2e-test-data/notifications.json
@@ -1,0 +1,20 @@
+{
+  "name": "Notifications",
+  "platforms": "Web",
+  "version": ">2.0.0-beta.0",
+  "checkIsSupported": {
+    "domElementName": "checkCapabilityNotifications"
+  },
+  "testCases": [
+    {
+      "title": "showNotification API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_showNotification",
+      "inputValue": {
+        "message": "testMessage",
+        "notificationType": "fileDownloadStart"
+      },
+      "expectedAlertValue": "showNotification called with ##JSON_INPUT_VALUE##"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/pages.appButton.json
+++ b/apps/teams-test-app/e2e-test-data/pages.appButton.json
@@ -1,0 +1,34 @@
+{
+  "name": "Pages AppButton",
+  "platforms": "Web",
+  "testCases": [
+    {
+      "title": "registerAppButtonClick API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerAppButtonClickHandler",
+      "eventName": "appButtonClick",
+      "expectedTestAppValue": "successfully called"
+    },
+    {
+      "title": "registerAppButtonHoverEnterHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerAppButtonHoverEnterHandler",
+      "eventName": "appButtonHoverEnter",
+      "expectedTestAppValue": "successfully called"
+    },
+    {
+      "title": "registerAppButtonHoverLeaveHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerAppButtonHoverLeaveHandler",
+      "eventName": "appButtonHoverLeave",
+      "expectedTestAppValue": "successfully called"
+    },
+    {
+      "title": "registerAppButtonHoverLeaveHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerAppButtonHoverLeaveHandler",
+      "eventName": "appButtonHoverLeave",
+      "expectedTestAppValue": "successfully called"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/pages.backStack.json
+++ b/apps/teams-test-app/e2e-test-data/pages.backStack.json
@@ -1,0 +1,13 @@
+{
+  "name": "Pages BackStack",
+  "platforms": "*",
+  "testCases": [
+    {
+      "title": "navigateBack API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_navigateBack",
+      "expectedAlertValue": "navigateBack called",
+      "expectedTestAppValue": "Completed"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/pages.config.json
+++ b/apps/teams-test-app/e2e-test-data/pages.config.json
@@ -1,0 +1,118 @@
+{
+  "name": "Pages Config",
+  "checkIsSupported": {
+    "capabilityName": "PageConfig",
+    "expectedOutput": "Pages.config module is not supported",
+    "testUrlParams": []
+  },
+  "platforms": "*",
+  "testUrlParams": [["frameContext", "settings"]],
+  "testCases": [
+    {
+      "title": "setConfig API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_config_setConfig",
+      "inputValue": {
+        "contentUrl": "https://www.bing.com",
+        "entityId": "1",
+        "suggestedDisplayName": "MetaOSApp"
+      },
+      "expectedAlertValue": "setConfig called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "setValidityState API Call - Success - true",
+      "type": "callResponse",
+      "version": "1.x || >2.0.0-beta.2",
+      "boxSelector": "#box_config_setValidityState2",
+      "checkboxState": true,
+      "expectedAlertValue": "setValidityState called with true",
+      "expectedTestAppValue": "Set validity state to true"
+    },
+    {
+      "title": "setValidityState API Call - Success - true",
+      "type": "callResponse",
+      "version": "2.0.0-beta.2",
+      "boxSelector": "#box_config_setValidityState",
+      "inputValue": true,
+      "expectedAlertValue": "setValidityState called with true",
+      "expectedTestAppValue": "Set validity state to true"
+    },
+    {
+      "title": "setValidityState API Call - Success - false",
+      "type": "callResponse",
+      "version": "1.x || >2.0.0-beta.2",
+      "boxSelector": "#box_config_setValidityState2",
+      "expectedAlertValue": "setValidityState called with false",
+      "expectedTestAppValue": "Set validity state to false"
+    },
+    {
+      "title": "setValidityState API Call - Success - false",
+      "type": "callResponse",
+      "version": "2.0.0-beta.2",
+      "boxSelector": "#box_config_setValidityState",
+      "inputValue": false,
+      "expectedAlertValue": "setValidityState called with false",
+      "expectedTestAppValue": "Set validity state to false"
+    },
+    {
+      "title": "settings.save event without registration",
+      "type": "raiseEvent",
+      "platformsExcluded": ["iOS"],
+      "eventName": "settings.save",
+      "eventData": {
+        "webhookUrl": "sampleWebhook"
+      },
+      "expectedAlertValue": "onSaveSuccess called"
+    },
+    {
+      "title": "settings.remove event without registration",
+      "type": "raiseEvent",
+      "platformsExcluded": ["iOS"],
+      "eventName": "settings.remove",
+      "expectedAlertValue": "onRemoveSuccess called"
+    },
+    {
+      "title": "registerOnSaveHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_config_registerOnSaveHandler",
+      "eventName": "settings.save",
+      "eventData": {
+        "webhookUrl": "sampleWebhook"
+      },
+      "expectedAlertValue": "onSaveSuccess called",
+      "expectedTestAppValue": "Save event received."
+    },
+    {
+      "title": "registerOnRemoveHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_config_registerOnRemoveHandler",
+      "eventName": "settings.remove",
+      "expectedAlertValue": "onRemoveSuccess called",
+      "expectedTestAppValue": "Remove event received."
+    },
+    {
+      "title": "registerOnRemoveHandler API Call - Handler Failure",
+      "type": "registerAndRaiseEvent",
+      "version": ">2.0.0",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_config_registerOnRemoveHandlerFailure",
+      "eventName": "settings.remove",
+      "eventData": null,
+      "expectedAlertValue": "onRemoveFailure called with someReason",
+      "expectedTestAppValue": "Remove event failed."
+    },
+    {
+      "title": "registerChangeConfigsHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "version": ">2.0.0-beta.0",
+      "platformsExcluded": ["iOS"],
+      "testUrlParams": [["frameContext", "content"]],
+      "boxSelector": "#box_config_registerChangeConfigsHandler",
+      "eventName": "changeSettings",
+      "expectedTestAppValue": "successfully called"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/pages.config.json
+++ b/apps/teams-test-app/e2e-test-data/pages.config.json
@@ -15,7 +15,7 @@
       "inputValue": {
         "contentUrl": "https://www.bing.com",
         "entityId": "1",
-        "suggestedDisplayName": "MsftApp"
+        "suggestedDisplayName": "M365TestApp"
       },
       "expectedAlertValue": "setConfig called with ##JSON_INPUT_VALUE##",
       "expectedTestAppValue": "Completed"

--- a/apps/teams-test-app/e2e-test-data/pages.config.json
+++ b/apps/teams-test-app/e2e-test-data/pages.config.json
@@ -15,7 +15,7 @@
       "inputValue": {
         "contentUrl": "https://www.bing.com",
         "entityId": "1",
-        "suggestedDisplayName": "MetaOSApp"
+        "suggestedDisplayName": "MsftApp"
       },
       "expectedAlertValue": "setConfig called with ##JSON_INPUT_VALUE##",
       "expectedTestAppValue": "Completed"

--- a/apps/teams-test-app/e2e-test-data/pages.currentApp.json
+++ b/apps/teams-test-app/e2e-test-data/pages.currentApp.json
@@ -1,0 +1,51 @@
+{
+  "name": "Pages CurrentApp",
+  "platforms": "Web",
+  "checkIsSupported": {
+    "capabilityName": "PageCurrentApp",
+    "expectedOutput": "Pages.currentApp module is supported",
+    "testUrlParams": [],
+    "version": ">2.3.0"
+  },
+  "testCases": [
+    {
+      "title": "navigateTo API Call - Success",
+      "type": "callResponse",
+      "version": ">2.3.0",
+      "boxSelector": "#box_navigateTo",
+      "inputValue": {
+        "pageId": "tasklist123",
+        "subPageId": "task456"
+      },
+      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.metaostestapp.test\",\"pageId\":\"tasklist123\",\"subPageId\":\"task456\"}",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "navigateTo API Call no subPageID- Success",
+      "type": "callResponse",
+      "version": ">2.3.0",
+      "boxSelector": "#box_navigateTo",
+      "inputValue": {
+        "pageId": "tasklist123"
+      },
+      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.metaostestapp.test\",\"pageId\":\"tasklist123\"}",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "navigateTo API Call - Failure",
+      "type": "callResponse",
+      "version": ">2.3.0",
+      "boxSelector": "#box_navigateTo",
+      "inputValue": {},
+      "expectedTestAppValue": "Error: PageID are required."
+    },
+    {
+      "title": "navigateToDefaultPage API Call - Success",
+      "type": "callResponse",
+      "version": ">2.3.0",
+      "boxSelector": "#box_navigateToDefaultPage",
+      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.metaostestapp.test\",\"pageId\":\"serverUrl\"}",
+      "expectedTestAppValue": "Completed"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/pages.currentApp.json
+++ b/apps/teams-test-app/e2e-test-data/pages.currentApp.json
@@ -17,7 +17,7 @@
         "pageId": "tasklist123",
         "subPageId": "task456"
       },
-      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.metaostestapp.test\",\"pageId\":\"tasklist123\",\"subPageId\":\"task456\"}",
+      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.msfttestapp.test\",\"pageId\":\"tasklist123\",\"subPageId\":\"task456\"}",
       "expectedTestAppValue": "Completed"
     },
     {
@@ -28,7 +28,7 @@
       "inputValue": {
         "pageId": "tasklist123"
       },
-      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.metaostestapp.test\",\"pageId\":\"tasklist123\"}",
+      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.msfttestapp.test\",\"pageId\":\"tasklist123\"}",
       "expectedTestAppValue": "Completed"
     },
     {
@@ -44,7 +44,7 @@
       "type": "callResponse",
       "version": ">2.3.0",
       "boxSelector": "#box_navigateToDefaultPage",
-      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.metaostestapp.test\",\"pageId\":\"serverUrl\"}",
+      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.msfttestapp.test\",\"pageId\":\"serverUrl\"}",
       "expectedTestAppValue": "Completed"
     }
   ]

--- a/apps/teams-test-app/e2e-test-data/pages.currentApp.json
+++ b/apps/teams-test-app/e2e-test-data/pages.currentApp.json
@@ -17,7 +17,7 @@
         "pageId": "tasklist123",
         "subPageId": "task456"
       },
-      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.msfttestapp.test\",\"pageId\":\"tasklist123\",\"subPageId\":\"task456\"}",
+      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.m365testapp.test\",\"pageId\":\"tasklist123\",\"subPageId\":\"task456\"}",
       "expectedTestAppValue": "Completed"
     },
     {
@@ -28,7 +28,7 @@
       "inputValue": {
         "pageId": "tasklist123"
       },
-      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.msfttestapp.test\",\"pageId\":\"tasklist123\"}",
+      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.m365testapp.test\",\"pageId\":\"tasklist123\"}",
       "expectedTestAppValue": "Completed"
     },
     {
@@ -44,7 +44,7 @@
       "type": "callResponse",
       "version": ">2.3.0",
       "boxSelector": "#box_navigateToDefaultPage",
-      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.msfttestapp.test\",\"pageId\":\"serverUrl\"}",
+      "expectedAlertValue": "navigateToApp called with {\"appId\":\"com.example.m365testapp.test\",\"pageId\":\"serverUrl\"}",
       "expectedTestAppValue": "Completed"
     }
   ]

--- a/apps/teams-test-app/e2e-test-data/pages.fullTrust.json
+++ b/apps/teams-test-app/e2e-test-data/pages.fullTrust.json
@@ -1,0 +1,19 @@
+{
+  "name": "Pages FullTrust",
+  "platforms": "Web",
+  "version": ">2.0.0-beta.0",
+  "testCases": [
+    {
+      "title": "enterFullscreen API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_enterFullscreen",
+      "expectedAlertValue": "enterFullscreen called"
+    },
+    {
+      "title": "exitFullscreen API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_exitFullscreen",
+      "expectedAlertValue": "exitFullscreen called"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/pages.json
+++ b/apps/teams-test-app/e2e-test-data/pages.json
@@ -1,0 +1,119 @@
+{
+  "name": "Pages",
+  "platforms": "*",
+  "testCases": [
+    {
+      "title": "getConfig API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_config_getConfig",
+      "expectedAlertValue": "getConfig called",
+      "expectedTestAppValue": "{\"contentUrl\":\"https://www.bing.com\",\"entityId\":\"1\",\"suggestedDisplayName\":\"MetaOSApp\"}"
+    },
+    {
+      "title": "getConfig API Call - Default Response",
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_config_getConfig",
+      "modulesToDisable": ["pageConfigToggle"],
+      "expectedTestAppValue": "{\"contentUrl\":\"https://localhost:4000\",\"entityId\":\"serverUrl\",\"suggestedDisplayName\":\"Server Url\"}"
+    },
+    {
+      "title": "returnFocus API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_returnFocus",
+      "checkboxState": true,
+      "expectedAlertValue": "returnFocus called with true",
+      "expectedTestAppValue": "Current navigateForward state is true"
+    },
+    {
+      "title": "setCurrentFrame API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_setCurrentFrame",
+      "inputValue": {
+        "contentUrl": "https://localhost:4000/app",
+        "websiteUrl": "https://localhost:4000/website"
+      },
+      "expectedAlertValue": "setCurrentFrame called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "called"
+    },
+    {
+      "title": "navigateToApp API Call - Success",
+      "type": "callResponse",
+      "version": ">2.0.0-beta.2",
+      "boxSelector": "#box_navigateToApp",
+      "inputValue": {
+        "appId": "fe4a8eba-2a31-4737-8e33-e5fae6fee194",
+        "pageId": "tasklist123",
+        "webUrl": "https://tasklist.example.com/123",
+        "subPageId": "task456",
+        "channelId": "19:cbe3683f25094106b826c9cada3afbe0@thread.skype"
+      },
+      "expectedAlertValue": "navigateToApp called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "navigateCrossDomain API Call - Success",
+      "type": "callResponse",
+      "version": ">2.0.0-beta.2",
+      "boxSelector": "#box_navigateCrossDomain2",
+      "inputValue": "https://teams-test-tab.azurewebsites.net",
+      "expectedIFrameTarget": "https://teams-test-tab.azurewebsites.net"
+    },
+    {
+      "title": "navigateCrossDomain API Call - Success",
+      "type": "callResponse",
+      "version": "2.0.0-beta.2",
+      "boxSelector": "#box_navigateCrossDomain",
+      "inputValue": "https://teams-test-tab.azurewebsites.net",
+      "skipJsonStringifyOnInputValue": true,
+      "expectedIFrameTarget": "https://teams-test-tab.azurewebsites.net"
+    },
+    {
+      "title": "shareDeepLink API Call - Success",
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "version": "<=2.1.0",
+      "boxSelector": "#box_core\\.shareDeepLink",
+      "inputValue": {
+        "subEntityId": "testId",
+        "subEntityLabel": "testLabel",
+        "subEntityWebUrl": "testUrl"
+      },
+      "expectedAlertValue": "shareDeepLink called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "called shareDeepLink"
+    },
+    {
+      "title": "shareDeepLink API Call - Success",
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "version": ">2.1.0",
+      "boxSelector": "#box_pages\\.shareDeepLink",
+      "inputValue": {
+        "subEntityId": "testId",
+        "subEntityLabel": "testLabel",
+        "subEntityWebUrl": "testUrl"
+      },
+      "expectedAlertValue": "shareDeepLink called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "called shareDeepLink"
+    },
+    {
+      "title": "registerFullScreenChangeHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_registerFullScreenChangeHandler",
+      "eventName": "fullScreenChange",
+      "eventData": true,
+      "expectedTestAppValue": "successfully called with isFullScreen:true"
+    },
+    {
+      "title": "registerFocusEnterHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "platformsExcluded": ["iOS"],
+      "version": "1.x || >2.0.0-beta.2",
+      "boxSelector": "#box_registerFocusEnterHandler",
+      "eventName": "focusEnter",
+      "eventData": true,
+      "expectedTestAppValue": "successfully called with navigateForward:true"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/pages.json
+++ b/apps/teams-test-app/e2e-test-data/pages.json
@@ -7,7 +7,7 @@
       "type": "callResponse",
       "boxSelector": "#box_config_getConfig",
       "expectedAlertValue": "getConfig called",
-      "expectedTestAppValue": "{\"contentUrl\":\"https://www.bing.com\",\"entityId\":\"1\",\"suggestedDisplayName\":\"MsftTestApp\"}"
+      "expectedTestAppValue": "{\"contentUrl\":\"https://www.bing.com\",\"entityId\":\"1\",\"suggestedDisplayName\":\"M365TestApp\"}"
     },
     {
       "title": "getConfig API Call - Default Response",

--- a/apps/teams-test-app/e2e-test-data/pages.json
+++ b/apps/teams-test-app/e2e-test-data/pages.json
@@ -7,7 +7,7 @@
       "type": "callResponse",
       "boxSelector": "#box_config_getConfig",
       "expectedAlertValue": "getConfig called",
-      "expectedTestAppValue": "{\"contentUrl\":\"https://www.bing.com\",\"entityId\":\"1\",\"suggestedDisplayName\":\"MetaOSApp\"}"
+      "expectedTestAppValue": "{\"contentUrl\":\"https://www.bing.com\",\"entityId\":\"1\",\"suggestedDisplayName\":\"MsftTestApp\"}"
     },
     {
       "title": "getConfig API Call - Default Response",

--- a/apps/teams-test-app/e2e-test-data/pages.tabs.json
+++ b/apps/teams-test-app/e2e-test-data/pages.tabs.json
@@ -1,0 +1,43 @@
+{
+  "name": "Pages Tabs",
+  "platforms": "Web",
+  "checkIsSupported": {
+    "capabilityName": "PageTabs",
+    "expectedOutput": "Pages.tabs module is not supported"
+  },
+  "testCases": [
+    {
+      "title": "navigateToTab API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_navigateToTab",
+      "inputValue": {
+        "tabName": "TestTab",
+        "internalTabInstanceId": "23",
+        "channelIsFavorite": true,
+        "url": "https://test.com"
+      },
+      "expectedAlertValue": "navigateToTab called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "getTabInstance API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getTabInstance",
+      "inputValue": {
+        "favoriteTeamsOnly": true
+      },
+      "expectedAlertValue": "getTabInstances called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "{\"teamTabs\":[{\"tabName\":\"dummy1\",\"channelId\":\"1\"},{\"tabName\":\"dummy2\",\"channelId\":\"1\"}]}"
+    },
+    {
+      "title": "getMRUTabInstance API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getMRUTabInstance",
+      "inputValue": {
+        "favoriteTeamsOnly": true
+      },
+      "expectedAlertValue": "getMruTabInstances called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "{\"teamTabs\":[{\"tabName\":\"dummy1\",\"channelId\":\"1\"},{\"tabName\":\"dummy2\",\"channelId\":\"1\"}]}"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/people.json
+++ b/apps/teams-test-app/e2e-test-data/people.json
@@ -1,0 +1,19 @@
+{
+  "name": "People",
+  "platforms": "*",
+  "testCases": [
+    {
+      "title": "selectPeople API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_selectPeople",
+      "inputValue": {
+        "title": "title",
+        "setSelected": ["setSelected"],
+        "openOrgWideSearchInChatOrChannel": true,
+        "singleSelect": true
+      },
+      "expectedAlertValue": "selectPeople called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "[{\"objectId\":\"1\",\"displayName\":\"Name\",\"email\":\"test@microsoft.com\"}]"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/profile.json
+++ b/apps/teams-test-app/e2e-test-data/profile.json
@@ -1,0 +1,31 @@
+{
+  "name": "Profile",
+  "platforms": "Web",
+  "version": ">2.5.0",
+  "checkIsSupported": {
+    "domElementName": "checkCapabilityProfile"
+  },
+  "testCases": [
+    {
+      "title": "showProfile API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_showProfile",
+      "inputValue": {
+        "modality": "Card",
+        "persona": {
+          "identifiers": {
+            "Smtp": "test@microsoft.com"
+          }
+        },
+        "targetElementBoundingRect": {
+          "x": 0,
+          "y": 0,
+          "width": 0,
+          "height": 0
+        },
+        "triggerType": "MouseClick"
+      },
+      "expectedAlertValue": "showProfile called with {\"modality\":\"Card\",\"persona\":{\"identifiers\":{\"Smtp\":\"test@microsoft.com\"}},\"targetElementBoundingRect\":{\"x\":243,\"y\":0,\"width\":0,\"height\":0,\"top\":0,\"right\":243,\"bottom\":0,\"left\":243},\"triggerType\":\"MouseClick\"}"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/remoteCamera.json
+++ b/apps/teams-test-app/e2e-test-data/remoteCamera.json
@@ -1,0 +1,111 @@
+{
+  "name": "RemoteCamera",
+  "platforms": "Web",
+  "checkIsSupported": {
+    "expectedOutput": "Remote Camera module is not supported",
+    "version": ">2.0.0-beta.2"
+  },
+  "testUrlParams": [["frameContext", "sidePanel"]],
+  "testCases": [
+    {
+      "title": "getCapableParticipants API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getCapableParticipants",
+      "expectedAlertValue": "getCapableParticipants is called",
+      "expectedTestAppValue": "[{\"id\":\"sampleParticipantID\",\"displayName\":\"SampleDisplayName\",\"active\":true}]"
+    },
+    {
+      "title": "requestControl API Call - Success",
+      "version": ">2.0.0-beta.2",
+      "type": "callResponse",
+      "boxSelector": "#box_requestControl",
+      "inputValue": {
+        "id": "sampleParticipantID",
+        "displayName": "SampleDisplayName",
+        "active": true
+      },
+      "expectedAlertValue": "requestControl is called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "true"
+    },
+    {
+      "title": "sendControlCommand API Call - Success",
+      "version": ">2.0.0-beta.2",
+      "type": "callResponse",
+      "boxSelector": "#box_sendControlCommand",
+      "inputValue": "Reset",
+      "expectedAlertValue": "sendControlCommand is called with ##JSON_INPUT_VALUE##"
+    },
+    {
+      "title": "sendControlCommand API Call - Success",
+      "version": "2.0.0-beta.2",
+      "type": "callResponse",
+      "boxSelector": "#box_sendControlCommand",
+      "inputValue": "Reset",
+      "skipJsonStringifyOnInputValue": true,
+      "expectedAlertValue": "sendControlCommand is called with ##JSON_INPUT_VALUE##"
+    },
+    {
+      "title": "terminateSession API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_terminateSession",
+      "expectedAlertValue": "terminateSession is called"
+    },
+    {
+      "title": "registerOnCapableParticipantsChangeHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerOnCapableParticipantsChangeHandler",
+      "eventName": "capableParticipantsChange",
+      "eventData": [
+        {
+          "id": "Participant_1",
+          "displayName": "SampleDisplayName",
+          "active": false
+        },
+        {
+          "id": "Participant_2",
+          "displayName": "SampleDisplayName",
+          "active": true
+        }
+      ],
+      "expectedTestAppValue": "participantChange: ##JSON_EVENT_DATA##"
+    },
+    {
+      "title": "registerOnErrorHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerOnErrorHandler",
+      "eventName": "handlerError",
+      "eventData": 1,
+      "expectedTestAppValue": "1"
+    },
+    {
+      "title": "registerOnDeviceStateChangeHandler API Call - Handler",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerOnDeviceStateChangeHandler",
+      "eventName": "deviceStateChange",
+      "eventData": {
+        "available": true,
+        "error": true,
+        "reset": true,
+        "zoomIn": true,
+        "zoomOut": true,
+        "panLeft": true,
+        "panRight": true,
+        "tiltUp": true,
+        "tiltDown": true
+      },
+      "expectedTestAppValue": "##JSON_EVENT_DATA##"
+    },
+    {
+      "title": "registerOnSessionStatusChangeHandler API Call - Handler",
+      "version": ">2.0.0-beta.2",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerOnSessionStatusChangeHandler",
+      "eventName": "sessionStatusChange",
+      "eventData": {
+        "inControl": true,
+        "terminatedReason": 5
+      },
+      "expectedTestAppValue": "##JSON_EVENT_DATA##"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/search.json
+++ b/apps/teams-test-app/e2e-test-data/search.json
@@ -1,0 +1,52 @@
+{
+  "name": "Search",
+  "platforms": "Web",
+  "testCases": [
+    {
+      "version": ">2.4.0-beta.1",
+      "title": "registerHandlers - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_search_registerHandlers",
+      "expectedTestAppValue": "received"
+    },
+    {
+      "version": ">2.4.0-beta.1",
+      "title": "registerHandlers and call onChange event",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_search_registerHandlers",
+      "eventName": "queryChange",
+      "eventData": [
+        {
+          "searchTerm": "Hello, world"
+        }
+      ],
+      "expectedTestAppValue": "Update your application with the changed search query: Hello, world"
+    },
+    {
+      "version": ">2.4.0-beta.1",
+      "title": "registerHandlers and call onExecute event",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_search_registerHandlers",
+      "eventName": "queryExecute",
+      "eventData": [
+        {
+          "searchTerm": "Hello, world"
+        }
+      ],
+      "expectedTestAppValue": "Update your application to handle an executed search result: Hello, world"
+    },
+    {
+      "version": ">2.4.0-beta.1",
+      "title": "registerHandlers and call queryClose event",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_search_registerHandlers",
+      "eventName": "queryClose",
+      "eventData": [
+        {
+          "searchTerm": "Hello, world"
+        }
+      ],
+      "expectedTestAppValue": "Update your application to handle the search experience being closed. Last query: Hello, world"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/sharing.json
+++ b/apps/teams-test-app/e2e-test-data/sharing.json
@@ -1,0 +1,24 @@
+{
+  "name": "Sharing",
+  "platforms": "Web",
+  "checkIsSupported": {
+    "expectedOutput": "Sharing is not supported"
+  },
+  "testCases": [
+    {
+      "title": "shareWebContent API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_share_shareWebContent",
+      "inputValue": {
+        "content": [
+          {
+            "type": "URL",
+            "url": "https://bing.com",
+            "message": "def"
+          }
+        ]
+      },
+      "expectedAlertValue": "shareWebContent called with ##JSON_INPUT_VALUE##"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/stageView.json
+++ b/apps/teams-test-app/e2e-test-data/stageView.json
@@ -1,0 +1,27 @@
+{
+  "name": "StageView",
+  "platforms": "Web",
+  "version": ">2.0.0-beta.3",
+  "checkIsSupported": {
+    "expectedOutput": "StageView is not supported",
+    "version": ">2.0.0"
+  },
+  "testCases": [
+    {
+      "title": "openStageView API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_stageViewOpen",
+      "inputValue": {
+        "appId": "appId",
+        "contentUrl": "contentUrl",
+        "threadId": "threadId",
+        "title": "title",
+        "websiteUrl": "websiteUrl",
+        "entityId": "entityId"
+      },
+      "expectedAlertValue": "stageView.open called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "opened",
+      "skipForCallbackBasedRuns": true
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/teams.fullTrust.joinedTeams.json
+++ b/apps/teams-test-app/e2e-test-data/teams.fullTrust.joinedTeams.json
@@ -1,0 +1,17 @@
+{
+  "name": "Teams FullTrust JoinedTeams",
+  "platforms": "Web",
+  "version": ">2.0.0-beta.0",
+  "testCases": [
+    {
+      "title": "getUserJoinedTeams API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getUserJoinedTeams",
+      "inputValue": {
+        "favoriteTeamsOnly": true
+      },
+      "expectedAlertValue": "getUserJoinedTeams called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "{\"userJoinedTeams\":[{\"teamId\":\"testTeamId\",\"teamName\":\"testTeamName\"}]}"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/teams.fullTrust.json
+++ b/apps/teams-test-app/e2e-test-data/teams.fullTrust.json
@@ -1,0 +1,25 @@
+{
+  "name": "Teams FullTrust",
+  "platforms": "Web",
+  "version": ">2.0.0-beta.0",
+  "testCases": [
+    {
+      "title": "getConfigSetting API Call - Success",
+      "type": "callResponse",
+      "version": ">2.0.0-beta.2",
+      "boxSelector": "#box_getConfigSetting2",
+      "inputValue": "testKey",
+      "expectedAlertValue": "getConfigSetting called",
+      "expectedTestAppValue": "testValue"
+    },
+    {
+      "title": "getConfigSetting API Call - Success",
+      "type": "callResponse",
+      "version": "2.0.0-beta.2",
+      "boxSelector": "#box_getConfigSetting",
+      "inputValue": "testKey",
+      "expectedAlertValue": "getConfigSetting called",
+      "expectedTestAppValue": "testValue"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/teams.json
+++ b/apps/teams-test-app/e2e-test-data/teams.json
@@ -1,0 +1,23 @@
+{
+  "name": "Teams",
+  "platforms": "Web",
+  "version": "1.x || >2.0.0-beta.2",
+  "testCases": [
+    {
+      "title": "getTeamChannels API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_getTeamChannels2",
+      "inputValue": "groupId",
+      "expectedAlertValue": "getTeamChannels called",
+      "expectedTestAppValue": "[{\"siteUrl\":\"siteURL\",\"objectId\":\"objectId\",\"folderRelativeUrl\":\"folderRelativeUrl\",\"displayName\":\"displayname\",\"channelType\":\"Regular\"}]"
+    },
+    {
+      "title": "refreshSiteUrl API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_refreshSiteUrl2",
+      "inputValue": "threadId",
+      "expectedAlertValue": "refreshSiteUrl called",
+      "expectedTestAppValue": "Success"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/video.json
+++ b/apps/teams-test-app/e2e-test-data/video.json
@@ -1,0 +1,99 @@
+{
+  "name": "Video",
+  "platforms": "Web",
+  "testUrlParams": [["frameContext", "sidePanel"]],
+  "version": ">2.11.0",
+  "testCases": [
+    {
+      "title": "video.isSupported - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_videoIsSupported",
+      "expectedTestAppValue": "video is supported"
+    },
+    {
+      "title": "videoEffectPickedInVideoApp - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_notifySelectedVideoEffectChanged",
+      "inputValue": "dummyEffectId",
+      "expectedAlertValue": "videoEffectPickedInVideoApp called with changeType: EffectChanged, effectId: dummyEffectId, effectParameter: undefined",
+      "expectedTestAppValue": "Success"
+    },
+    {
+      "title": "videoEffectPickedInVideoApp with effect param - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_videoExNotifySelectedVideoEffectChanged",
+      "inputValue": "dummyEffectId, dummyEffectParam",
+      "expectedAlertValue": "videoEffectPickedInVideoApp called with changeType: EffectChanged, effectId: dummyEffectId, effectParameter: dummyEffectParam",
+      "expectedTestAppValue": "Success"
+    },
+    {
+      "title": "registerForVideoEffect - Handler - Success",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerForVideoEffect",
+      "eventName": "videoEffectToApply",
+      "eventData": {
+        "effectId": "nextEffectId"
+      },
+      "expectedTestAppValue": "video effect changed to \"nextEffectId\"",
+      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: true, effectId: nextEffectId, detail: undefined"
+    },
+    {
+      "title": "registerForVideoEffect - Handler - Failed",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerForVideoEffect",
+      "eventName": "videoEffectToApply",
+      "eventData": {
+        "effectId": "anInvalidEffectId"
+      },
+      "expectedTestAppValue": "failed to change effect to \"anInvalidEffectId\"",
+      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: false, effectId: anInvalidEffectId, detail: InvalidEffectId"
+    },
+    {
+      "title": "updatePersonalizedEffects - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_updatePersonalizedEffects",
+      "inputValue": [
+        {
+          "id": "effect-1",
+          "name": "effect-1",
+          "type": "avatar",
+          "thumbnail": "data:image/png;base64,iVBORa=="
+        },
+        {
+          "id": "effect-2",
+          "name": "effect-2",
+          "type": "background",
+          "thumbnail": "data:image/png;base64,iVBORb=="
+        }
+      ],
+      "expectedAlertValue": "personalizedEffectsChanged called with: [{\"id\":\"effect-1\",\"name\":\"effect-1\",\"type\":\"avatar\",\"thumbnail\":\"data:image/png;base64,iVBORa==\"},{\"id\":\"effect-2\",\"name\":\"effect-2\",\"type\":\"background\",\"thumbnail\":\"data:image/png;base64,iVBORb==\"}]",
+      "expectedTestAppValue": "Success"
+    },
+    {
+      "title": "videoEx.registerForVideoEffect - Handler - Success",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_videoExRegisterForVideoEffect",
+      "eventName": "videoEffectToApply",
+      "eventData": {
+        "effectId": "nextEffectId",
+        "effectParameter": "nextEffectParam"
+      },
+      "expectedTestAppValue": "video effect changed to \"nextEffectId\", effect param: \"nextEffectParam\"",
+      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: true, effectId: nextEffectId, detail: undefined"
+    },
+    {
+      "title": " videoEx.NotifyFatalError - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_videoExNotifyFatalError",
+      "inputValue": "anError",
+      "expectedAlertValue": "notifyError called with errorMessage: anError, errorLevel: fatal",
+      "expectedTestAppValue": "Success"
+    },
+    {
+      "title": "videoEx.isSupported - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_videoExIsSupported",
+      "expectedTestAppValue": "videoEx is supported"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/video.mediaStream.json
+++ b/apps/teams-test-app/e2e-test-data/video.mediaStream.json
@@ -1,0 +1,15 @@
+{
+  "name": "Video MediaStream",
+  "platforms": "Web",
+  "testUrlParams": [["frameContext", "sidePanel"]],
+  "version": ">2.11.0",
+  "testCases": [
+    {
+      "title": "video.mediaStream.registerForVideoFrame - Throw error",
+      "type": "callResponse",
+      "modulesToDisable": ["videoSharedFrame"],
+      "boxSelector": "#box_videoMediaStreamRegisterForVideoFrame",
+      "expectedTestAppValue": "Faild to register for video frame: {\"errorCode\":100}"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/video.sharedFrame.json
+++ b/apps/teams-test-app/e2e-test-data/video.sharedFrame.json
@@ -1,0 +1,24 @@
+{
+  "name": "Video SharedFrame",
+  "platforms": "Web",
+  "testUrlParams": [["frameContext", "sidePanel"]],
+  "version": ">2.11.0",
+  "testCases": [
+    {
+      "title": "video.sharedFrame.registerForVideoFrame - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_videoSharedFrameRegisterForVideoFrame",
+      "modulesToDisable": ["videoMediaStream"],
+      "expectedTestAppValue": "Registration attempt has been initiated. If successful, this message will change when it is invoked on video frame received.",
+      "expectedAlertValue": "sharedFrame.registerForVideoFrame called with config: {\"format\":\"NV12\"}"
+    },
+    {
+      "title": "videoEx.sharedFrame.registerForVideoFrame - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_videoExSharedFrameRegisterForVideoFrame",
+      "modulesToDisable": ["videoMediaStream"],
+      "expectedTestAppValue": "Registration attempt has been initiated. If successful, this message will change when it is invoked on video frame received.",
+      "expectedAlertValue": "sharedFrame.registerForVideoFrame called with config: {\"format\":\"NV12\",\"requireCameraStream\":false,\"audioInferenceModel\":{}}"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

This PR is to add testing json data under Teams-JS library repo so that data could be shared to each host SDK team. Teams could use the data to drive/build their own E2E test and the data in Teams-JS library side have access for the single control and change on E2E test for each host. If anyone want to do change on any case, the data will now make sure the change takes effect on other hosts at the same time, which reduce the cost of time and labor and make across-platform developing easier. 

backward-compatible E2E testing data is extended by adding two fields, `platforms` for capability-wide control and `platformsExcluded` for case-wide control. For example, `platforms: '*'` means testing cases under this capability should be supported by all platforms (web, iOS and Android in the future). And `platforms: 'Web'` means testing cases under this capability are only be supported in Web Host SDK side. `platformsExcluded` field provides the ability to exclude a case for a specific platform, i.e. `platformsExcluded: 'iOS'` will exclude corresponding test case for iOS platform (case will not be built in iOS side).  

### Main changes in the PR:

1. Testing json data files
2. Json data schema

## Validation

### Validation performed:

1. You need to have permission and access to each host repo to check the migrating PR and see if it works.

### Unit Tests added: No

### End-to-end tests added: No

## Additional Requirements

### Change file added: No
