### PR TITLE
Fixing video import/export naming

### DIFF
--- a/change/@microsoft-teams-js-6fa795d7-0fc0-4847-8537-676a2be140ee.json
+++ b/change/@microsoft-teams-js-6fa795d7-0fc0-4847-8537-676a2be140ee.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Replaced `export VideoFrameCallback` in `videoUtils.ts` with `export VideoFrameCallback as DefaultVideoFrameCallback` and removed `export type VideoFrameCallback = DefaultVideoFrameCallback` in `videoEx.ts`",
+  "comment": "Fixed exports in `video` capability",
   "packageName": "@microsoft/teams-js",
   "email": "jadahiya@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-6fa795d7-0fc0-4847-8537-676a2be140ee.json
+++ b/change/@microsoft-teams-js-6fa795d7-0fc0-4847-8537-676a2be140ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replaced `export VideoFrameCallback` in `videoUtils.ts` with `export VideoFrameCallback as DefaultVideoFrameCallback` and removed `export type VideoFrameCallback = DefaultVideoFrameCallback` in `videoEx.ts`",
+  "packageName": "@microsoft/teams-js",
+  "email": "jadahiya@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/videoUtils.ts
+++ b/packages/teams-js/src/internal/videoUtils.ts
@@ -110,8 +110,13 @@ function createProcessedStreamGenerator(
 
 /**
  * @hidden
+ * Video effect change call back function definition
+ * @beta
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
-export type VideoEffectCallBack = (effectId: string | undefined, effectParam?: string) => Promise<void>;
+type VideoEffectCallBack = (effectId: string | undefined, effectParam?: string) => Promise<void>;
 
 /**
  * @hidden
@@ -129,3 +134,5 @@ export function createEffectParameterChangeCallback(callback: VideoEffectCallBac
       });
   };
 }
+
+export { VideoEffectCallBack as DefaultVideoEffectCallBack };

--- a/packages/teams-js/src/private/videoEx.ts
+++ b/packages/teams-js/src/private/videoEx.ts
@@ -3,7 +3,7 @@ import { registerHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
 import {
   createEffectParameterChangeCallback,
-  VideoEffectCallBack as DefaultVideoEffectCallBack,
+  DefaultVideoEffectCallBack as VideoEffectCallBack,
 } from '../internal/videoUtils';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
 import { runtime } from '../public/runtime';
@@ -175,16 +175,6 @@ export namespace videoEx {
     }
     sendMessageToParent('video.videoEffectChanged', [effectChangeType, effectId, effectParam]);
   }
-
-  /**
-   * @hidden
-   * Video effect change call back function definition
-   * @beta
-   *
-   * @internal
-   * Limited to Microsoft-internal use
-   */
-  export type VideoEffectCallBack = DefaultVideoEffectCallBack;
 
   /**
    * @hidden


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Removing `export type = other type` convention from `videoEx.ts`. This is because exporting a type that was imported as {insert name here} can not properly generate the type when making a .d.ts file. Replacing it with proper convention to export type as {GENERIC_TYPE_NAME} and to import as {LOCAL_TYPE_NAME} without exporting the local version.