### PR TITLE
Revert "Mark our pipeline as something that generates prod assets (#1…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,8 +2,6 @@ variables:
   - group: InfoSec-SecurityResults
   - name: products
     value: 6eff390d-80c0-4456-81b6-6abafa71e768
-  - name: tags
-    value: production
 
 trigger:
   branches:


### PR DESCRIPTION
…756)"

This reverts commit 0a6a1f86e0f5dc74d7718a040366d886a82ed054.

For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This is causing some temporary weirdness in our pipeline, so reverting while we investigate

### Main changes in the PR:

Revert the change to add prod markings to our pipeline yaml.

## Validation

None

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No