### PR TITLE
Refactor Web API Geolocation for Testing

### DIFF
--- a/apps/teams-test-app/src/components/GeoLocationAPIs.tsx
+++ b/apps/teams-test-app/src/components/GeoLocationAPIs.tsx
@@ -82,15 +82,27 @@ const WebAPIGetCurrentPosition = (): React.ReactElement =>
     onClick: async (setResult) => {
       let result;
       if (navigator.geolocation) {
-        navigator.geolocation.getCurrentPosition((position) => {
-          result = 'Latitude: ' + position.coords.latitude + ' Longitude: ' + position.coords.longitude;
-          setResult(result);
-        });
+        navigator.geolocation.getCurrentPosition(
+          (position) => {
+            result = 'Latitude: ' + position.coords.latitude + ' Longitude: ' + position.coords.longitude;
+            setResult(result);
+          },
+          (error) => {
+            result = 'Error occurred. Error code: ' + JSON.stringify(error);
+            setResult(result);
+          },
+          {
+            enableHighAccuracy: true,
+            timeout: 10000,
+            maximumAge: 0,
+          },
+        );
+        return JSON.stringify('Requesting location');
       } else {
         result = 'navigator.geolocation is not accessible';
         setResult(result);
+        return JSON.stringify(result);
       }
-      return JSON.stringify('Do not have required permissions to access location');
     },
   });
 


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Small updates to the test app for Android E2E tests. We need to add some parameters to the `navigator.geolocation.getCurrentPosition()` call to make the call work on Android WebViews. This PR also adds an error callback that we need to test the permission denied scenario.

### Main changes in the PR:

1. Add enableHighAccuracy, timeout, and maximumAge parameters to the Web API geolocation control in the test app
2. Add an error callback to the Web API geolocation call in the test app.

## Validation

### Validation performed:

1. WebAPI get position control tested against web, Android, and iOS hosts

### Unit Tests added:

No unit tests added, test app change only

### End-to-end tests added:

Android E2E tests can be checked in after this change

## Additional Requirements

### Change file added:

No, test app changes only

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a