### PR TITLE
Error handling for getNewerPrefix in prepBetaRelease script

### DIFF
--- a/change/@microsoft-teams-js-d2dd363b-e9f0-4ea2-ac07-2f772a296990.json
+++ b/change/@microsoft-teams-js-d2dd363b-e9f0-4ea2-ac07-2f772a296990.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added in error statement in getNewerPrefix if we make it out of the for loop comparison check between beta prefix and package prefix.",
+  "packageName": "@microsoft/teams-js",
+  "email": "jadahiya@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/prepBetaRelease.js
+++ b/packages/teams-js/prepBetaRelease.js
@@ -84,6 +84,10 @@ function getNewerPrefix(currBetaVer, currPkgJsonVer) {
       return currPkgPrefix;
     }
   }
+  //If we complete the loop and haven't returned, then there is an error in prefix comparisons
+  throw new Error(
+    `Error in comparing Current Beta Version: ${currBetaVer} with prefix ${currBetaPrefix} to Current Package Version: ${currPkgJsonVer} with prefix ${currPkgPrefix}`,
+  );
 }
 
 /**


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

Description
Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

Main changes in the PR:
Added in a throw error statement if getNewerPrefix completes the for loop without returning.