### PR TITLE
Wrapped live share code in liveShare namespace

### DIFF
--- a/change/@microsoft-teams-js-5196eee3-7902-44c5-94b3-64df90603d42.json
+++ b/change/@microsoft-teams-js-5196eee3-7902-44c5-94b3-64df90603d42.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "wrapped live share code in liveShare namespace",
+  "packageName": "@microsoft/teams-js",
+  "email": "jameshunt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-e646b065-a018-43a0-9323-e7647c23b227.json
+++ b/change/@microsoft-teams-js-e646b065-a018-43a0-9323-e7647c23b227.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "wrapped live share code in liveShare namespace",
   "packageName": "@microsoft/teams-js",
   "email": "jameshunt@microsoft.com",

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -92,4 +92,4 @@ export {
 export { returnFocus, navigateBack, navigateCrossDomain, navigateToTab } from './navigation';
 export { settings } from './settings';
 export { tasks } from './tasks';
-export * from './liveShareHost';
+export { liveShare, LiveShareHost } from './liveShareHost';

--- a/packages/teams-js/src/public/liveShareHost.ts
+++ b/packages/teams-js/src/public/liveShareHost.ts
@@ -3,9 +3,16 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { FrameContexts } from './constants';
 import { runtime } from './runtime';
 
+/**
+ * APIs involving Live Share, a framework for building real-time collaborative apps.
+ * For more information, visit https://aka.ms/teamsliveshare
+ *
+ * @see LiveShareHost
+ */
 export namespace liveShare {
   /**
-   * Meeting Roles.
+   * The meeting roles of a user.
+   * Used in Live Share for its role verification feature.
    */
   export enum UserMeetingRole {
     /**
@@ -27,7 +34,8 @@ export namespace liveShare {
   }
 
   /**
-   * State of the current Live Share sessions backing fluid container.
+   * State of the current Live Share session's Fluid container.
+   * This is used internally by the `LiveShareClient` when joining a Live Share session.
    */
   export enum ContainerState {
     /**
@@ -37,26 +45,27 @@ export namespace liveShare {
     added = 'Added',
 
     /**
-     * A container mapping for the current Live Share Session already exists and should be used
-     * when joining the sessions Fluid container.
+     * A container mapping for the current Live Share session already exists.
+     * This indicates to Live Share that a new container does not need be created.
      */
     alreadyExists = 'AlreadyExists',
 
     /**
-     * The call to `LiveShareHost.setContainerId()` failed to create the container mapping due to
-     * another client having already set the container ID for the current Live Share session.
+     * The call to `LiveShareHost.setContainerId()` failed to create the container mapping.
+     * This happens when another client has already set the container ID for the session.
      */
     conflict = 'Conflict',
 
     /**
-     * A container mapping for the current Live Share session doesn't exist yet.
+     * A container mapping for the current Live Share session does not yet exist.
+     * This indicates to Live Share that a new container should be created.
      */
     notFound = 'NotFound',
   }
 
   /**
-   * Returned from `LiveShareHost.get/setFluidContainerId()` to specify the container mapping for the
-   * current Live Share session.
+   * Returned from `LiveShareHost.getFluidContainerId()` and `LiveShareHost.setFluidContainerId`.
+   * This response specifies the container mapping information for the current Live Share session.
    */
   export interface IFluidContainerInfo {
     /**
@@ -77,9 +86,9 @@ export namespace liveShare {
     shouldCreate: boolean;
 
     /**
-     * If `containerId` is undefined and `shouldCreate` is false, the container isn't ready but
-     * another client is creating it. The local client should wait the specified amount of time and
-     * then ask for the container info again.
+     * If `containerId` is undefined and `shouldCreate` is false, the container isn't ready
+     * but another client is creating it. In this case, the local client should wait the specified
+     * amount of time before calling `LiveShareHost.getFluidContainerId()` again.
      */
     retryAfter: number;
   }
@@ -122,15 +131,16 @@ export namespace liveShare {
    */
   export interface IClientInfo {
     /**
-     * Teams userId associated with clientId
+     * The host user's `userId` associated with a given `clientId`
      */
     userId: string;
     /**
-     * Meeting roles associated with clientId
+     * User's meeting roles associated with a given `clientId`
      */
     roles: UserMeetingRole[];
     /**
-     * DisplayName associated with clientId
+     * The user's display name associated with a given `clientId`.
+     * If this returns as `undefined`, the user may need to update their host client.
      */
     displayName?: string;
   }

--- a/packages/teams-js/src/public/liveShareHost.ts
+++ b/packages/teams-js/src/public/liveShareHost.ts
@@ -147,131 +147,128 @@ export namespace liveShare {
       ? true
       : false;
   }
-
-  /**
-   * Live Share host implementation for O365 and Teams clients.
-   */
-  export class LiveShareHost {
-    /**
-     * Returns the Fluid Tenant connection info for user's current context.
-     */
-    public getFluidTenantInfo(): Promise<liveShare.IFluidTenantInfo> {
-      ensureSupported();
-      return new Promise<liveShare.IFluidTenantInfo>((resolve) => {
-        resolve(sendAndHandleSdkError('interactive.getFluidTenantInfo'));
-      });
-    }
-
-    /**
-     * Returns the fluid access token for mapped container Id.
-     *
-     * @param containerId Fluid's container Id for the request. Undefined for new containers.
-     * @returns token for connecting to Fluid's session.
-     */
-    public getFluidToken(containerId?: string): Promise<string> {
-      ensureSupported();
-      return new Promise<string>((resolve) => {
-        // eslint-disable-next-line strict-null-checks/all
-        resolve(sendAndHandleSdkError('interactive.getFluidToken', containerId));
-      });
-    }
-
-    /**
-     * Returns the ID of the fluid container associated with the user's current context.
-     */
-    public getFluidContainerId(): Promise<liveShare.IFluidContainerInfo> {
-      ensureSupported();
-      return new Promise<liveShare.IFluidContainerInfo>((resolve) => {
-        resolve(sendAndHandleSdkError('interactive.getFluidContainerId'));
-      });
-    }
-
-    /**
-     * Sets the ID of the fluid container associated with the current context.
-     *
-     * @remarks
-     * If this returns false, the client should delete the container they created and then call
-     * `getFluidContainerId()` to get the ID of the container being used.
-     * @param containerId ID of the fluid container the client created.
-     * @returns A data structure with a `containerState` indicating the success or failure of the request.
-     */
-    public setFluidContainerId(containerId: string): Promise<liveShare.IFluidContainerInfo> {
-      ensureSupported();
-      return new Promise<liveShare.IFluidContainerInfo>((resolve) => {
-        resolve(sendAndHandleSdkError('interactive.setFluidContainerId', containerId));
-      });
-    }
-
-    /**
-     * Returns the shared clock server's current time.
-     */
-    public getNtpTime(): Promise<liveShare.INtpTimeInfo> {
-      ensureSupported();
-      return new Promise<liveShare.INtpTimeInfo>((resolve) => {
-        resolve(sendAndHandleSdkError('interactive.getNtpTime'));
-      });
-    }
-
-    /**
-     * Associates the fluid client ID with a set of user roles.
-     *
-     * @param clientId The ID for the current user's Fluid client. Changes on reconnects.
-     * @returns The roles for the current user.
-     */
-    public registerClientId(clientId: string): Promise<liveShare.UserMeetingRole[]> {
-      ensureSupported();
-      return new Promise<liveShare.UserMeetingRole[]>((resolve) => {
-        resolve(sendAndHandleSdkError('interactive.registerClientId', clientId));
-      });
-    }
-
-    /**
-     * Returns the roles associated with a client ID.
-     *
-     * @param clientId The Client ID the message was received from.
-     * @returns The roles for a given client. Returns `undefined` if the client ID hasn't been registered yet.
-     */
-    public getClientRoles(clientId: string): Promise<liveShare.UserMeetingRole[] | undefined> {
-      ensureSupported();
-      return new Promise<liveShare.UserMeetingRole[] | undefined>((resolve) => {
-        resolve(sendAndHandleSdkError('interactive.getClientRoles', clientId));
-      });
-    }
-
-    /**
-     * Returns the `IClientInfo` associated with a client ID.
-     *
-     * @param clientId The Client ID the message was received from.
-     * @returns The info for a given client. Returns `undefined` if the client ID hasn't been registered yet.
-     */
-    public getClientInfo(clientId: string): Promise<liveShare.IClientInfo | undefined> {
-      ensureSupported();
-      return new Promise<liveShare.IClientInfo | undefined>((resolve) => {
-        resolve(sendAndHandleSdkError('interactive.getClientInfo', clientId));
-      });
-    }
-
-    /**
-     * Returns a host instance for the client that can be passed to the `LiveShareClient` class.
-     *
-     * @remarks
-     * The application must first be initialized and may only be called from `meetingStage` or `sidePanel` contexts.
-     */
-    public static create(): LiveShareHost {
-      ensureSupported();
-
-      return new LiveShareHost();
-    }
-  }
-
-  function ensureSupported(): void {
-    if (!liveShare.isSupported()) {
-      throw new Error('LiveShareHost Not supported');
-    }
-  }
 }
 
 /**
- * Live Share host implementation for O365 and Teams clients.
+ * Live Share host implementation for connecting to real-time collaborative sessions.
+ * Designed for use with the `LiveShareClient` class in the `@microsoft/live-share` package.
+ * Learn more at https://aka.ms/teamsliveshare
  */
-export const LiveShareHost = liveShare.LiveShareHost;
+export class LiveShareHost {
+  /**
+   * Returns the Fluid Tenant connection info for user's current context.
+   */
+  public getFluidTenantInfo(): Promise<liveShare.IFluidTenantInfo> {
+    ensureSupported();
+    return new Promise<liveShare.IFluidTenantInfo>((resolve) => {
+      resolve(sendAndHandleSdkError('interactive.getFluidTenantInfo'));
+    });
+  }
+
+  /**
+   * Returns the fluid access token for mapped container Id.
+   *
+   * @param containerId Fluid's container Id for the request. Undefined for new containers.
+   * @returns token for connecting to Fluid's session.
+   */
+  public getFluidToken(containerId?: string): Promise<string> {
+    ensureSupported();
+    return new Promise<string>((resolve) => {
+      // eslint-disable-next-line strict-null-checks/all
+      resolve(sendAndHandleSdkError('interactive.getFluidToken', containerId));
+    });
+  }
+
+  /**
+   * Returns the ID of the fluid container associated with the user's current context.
+   */
+  public getFluidContainerId(): Promise<liveShare.IFluidContainerInfo> {
+    ensureSupported();
+    return new Promise<liveShare.IFluidContainerInfo>((resolve) => {
+      resolve(sendAndHandleSdkError('interactive.getFluidContainerId'));
+    });
+  }
+
+  /**
+   * Sets the ID of the fluid container associated with the current context.
+   *
+   * @remarks
+   * If this returns false, the client should delete the container they created and then call
+   * `getFluidContainerId()` to get the ID of the container being used.
+   * @param containerId ID of the fluid container the client created.
+   * @returns A data structure with a `containerState` indicating the success or failure of the request.
+   */
+  public setFluidContainerId(containerId: string): Promise<liveShare.IFluidContainerInfo> {
+    ensureSupported();
+    return new Promise<liveShare.IFluidContainerInfo>((resolve) => {
+      resolve(sendAndHandleSdkError('interactive.setFluidContainerId', containerId));
+    });
+  }
+
+  /**
+   * Returns the shared clock server's current time.
+   */
+  public getNtpTime(): Promise<liveShare.INtpTimeInfo> {
+    ensureSupported();
+    return new Promise<liveShare.INtpTimeInfo>((resolve) => {
+      resolve(sendAndHandleSdkError('interactive.getNtpTime'));
+    });
+  }
+
+  /**
+   * Associates the fluid client ID with a set of user roles.
+   *
+   * @param clientId The ID for the current user's Fluid client. Changes on reconnects.
+   * @returns The roles for the current user.
+   */
+  public registerClientId(clientId: string): Promise<liveShare.UserMeetingRole[]> {
+    ensureSupported();
+    return new Promise<liveShare.UserMeetingRole[]>((resolve) => {
+      resolve(sendAndHandleSdkError('interactive.registerClientId', clientId));
+    });
+  }
+
+  /**
+   * Returns the roles associated with a client ID.
+   *
+   * @param clientId The Client ID the message was received from.
+   * @returns The roles for a given client. Returns `undefined` if the client ID hasn't been registered yet.
+   */
+  public getClientRoles(clientId: string): Promise<liveShare.UserMeetingRole[] | undefined> {
+    ensureSupported();
+    return new Promise<liveShare.UserMeetingRole[] | undefined>((resolve) => {
+      resolve(sendAndHandleSdkError('interactive.getClientRoles', clientId));
+    });
+  }
+
+  /**
+   * Returns the `IClientInfo` associated with a client ID.
+   *
+   * @param clientId The Client ID the message was received from.
+   * @returns The info for a given client. Returns `undefined` if the client ID hasn't been registered yet.
+   */
+  public getClientInfo(clientId: string): Promise<liveShare.IClientInfo | undefined> {
+    ensureSupported();
+    return new Promise<liveShare.IClientInfo | undefined>((resolve) => {
+      resolve(sendAndHandleSdkError('interactive.getClientInfo', clientId));
+    });
+  }
+
+  /**
+   * Returns a host instance for the client that can be passed to the `LiveShareClient` class.
+   *
+   * @remarks
+   * The application must first be initialized and may only be called from `meetingStage` or `sidePanel` contexts.
+   */
+  public static create(): LiveShareHost {
+    ensureSupported();
+
+    return new LiveShareHost();
+  }
+}
+
+function ensureSupported(): void {
+  if (!liveShare.isSupported()) {
+    throw new Error('LiveShareHost Not supported');
+  }
+}

--- a/packages/teams-js/src/public/liveShareHost.ts
+++ b/packages/teams-js/src/public/liveShareHost.ts
@@ -171,8 +171,8 @@ export namespace liveShare {
  * Learn more at https://aka.ms/teamsliveshare
  *
  * @remarks
- * The APIs in this class are not intended to be used directly by your app.
- * The `LiveShareClient` class from Live Share uses this to join/manage the session.
+ * The `LiveShareClient` class from Live Share uses the hidden API's to join/manage the session.
+ * To create a new `LiveShareHost` instance use the static `LiveShareHost.create()` function.
  */
 export class LiveShareHost {
   /**

--- a/packages/teams-js/src/public/liveShareHost.ts
+++ b/packages/teams-js/src/public/liveShareHost.ts
@@ -11,6 +11,7 @@ import { runtime } from './runtime';
  */
 export namespace liveShare {
   /**
+   * @hidden
    * The meeting roles of a user.
    * Used in Live Share for its role verification feature.
    */
@@ -34,6 +35,7 @@ export namespace liveShare {
   }
 
   /**
+   * @hidden
    * State of the current Live Share session's Fluid container.
    * This is used internally by the `LiveShareClient` when joining a Live Share session.
    */
@@ -64,6 +66,7 @@ export namespace liveShare {
   }
 
   /**
+   * @hidden
    * Returned from `LiveShareHost.getFluidContainerId()` and `LiveShareHost.setFluidContainerId`.
    * This response specifies the container mapping information for the current Live Share session.
    */
@@ -94,6 +97,7 @@ export namespace liveShare {
   }
 
   /**
+   * @hidden
    * Returned from `LiveShareHost.getNtpTime()` to specify the global timestamp for the current
    * Live Share session.
    */
@@ -110,6 +114,7 @@ export namespace liveShare {
   }
 
   /**
+   * @hidden
    * Returned from `LiveShareHost.getFluidTenantInfo()` to specify the Fluid service to use for the
    * current Live Share session.
    */
@@ -126,6 +131,7 @@ export namespace liveShare {
   }
 
   /**
+   * @hidden
    * Returned from `LiveShareHost.getClientInfo()` to specify the client info for a
    * particular client in a Live Share session.
    */
@@ -163,6 +169,10 @@ export namespace liveShare {
  * Live Share host implementation for connecting to real-time collaborative sessions.
  * Designed for use with the `LiveShareClient` class in the `@microsoft/live-share` package.
  * Learn more at https://aka.ms/teamsliveshare
+ *
+ * @remarks
+ * The APIs in this class are not intended to be used directly by your app.
+ * The `LiveShareClient` class from Live Share uses this to join/manage the session.
  */
 export class LiveShareHost {
   /**

--- a/packages/teams-js/src/public/liveShareHost.ts
+++ b/packages/teams-js/src/public/liveShareHost.ts
@@ -3,297 +3,275 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { FrameContexts } from './constants';
 import { runtime } from './runtime';
 
-/**
- * @hidden
- * Allowed roles during a meeting.
- *
- * @beta
- */
-export enum UserMeetingRole {
-  guest = 'Guest',
-  attendee = 'Attendee',
-  presenter = 'Presenter',
-  organizer = 'Organizer',
+export namespace liveShare {
+  /**
+   * Meeting Roles.
+   */
+  export enum UserMeetingRole {
+    /**
+     * Guest role.
+     */
+    guest = 'Guest',
+    /**
+     * Attendee role.
+     */
+    attendee = 'Attendee',
+    /**
+     * Presenter role.
+     */
+    presenter = 'Presenter',
+    /**
+     * Organizer role.
+     */
+    organizer = 'Organizer',
+  }
+
+  /**
+   * State of the current Live Share sessions backing fluid container.
+   */
+  export enum ContainerState {
+    /**
+     * The call to `LiveShareHost.setContainerId()` successfully created the container mapping
+     * for the current Live Share session.
+     */
+    added = 'Added',
+
+    /**
+     * A container mapping for the current Live Share Session already exists and should be used
+     * when joining the sessions Fluid container.
+     */
+    alreadyExists = 'AlreadyExists',
+
+    /**
+     * The call to `LiveShareHost.setContainerId()` failed to create the container mapping due to
+     * another client having already set the container ID for the current Live Share session.
+     */
+    conflict = 'Conflict',
+
+    /**
+     * A container mapping for the current Live Share session doesn't exist yet.
+     */
+    notFound = 'NotFound',
+  }
+
+  /**
+   * Returned from `LiveShareHost.get/setFluidContainerId()` to specify the container mapping for the
+   * current Live Share session.
+   */
+  export interface IFluidContainerInfo {
+    /**
+     * State of the containerId mapping.
+     */
+    containerState: ContainerState;
+
+    /**
+     * ID of the container to join for the meeting. Undefined if the container hasn't been
+     * created yet.
+     */
+    containerId: string | undefined;
+
+    /**
+     * If true, the local client should create the container and then save the created containers
+     * ID to the mapping service.
+     */
+    shouldCreate: boolean;
+
+    /**
+     * If `containerId` is undefined and `shouldCreate` is false, the container isn't ready but
+     * another client is creating it. The local client should wait the specified amount of time and
+     * then ask for the container info again.
+     */
+    retryAfter: number;
+  }
+
+  /**
+   * Returned from `LiveShareHost.getNtpTime()` to specify the global timestamp for the current
+   * Live Share session.
+   */
+  export interface INtpTimeInfo {
+    /**
+     * ISO 8601 formatted server time. For example: '2019-09-07T15:50-04:00'
+     */
+    ntpTime: string;
+
+    /**
+     * Server time expressed as the number of milliseconds since the ECMAScript epoch.
+     */
+    ntpTimeInUTC: number;
+  }
+
+  /**
+   * Returned from `LiveShareHost.getFluidTenantInfo()` to specify the Fluid service to use for the
+   * current Live Share session.
+   */
+  export interface IFluidTenantInfo {
+    /**
+     * The Fluid Tenant ID Live Share should use.
+     */
+    tenantId: string;
+
+    /**
+     * The Fluid service endpoint Live Share should use.
+     */
+    serviceEndpoint: string;
+  }
+
+  /**
+   * Returned from `LiveShareHost.getClientInfo()` to specify the client info for a
+   * particular client in a Live Share session.
+   */
+  export interface IClientInfo {
+    /**
+     * Teams userId associated with clientId
+     */
+    userId: string;
+    /**
+     * Meeting roles associated with clientId
+     */
+    roles: UserMeetingRole[];
+    /**
+     * DisplayName associated with clientId
+     */
+    displayName?: string;
+  }
+
+  /**
+   * Checks if the interactive capability is supported by the host
+   * @returns boolean to represent whether the interactive capability is supported
+   *
+   * @throws Error if {@linkcode app.initialize} has not successfully completed
+   */
+  export function isSupported(): boolean {
+    return ensureInitialized(runtime, FrameContexts.meetingStage, FrameContexts.sidePanel) &&
+      runtime.supports.interactive
+      ? true
+      : false;
+  }
+
+  /**
+   * Live Share host implementation for O365 and Teams clients.
+   */
+  export class LiveShareHost {
+    /**
+     * Returns the Fluid Tenant connection info for user's current context.
+     */
+    public getFluidTenantInfo(): Promise<liveShare.IFluidTenantInfo> {
+      ensureSupported();
+      return new Promise<liveShare.IFluidTenantInfo>((resolve) => {
+        resolve(sendAndHandleSdkError('interactive.getFluidTenantInfo'));
+      });
+    }
+
+    /**
+     * Returns the fluid access token for mapped container Id.
+     *
+     * @param containerId Fluid's container Id for the request. Undefined for new containers.
+     * @returns token for connecting to Fluid's session.
+     */
+    public getFluidToken(containerId?: string): Promise<string> {
+      ensureSupported();
+      return new Promise<string>((resolve) => {
+        // eslint-disable-next-line strict-null-checks/all
+        resolve(sendAndHandleSdkError('interactive.getFluidToken', containerId));
+      });
+    }
+
+    /**
+     * Returns the ID of the fluid container associated with the user's current context.
+     */
+    public getFluidContainerId(): Promise<liveShare.IFluidContainerInfo> {
+      ensureSupported();
+      return new Promise<liveShare.IFluidContainerInfo>((resolve) => {
+        resolve(sendAndHandleSdkError('interactive.getFluidContainerId'));
+      });
+    }
+
+    /**
+     * Sets the ID of the fluid container associated with the current context.
+     *
+     * @remarks
+     * If this returns false, the client should delete the container they created and then call
+     * `getFluidContainerId()` to get the ID of the container being used.
+     * @param containerId ID of the fluid container the client created.
+     * @returns A data structure with a `containerState` indicating the success or failure of the request.
+     */
+    public setFluidContainerId(containerId: string): Promise<liveShare.IFluidContainerInfo> {
+      ensureSupported();
+      return new Promise<liveShare.IFluidContainerInfo>((resolve) => {
+        resolve(sendAndHandleSdkError('interactive.setFluidContainerId', containerId));
+      });
+    }
+
+    /**
+     * Returns the shared clock server's current time.
+     */
+    public getNtpTime(): Promise<liveShare.INtpTimeInfo> {
+      ensureSupported();
+      return new Promise<liveShare.INtpTimeInfo>((resolve) => {
+        resolve(sendAndHandleSdkError('interactive.getNtpTime'));
+      });
+    }
+
+    /**
+     * Associates the fluid client ID with a set of user roles.
+     *
+     * @param clientId The ID for the current user's Fluid client. Changes on reconnects.
+     * @returns The roles for the current user.
+     */
+    public registerClientId(clientId: string): Promise<liveShare.UserMeetingRole[]> {
+      ensureSupported();
+      return new Promise<liveShare.UserMeetingRole[]>((resolve) => {
+        resolve(sendAndHandleSdkError('interactive.registerClientId', clientId));
+      });
+    }
+
+    /**
+     * Returns the roles associated with a client ID.
+     *
+     * @param clientId The Client ID the message was received from.
+     * @returns The roles for a given client. Returns `undefined` if the client ID hasn't been registered yet.
+     */
+    public getClientRoles(clientId: string): Promise<liveShare.UserMeetingRole[] | undefined> {
+      ensureSupported();
+      return new Promise<liveShare.UserMeetingRole[] | undefined>((resolve) => {
+        resolve(sendAndHandleSdkError('interactive.getClientRoles', clientId));
+      });
+    }
+
+    /**
+     * Returns the `IClientInfo` associated with a client ID.
+     *
+     * @param clientId The Client ID the message was received from.
+     * @returns The info for a given client. Returns `undefined` if the client ID hasn't been registered yet.
+     */
+    public getClientInfo(clientId: string): Promise<liveShare.IClientInfo | undefined> {
+      ensureSupported();
+      return new Promise<liveShare.IClientInfo | undefined>((resolve) => {
+        resolve(sendAndHandleSdkError('interactive.getClientInfo', clientId));
+      });
+    }
+
+    /**
+     * Returns a host instance for the client that can be passed to the `LiveShareClient` class.
+     *
+     * @remarks
+     * The application must first be initialized and may only be called from `meetingStage` or `sidePanel` contexts.
+     */
+    public static create(): LiveShareHost {
+      ensureSupported();
+
+      return new LiveShareHost();
+    }
+  }
+
+  function ensureSupported(): void {
+    if (!liveShare.isSupported()) {
+      throw new Error('LiveShareHost Not supported');
+    }
+  }
 }
 
 /**
- * @hidden
- * State of the current Live Share sessions backing fluid container.
- *
- * @beta
- */
-export enum ContainerState {
-  /**
-   * The call to `LiveShareHost.setContainerId()` successfully created the container mapping
-   * for the current Live Share session.
-   */
-  added = 'Added',
-
-  /**
-   * A container mapping for the current Live Share Session already exists and should be used
-   * when joining the sessions Fluid container.
-   */
-  alreadyExists = 'AlreadyExists',
-
-  /**
-   * The call to `LiveShareHost.setContainerId()` failed to create the container mapping due to
-   * another client having already set the container ID for the current Live Share session.
-   */
-  conflict = 'Conflict',
-
-  /**
-   * A container mapping for the current Live Share session doesn't exist yet.
-   */
-  notFound = 'NotFound',
-}
-
-/**
- * @hidden
- * Returned from `LiveShareHost.get/setFluidContainerId()` to specify the container mapping for the
- * current Live Share session.
- *
- * @beta
- */
-export interface IFluidContainerInfo {
-  /**
-   * State of the containerId mapping.
-   */
-  containerState: ContainerState;
-
-  /**
-   * ID of the container to join for the meeting. Undefined if the container hasn't been
-   * created yet.
-   */
-  containerId: string | undefined;
-
-  /**
-   * If true, the local client should create the container and then save the created containers
-   * ID to the mapping service.
-   */
-  shouldCreate: boolean;
-
-  /**
-   * If `containerId` is undefined and `shouldCreate` is false, the container isn't ready but
-   * another client is creating it. The local client should wait the specified amount of time and
-   * then ask for the container info again.
-   */
-  retryAfter: number;
-}
-
-/**
- * @hidden
- * Returned from `LiveShareHost.getNtpTime()` to specify the global timestamp for the current
- * Live Share session.
- *
- * @beta
- */
-export interface INtpTimeInfo {
-  /**
-   * ISO 8601 formatted server time. For example: '2019-09-07T15:50-04:00'
-   */
-  ntpTime: string;
-
-  /**
-   * Server time expressed as the number of milliseconds since the ECMAScript epoch.
-   */
-  ntpTimeInUTC: number;
-}
-
-/**
- * @hidden
- * Returned from `LiveShareHost.getFluidTenantInfo()` to specify the Fluid service to use for the
- * current Live Share session.
- *
- * @beta
- */
-export interface IFluidTenantInfo {
-  /**
-   * The Fluid Tenant ID Live Share should use.
-   */
-  tenantId: string;
-
-  /**
-   * The Fluid service endpoint Live Share should use.
-   */
-  serviceEndpoint: string;
-}
-
-/**
- * @hidden
- * Returned from `LiveShareHost.getClientInfo()` to specify the client info for a
- * particular client in a Live Share session.
- *
- * @beta
- */
-export interface IClientInfo {
-  userId: string;
-  roles: UserMeetingRole[];
-  displayName?: string;
-}
-
-/**
- * @hidden
  * Live Share host implementation for O365 and Teams clients.
- *
- * @beta
  */
-export class LiveShareHost {
-  /**
-   * @hidden
-   * Returns the Fluid Tenant connection info for user's current context.
-   *
-   * @beta
-   */
-  public getFluidTenantInfo(): Promise<IFluidTenantInfo> {
-    ensureSupported();
-    return new Promise<IFluidTenantInfo>((resolve) => {
-      resolve(sendAndHandleSdkError('interactive.getFluidTenantInfo'));
-    });
-  }
-
-  /**
-   * @hidden
-   * Returns the fluid access token for mapped container Id.
-   *
-   * @param containerId Fluid's container Id for the request. Undefined for new containers.
-   * @returns token for connecting to Fluid's session.
-   *
-   * @beta
-   */
-  public getFluidToken(containerId?: string): Promise<string> {
-    ensureSupported();
-    return new Promise<string>((resolve) => {
-      // eslint-disable-next-line strict-null-checks/all
-      resolve(sendAndHandleSdkError('interactive.getFluidToken', containerId));
-    });
-  }
-
-  /**
-   * @hidden
-   * Returns the ID of the fluid container associated with the user's current context.
-   *
-   * @beta
-   */
-  public getFluidContainerId(): Promise<IFluidContainerInfo> {
-    ensureSupported();
-    return new Promise<IFluidContainerInfo>((resolve) => {
-      resolve(sendAndHandleSdkError('interactive.getFluidContainerId'));
-    });
-  }
-
-  /**
-   * @hidden
-   * Sets the ID of the fluid container associated with the current context.
-   *
-   * @remarks
-   * If this returns false, the client should delete the container they created and then call
-   * `getFluidContainerId()` to get the ID of the container being used.
-   * @param containerId ID of the fluid container the client created.
-   * @returns A data structure with a `containerState` indicating the success or failure of the request.
-   *
-   * @beta
-   */
-  public setFluidContainerId(containerId: string): Promise<IFluidContainerInfo> {
-    ensureSupported();
-    return new Promise<IFluidContainerInfo>((resolve) => {
-      resolve(sendAndHandleSdkError('interactive.setFluidContainerId', containerId));
-    });
-  }
-
-  /**
-   * @hidden
-   * Returns the shared clock server's current time.
-   *
-   * @beta
-   */
-  public getNtpTime(): Promise<INtpTimeInfo> {
-    ensureSupported();
-    return new Promise<INtpTimeInfo>((resolve) => {
-      resolve(sendAndHandleSdkError('interactive.getNtpTime'));
-    });
-  }
-
-  /**
-   * @hidden
-   * Associates the fluid client ID with a set of user roles.
-   *
-   * @param clientId The ID for the current user's Fluid client. Changes on reconnects.
-   * @returns The roles for the current user.
-   *
-   * @beta
-   */
-  public registerClientId(clientId: string): Promise<UserMeetingRole[]> {
-    ensureSupported();
-    return new Promise<UserMeetingRole[]>((resolve) => {
-      resolve(sendAndHandleSdkError('interactive.registerClientId', clientId));
-    });
-  }
-
-  /**
-   * @hidden
-   * Returns the roles associated with a client ID.
-   *
-   * @param clientId The Client ID the message was received from.
-   * @returns The roles for a given client. Returns `undefined` if the client ID hasn't been registered yet.
-   *
-   * @beta
-   */
-  public getClientRoles(clientId: string): Promise<UserMeetingRole[] | undefined> {
-    ensureSupported();
-    return new Promise<UserMeetingRole[] | undefined>((resolve) => {
-      resolve(sendAndHandleSdkError('interactive.getClientRoles', clientId));
-    });
-  }
-
-  /**
-   * @hidden
-   * Returns the `IClientInfo` associated with a client ID.
-   *
-   * @param clientId The Client ID the message was received from.
-   * @returns The info for a given client. Returns `undefined` if the client ID hasn't been registered yet.
-   *
-   * @beta
-   */
-  public getClientInfo(clientId: string): Promise<IClientInfo | undefined> {
-    ensureSupported();
-    return new Promise<IClientInfo | undefined>((resolve) => {
-      resolve(sendAndHandleSdkError('interactive.getClientInfo', clientId));
-    });
-  }
-
-  /**
-   * Returns a host instance for the client that can be passed to the `LiveShareClient` class.
-   *
-   * @remarks
-   * The application must first be initialized and may only be called from `meetingStage` or `sidePanel` contexts.
-   *
-   * @beta
-   */
-  public static create(): LiveShareHost {
-    ensureSupported();
-
-    return new LiveShareHost();
-  }
-}
-/**
- * @hidden
- *
- * Checks if the interactive capability is supported by the host
- * @returns boolean to represent whether the interactive capability is supported
- *
- * @throws Error if {@linkcode app.initialize} has not successfully completed
- *
- * @internal
- * Limited to Microsoft-internal use
- */
-export function isSupported(): boolean {
-  return ensureInitialized(runtime, FrameContexts.meetingStage, FrameContexts.sidePanel) && runtime.supports.interactive
-    ? true
-    : false;
-}
-
-function ensureSupported(): void {
-  if (!isSupported()) {
-    throw new Error('LiveShareHost Not supported');
-  }
-}
+export const LiveShareHost = liveShare.LiveShareHost;

--- a/packages/teams-js/src/public/liveShareHost.ts
+++ b/packages/teams-js/src/public/liveShareHost.ts
@@ -176,6 +176,7 @@ export namespace liveShare {
  */
 export class LiveShareHost {
   /**
+   * @hidden
    * Returns the Fluid Tenant connection info for user's current context.
    */
   public getFluidTenantInfo(): Promise<liveShare.IFluidTenantInfo> {
@@ -186,6 +187,7 @@ export class LiveShareHost {
   }
 
   /**
+   * @hidden
    * Returns the fluid access token for mapped container Id.
    *
    * @param containerId Fluid's container Id for the request. Undefined for new containers.
@@ -200,6 +202,7 @@ export class LiveShareHost {
   }
 
   /**
+   * @hidden
    * Returns the ID of the fluid container associated with the user's current context.
    */
   public getFluidContainerId(): Promise<liveShare.IFluidContainerInfo> {
@@ -210,6 +213,7 @@ export class LiveShareHost {
   }
 
   /**
+   * @hidden
    * Sets the ID of the fluid container associated with the current context.
    *
    * @remarks
@@ -226,6 +230,7 @@ export class LiveShareHost {
   }
 
   /**
+   * @hidden
    * Returns the shared clock server's current time.
    */
   public getNtpTime(): Promise<liveShare.INtpTimeInfo> {
@@ -236,6 +241,7 @@ export class LiveShareHost {
   }
 
   /**
+   * @hidden
    * Associates the fluid client ID with a set of user roles.
    *
    * @param clientId The ID for the current user's Fluid client. Changes on reconnects.
@@ -249,6 +255,7 @@ export class LiveShareHost {
   }
 
   /**
+   * @hidden
    * Returns the roles associated with a client ID.
    *
    * @param clientId The Client ID the message was received from.
@@ -262,6 +269,7 @@ export class LiveShareHost {
   }
 
   /**
+   * @hidden
    * Returns the `IClientInfo` associated with a client ID.
    *
    * @param clientId The Client ID the message was received from.
@@ -275,10 +283,12 @@ export class LiveShareHost {
   }
 
   /**
-   * Returns a host instance for the client that can be passed to the `LiveShareClient` class.
+   * Factories a new `LiveShareHost` instance for use with the `LiveShareClient` class
+   * in the `@microsoft/live-share` package.
    *
    * @remarks
-   * The application must first be initialized and may only be called from `meetingStage` or `sidePanel` contexts.
+   * `app.initialize()` must first be called before using this API.
+   * This API can only be called from `meetingStage` or `sidePanel` contexts.
    */
   public static create(): LiveShareHost {
     ensureSupported();

--- a/packages/teams-js/test/public/liveShareHost.spec.ts
+++ b/packages/teams-js/test/public/liveShareHost.spec.ts
@@ -1,15 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { app } from '../../src/public/app';
-import {
-  ContainerState,
-  IClientInfo,
-  IFluidContainerInfo,
-  IFluidTenantInfo,
-  INtpTimeInfo,
-  isSupported,
-  LiveShareHost,
-  UserMeetingRole,
-} from '../../src/public/liveShareHost';
+import { liveShare, LiveShareHost } from '../../src/public/liveShareHost';
 import { setUnitializedRuntime } from '../../src/public/runtime';
 import { Utils } from '../utils';
 
@@ -84,7 +75,7 @@ describe('LiveShareHost', () => {
 
     it('should resolve promise correctly', async () => {
       await utils.initializeWithContext('meetingStage');
-      const mockTenantInfo: IFluidTenantInfo = {
+      const mockTenantInfo: liveShare.IFluidTenantInfo = {
         tenantId: 'test-tenant',
         serviceEndpoint: 'https://test.azure.com',
       };
@@ -157,8 +148,8 @@ describe('LiveShareHost', () => {
 
     it('should resolve promise correctly', async () => {
       await utils.initializeWithContext('meetingStage');
-      const mockContainerInfo: IFluidContainerInfo = {
-        containerState: ContainerState.notFound,
+      const mockContainerInfo: liveShare.IFluidContainerInfo = {
+        containerState: liveShare.ContainerState.notFound,
         containerId: undefined,
         shouldCreate: false,
         retryAfter: 500,
@@ -197,8 +188,8 @@ describe('LiveShareHost', () => {
 
     it('should resolve promise correctly', async () => {
       await utils.initializeWithContext('meetingStage');
-      const mockContainerInfo: IFluidContainerInfo = {
-        containerState: ContainerState.added,
+      const mockContainerInfo: liveShare.IFluidContainerInfo = {
+        containerState: liveShare.ContainerState.added,
         containerId: '1234',
         shouldCreate: false,
         retryAfter: 0,
@@ -238,7 +229,7 @@ describe('LiveShareHost', () => {
 
     it('should resolve promise correctly', async () => {
       await utils.initializeWithContext('meetingStage');
-      const mockNtpTime: INtpTimeInfo = {
+      const mockNtpTime: liveShare.INtpTimeInfo = {
         ntpTime: 'some-time',
         ntpTimeInUTC: 12345,
       };
@@ -276,7 +267,7 @@ describe('LiveShareHost', () => {
 
     it('should resolve promise correctly', async () => {
       await utils.initializeWithContext('meetingStage');
-      const userRoles = [UserMeetingRole.presenter];
+      const userRoles = [liveShare.UserMeetingRole.presenter];
       const promise = host.registerClientId('test-client');
 
       const registerClientIdMessage = utils.findMessageByFunc('interactive.registerClientId');
@@ -311,7 +302,7 @@ describe('LiveShareHost', () => {
 
     it('should resolve promise correctly', async () => {
       await utils.initializeWithContext('meetingStage');
-      const userRoles = [UserMeetingRole.presenter];
+      const userRoles = [liveShare.UserMeetingRole.presenter];
       const promise = host.getClientRoles('test-client');
 
       const getClientRolesMessage = utils.findMessageByFunc('interactive.getClientRoles');
@@ -346,9 +337,9 @@ describe('LiveShareHost', () => {
 
     it('should resolve promise correctly', async () => {
       await utils.initializeWithContext('meetingStage');
-      const userInfo: IClientInfo = {
+      const userInfo: liveShare.IClientInfo = {
         userId: 'test userId',
-        roles: [UserMeetingRole.presenter],
+        roles: [liveShare.UserMeetingRole.presenter],
         displayName: 'test name',
       };
       const promise = host.getClientInfo('test-client');
@@ -364,7 +355,7 @@ describe('LiveShareHost', () => {
   describe('Testing isSupported', () => {
     it('should not be supported before initialization', () => {
       setUnitializedRuntime();
-      expect(() => isSupported()).toThrowError(new Error(errorLibraryNotInitialized));
+      expect(() => liveShare.isSupported()).toThrowError(new Error(errorLibraryNotInitialized));
     });
   });
 });


### PR DESCRIPTION
## Description
This is primarily a cleanup PR to align the liveShare code with the rest of the code. Other features are wrapped in their own namespace, which was never done for Live Share.

LiveShareHost is still outside the namespace. Moving that inside the namespace would be a breaking change for LiveShare users.

removed @beta comments, updated doc comments.

## Validation

### Validation performed:

1. Tested LiveShare apps with teams-js changes

### Unit Tests added: no

No logic changes were introduced, just aligning code patterns.

### Change file added: yes
