### PR TITLE
Modified condition for publishing bundle analysis

### DIFF
--- a/tools/yaml-templates/build-test-publish.yml
+++ b/tools/yaml-templates/build-test-publish.yml
@@ -82,7 +82,8 @@ steps:
   - task: PublishBuildArtifacts@1
     condition: and(
       in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues'),
-      ne(variables['Build.Reason'], 'PullRequest'))
+      eq(variables['Build.Reason'], 'PullRequest'),
+      eq(variables['System.PullRequest.TargetBranch'], 'main'))
     inputs:
       PathtoPublish: './common/temp/bundleAnalysis'
       ArtifactName: '$(bundleArtifactName)'


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Publish bundle analysis task hasn't been executing for a while now, this is because it was running on a condition that always returned false. Modified the condition to now only run on PR targeting the main branch.

## Validation

### Validation performed:

1. Ran the pipeline and saw that the bundle analysis artifact was correctly published.