### PR TITLE
Change incorrect instruction in top level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Welcome to the Teams client library monorepo! For breaking changes, please refer
 
 ## Getting Started
 
-1. Fork the repo
+1. Create a new branch in the repo (see [Contributing](CONTRIBUTING.md) for more details)
 2. Run `pnpm install` from repo root
 3. Run `pnpm build` from repo root
 4. To run Unit tests, run `pnpm test`
 
-NOTE: Make sure `pnpm@7.30.1` is installed as a global tool, by running `npm install -g pnpm@7.30.1`.  
+NOTE: Make sure `pnpm@7.30.1` is installed as a global tool, by running `npm install -g pnpm@7.30.1`.
 
 TIP: whenever building or testing the Teams client library, you can run `pnpm build` or `pnpm test` from the `packages/teams-js` directory.
 


### PR DESCRIPTION
## Description

Change README instruction to say to make a branch instead of a fork

### Main changes in the PR:

1. Change README instruction to say to make a branch instead of a fork

## Validation

### Validation performed:

None

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No
