### PR TITLE
iOS CI Yaml File Task Bash Script Fix

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -119,7 +119,7 @@ const App = (): ReactElement => {
   return (
     <div>
       <div className="App-container">
-        <AppAPIs />
+        {/* <AppAPIs />
         <AppInitializationAPIs />
         <AppInstallDialogAPIs />
         <AuthenticationAPIs />
@@ -165,7 +165,7 @@ const App = (): ReactElement => {
         <TeamsCoreAPIs />
         <TeamsAPIs />
         <VideoAPIs />
-        <VideoExAPIs />
+        <VideoExAPIs /> */}
       </div>
       <Version />
     </div>

--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -3,55 +3,8 @@ import './App.css';
 import { app, appInitialization, initialize } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import AppAPIs from './components/AppAPIs';
-import AppEntityAPIs from './components/AppEntityAPIs';
-import AppInitializationAPIs from './components/AppInitialization';
-import AppInstallDialogAPIs from './components/AppInstallDialog';
-import AuthenticationAPIs from './components/AuthenticationAPIs';
-import BarCodeAPIs from './components/BarCodeAPIs';
-import CalendarAPIs from './components/CalendarAPIs';
-import CallAPIs from './components/CallAPIs';
-import DialogAPIs from './components/DialogAPIs';
-import DialogCardAPIs from './components/DialogCardAPIs';
-import DialogCardBotAPIs from './components/DialogCardBotAPIs';
-import DialogUpdateAPIs from './components/DialogUpdateAPIs';
-import DialogUrlAPIs from './components/DialogUrlAPIs';
-import DialogUrlBotAPIs from './components/DialogUrlBotAPIs';
-import GeoLocationAPIs from './components/GeoLocationAPIs';
-import Links from './components/Links';
-import LocationAPIs from './components/LocationAPIs';
-import LogAPIs from './components/LogsAPIs';
-import MailAPIs from './components/MailAPIs';
-import MediaAPIs from './components/MediaAPIs';
-import MeetingAPIs from './components/MeetingAPIs';
-import MenusAPIs from './components/MenusAPIs';
-import PagesAPIs from './components/PagesAPIs';
-import PagesAppButtonAPIs from './components/PagesAppButtonAPIs';
-import PagesBackStackAPIs from './components/PagesBackStackAPIs';
-import PagesConfigAPIs from './components/PagesConfigAPIs';
-import PagesCurrentAppAPIs from './components/PagesCurrentAppAPIs';
-import PagesTabsAPIs from './components/PagesTabsAPIs';
-import PeopleAPIs from './components/PeopleAPIs';
-import ChatAPIs from './components/privateApis/ChatAPIs';
-import FilesAPIs from './components/privateApis/FilesAPIs';
-import FullTrustAPIs from './components/privateApis/FullTrustAPIs';
-import MeetingRoomAPIs from './components/privateApis/MeetingRoomAPIs';
-import MonetizationAPIs from './components/privateApis/MonetizationAPIs';
-import NotificationAPIs from './components/privateApis/NotificationAPIs';
-import PrivateAPIs from './components/privateApis/PrivateAPIs';
-import TeamsAPIs from './components/privateApis/TeamsAPIs';
-import VideoExAPIs from './components/privateApis/VideoExAPIs';
-import ProfileAPIs from './components/ProfileAPIs';
-import RemoteCameraAPIs from './components/RemoteCameraAPIs';
-import SearchAPIs from './components/SearchAPIs';
-import SecondaryBrowserAPIs from './components/SecondaryBrowserAPIs';
-import SharingAPIs from './components/SharingAPIs';
-import StageViewAPIs from './components/StageViewAPIs';
-import TeamsCoreAPIs from './components/TeamsCoreAPIs';
 import { isTestBackCompat } from './components/utils/isTestBackCompat';
 import Version from './components/Version';
-import VideoAPIs from './components/VideoApis';
-import WebStorageAPIs from './components/WebStorageAPIs';
 
 const urlParams = new URLSearchParams(window.location.search);
 
@@ -118,55 +71,7 @@ export const generateRegistrationMsg = (changeCause: string): string => {
 const App = (): ReactElement => {
   return (
     <div>
-      <div className="App-container">
-        {/* <AppAPIs />
-        <AppInitializationAPIs />
-        <AppInstallDialogAPIs />
-        <AuthenticationAPIs />
-        <AppEntityAPIs />
-        <BarCodeAPIs />
-        <CalendarAPIs />
-        <CallAPIs />
-        <ChatAPIs />
-        <DialogAPIs />
-        <DialogCardAPIs />
-        <DialogCardBotAPIs />
-        <DialogUpdateAPIs />
-        <DialogUrlAPIs />
-        <DialogUrlBotAPIs />
-        <FilesAPIs />
-        <FullTrustAPIs />
-        <GeoLocationAPIs />
-        <Links />
-        <LocationAPIs />
-        <LogAPIs />
-        <MailAPIs />
-        <MediaAPIs />
-        <MeetingAPIs />
-        <MeetingRoomAPIs />
-        <MenusAPIs />
-        <MonetizationAPIs />
-        <NotificationAPIs />
-        <PagesAPIs />
-        <PagesAppButtonAPIs />
-        <PagesBackStackAPIs />
-        <PagesConfigAPIs />
-        <PagesCurrentAppAPIs />
-        <PagesTabsAPIs />
-        <PeopleAPIs />
-        <PrivateAPIs />
-        <ProfileAPIs />
-        <RemoteCameraAPIs />
-        <SearchAPIs />
-        <SecondaryBrowserAPIs />
-        <SharingAPIs />
-        <WebStorageAPIs />
-        <StageViewAPIs />
-        <TeamsCoreAPIs />
-        <TeamsAPIs />
-        <VideoAPIs />
-        <VideoExAPIs /> */}
-      </div>
+      <div className="App-container"></div>
       <Version />
     </div>
   );

--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -3,8 +3,55 @@ import './App.css';
 import { app, appInitialization, initialize } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
+import AppAPIs from './components/AppAPIs';
+import AppEntityAPIs from './components/AppEntityAPIs';
+import AppInitializationAPIs from './components/AppInitialization';
+import AppInstallDialogAPIs from './components/AppInstallDialog';
+import AuthenticationAPIs from './components/AuthenticationAPIs';
+import BarCodeAPIs from './components/BarCodeAPIs';
+import CalendarAPIs from './components/CalendarAPIs';
+import CallAPIs from './components/CallAPIs';
+import DialogAPIs from './components/DialogAPIs';
+import DialogCardAPIs from './components/DialogCardAPIs';
+import DialogCardBotAPIs from './components/DialogCardBotAPIs';
+import DialogUpdateAPIs from './components/DialogUpdateAPIs';
+import DialogUrlAPIs from './components/DialogUrlAPIs';
+import DialogUrlBotAPIs from './components/DialogUrlBotAPIs';
+import GeoLocationAPIs from './components/GeoLocationAPIs';
+import Links from './components/Links';
+import LocationAPIs from './components/LocationAPIs';
+import LogAPIs from './components/LogsAPIs';
+import MailAPIs from './components/MailAPIs';
+import MediaAPIs from './components/MediaAPIs';
+import MeetingAPIs from './components/MeetingAPIs';
+import MenusAPIs from './components/MenusAPIs';
+import PagesAPIs from './components/PagesAPIs';
+import PagesAppButtonAPIs from './components/PagesAppButtonAPIs';
+import PagesBackStackAPIs from './components/PagesBackStackAPIs';
+import PagesConfigAPIs from './components/PagesConfigAPIs';
+import PagesCurrentAppAPIs from './components/PagesCurrentAppAPIs';
+import PagesTabsAPIs from './components/PagesTabsAPIs';
+import PeopleAPIs from './components/PeopleAPIs';
+import ChatAPIs from './components/privateApis/ChatAPIs';
+import FilesAPIs from './components/privateApis/FilesAPIs';
+import FullTrustAPIs from './components/privateApis/FullTrustAPIs';
+import MeetingRoomAPIs from './components/privateApis/MeetingRoomAPIs';
+import MonetizationAPIs from './components/privateApis/MonetizationAPIs';
+import NotificationAPIs from './components/privateApis/NotificationAPIs';
+import PrivateAPIs from './components/privateApis/PrivateAPIs';
+import TeamsAPIs from './components/privateApis/TeamsAPIs';
+import VideoExAPIs from './components/privateApis/VideoExAPIs';
+import ProfileAPIs from './components/ProfileAPIs';
+import RemoteCameraAPIs from './components/RemoteCameraAPIs';
+import SearchAPIs from './components/SearchAPIs';
+import SecondaryBrowserAPIs from './components/SecondaryBrowserAPIs';
+import SharingAPIs from './components/SharingAPIs';
+import StageViewAPIs from './components/StageViewAPIs';
+import TeamsCoreAPIs from './components/TeamsCoreAPIs';
 import { isTestBackCompat } from './components/utils/isTestBackCompat';
 import Version from './components/Version';
+import VideoAPIs from './components/VideoApis';
+import WebStorageAPIs from './components/WebStorageAPIs';
 
 const urlParams = new URLSearchParams(window.location.search);
 
@@ -71,7 +118,55 @@ export const generateRegistrationMsg = (changeCause: string): string => {
 const App = (): ReactElement => {
   return (
     <div>
-      <div className="App-container"></div>
+      <div className="App-container">
+        <AppAPIs />
+        <AppInitializationAPIs />
+        <AppInstallDialogAPIs />
+        <AuthenticationAPIs />
+        <AppEntityAPIs />
+        <BarCodeAPIs />
+        <CalendarAPIs />
+        <CallAPIs />
+        <ChatAPIs />
+        <DialogAPIs />
+        <DialogCardAPIs />
+        <DialogCardBotAPIs />
+        <DialogUpdateAPIs />
+        <DialogUrlAPIs />
+        <DialogUrlBotAPIs />
+        <FilesAPIs />
+        <FullTrustAPIs />
+        <GeoLocationAPIs />
+        <Links />
+        <LocationAPIs />
+        <LogAPIs />
+        <MailAPIs />
+        <MediaAPIs />
+        <MeetingAPIs />
+        <MeetingRoomAPIs />
+        <MenusAPIs />
+        <MonetizationAPIs />
+        <NotificationAPIs />
+        <PagesAPIs />
+        <PagesAppButtonAPIs />
+        <PagesBackStackAPIs />
+        <PagesConfigAPIs />
+        <PagesCurrentAppAPIs />
+        <PagesTabsAPIs />
+        <PeopleAPIs />
+        <PrivateAPIs />
+        <ProfileAPIs />
+        <RemoteCameraAPIs />
+        <SearchAPIs />
+        <SecondaryBrowserAPIs />
+        <SharingAPIs />
+        <WebStorageAPIs />
+        <StageViewAPIs />
+        <TeamsCoreAPIs />
+        <TeamsAPIs />
+        <VideoAPIs />
+        <VideoExAPIs />
+      </div>
       <Version />
     </div>
   );

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -87,10 +87,10 @@ steps:
 
       if [[ $? == 0 ]];
       then
-      echo "E2E Test passes successfully"
+      echo "E2E Test passes successfully";
       exit 0;
       else
-      echo "E2E Test failed"
+      echo "E2E Test failed";
       exit 1;
       fi;
     displayName: 'iOS UI/E2E Tests'

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -100,10 +100,10 @@ steps:
 
       if [[ $? == 0 ]];
       then
-      echo "Test report has been generated successfully."
+      echo "Test report has been generated successfully.";
       exit 0;
       else
-      echo "Test report generating process failed for some reasons."
+      echo "Test report generating process failed for some reasons.";
       exit 1;
       fi;
     displayName: 'Generate E2E test report'


### PR DESCRIPTION
## Description

There are two parts of bash scripts in YAML file missed semicolons so that the prompts are not properly processed and the failure cannot be thrown as a task failed. Thus, semicolons are added as a fix.

### Main changes in the PR:

1. add semicolons for separating bash scripts in iOS-test.yml file

## Validation

Check this example run(after fix): https://office.visualstudio.com/ISS/_build/results?buildId=20898393&view=logs&j=a19010f7-e5b6-5d4e-f3f8-d8dc77971e5f&t=75310659-ec5b-5afc-1cb9-4cce342f4b2f

task failed without prompting "exit 1" at the end of task "iOS UI/E2E Test".

The behavior before fix can be seen here: https://office.visualstudio.com/ISS/_build/results?buildId=20885082&view=results

iOS E2E test actually failed but the task still showing successful because the "exit 1" bash script is not properly handled as semicolon is missing.

### Unit Tests added: No

### End-to-end tests added: No