### PR TITLE
Xjwu/add marketplace capability

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -22,6 +22,7 @@ import Links from './components/Links';
 import LocationAPIs from './components/LocationAPIs';
 import LogAPIs from './components/LogsAPIs';
 import MailAPIs from './components/MailAPIs';
+import MarketplaceAPIs from './components/MarketplaceAPIs';
 import MediaAPIs from './components/MediaAPIs';
 import MeetingAPIs from './components/MeetingAPIs';
 import MenusAPIs from './components/MenusAPIs';
@@ -141,6 +142,7 @@ const App = (): ReactElement => {
         <LocationAPIs />
         <LogAPIs />
         <MailAPIs />
+        <MarketplaceAPIs />
         <MediaAPIs />
         <MeetingAPIs />
         <MeetingRoomAPIs />

--- a/apps/teams-test-app/src/components/MarketplaceAPIs.tsx
+++ b/apps/teams-test-app/src/components/MarketplaceAPIs.tsx
@@ -1,0 +1,97 @@
+import { marketplace } from '@microsoft/teams-js';
+import React, { ReactElement } from 'react';
+
+import { ApiWithoutInput, ApiWithTextInput } from './utils';
+import { ModuleWrapper } from './utils/ModuleWrapper';
+
+const GetCart = (): ReactElement =>
+  ApiWithoutInput({
+    name: 'getCart',
+    title: 'Get Cart',
+    onClick: async () => {
+      const cart = await marketplace.getCart();
+      return JSON.stringify(cart);
+    },
+  });
+
+const AddOrUpdateCartItems = (): ReactElement =>
+  ApiWithTextInput<marketplace.CartItem[]>({
+    name: 'addOrUpdateCartItems',
+    title: 'Add Or Update CartItems',
+    onClick: {
+      validateInput: (input) => {
+        if (!input) {
+          throw new Error('input is undefined');
+        }
+      },
+      submit: async (cartItems, setResult) => {
+        await marketplace.addOrUpdateCartItems(cartItems);
+        const msg = 'update cart items succeeded';
+        setResult(msg);
+        return msg;
+      },
+    },
+  });
+
+const RemoveCartItems = (): ReactElement =>
+  ApiWithTextInput<string[]>({
+    name: 'removeCartItems',
+    title: 'Remove Cart Items',
+    onClick: {
+      validateInput: (input) => {
+        if (!input) {
+          throw new Error('input is undefined');
+        }
+      },
+      submit: async (cartItemIds, setResult) => {
+        await marketplace.removeCartItems(cartItemIds);
+        const msg = 'remove cart items succeeded';
+        setResult(msg);
+        return msg;
+      },
+    },
+  });
+
+const UpdateCartStatus = (): ReactElement =>
+  ApiWithTextInput<marketplace.UpdateCartStatusParams>({
+    name: 'updateCartStatus',
+    title: 'Update Cart Status',
+    onClick: {
+      validateInput: (input) => {
+        if (!input) {
+          throw new Error('input is undefined');
+        }
+      },
+      submit: async (updateCartStatusParams, setResult) => {
+        await marketplace.updateCartStatus(updateCartStatusParams);
+        const msg = 'update cart status succeeded';
+        setResult(msg);
+        return msg;
+      },
+    },
+  });
+
+const CheckMarketplaceCapability = (): ReactElement =>
+  ApiWithoutInput({
+    name: 'checkMarketplaceCapability',
+    title: 'Check Marketplace Capability ',
+    onClick: async () => {
+      if (marketplace.isSupported()) {
+        return 'marketplace module is supported';
+      } else {
+        return 'marketplace module is not supported';
+      }
+    },
+  });
+
+const MarketplaceAPIs = (): ReactElement => (
+  <ModuleWrapper title="MarketplaceAPIs">
+    <CheckMarketplaceCapability />
+    <GetCart />
+    <AddOrUpdateCartItems />
+    <RemoveCartItems />
+    <UpdateCartStatus />
+  </ModuleWrapper>
+);
+
+export default MarketplaceAPIs;

--- a/apps/teams-test-app/src/components/MarketplaceAPIs.tsx
+++ b/apps/teams-test-app/src/components/MarketplaceAPIs.tsx
@@ -15,7 +15,7 @@ const GetCart = (): ReactElement =>
   });
 
 const AddOrUpdateCartItems = (): ReactElement =>
-  ApiWithTextInput<marketplace.CartItem[]>({
+  ApiWithTextInput<marketplace.AddOrUpdateCartItemsParams>({
     name: 'addOrUpdateCartItems',
     title: 'Add Or Update CartItems',
     onClick: {
@@ -24,17 +24,15 @@ const AddOrUpdateCartItems = (): ReactElement =>
           throw new Error('input is undefined');
         }
       },
-      submit: async (cartItems, setResult) => {
-        await marketplace.addOrUpdateCartItems(cartItems);
-        const msg = 'update cart items succeeded';
-        setResult(msg);
-        return msg;
+      submit: async (addOrUpdateCartItemsParams) => {
+        const cart = await marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams);
+        return JSON.stringify(cart);
       },
     },
   });
 
 const RemoveCartItems = (): ReactElement =>
-  ApiWithTextInput<string[]>({
+  ApiWithTextInput<marketplace.RemoveCartItemsParams>({
     name: 'removeCartItems',
     title: 'Remove Cart Items',
     onClick: {
@@ -43,11 +41,9 @@ const RemoveCartItems = (): ReactElement =>
           throw new Error('input is undefined');
         }
       },
-      submit: async (cartItemIds, setResult) => {
-        await marketplace.removeCartItems(cartItemIds);
-        const msg = 'remove cart items succeeded';
-        setResult(msg);
-        return msg;
+      submit: async (removeCartItemsParams) => {
+        const cart = await marketplace.removeCartItems(removeCartItemsParams);
+        return JSON.stringify(cart);
       },
     },
   });
@@ -62,11 +58,9 @@ const UpdateCartStatus = (): ReactElement =>
           throw new Error('input is undefined');
         }
       },
-      submit: async (updateCartStatusParams, setResult) => {
-        await marketplace.updateCartStatus(updateCartStatusParams);
-        const msg = 'update cart status succeeded';
-        setResult(msg);
-        return msg;
+      submit: async (updateCartStatusParams) => {
+        const cart = await marketplace.updateCartStatus(updateCartStatusParams);
+        return JSON.stringify(cart);
       },
     },
   });

--- a/change/@microsoft-teams-js-dfa943bb-061a-490f-9c87-be8069f3586e.json
+++ b/change/@microsoft-teams-js-dfa943bb-061a-490f-9c87-be8069f3586e.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Added `marketplace` capability that helps app developers interact with a checkout flow",
+  "comment": "Added `marketplace` capability that helps app developers interact with the checkout flow",
   "packageName": "@microsoft/teams-js",
   "email": "xiaojunwu@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-dfa943bb-061a-490f-9c87-be8069f3586e.json
+++ b/change/@microsoft-teams-js-dfa943bb-061a-490f-9c87-be8069f3586e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add `marketplace` capability as well as 4 methods to interact with `cart`",
+  "packageName": "@microsoft/teams-js",
+  "email": "xiaojunwu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-dfa943bb-061a-490f-9c87-be8069f3586e.json
+++ b/change/@microsoft-teams-js-dfa943bb-061a-490f-9c87-be8069f3586e.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "add `marketplace` capability as well as 4 methods to interact with `cart`",
+  "comment": "Added `marketplace` capability that helps app developers interact with a checkout flow",
   "packageName": "@microsoft/teams-js",
   "email": "xiaojunwu@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/internal/marketplaceUtils.ts
+++ b/packages/teams-js/src/internal/marketplaceUtils.ts
@@ -1,59 +1,145 @@
+import { validate } from 'uuid';
+
 import { marketplace } from '../public';
 
 /**
  * @hidden
- * Validates the cart item properties are valid
+ * Validate the cart item properties are valid
  * @param cartItems The cart items
- * @returns [true, undefined] if all properties of all cart items are valid, [false, error message] otherwise
  *
  * @internal
  * Limited to Microsoft-internal use
  */
-export function validateCartItems(cartItems: marketplace.CartItem[]): [boolean, string | undefined] {
-  for (const cartItem of cartItems) {
-    const priceValidationResult = validatePrice(cartItem.price);
-    if (!priceValidationResult[0]) {
-      return priceValidationResult;
-    }
-    const quantityValidationResult = validateQuantity(cartItem.quantity);
-    if (!quantityValidationResult[0]) {
-      return quantityValidationResult;
-    }
+export function validateCartItems(cartItems: marketplace.CartItem[]): void {
+  if (!Array.isArray(cartItems) || cartItems.length === 0) {
+    throw new Error('cartItems must be a non-empty array');
   }
-  return [true, undefined];
+  for (const cartItem of cartItems) {
+    validateBasicCartItem(cartItem);
+    validateAccessoryItems(cartItem.accessories);
+  }
 }
 
 /**
  * @hidden
- * Validates the cart item properties are valid
- * @param price The price to be validated
- * @returns [true, undefined] if price is valid, [false, error message] otherwise
+ * Validate accessories
+ * @param accessoryItems The accessories to be validated
  *
  * @internal
  * Limited to Microsoft-internal use
  */
-export function validatePrice(price: number): [boolean, string | undefined] {
+export function validateAccessoryItems(accessoryItems: marketplace.Item[] | undefined | null): void {
+  if (accessoryItems === null || accessoryItems === undefined) {
+    return;
+  }
+  if (!Array.isArray(accessoryItems) || accessoryItems.length === 0) {
+    throw new Error('CartItem.accessories must be a non-empty array');
+  }
+  for (const accessoryItem of accessoryItems) {
+    if (accessoryItem['accessories']) {
+      throw new Error('Item in CartItem.accessories cannot have accessories');
+    }
+    validateBasicCartItem(accessoryItem);
+  }
+}
+
+/**
+ * @hidden
+ * Validate the basic cart item properties are valid
+ * @param basicCartItem The basic cart item
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function validateBasicCartItem(basicCartItem: marketplace.Item): void {
+  if (!basicCartItem.name) {
+    throw new Error('cartItem.name must not be empty');
+  }
+  validatePrice(basicCartItem.price);
+  validateQuantity(basicCartItem.quantity);
+  validateUrl(basicCartItem.imageURL);
+}
+
+/**
+ * @hidden
+ * Validate the id is valid
+ * @param id A uuid string
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function validateUuid(id: string | undefined | null): void {
+  if (id === undefined || id === null) {
+    return;
+  }
+  if (!id) {
+    throw new Error('id must not be empty');
+  }
+  if (validate(id) === false) {
+    throw new Error('id must be a valid UUID');
+  }
+}
+
+/**
+ * @hidden
+ * Validate the cart item properties are valid
+ * @param price The price to be validated
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function validatePrice(price: number): void {
   if (typeof price !== 'number' || price < 0) {
-    return [false, `price ${price} must be a number not less than 0`];
+    throw new Error(`price ${price} must be a number not less than 0`);
   }
   if (parseFloat(price.toFixed(3)) !== price) {
-    return [false, `price ${price} must have at most 3 decimal places`];
+    throw new Error(`price ${price} must have at most 3 decimal places`);
   }
-  return [true, undefined];
 }
 
 /**
  * @hidden
- * Validates quantity
+ * Validate quantity
  * @param quantity The quantity to be validated
- * @returns [true, undefined] if quantity is valid, [false, error message] otherwise
  *
  * @internal
  * Limited to Microsoft-internal use
  */
-export function validateQuantity(quantity: number): [boolean, string | undefined] {
+export function validateQuantity(quantity: number): void {
   if (typeof quantity !== 'number' || quantity <= 0 || parseInt(quantity.toString()) !== quantity) {
-    return [false, `quantity ${quantity} must be an integer greater than 0`];
+    throw new Error(`quantity ${quantity} must be an integer greater than 0`);
   }
-  return [true, undefined];
+}
+
+/**
+ * @hidden
+ * Validate url
+ * @param url The url to be validated
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function validateUrl(url: string | undefined | null): void {
+  if (url === undefined || url === null) {
+    return;
+  }
+  try {
+    new URL(url);
+  } catch (e) {
+    throw new Error(`url ${url} is not valid`);
+  }
+}
+
+/**
+ * @hidden
+ * Validate cart status
+ * @param cartStatus The cartStatus to be validated
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function validateCartStatus(cartStatus: marketplace.CartStatus): void {
+  if (!Object.values(marketplace.CartStatus).includes(cartStatus)) {
+    throw new Error(`cartStatus ${cartStatus} is not valid`);
+  }
 }

--- a/packages/teams-js/src/internal/marketplaceUtils.ts
+++ b/packages/teams-js/src/internal/marketplaceUtils.ts
@@ -1,0 +1,62 @@
+import { marketplace } from '../public';
+
+/**
+ * @hidden
+ * Validates the cart item properties are valid
+ * @param cartItems The cart items
+ * @returns [true, undefined] if all properties of all cart items are valid, [false, error message] otherwise
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function validateCartItems(cartItems: marketplace.CartItem[]): [boolean, string | undefined] {
+  for (const cartItem of cartItems) {
+    const priceValidationResult = validatePrice(cartItem.price);
+    if (!priceValidationResult[0]) {
+      return priceValidationResult;
+    }
+    const quantityValidationResult = validateQuantity(cartItem.quantity);
+    if (!quantityValidationResult[0]) {
+      return quantityValidationResult;
+    }
+  }
+  return [true, undefined];
+}
+
+/**
+ * @hidden
+ * Validates the cart item properties are valid
+ * @param price The price to be validated
+ * @returns [true, undefined] if price is valid, [false, error message] otherwise
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+function validatePrice(price: number): [boolean, string | undefined] {
+  if (typeof price !== 'number' || price < 0) {
+    return [false, `price ${price} must be a number not less than 0`];
+  }
+  if (parseFloat(price.toFixed(3)) !== price) {
+    return [false, `price ${price} must have at most 3 decimal places`];
+  }
+  return [true, undefined];
+}
+
+/**
+ * @hidden
+ * Validates quantity is valid
+ * @param quantity The quantity to be validated
+ * @returns [true, undefined] if quantity is valid, [false, error message] otherwise
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+function validateQuantity(quantity: number): [boolean, string | undefined] {
+  if (typeof quantity !== 'number' || quantity <= 0) {
+    return [false, `quantity ${quantity} must be a number greater than 0`];
+  }
+  if (parseInt(quantity.toString()) !== quantity) {
+    return [false, `quantity ${quantity} must be an integer`];
+  }
+  return [true, undefined];
+}

--- a/packages/teams-js/src/internal/marketplaceUtils.ts
+++ b/packages/teams-js/src/internal/marketplaceUtils.ts
@@ -32,7 +32,7 @@ export function validateCartItems(cartItems: marketplace.CartItem[]): [boolean, 
  * @internal
  * Limited to Microsoft-internal use
  */
-function validatePrice(price: number): [boolean, string | undefined] {
+export function validatePrice(price: number): [boolean, string | undefined] {
   if (typeof price !== 'number' || price < 0) {
     return [false, `price ${price} must be a number not less than 0`];
   }
@@ -44,19 +44,16 @@ function validatePrice(price: number): [boolean, string | undefined] {
 
 /**
  * @hidden
- * Validates quantity is valid
+ * Validates quantity
  * @param quantity The quantity to be validated
  * @returns [true, undefined] if quantity is valid, [false, error message] otherwise
  *
  * @internal
  * Limited to Microsoft-internal use
  */
-function validateQuantity(quantity: number): [boolean, string | undefined] {
-  if (typeof quantity !== 'number' || quantity <= 0) {
-    return [false, `quantity ${quantity} must be a number greater than 0`];
-  }
-  if (parseInt(quantity.toString()) !== quantity) {
-    return [false, `quantity ${quantity} must be an integer`];
+export function validateQuantity(quantity: number): [boolean, string | undefined] {
+  if (typeof quantity !== 'number' || quantity <= 0 || parseInt(quantity.toString()) !== quantity) {
+    return [false, `quantity ${quantity} must be an integer greater than 0`];
   }
   return [true, undefined];
 }

--- a/packages/teams-js/src/internal/marketplaceUtils.ts
+++ b/packages/teams-js/src/internal/marketplaceUtils.ts
@@ -52,6 +52,9 @@ export function validateAccessoryItems(accessoryItems: marketplace.Item[] | unde
  * Limited to Microsoft-internal use
  */
 export function validateBasicCartItem(basicCartItem: marketplace.Item): void {
+  if (!basicCartItem.id) {
+    throw new Error('cartItem.id must not be empty');
+  }
   if (!basicCartItem.name) {
     throw new Error('cartItem.name must not be empty');
   }

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -93,3 +93,4 @@ export { returnFocus, navigateBack, navigateCrossDomain, navigateToTab } from '.
 export { settings } from './settings';
 export { tasks } from './tasks';
 export { liveShare, LiveShareHost } from './liveShareHost';
+export { marketplace } from './marketplace';

--- a/packages/teams-js/src/public/marketplace.ts
+++ b/packages/teams-js/src/public/marketplace.ts
@@ -1,3 +1,5 @@
+import { UUID } from 'crypto';
+
 import { sendAndHandleSdkError } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { validateCartItems } from '../internal/marketplaceUtils';
@@ -27,7 +29,7 @@ export namespace marketplace {
      * @hidden
      * The id of the cart.
      */
-    readonly id: string;
+    readonly id: UUID;
     /**
      * @hidden
      * The cart info.
@@ -75,7 +77,7 @@ export namespace marketplace {
     readonly market: string;
     /**
      * @hidden
-     * The identifier to tell the cart is checked out by admin or information worker
+     * The identifier to tell the cart is checked out by admin or end user.
      */
     readonly intent: Intent;
     /**
@@ -128,7 +130,7 @@ export namespace marketplace {
      * @hidden
      * The display name of the cart item.
      */
-    name: string;
+    readonly name: string;
     /**
      * @hidden
      * The quantity of the cart item.
@@ -247,7 +249,9 @@ export namespace marketplace {
    * @hidden
    * Add or update cart items in the cart owned by the host.
    *
-   * @param cartItems - A list of cart items, if item id exists, overwrite the item, otherwise add new items to cart.
+   * @param cartItems - A list of cart items object, for each item,
+   * if item id exists in the cart, overwrite the item price and quantity,
+   * otherwise add new items to cart.
    *
    * @beta
    */
@@ -290,7 +294,7 @@ export namespace marketplace {
    *
    * @param updateCartStatusParams
    * updateCartStatusParams.cartStatus - cart status.
-   * updateCartStatusParams.message - extra info to the status.
+   * updateCartStatusParams.statusInfo - extra info to the status.
    *
    * @beta
    */

--- a/packages/teams-js/src/public/marketplace.ts
+++ b/packages/teams-js/src/public/marketplace.ts
@@ -278,6 +278,9 @@ export namespace marketplace {
       if (!isSupported()) {
         throw errorNotSupportedOnPlatform;
       }
+      if (!Array.isArray(cartItemIds) || cartItemIds.length === 0) {
+        throw new Error('cartItemIds must be a non-empty array');
+      }
       resolve(sendAndHandleSdkError('marketplace.removeCartItems', cartItemIds));
     });
   }
@@ -296,9 +299,6 @@ export namespace marketplace {
       ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
       if (!isSupported()) {
         throw errorNotSupportedOnPlatform;
-      }
-      if (!Array.isArray(updateCartStatusParams) || updateCartStatusParams.length === 0) {
-        throw new Error('updateCartStatusParams must be a non-empty array');
       }
       resolve(sendAndHandleSdkError('marketplace.updateCartStatus', updateCartStatusParams));
     });

--- a/packages/teams-js/src/public/marketplace.ts
+++ b/packages/teams-js/src/public/marketplace.ts
@@ -1,0 +1,319 @@
+import { sendAndHandleSdkError } from '../internal/communication';
+import { ensureInitialized } from '../internal/internalAPIs';
+import { validateCartItems } from '../internal/marketplaceUtils';
+import { errorNotSupportedOnPlatform, FrameContexts } from './constants';
+import { runtime } from './runtime';
+
+/**
+ * @hidden
+ * Namespace for an app to support a checkout flow by interacting with the marketplace cart in the host.
+ *
+ * @beta
+ */
+export namespace marketplace {
+  /**
+   * @hidden
+   * Represents the cart object for the app checkout flow.
+   *
+   * @beta
+   */
+  export interface Cart {
+    /**
+     * @hidden
+     * Version of the cart.
+     */
+    readonly version: CartVersion;
+    /**
+     * @hidden
+     * The id of the cart.
+     */
+    readonly id: string;
+    /**
+     * @hidden
+     * The cart info.
+     */
+    cartInfo: CartInfo;
+    /**
+     * @hidden
+     * The cart items.
+     */
+    cartItems: CartItem[];
+  }
+
+  /**
+   * @hidden
+   * Version of the cart.
+   *
+   * @beta
+   */
+  interface CartVersion {
+    /**
+     * @hidden
+     * Represents the major version number.
+     */
+    majorVersion: number;
+    /**
+     * @hidden
+     * Represents the minor version number.
+     */
+    minorVersion: number;
+  }
+
+  /**
+   * @hidden
+   * Represents the cart information
+   *
+   * @beta
+   */
+  interface CartInfo {
+    /**
+     * @hidden
+     * The country market where the products are selling.
+     * Should be country code in ISO 3166-1 alpha-2 format, e.g. CA for Canada.
+     * https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+     */
+    readonly market: string;
+    /**
+     * @hidden
+     * The identifier to tell the cart is checked out by admin or information worker
+     */
+    readonly intent: Intent;
+    /**
+     * @hidden
+     * Locale the app should render for the user
+     * Should be a BCP 47 language tag, e.g. en-US ([primary tag]-[ISO 3166-1 alpha-2 code]).
+     * https://en.wikipedia.org/wiki/IETF_language_tag
+     */
+    readonly locale: string;
+    /**
+     * @hidden
+     * The status of the cart.
+     */
+    status: CartStatus;
+    /**
+     * @hidden
+     * ISO 4217 currency code for the cart item price, e.g. USD for US Dollar.
+     * https://en.wikipedia.org/wiki/ISO_4217
+     */
+    readonly currency: string;
+    /**
+     * @hidden
+     * ISO 8601 timestamp string in UTC, indicates when the cart is created.
+     * e.g. 2023-06-19T22:06:59Z
+     * https://en.wikipedia.org/wiki/ISO_8601
+     */
+    readonly createdAt: string;
+    /**
+     * @hidden
+     * ISO 8601 timestamp string in UTC, indicates when the cart is updated.
+     * e.g. 2023-06-19T22:06:59Z
+     * https://en.wikipedia.org/wiki/ISO_8601
+     */
+    readonly updatedAt: string;
+  }
+
+  /**
+   * @hidden
+   * Represents the basic cart item information.
+   *
+   * @beta
+   */
+  interface Item {
+    /**
+     * @hidden
+     * The id of the cart item.
+     */
+    readonly id: string;
+    /**
+     * @hidden
+     * The display name of the cart item.
+     */
+    name: string;
+    /**
+     * @hidden
+     * The quantity of the cart item.
+     */
+    quantity: number;
+    /**
+     * @hidden
+     * The price of the single cart item.
+     */
+    price: number;
+    /**
+     * @hidden
+     * The thumbnail imageURL of the cart item.
+     */
+    readonly imageURL?: string;
+  }
+
+  /**
+   * @hidden
+   * Represents the cart item that could have accessories
+   *
+   * @beta
+   */
+  export interface CartItem extends Item {
+    /**
+     * @hidden
+     * Accessories to the item if existing.
+     */
+    readonly accessories?: Item[];
+  }
+
+  /**
+   * @hidden
+   * Represents the persona creating the cart.
+   *
+   * @beta
+   */
+  export enum Intent {
+    /**
+     * @hidden
+     * The cart is created by admin of an organization.
+     */
+    AdminUser = 'AdminUser',
+    /**
+     * @hidden
+     * The cart is created by end user of an organization.
+     */
+    EndUser = 'EndUser',
+  }
+
+  /**
+   * @hidden
+   * Represents the status of the cart.
+   *
+   * @beta
+   */
+  export enum CartStatus {
+    /**
+     * @hidden
+     * Cart is created but not checked out yet.
+     */
+    Open = 'Open',
+    /**
+     * @hidden
+     * Cart is checked out but not completed yet.
+     */
+    Processing = 'Processing',
+    /**
+     * @hidden
+     * Indicate checking out is completed and the host should
+     * response a new cart in the next getCart call.
+     */
+    Processed = 'Processed',
+    /**
+     * @hidden
+     * Indicate checking out is failed and the host should
+     * response a new cart in the next getCart call.
+     */
+    Error = 'Error',
+  }
+  /**
+   * @hidden
+   * Represents the parameters to update the cart status.
+   *
+   * @beta
+   */
+  export interface UpdateCartStatusParams {
+    /**
+     * @hidden
+     * Status of the cart.
+     */
+    cartStatus: CartStatus;
+    /**
+     * @hidden
+     * Extra info to the status.
+     */
+    statusInfo?: string;
+  }
+
+  /**
+   * @hidden
+   * Get the cart object owned by the host to checkout.
+   *
+   * @beta
+   */
+  export function getCart(): Promise<Cart> {
+    return new Promise<Cart>((resolve) => {
+      ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+      resolve(sendAndHandleSdkError('marketplace.getCart'));
+    });
+  }
+  /**
+   * @hidden
+   * Add or update cart items in the cart owned by the host.
+   *
+   * @param cartItems - A list of cart items, if item id exists, overwrite the item, otherwise add new items to cart.
+   *
+   * @beta
+   */
+  export function addOrUpdateCartItems(cartItems: CartItem[]): Promise<void> {
+    return new Promise<void>((resolve) => {
+      ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+      const [isValidItems, invalidItemsMessage] = validateCartItems(cartItems);
+      if (!isValidItems) {
+        throw new Error(invalidItemsMessage);
+      }
+      resolve(sendAndHandleSdkError('marketplace.addOrUpdateCartItems', cartItems));
+    });
+  }
+  /**
+   * @hidden
+   * Remove cart items from the cart owned by the host.
+   *
+   * @param cartItemIds - A list of cart id, delete the cart item accordingly.
+   *
+   * @beta
+   */
+  export function removeCartItems(cartItemIds: string[]): Promise<void> {
+    return new Promise<void>((resolve) => {
+      ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+      resolve(sendAndHandleSdkError('marketplace.removeCartItems', cartItemIds));
+    });
+  }
+  /**
+   * @hidden
+   * Update cart status in the cart owned by the host.
+   *
+   * @param updateCartStatusParams
+   * updateCartStatusParams.cartStatus - cart status.
+   * updateCartStatusParams.message - extra info to the status.
+   *
+   * @beta
+   */
+  export function updateCartStatus(updateCartStatusParams: UpdateCartStatusParams): Promise<void> {
+    return new Promise<void>((resolve) => {
+      ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+      if (!isSupported()) {
+        throw errorNotSupportedOnPlatform;
+      }
+      if (!Array.isArray(updateCartStatusParams) || updateCartStatusParams.length === 0) {
+        throw new Error('updateCartStatusParams must be a non-empty array');
+      }
+      resolve(sendAndHandleSdkError('marketplace.updateCartStatus', updateCartStatusParams));
+    });
+  }
+  /**
+   * @hidden
+   * Checks if the marketplace capability is supported by the host.
+   *
+   * @returns Boolean to represent whether the marketplace capability is supported.
+   *
+   * @throws Error if {@linkcode app.initialize} has not successfully completed.
+   *
+   * @beta
+   */
+  export function isSupported(): boolean {
+    return ensureInitialized(runtime) && runtime.supports.marketplace ? true : false;
+  }
+}

--- a/packages/teams-js/src/public/marketplace.ts
+++ b/packages/teams-js/src/public/marketplace.ts
@@ -12,6 +12,27 @@ import { runtime } from './runtime';
 export namespace marketplace {
   /**
    * @hidden
+   * the version of the current cart interface
+   * which is forced to send to the host in the calls.
+   * @beta
+   */
+  export const cartVersion: CartVersion = {
+    /**
+     * @hidden
+     * Represents the major version of the current cart interface,
+     * it is increased when incompatible interface update happens.
+     */
+    majorVersion: 1,
+    /**
+     * @hidden
+     * The minor version of the current cart interface, which is compatible
+     * with the previous minor version in the same major version.
+     */
+    minorVersion: 1,
+  };
+
+  /**
+   * @hidden
    * Represents the cart object for the app checkout flow.
    * @beta
    */
@@ -40,18 +61,20 @@ export namespace marketplace {
 
   /**
    * @hidden
-   * Version of the cart.
+   * Version of the cart that is used by the app.
    * @beta
    */
   interface CartVersion {
     /**
      * @hidden
-     * Represents the major version number.
+     * Represents the major version of a cart, it
+     * not compatible with the previous major version.
      */
     readonly majorVersion: number;
     /**
      * @hidden
-     * Represents the minor version number.
+     * The minor version of a cart, which is compatible
+     * with the previous minor version in the same major version.
      */
     readonly minorVersion: number;
   }
@@ -271,81 +294,82 @@ export namespace marketplace {
   /**
    * @hidden
    * Get the cart object owned by the host to checkout.
-   * @returns A promise of the cart object.
+   * @returns A promise of the cart object in the cartVersion.
    * @beta
    */
   export function getCart(): Promise<Cart> {
-    return new Promise<Cart>((resolve) => {
-      ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
-      }
-      resolve(sendAndHandleSdkError('marketplace.getCart'));
-    });
+    ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+    if (!isSupported()) {
+      throw errorNotSupportedOnPlatform;
+    }
+    return sendAndHandleSdkError('marketplace.getCart', cartVersion);
   }
   /**
    * @hidden
    * Add or update cart items in the cart owned by the host.
    * @param addOrUpdateCartItemsParams Represents the parameters to update the cart items.
-   * @returns A promise of the updated cart object.
+   * @returns A promise of the updated cart object in the cartVersion.
    * @beta
    */
   export function addOrUpdateCartItems(addOrUpdateCartItemsParams: AddOrUpdateCartItemsParams): Promise<Cart> {
-    return new Promise<Cart>((resolve) => {
-      ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
-      }
-      if (!addOrUpdateCartItemsParams) {
-        throw new Error('addOrUpdateCartItemsParams must be provided');
-      }
-      validateUuid(addOrUpdateCartItemsParams?.cartId);
-      validateCartItems(addOrUpdateCartItemsParams?.cartItems);
-      resolve(sendAndHandleSdkError('marketplace.addOrUpdateCartItems', addOrUpdateCartItemsParams));
+    ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+    if (!isSupported()) {
+      throw errorNotSupportedOnPlatform;
+    }
+    if (!addOrUpdateCartItemsParams) {
+      throw new Error('addOrUpdateCartItemsParams must be provided');
+    }
+    validateUuid(addOrUpdateCartItemsParams?.cartId);
+    validateCartItems(addOrUpdateCartItemsParams?.cartItems);
+    return sendAndHandleSdkError('marketplace.addOrUpdateCartItems', {
+      ...addOrUpdateCartItemsParams,
+      cartVersion,
     });
   }
   /**
    * @hidden
    * Remove cart items from the cart owned by the host.
    * @param removeCartItemsParams The parameters to remove the cart items.
-   * @returns A promise of the updated cart object.
+   * @returns A promise of the updated cart object in the cartVersion.
    * @beta
    */
   export function removeCartItems(removeCartItemsParams: RemoveCartItemsParams): Promise<Cart> {
-    return new Promise<Cart>((resolve) => {
-      ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
-      }
-      if (!removeCartItemsParams) {
-        throw new Error('removeCartItemsParams must be provided');
-      }
-      validateUuid(removeCartItemsParams?.cartId);
-      if (!Array.isArray(removeCartItemsParams?.cartItemIds) || removeCartItemsParams?.cartItemIds.length === 0) {
-        throw new Error('cartItemIds must be a non-empty array');
-      }
-      resolve(sendAndHandleSdkError('marketplace.removeCartItems', removeCartItemsParams));
+    ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+    if (!isSupported()) {
+      throw errorNotSupportedOnPlatform;
+    }
+    if (!removeCartItemsParams) {
+      throw new Error('removeCartItemsParams must be provided');
+    }
+    validateUuid(removeCartItemsParams?.cartId);
+    if (!Array.isArray(removeCartItemsParams?.cartItemIds) || removeCartItemsParams?.cartItemIds.length === 0) {
+      throw new Error('cartItemIds must be a non-empty array');
+    }
+    return sendAndHandleSdkError('marketplace.removeCartItems', {
+      ...removeCartItemsParams,
+      cartVersion,
     });
   }
   /**
    * @hidden
    * Update cart status in the cart owned by the host.
    * @param updateCartStatusParams The parameters to update the cart status.
-   * @returns A promise of the updated cart object.
+   * @returns A promise of the updated cart object in the cartVersion.
    * @beta
    */
   export function updateCartStatus(updateCartStatusParams: UpdateCartStatusParams): Promise<Cart> {
-    return new Promise<Cart>((resolve) => {
-      ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
-      }
-      if (!updateCartStatusParams) {
-        throw new Error('updateCartStatusParams must be provided');
-      }
-      validateUuid(updateCartStatusParams?.cartId);
-      validateCartStatus(updateCartStatusParams?.cartStatus);
-      resolve(sendAndHandleSdkError('marketplace.updateCartStatus', updateCartStatusParams));
+    ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+    if (!isSupported()) {
+      throw errorNotSupportedOnPlatform;
+    }
+    if (!updateCartStatusParams) {
+      throw new Error('updateCartStatusParams must be provided');
+    }
+    validateUuid(updateCartStatusParams?.cartId);
+    validateCartStatus(updateCartStatusParams?.cartStatus);
+    return sendAndHandleSdkError('marketplace.updateCartStatus', {
+      ...updateCartStatusParams,
+      cartVersion,
     });
   }
   /**

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -110,6 +110,7 @@ interface IRuntimeV2 extends IBaseRuntime {
     readonly location?: {};
     readonly logs?: {};
     readonly mail?: {};
+    readonly marketplace?: {};
     readonly meetingRoom?: {};
     readonly menus?: {};
     readonly monetization?: {};

--- a/packages/teams-js/test/internal/marketplaceUtils.spec.ts
+++ b/packages/teams-js/test/internal/marketplaceUtils.spec.ts
@@ -2,18 +2,20 @@
 import { v4 as uuid } from 'uuid';
 
 import {
+  deserializeCart,
+  deserializeCartItems,
+  serializeCartItems,
   validateAccessoryItems,
   validateBasicCartItem,
   validateCartItems,
   validateCartStatus,
   validatePrice,
   validateQuantity,
-  validateUrl,
   validateUuid,
 } from '../../src/internal/marketplaceUtils';
 import { marketplace } from '../../src/public';
 
-describe.only('Testing marketplace utils', () => {
+describe('Testing marketplace validation', () => {
   it('should validate cart items in parameters', () => {
     const cartItems = [
       { id: '1', name: 'Item 1', price: 10, quantity: 1 },
@@ -60,17 +62,122 @@ describe.only('Testing marketplace utils', () => {
     expect(() => validateBasicCartItem(nestedAccessories)).toThrowError('cartItem.name must not be empty');
     expect(() => validateBasicCartItem(emptyIdItem)).toThrowError('cartItem.id must not be empty');
   });
-  it('should validate url', () => {
-    expect(() => validateUrl(null)).not.toThrowError();
-    expect(() => validateUrl('http://www.microsoft.com/image.jpg')).not.toThrowError();
-    expect(() => validateUrl('https://abc12345')).not.toThrowError();
-    expect(() => validateUrl('url')).toThrowError('url url is not valid');
-    expect(() => validateUrl('')).toThrowError('url  is not valid');
-  });
   it('should validate cartStatus', () => {
     expect(() => validateCartStatus(marketplace.CartStatus.Open)).not.toThrowError();
     expect(() => validateCartStatus('InvalidStatus' as marketplace.CartStatus)).toThrowError(
       'cartStatus InvalidStatus is not valid',
     );
+  });
+});
+
+describe('Testing marketplace serialization', () => {
+  const cartItems: marketplace.CartItem[] = [
+    { id: '1', name: 'Item 1', price: 10, quantity: 1 },
+    { id: '2', name: 'Item 1', price: 10, quantity: 1, imageURL: new URL('https://example.com/image.jpg?q=1&p=2') },
+    {
+      id: '3',
+      name: 'Item 2',
+      price: 10,
+      quantity: 2,
+      imageURL: new URL('https://example.com/image.jpg?q=1&p=2'),
+      accessories: [
+        {
+          id: '33',
+          name: 'Item 2',
+          price: 10,
+          quantity: 2,
+          imageURL: new URL('https://example.com/image.jpg?q=1&p=2'),
+        },
+      ],
+    },
+    {
+      id: '4',
+      name: 'Item 2',
+      price: 10,
+      quantity: 2,
+      accessories: [
+        {
+          id: '44',
+          name: 'Item 2',
+          price: 10,
+          quantity: 2,
+          imageURL: new URL('https://example.com/image.jpg?q=1&p=2'),
+        },
+      ],
+    },
+  ];
+  const cartItemsData = [
+    { id: '1', name: 'Item 1', price: 10, quantity: 1 },
+    { id: '2', name: 'Item 1', price: 10, quantity: 1, imageURL: 'https://example.com/image.jpg?q=1&p=2' },
+    {
+      id: '3',
+      name: 'Item 2',
+      price: 10,
+      quantity: 2,
+      imageURL: 'https://example.com/image.jpg?q=1&p=2',
+      accessories: [
+        { id: '33', name: 'Item 2', price: 10, quantity: 2, imageURL: 'https://example.com/image.jpg?q=1&p=2' },
+      ],
+    },
+    {
+      id: '4',
+      name: 'Item 2',
+      price: 10,
+      quantity: 2,
+      accessories: [
+        { id: '44', name: 'Item 2', price: 10, quantity: 2, imageURL: 'https://example.com/image.jpg?q=1&p=2' },
+      ],
+    },
+  ];
+  it('should serialize cart items', () => {
+    expect(serializeCartItems(cartItems)).toEqual(cartItemsData);
+  });
+
+  it('should deserialize cart items', () => {
+    expect(deserializeCartItems(cartItemsData)).toEqual(cartItems);
+  });
+
+  it('should deserialize cart', () => {
+    const cart: marketplace.Cart = {
+      id: '90080f28-53e9-400f-811a-fcadd107891a',
+      version: {
+        majorVersion: 1,
+        minorVersion: 0,
+      },
+      cartInfo: {
+        market: 'US',
+        intent: marketplace.Intent.TeamsAdminUser,
+        locale: 'en-US',
+        status: marketplace.CartStatus.Open,
+        currency: 'USD',
+        createdAt: '2023-06-19T22:06:59Z',
+        updatedAt: '2023-06-19T22:06:59Z',
+      },
+      cartItems: cartItems,
+    };
+    const cartData = {
+      id: '90080f28-53e9-400f-811a-fcadd107891a',
+      version: {
+        majorVersion: 1,
+        minorVersion: 0,
+      },
+      cartInfo: {
+        market: 'US',
+        intent: marketplace.Intent.TeamsAdminUser,
+        locale: 'en-US',
+        status: marketplace.CartStatus.Open,
+        currency: 'USD',
+        createdAt: '2023-06-19T22:06:59Z',
+        updatedAt: '2023-06-19T22:06:59Z',
+      },
+      cartItems: cartItemsData,
+    };
+    expect(deserializeCart(cartData)).toEqual(cart);
+  });
+  it('should throw deserialize cart error', () => {
+    const cartData = {
+      cartItems: { id: '2', name: 'Item 1', price: 10, quantity: 1, imageURL: 'abc' },
+    };
+    expect(() => deserializeCart(cartData)).toThrowError(new Error('Error deserializing cart'));
   });
 });

--- a/packages/teams-js/test/internal/marketplaceUtils.spec.ts
+++ b/packages/teams-js/test/internal/marketplaceUtils.spec.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @microsoft/sdl/no-insecure-url */
+import { v4 as uuid } from 'uuid';
+
+import {
+  validateAccessoryItems,
+  validateBasicCartItem,
+  validateCartItems,
+  validateCartStatus,
+  validatePrice,
+  validateQuantity,
+  validateUrl,
+  validateUuid,
+} from '../../src/internal/marketplaceUtils';
+import { marketplace } from '../../src/public';
+
+describe.only('Testing marketplace utils', () => {
+  it('should validate cart items in parameters', () => {
+    const cartItems = [
+      { id: '1', name: 'Item 1', price: 10, quantity: 1 },
+      { id: '2', name: 'Item 2', price: 10, quantity: 2 },
+    ];
+    expect(() => validateCartItems(cartItems)).not.toThrowError();
+  });
+  it('should validate price of cart items', () => {
+    expect(() => validatePrice(12.34)).not.toThrowError();
+    expect(() => validatePrice(12.346)).not.toThrowError();
+    expect(() => validatePrice(0)).not.toThrowError();
+    expect(() => validatePrice(-12.34)).toThrowError('price -12.34 must be a number not less than 0');
+    expect(() => validatePrice(12.3456)).toThrowError('price 12.3456 must have at most 3 decimal places');
+  });
+  it('should validate quantity of cart items', () => {
+    expect(() => validateQuantity(0)).toThrowError('quantity 0 must be an integer greater than 0');
+    expect(() => validateQuantity(3.2)).toThrowError('quantity 3.2 must be an integer greater than 0');
+    expect(() => validateQuantity(-2)).toThrowError('quantity -2 must be an integer greater than 0');
+    expect(() => validateQuantity(3)).not.toThrowError();
+  });
+  it('should validate id of the cart', () => {
+    expect(() => validateUuid(uuid())).not.toThrowError();
+    expect(() => validateUuid('')).toThrowError('id must not be empty');
+    expect(() => validateUuid('123')).toThrowError('id must be a valid UUID');
+  });
+  it('should validate the accessories of a cart item', () => {
+    const accessories = [
+      { id: '1', name: 'Item 1', price: 10, quantity: 1 },
+      { id: '2', name: 'Item 2', price: 10, quantity: 2 },
+    ];
+    const nestedAccessories = [{ id: '2', name: 'Item 2', price: 10, quantity: 2, accessories: [] }];
+    expect(() => validateAccessoryItems(accessories)).not.toThrowError();
+    expect(() => validateAccessoryItems(null)).not.toThrowError();
+    expect(() => validateAccessoryItems([])).toThrowError('CartItem.accessories must be a non-empty array');
+    expect(() => validateAccessoryItems(nestedAccessories)).toThrowError(
+      'Item in CartItem.accessories cannot have accessories',
+    );
+  });
+  it('should validate basic cart item', () => {
+    const basicCartItem = { id: '1', name: 'Item 1', price: 10, quantity: 1 };
+    const nestedAccessories = { id: '2', name: '', price: 10, quantity: 2, accessories: [] };
+    expect(() => validateBasicCartItem(basicCartItem)).not.toThrowError();
+    expect(() => validateBasicCartItem(nestedAccessories)).toThrowError('cartItem.name must not be empty');
+  });
+  it('should validate url', () => {
+    expect(() => validateUrl(null)).not.toThrowError();
+    expect(() => validateUrl('http://www.microsoft.com/image.jpg')).not.toThrowError();
+    expect(() => validateUrl('https://abc12345')).not.toThrowError();
+    expect(() => validateUrl('url')).toThrowError('url url is not valid');
+    expect(() => validateUrl('')).toThrowError('url  is not valid');
+  });
+  it('should validate cartStatus', () => {
+    expect(() => validateCartStatus(marketplace.CartStatus.Open)).not.toThrowError();
+    expect(() => validateCartStatus('InvalidStatus' as marketplace.CartStatus)).toThrowError(
+      'cartStatus InvalidStatus is not valid',
+    );
+  });
+});

--- a/packages/teams-js/test/internal/marketplaceUtils.spec.ts
+++ b/packages/teams-js/test/internal/marketplaceUtils.spec.ts
@@ -55,8 +55,10 @@ describe.only('Testing marketplace utils', () => {
   it('should validate basic cart item', () => {
     const basicCartItem = { id: '1', name: 'Item 1', price: 10, quantity: 1 };
     const nestedAccessories = { id: '2', name: '', price: 10, quantity: 2, accessories: [] };
+    const emptyIdItem = { id: '', name: 'Item 1', price: 10, quantity: 1 };
     expect(() => validateBasicCartItem(basicCartItem)).not.toThrowError();
     expect(() => validateBasicCartItem(nestedAccessories)).toThrowError('cartItem.name must not be empty');
+    expect(() => validateBasicCartItem(emptyIdItem)).toThrowError('cartItem.id must not be empty');
   });
   it('should validate url', () => {
     expect(() => validateUrl(null)).not.toThrowError();

--- a/packages/teams-js/test/public/marketplace.spec.ts
+++ b/packages/teams-js/test/public/marketplace.spec.ts
@@ -123,6 +123,14 @@ describe('Testing marketplace capability', () => {
               );
             });
 
+            it('marketplace.addOrUpdateCartItems should throw error with invalid addOrUpdateCartItemsParams input', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+              expect(
+                marketplace.addOrUpdateCartItems(null as unknown as marketplace.AddOrUpdateCartItemsParams),
+              ).rejects.toThrowError(new Error('addOrUpdateCartItemsParams must be provided'));
+            });
+
             it('marketplace.addOrUpdateCartItems should successfully send the addOrUpdateCartItems message', async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
@@ -172,6 +180,14 @@ describe('Testing marketplace capability', () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
               expect(marketplace.removeCartItems(removeCartItemsParams)).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it('marketplace.removeCartItems should throw error with invalid removeCartItemsParams input', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+              expect(
+                marketplace.removeCartItems(null as unknown as marketplace.RemoveCartItemsParams),
+              ).rejects.toThrowError(new Error('removeCartItemsParams must be provided'));
             });
 
             it('marketplace.removeCartItems should throw error with invalid cart item array input', async () => {
@@ -237,6 +253,14 @@ describe('Testing marketplace capability', () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
               expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it('marketplace.updateCartStatus should throw error with invalid updateCartStatusParams input', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+              expect(
+                marketplace.updateCartStatus(null as unknown as marketplace.UpdateCartStatusParams),
+              ).rejects.toThrowError(new Error('updateCartStatusParams must be provided'));
             });
 
             it('marketplace.updateCartStatus should successfully send the updateCartStatus message', async () => {
@@ -392,6 +416,14 @@ describe('Testing marketplace capability', () => {
               );
             });
 
+            it('marketplace.addOrUpdateCartItems should throw error with invalid addOrUpdateCartItemsParams input', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+              expect(
+                marketplace.addOrUpdateCartItems(null as unknown as marketplace.AddOrUpdateCartItemsParams),
+              ).rejects.toThrowError(new Error('addOrUpdateCartItemsParams must be provided'));
+            });
+
             it('marketplace.addOrUpdateCartItems should successfully send the addOrUpdateCartItems message', async () => {
               const cart: marketplace.Cart = {
                 id: uuid(),
@@ -458,6 +490,14 @@ describe('Testing marketplace capability', () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
               expect(marketplace.removeCartItems(removeCartItemsParams)).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it('marketplace.removeCartItems should throw error with invalid removeCartItemsParams input', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+              expect(
+                marketplace.removeCartItems(null as unknown as marketplace.RemoveCartItemsParams),
+              ).rejects.toThrowError(new Error('removeCartItemsParams must be provided'));
             });
 
             it('marketplace.removeCartItems should throw error with empty cart item array input', async () => {
@@ -540,6 +580,14 @@ describe('Testing marketplace capability', () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
               expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it('marketplace.updateCartStatus should throw error with invalid updateCartStatusParams input', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+              expect(
+                marketplace.updateCartStatus(null as unknown as marketplace.UpdateCartStatusParams),
+              ).rejects.toThrowError(new Error('updateCartStatusParams must be provided'));
             });
 
             it('marketplace.updateCartStatus should successfully send the updateCartStatus message', async () => {

--- a/packages/teams-js/test/public/marketplace.spec.ts
+++ b/packages/teams-js/test/public/marketplace.spec.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { v4 as uuid } from 'uuid';
-
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
@@ -10,6 +8,30 @@ import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/con
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { MatcherType, validateExpectedArgumentsInRequest } from '../resultValidation';
 import { Utils } from '../utils';
+
+jest.mock('../../src/internal/marketplaceUtils', () => ({
+  validateCartItems: jest.fn(),
+  validateUuid: jest.fn(),
+  validateCartStatus: jest.fn(),
+  deserializeCart: jest.fn().mockReturnValue({
+    id: '90080f28-53e9-400f-811a-fcadd107891a',
+    version: {
+      majorVersion: 1,
+      minorVersion: 0,
+    },
+    cartInfo: {
+      market: 'US',
+      intent: 'TeamsAdminUser',
+      locale: 'en-US',
+      status: 'Open',
+      currency: 'USD',
+      createdAt: '2023-06-19T22:06:59Z',
+      updatedAt: '2023-06-19T22:06:59Z',
+    },
+    cartItems: [],
+  }),
+  serializeCartItems: jest.fn().mockReturnValue([{ id: '1', name: 'Item 1', price: 10, quantity: 1 }]),
+}));
 
 /* As part of enabling eslint on test files, we need to disable eslint checking on the specific files with
    large numbers of errors. Then, over time, we can fix the errors and reenable eslint on a per file basis. */
@@ -23,11 +45,6 @@ describe('Testing marketplace capability', () => {
       utils.messages = [];
       utils.childMessages = [];
       utils.childWindow.closed = false;
-      jest.mock('../../src/internal/marketplaceUtils', () => ({
-        validateCartItems: jest.fn(),
-        validateUuid: jest.fn(),
-        validateCartStatus: jest.fn(),
-      }));
 
       // Set a mock window for testing
       app._initialize(utils.mockWindow);
@@ -106,7 +123,7 @@ describe('Testing marketplace capability', () => {
       describe('Testing marketplace.addOrUpdateCartItems function', () => {
         const addOrUpdateCartItemsParams = {
           cartItems: [{ id: '1', name: 'Item 1', price: 10, quantity: 1 }],
-          cartId: uuid(),
+          cartId: '90080f28-53e9-400f-811a-fcadd107891a',
         };
 
         it('marketplace.addOrUpdateCartItems should not allow calls before initialization', async () => {
@@ -170,7 +187,7 @@ describe('Testing marketplace capability', () => {
       describe('Testing marketplace.removeCartItems function', () => {
         const removeCartItemsParams = {
           cartItemIds: ['1'],
-          cartId: uuid(),
+          cartId: '90080f28-53e9-400f-811a-fcadd107891a',
         };
 
         it('marketplace.removeCartItems should not allow calls before initialization', async () => {
@@ -200,11 +217,11 @@ describe('Testing marketplace capability', () => {
             it('marketplace.removeCartItems should throw error with invalid cart item array input', async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
-              const emptyCartItemIds = { cartItemIds: [], cartId: uuid() };
+              const emptyCartItemIds = { cartItemIds: [], cartId: '90080f28-53e9-400f-811a-fcadd107891a' };
               expect(() => marketplace.removeCartItems(emptyCartItemIds)).toThrowError(
                 new Error('cartItemIds must be a non-empty array'),
               );
-              const nullRemoveCartItemIds = { cartItemIds: null, cartId: uuid() };
+              const nullRemoveCartItemIds = { cartItemIds: null, cartId: '90080f28-53e9-400f-811a-fcadd107891a' };
               expect(() =>
                 marketplace.removeCartItems(nullRemoveCartItemIds as unknown as marketplace.RemoveCartItemsParams),
               ).toThrowError(new Error('cartItemIds must be a non-empty array'));
@@ -246,7 +263,7 @@ describe('Testing marketplace capability', () => {
 
       describe('Testing marketplace.updateCartStatus function', () => {
         const cartStatusParams = {
-          cartId: uuid(),
+          cartId: '90080f28-53e9-400f-811a-fcadd107891a',
           cartStatus: marketplace.CartStatus.Error,
           statusInfo: 'error message',
         };
@@ -318,11 +335,6 @@ describe('Testing marketplace capability', () => {
       utils.mockWindow.parent = undefined;
       utils.messages = [];
       GlobalVars.isFramelessWindow = false;
-      jest.mock('../../src/internal/marketplaceUtils', () => ({
-        validateCartItems: jest.fn(),
-        validateUuid: jest.fn(),
-        validateCartStatus: jest.fn(),
-      }));
     });
     afterEach(() => {
       app._uninitialize();
@@ -365,14 +377,14 @@ describe('Testing marketplace capability', () => {
 
             it('marketplace.getCart should successfully send the getCart message', async () => {
               const cart: marketplace.Cart = {
-                id: uuid(),
+                id: '90080f28-53e9-400f-811a-fcadd107891a',
                 version: {
                   majorVersion: 1,
                   minorVersion: 0,
                 },
                 cartInfo: {
                   market: 'US',
-                  intent: marketplace.Intent.AdminUser,
+                  intent: marketplace.Intent.TeamsAdminUser,
                   locale: 'en-US',
                   status: marketplace.CartStatus.Open,
                   currency: 'USD',
@@ -395,7 +407,7 @@ describe('Testing marketplace capability', () => {
               } as DOMMessageEvent);
 
               await promise;
-              await expect(promise).resolves.toBe(cart);
+              await expect(promise).resolves.toEqual(cart);
             });
           } else {
             it(`marketplace.getCart should not allow calls from ${context} context`, async () => {
@@ -414,7 +426,7 @@ describe('Testing marketplace capability', () => {
       describe('Testing marketplace.addOrUpdateCartItems function', () => {
         const addOrUpdateCartItemsParams = {
           cartItems: [{ id: '1', name: 'Item 1', price: 10, quantity: 1 }],
-          cartId: uuid(),
+          cartId: '90080f28-53e9-400f-811a-fcadd107891a',
         };
 
         it('marketplace.addOrUpdateCartItems should not allow calls before initialization', async () => {
@@ -443,14 +455,14 @@ describe('Testing marketplace capability', () => {
 
             it('marketplace.addOrUpdateCartItems should successfully send the addOrUpdateCartItems message', async () => {
               const cart: marketplace.Cart = {
-                id: uuid(),
+                id: '90080f28-53e9-400f-811a-fcadd107891a',
                 version: {
                   majorVersion: 1,
                   minorVersion: 0,
                 },
                 cartInfo: {
                   market: 'US',
-                  intent: marketplace.Intent.AdminUser,
+                  intent: marketplace.Intent.TeamsAdminUser,
                   locale: 'en-US',
                   status: marketplace.CartStatus.Open,
                   currency: 'USD',
@@ -473,7 +485,7 @@ describe('Testing marketplace capability', () => {
               } as DOMMessageEvent);
 
               await promise;
-              await expect(promise).resolves.toBe(cart);
+              await expect(promise).resolves.toEqual(cart);
             });
           } else {
             it(`marketplace.addOrUpdateCartItems should not allow calls from ${context} context`, async () => {
@@ -492,7 +504,7 @@ describe('Testing marketplace capability', () => {
       describe('Testing marketplace.removeCartItems function', () => {
         const removeCartItemsParams = {
           cartItemIds: ['1'],
-          cartId: uuid(),
+          cartId: '90080f28-53e9-400f-811a-fcadd107891a',
         };
 
         it('marketplace.removeCartItems should not allow calls before initialization', async () => {
@@ -522,11 +534,11 @@ describe('Testing marketplace capability', () => {
             it('marketplace.removeCartItems should throw error with empty cart item array input', async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
-              const emptyRemoveCartItemIds = { cartItemIds: [], cartId: uuid() };
+              const emptyRemoveCartItemIds = { cartItemIds: [], cartId: '90080f28-53e9-400f-811a-fcadd107891a' };
               expect(() => marketplace.removeCartItems(emptyRemoveCartItemIds)).toThrowError(
                 new Error('cartItemIds must be a non-empty array'),
               );
-              const nullRemoveCartItemIds = { cartItemIds: null, cartId: uuid() };
+              const nullRemoveCartItemIds = { cartItemIds: null, cartId: '90080f28-53e9-400f-811a-fcadd107891a' };
               expect(() =>
                 marketplace.removeCartItems(nullRemoveCartItemIds as unknown as marketplace.RemoveCartItemsParams),
               ).toThrowError(new Error('cartItemIds must be a non-empty array'));
@@ -534,14 +546,14 @@ describe('Testing marketplace capability', () => {
 
             it('marketplace.removeCartItems should successfully send the removeCartItems message', async () => {
               const cart: marketplace.Cart = {
-                id: uuid(),
+                id: '90080f28-53e9-400f-811a-fcadd107891a',
                 version: {
                   majorVersion: 1,
                   minorVersion: 0,
                 },
                 cartInfo: {
                   market: 'US',
-                  intent: marketplace.Intent.AdminUser,
+                  intent: marketplace.Intent.TeamsAdminUser,
                   locale: 'en-US',
                   status: marketplace.CartStatus.Open,
                   currency: 'USD',
@@ -564,7 +576,7 @@ describe('Testing marketplace capability', () => {
               } as DOMMessageEvent);
 
               await promise;
-              await expect(promise).resolves.toBe(cart);
+              await expect(promise).resolves.toEqual(cart);
             });
           } else {
             it(`marketplace.removeCartItems should not allow calls from ${context} context`, async () => {
@@ -582,7 +594,7 @@ describe('Testing marketplace capability', () => {
 
       describe('Testing marketplace.updateCartStatus function', () => {
         const cartStatusParams = {
-          cartId: uuid(),
+          cartId: '90080f28-53e9-400f-811a-fcadd107891a',
           cartStatus: marketplace.CartStatus.Error,
           statusInfo: 'error message',
         };
@@ -613,14 +625,14 @@ describe('Testing marketplace capability', () => {
 
             it('marketplace.updateCartStatus should successfully send the updateCartStatus message', async () => {
               const cart: marketplace.Cart = {
-                id: uuid(),
+                id: '90080f28-53e9-400f-811a-fcadd107891a',
                 version: {
                   majorVersion: 1,
                   minorVersion: 0,
                 },
                 cartInfo: {
                   market: 'US',
-                  intent: marketplace.Intent.AdminUser,
+                  intent: marketplace.Intent.TeamsAdminUser,
                   locale: 'en-US',
                   status: marketplace.CartStatus.Open,
                   currency: 'USD',
@@ -644,7 +656,7 @@ describe('Testing marketplace capability', () => {
               } as DOMMessageEvent);
 
               await promise;
-              await expect(promise).resolves.toBe(cart);
+              await expect(promise).resolves.toEqual(cart);
             });
           } else {
             it(`marketplace.updateCartStatus should not allow calls from ${context} context`, async () => {

--- a/packages/teams-js/test/public/marketplace.spec.ts
+++ b/packages/teams-js/test/public/marketplace.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { v4 as uuid } from 'uuid';
 
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
@@ -10,7 +11,6 @@ import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { MatcherType, validateExpectedArgumentsInRequest } from '../resultValidation';
 import { Utils } from '../utils';
 
-/* eslint-disable */
 /* As part of enabling eslint on test files, we need to disable eslint checking on the specific files with
    large numbers of errors. Then, over time, we can fix the errors and reenable eslint on a per file basis. */
 describe('Testing marketplace capability', () => {
@@ -64,7 +64,7 @@ describe('Testing marketplace capability', () => {
 
       describe('Testing marketplace.getCart function', () => {
         it('marketplace.getCart should not allow calls before initialization', async () => {
-          await expect(marketplace.getCart()).rejects.toThrowError(new Error(errorLibraryNotInitialized));
+          await expect(() => marketplace.getCart()).toThrowError(errorLibraryNotInitialized);
         });
 
         Object.values(FrameContexts).forEach((context) => {
@@ -72,7 +72,9 @@ describe('Testing marketplace capability', () => {
             it(`marketplace.getCart should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
-              expect(marketplace.getCart()).rejects.toEqual(errorNotSupportedOnPlatform);
+              expect(new Promise((resolve) => resolve(marketplace.getCart()))).rejects.toEqual(
+                errorNotSupportedOnPlatform,
+              );
             });
 
             it('marketplace.getCart should successfully send the getCart message', async () => {
@@ -90,7 +92,7 @@ describe('Testing marketplace capability', () => {
           } else {
             it(`marketplace.getCart should not allow calls from ${context} context`, async () => {
               await utils.initializeWithContext(context);
-              await expect(marketplace.getCart()).rejects.toThrowError(
+              await expect(() => marketplace.getCart()).toThrowError(
                 `This call is only allowed in following contexts: ${JSON.stringify([
                   FrameContexts.content,
                   FrameContexts.task,
@@ -108,7 +110,7 @@ describe('Testing marketplace capability', () => {
         };
 
         it('marketplace.addOrUpdateCartItems should not allow calls before initialization', async () => {
-          await expect(marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams)).rejects.toThrowError(
+          await expect(() => marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams)).toThrowError(
             new Error(errorLibraryNotInitialized),
           );
         });
@@ -118,17 +120,17 @@ describe('Testing marketplace capability', () => {
             it(`marketplace.addOrUpdateCartItems should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
-              expect(marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams)).rejects.toEqual(
-                errorNotSupportedOnPlatform,
-              );
+              expect(
+                new Promise((resolve) => resolve(marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams))),
+              ).rejects.toEqual(errorNotSupportedOnPlatform);
             });
 
             it('marketplace.addOrUpdateCartItems should throw error with invalid addOrUpdateCartItemsParams input', async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
-              expect(
+              expect(() =>
                 marketplace.addOrUpdateCartItems(null as unknown as marketplace.AddOrUpdateCartItemsParams),
-              ).rejects.toThrowError(new Error('addOrUpdateCartItemsParams must be provided'));
+              ).toThrowError(new Error('addOrUpdateCartItemsParams must be provided'));
             });
 
             it('marketplace.addOrUpdateCartItems should successfully send the addOrUpdateCartItems message', async () => {
@@ -142,7 +144,10 @@ describe('Testing marketplace capability', () => {
                 addOrUpdateCartItemsMessage,
                 'marketplace.addOrUpdateCartItems',
                 MatcherType.ToStrictEqual,
-                addOrUpdateCartItemsParams,
+                {
+                  ...addOrUpdateCartItemsParams,
+                  cartVersion: marketplace.cartVersion,
+                },
               );
 
               utils.respondToMessage(addOrUpdateCartItemsMessage!);
@@ -151,7 +156,7 @@ describe('Testing marketplace capability', () => {
           } else {
             it(`marketplace.addOrUpdateCartItems should not allow calls from ${context} context`, async () => {
               await utils.initializeWithContext(context);
-              await expect(marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams)).rejects.toThrowError(
+              await expect(() => marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams)).toThrowError(
                 `This call is only allowed in following contexts: ${JSON.stringify([
                   FrameContexts.content,
                   FrameContexts.task,
@@ -169,7 +174,7 @@ describe('Testing marketplace capability', () => {
         };
 
         it('marketplace.removeCartItems should not allow calls before initialization', async () => {
-          await expect(marketplace.removeCartItems(removeCartItemsParams)).rejects.toThrowError(
+          await expect(() => marketplace.removeCartItems(removeCartItemsParams)).toThrowError(
             new Error(errorLibraryNotInitialized),
           );
         });
@@ -179,28 +184,30 @@ describe('Testing marketplace capability', () => {
             it(`marketplace.removeCartItems should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
-              expect(marketplace.removeCartItems(removeCartItemsParams)).rejects.toEqual(errorNotSupportedOnPlatform);
+              expect(
+                new Promise((resolve) => resolve(marketplace.removeCartItems(removeCartItemsParams))),
+              ).rejects.toEqual(errorNotSupportedOnPlatform);
             });
 
             it('marketplace.removeCartItems should throw error with invalid removeCartItemsParams input', async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
-              expect(
+              expect(() =>
                 marketplace.removeCartItems(null as unknown as marketplace.RemoveCartItemsParams),
-              ).rejects.toThrowError(new Error('removeCartItemsParams must be provided'));
+              ).toThrowError(new Error('removeCartItemsParams must be provided'));
             });
 
             it('marketplace.removeCartItems should throw error with invalid cart item array input', async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
               const emptyCartItemIds = { cartItemIds: [], cartId: uuid() };
-              expect(marketplace.removeCartItems(emptyCartItemIds)).rejects.toThrowError(
+              expect(() => marketplace.removeCartItems(emptyCartItemIds)).toThrowError(
                 new Error('cartItemIds must be a non-empty array'),
               );
               const nullRemoveCartItemIds = { cartItemIds: null, cartId: uuid() };
-              expect(
+              expect(() =>
                 marketplace.removeCartItems(nullRemoveCartItemIds as unknown as marketplace.RemoveCartItemsParams),
-              ).rejects.toThrowError(new Error('cartItemIds must be a non-empty array'));
+              ).toThrowError(new Error('cartItemIds must be a non-empty array'));
             });
 
             it('marketplace.removeCartItems should successfully send the removeCartItems message', async () => {
@@ -214,7 +221,10 @@ describe('Testing marketplace capability', () => {
                 removeCartItemsMessage,
                 'marketplace.removeCartItems',
                 MatcherType.ToStrictEqual,
-                removeCartItemsParams,
+                {
+                  ...removeCartItemsParams,
+                  cartVersion: marketplace.cartVersion,
+                },
               );
 
               utils.respondToMessage(removeCartItemsMessage!);
@@ -223,7 +233,7 @@ describe('Testing marketplace capability', () => {
           } else {
             it(`marketplace.removeCartItems should not allow calls from ${context} context`, async () => {
               await utils.initializeWithContext(context);
-              await expect(marketplace.removeCartItems(removeCartItemsParams)).rejects.toThrowError(
+              await expect(() => marketplace.removeCartItems(removeCartItemsParams)).toThrowError(
                 `This call is only allowed in following contexts: ${JSON.stringify([
                   FrameContexts.content,
                   FrameContexts.task,
@@ -242,7 +252,7 @@ describe('Testing marketplace capability', () => {
         };
 
         it('marketplace.updateCartStatus should not allow calls before initialization', async () => {
-          await expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toThrowError(
+          await expect(() => marketplace.updateCartStatus(cartStatusParams)).toThrowError(
             new Error(errorLibraryNotInitialized),
           );
         });
@@ -252,15 +262,17 @@ describe('Testing marketplace capability', () => {
             it(`marketplace.updateCartStatus should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
-              expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toEqual(errorNotSupportedOnPlatform);
+              expect(new Promise((resolve) => resolve(marketplace.updateCartStatus(cartStatusParams)))).rejects.toEqual(
+                errorNotSupportedOnPlatform,
+              );
             });
 
             it('marketplace.updateCartStatus should throw error with invalid updateCartStatusParams input', async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
-              expect(
+              expect(() =>
                 marketplace.updateCartStatus(null as unknown as marketplace.UpdateCartStatusParams),
-              ).rejects.toThrowError(new Error('updateCartStatusParams must be provided'));
+              ).toThrowError(new Error('updateCartStatusParams must be provided'));
             });
 
             it('marketplace.updateCartStatus should successfully send the updateCartStatus message', async () => {
@@ -274,7 +286,10 @@ describe('Testing marketplace capability', () => {
                 updateCartStatusMessage,
                 'marketplace.updateCartStatus',
                 MatcherType.ToStrictEqual,
-                cartStatusParams,
+                {
+                  ...cartStatusParams,
+                  cartVersion: marketplace.cartVersion,
+                },
               );
 
               utils.respondToMessage(updateCartStatusMessage!);
@@ -283,7 +298,7 @@ describe('Testing marketplace capability', () => {
           } else {
             it(`marketplace.updateCartStatus should not allow calls from ${context} context`, async () => {
               await utils.initializeWithContext(context);
-              await expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toThrowError(
+              await expect(() => marketplace.updateCartStatus(cartStatusParams)).toThrowError(
                 `This call is only allowed in following contexts: ${JSON.stringify([
                   FrameContexts.content,
                   FrameContexts.task,
@@ -335,7 +350,7 @@ describe('Testing marketplace capability', () => {
 
       describe('Testing marketplace.getCart function', () => {
         it('marketplace.getCart should not allow calls before initialization', async () => {
-          await expect(marketplace.getCart()).rejects.toThrowError(new Error(errorLibraryNotInitialized));
+          await expect(() => marketplace.getCart()).toThrowError(new Error(errorLibraryNotInitialized));
         });
 
         Object.values(FrameContexts).forEach((context) => {
@@ -343,7 +358,9 @@ describe('Testing marketplace capability', () => {
             it(`marketplace.getCart should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
-              expect(marketplace.getCart()).rejects.toEqual(errorNotSupportedOnPlatform);
+              expect(new Promise((resolve) => resolve(marketplace.getCart()))).rejects.toEqual(
+                errorNotSupportedOnPlatform,
+              );
             });
 
             it('marketplace.getCart should successfully send the getCart message', async () => {
@@ -383,7 +400,7 @@ describe('Testing marketplace capability', () => {
           } else {
             it(`marketplace.getCart should not allow calls from ${context} context`, async () => {
               await utils.initializeWithContext(context);
-              await expect(marketplace.getCart()).rejects.toThrowError(
+              await expect(() => marketplace.getCart()).toThrowError(
                 `This call is only allowed in following contexts: ${JSON.stringify([
                   FrameContexts.content,
                   FrameContexts.task,
@@ -401,7 +418,7 @@ describe('Testing marketplace capability', () => {
         };
 
         it('marketplace.addOrUpdateCartItems should not allow calls before initialization', async () => {
-          await expect(marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams)).rejects.toThrowError(
+          await expect(() => marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams)).toThrowError(
             new Error(errorLibraryNotInitialized),
           );
         });
@@ -411,17 +428,17 @@ describe('Testing marketplace capability', () => {
             it(`marketplace.addOrUpdateCartItems should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
-              expect(marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams)).rejects.toEqual(
-                errorNotSupportedOnPlatform,
-              );
+              expect(
+                new Promise((resolve) => resolve(marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams))),
+              ).rejects.toEqual(errorNotSupportedOnPlatform);
             });
 
             it('marketplace.addOrUpdateCartItems should throw error with invalid addOrUpdateCartItemsParams input', async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
-              expect(
+              expect(() =>
                 marketplace.addOrUpdateCartItems(null as unknown as marketplace.AddOrUpdateCartItemsParams),
-              ).rejects.toThrowError(new Error('addOrUpdateCartItemsParams must be provided'));
+              ).toThrowError(new Error('addOrUpdateCartItemsParams must be provided'));
             });
 
             it('marketplace.addOrUpdateCartItems should successfully send the addOrUpdateCartItems message', async () => {
@@ -461,7 +478,7 @@ describe('Testing marketplace capability', () => {
           } else {
             it(`marketplace.addOrUpdateCartItems should not allow calls from ${context} context`, async () => {
               await utils.initializeWithContext(context);
-              await expect(marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams)).rejects.toThrowError(
+              await expect(() => marketplace.addOrUpdateCartItems(addOrUpdateCartItemsParams)).toThrowError(
                 `This call is only allowed in following contexts: ${JSON.stringify([
                   FrameContexts.content,
                   FrameContexts.task,
@@ -479,7 +496,7 @@ describe('Testing marketplace capability', () => {
         };
 
         it('marketplace.removeCartItems should not allow calls before initialization', async () => {
-          await expect(marketplace.removeCartItems(removeCartItemsParams)).rejects.toThrowError(
+          await expect(() => marketplace.removeCartItems(removeCartItemsParams)).toThrowError(
             new Error(errorLibraryNotInitialized),
           );
         });
@@ -489,28 +506,30 @@ describe('Testing marketplace capability', () => {
             it(`marketplace.removeCartItems should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
-              expect(marketplace.removeCartItems(removeCartItemsParams)).rejects.toEqual(errorNotSupportedOnPlatform);
+              expect(
+                new Promise((resolve) => resolve(marketplace.removeCartItems(removeCartItemsParams))),
+              ).rejects.toEqual(errorNotSupportedOnPlatform);
             });
 
             it('marketplace.removeCartItems should throw error with invalid removeCartItemsParams input', async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
-              expect(
+              expect(() =>
                 marketplace.removeCartItems(null as unknown as marketplace.RemoveCartItemsParams),
-              ).rejects.toThrowError(new Error('removeCartItemsParams must be provided'));
+              ).toThrowError(new Error('removeCartItemsParams must be provided'));
             });
 
             it('marketplace.removeCartItems should throw error with empty cart item array input', async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
               const emptyRemoveCartItemIds = { cartItemIds: [], cartId: uuid() };
-              expect(marketplace.removeCartItems(emptyRemoveCartItemIds)).rejects.toThrowError(
+              expect(() => marketplace.removeCartItems(emptyRemoveCartItemIds)).toThrowError(
                 new Error('cartItemIds must be a non-empty array'),
               );
               const nullRemoveCartItemIds = { cartItemIds: null, cartId: uuid() };
-              expect(
+              expect(() =>
                 marketplace.removeCartItems(nullRemoveCartItemIds as unknown as marketplace.RemoveCartItemsParams),
-              ).rejects.toThrowError(new Error('cartItemIds must be a non-empty array'));
+              ).toThrowError(new Error('cartItemIds must be a non-empty array'));
             });
 
             it('marketplace.removeCartItems should successfully send the removeCartItems message', async () => {
@@ -550,7 +569,7 @@ describe('Testing marketplace capability', () => {
           } else {
             it(`marketplace.removeCartItems should not allow calls from ${context} context`, async () => {
               await utils.initializeWithContext(context);
-              await expect(marketplace.removeCartItems(removeCartItemsParams)).rejects.toThrowError(
+              await expect(() => marketplace.removeCartItems(removeCartItemsParams)).toThrowError(
                 `This call is only allowed in following contexts: ${JSON.stringify([
                   FrameContexts.content,
                   FrameContexts.task,
@@ -569,7 +588,7 @@ describe('Testing marketplace capability', () => {
         };
 
         it('marketplace.updateCartStatus should not allow calls before initialization', async () => {
-          await expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toThrowError(
+          await expect(() => marketplace.updateCartStatus(cartStatusParams)).toThrowError(
             new Error(errorLibraryNotInitialized),
           );
         });
@@ -579,15 +598,17 @@ describe('Testing marketplace capability', () => {
             it(`marketplace.updateCartStatus should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
-              expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toEqual(errorNotSupportedOnPlatform);
+              expect(new Promise((resolve) => resolve(marketplace.updateCartStatus(cartStatusParams)))).rejects.toEqual(
+                errorNotSupportedOnPlatform,
+              );
             });
 
             it('marketplace.updateCartStatus should throw error with invalid updateCartStatusParams input', async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
-              expect(
+              expect(() =>
                 marketplace.updateCartStatus(null as unknown as marketplace.UpdateCartStatusParams),
-              ).rejects.toThrowError(new Error('updateCartStatusParams must be provided'));
+              ).toThrowError(new Error('updateCartStatusParams must be provided'));
             });
 
             it('marketplace.updateCartStatus should successfully send the updateCartStatus message', async () => {
@@ -628,7 +649,7 @@ describe('Testing marketplace capability', () => {
           } else {
             it(`marketplace.updateCartStatus should not allow calls from ${context} context`, async () => {
               await utils.initializeWithContext(context);
-              await expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toThrowError(
+              await expect(() => marketplace.updateCartStatus(cartStatusParams)).toThrowError(
                 `This call is only allowed in following contexts: ${JSON.stringify([
                   FrameContexts.content,
                   FrameContexts.task,

--- a/packages/teams-js/test/public/marketplace.spec.ts
+++ b/packages/teams-js/test/public/marketplace.spec.ts
@@ -1,0 +1,422 @@
+import { errorLibraryNotInitialized } from '../../src/internal/constants';
+import { GlobalVars } from '../../src/internal/globalVars';
+import { DOMMessageEvent } from '../../src/internal/interfaces';
+import { CartStatus, marketplace } from '../../src/public';
+import { app } from '../../src/public/app';
+import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
+import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
+import { MatcherType, validateExpectedArgumentsInRequest } from '../resultValidation';
+import { Utils } from '../utils';
+
+/* eslint-disable */
+/* As part of enabling eslint on test files, we need to disable eslint checking on the specific files with
+   large numbers of errors. Then, over time, we can fix the errors and reenable eslint on a per file basis. */
+describe('Testing marketplace capability', () => {
+  describe('Framed - Testing pages module', () => {
+    // Use to send a mock message from the app.
+    const utils = new Utils();
+
+    beforeEach(() => {
+      utils.processMessage = null;
+      utils.messages = [];
+      utils.childMessages = [];
+      utils.childWindow.closed = false;
+
+      // Set a mock window for testing
+      app._initialize(utils.mockWindow);
+    });
+
+    afterEach(() => {
+      // Reset the object since it's a singleton
+      if (app._uninitialize) {
+        utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
+        app._uninitialize();
+      }
+    });
+
+    describe('Testing marketplace name space', () => {
+      describe('Testing marketplace.isSupported function', () => {
+        it('marketplace.isSupported should return false if the runtime says marketplace is not supported', async () => {
+          await utils.initializeWithContext(FrameContexts.content);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+          expect(marketplace.isSupported()).not.toBeTruthy();
+        });
+
+        it('marketplace.isSupported should return true if the runtime says marketplace is supported', async () => {
+          await utils.initializeWithContext(FrameContexts.content);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+          expect(marketplace.isSupported()).toBeTruthy();
+        });
+
+        it('should throw if called before initialization', () => {
+          utils.uninitializeRuntimeConfig();
+          expect(() => marketplace.isSupported()).toThrowError(new Error(errorLibraryNotInitialized));
+        });
+      });
+
+      describe('Testing marketplace.getCart function', () => {
+        it('marketplace.getCart should not allow calls before initialization', async () => {
+          await expect(marketplace.getCart()).rejects.toThrowError(new Error(errorLibraryNotInitialized));
+        });
+
+        Object.values(FrameContexts).forEach((context) => {
+          if (context === FrameContexts.content) {
+            it(`marketplace.getCart should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+              expect(marketplace.getCart()).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+          } else {
+            it(`marketplace.getCart should not allow calls from ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              await expect(marketplace.getCart()).rejects.toThrowError(
+                `This call is only allowed in following contexts: ${JSON.stringify([
+                  FrameContexts.content,
+                ])}. Current context: "${context}".`,
+              );
+            });
+          }
+        });
+      });
+
+      describe('Testing marketplace.addOrUpdateCartItems function', () => {
+        const cartItems = [{ id: '1', name: 'Item 1', price: 10, quantity: 1 }];
+
+        it('marketplace.addOrUpdateCartItems should not allow calls before initialization', async () => {
+          await expect(marketplace.addOrUpdateCartItems(cartItems)).rejects.toThrowError(
+            new Error(errorLibraryNotInitialized),
+          );
+        });
+
+        Object.values(FrameContexts).forEach((context) => {
+          if (context === FrameContexts.content) {
+            it(`marketplace.addOrUpdateCartItems should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+              expect(marketplace.addOrUpdateCartItems(cartItems)).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it('marketplace.addOrUpdateCartItems should successfully send the addOrUpdateCartItems message', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+
+              const promise = marketplace.addOrUpdateCartItems(cartItems);
+
+              const addOrUpdateCartItemsMessage = utils.findMessageByFunc('marketplace.addOrUpdateCartItems');
+              validateExpectedArgumentsInRequest(
+                addOrUpdateCartItemsMessage,
+                'marketplace.addOrUpdateCartItems',
+                MatcherType.ToStrictEqual,
+                cartItems,
+              );
+
+              utils.respondToMessage(addOrUpdateCartItemsMessage!);
+              await promise;
+            });
+          } else {
+            it(`marketplace.addOrUpdateCartItems should not allow calls from ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              await expect(marketplace.addOrUpdateCartItems(cartItems)).rejects.toThrowError(
+                `This call is only allowed in following contexts: ${JSON.stringify([
+                  FrameContexts.content,
+                ])}. Current context: "${context}".`,
+              );
+            });
+          }
+        });
+      });
+
+      describe('Testing marketplace.removeCartItems function', () => {
+        const cartItemIds = ['001', '002', '003'];
+
+        it('marketplace.removeCartItems should not allow calls before initialization', async () => {
+          await expect(marketplace.removeCartItems(cartItemIds)).rejects.toThrowError(
+            new Error(errorLibraryNotInitialized),
+          );
+        });
+
+        Object.values(FrameContexts).forEach((context) => {
+          if (context === FrameContexts.content) {
+            it(`marketplace.removeCartItems should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+              expect(marketplace.removeCartItems(cartItemIds)).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it('marketplace.removeCartItems should successfully send the removeCartItems message', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+
+              const promise = marketplace.removeCartItems(cartItemIds);
+
+              const removeCartItemsMessage = utils.findMessageByFunc('marketplace.removeCartItems');
+              validateExpectedArgumentsInRequest(
+                removeCartItemsMessage,
+                'marketplace.removeCartItems',
+                MatcherType.ToStrictEqual,
+                cartItemIds,
+              );
+
+              utils.respondToMessage(removeCartItemsMessage!);
+              await promise;
+            });
+          } else {
+            it(`marketplace.removeCartItems should not allow calls from ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              await expect(marketplace.removeCartItems(cartItemIds)).rejects.toThrowError(
+                `This call is only allowed in following contexts: ${JSON.stringify([
+                  FrameContexts.content,
+                ])}. Current context: "${context}".`,
+              );
+            });
+          }
+        });
+      });
+
+      describe('Testing marketplace.updateCartStatus function', () => {
+        const cartStatusParams = {
+          cartStatus: CartStatus.Processed,
+          message: 'success message',
+        };
+
+        it('marketplace.updateCartStatus should not allow calls before initialization', async () => {
+          await expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toThrowError(
+            new Error(errorLibraryNotInitialized),
+          );
+        });
+
+        Object.values(FrameContexts).forEach((context) => {
+          if (context === FrameContexts.content) {
+            it(`marketplace.updateCartStatus should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+              expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it('marketplace.updateCartStatus should successfully send the updateCartStatus message', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+
+              const promise = marketplace.updateCartStatus(cartStatusParams);
+
+              const updateCartStatusMessage = utils.findMessageByFunc('marketplace.updateCartStatus');
+              validateExpectedArgumentsInRequest(
+                updateCartStatusMessage,
+                'marketplace.updateCartStatus',
+                MatcherType.ToStrictEqual,
+                cartStatusParams,
+              );
+
+              utils.respondToMessage(updateCartStatusMessage!);
+              await promise;
+            });
+          } else {
+            it(`marketplace.updateCartStatus should not allow calls from ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              await expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toThrowError(
+                `This call is only allowed in following contexts: ${JSON.stringify([
+                  FrameContexts.content,
+                ])}. Current context: "${context}".`,
+              );
+            });
+          }
+        });
+      });
+    });
+  });
+
+  describe('Frameless - Testing pages module in frameless framework', () => {
+    let utils: Utils = new Utils();
+    beforeEach(() => {
+      utils = new Utils();
+      utils.mockWindow.parent = undefined;
+      utils.messages = [];
+      GlobalVars.isFramelessWindow = false;
+    });
+    afterEach(() => {
+      app._uninitialize();
+      jest.clearAllMocks();
+      GlobalVars.isFramelessWindow = false;
+    });
+    describe('Testing marketplace name space', () => {
+      describe('Testing marketplace.isSupported function', () => {
+        it('marketplace.isSupported should return false if the runtime says marketplace is not supported', async () => {
+          await utils.initializeWithContext(FrameContexts.content);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+          expect(marketplace.isSupported()).not.toBeTruthy();
+        });
+
+        it('marketplace.isSupported should return true if the runtime says marketplace is supported', async () => {
+          await utils.initializeWithContext(FrameContexts.content);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+          expect(marketplace.isSupported()).toBeTruthy();
+        });
+
+        it('should throw if called before initialization', () => {
+          expect(() => marketplace.isSupported()).toThrowError(new Error(errorLibraryNotInitialized));
+        });
+      });
+
+      describe('Testing marketplace.getCart function', () => {
+        it('marketplace.getCart should not allow calls before initialization', async () => {
+          await expect(marketplace.getCart()).rejects.toThrowError(new Error(errorLibraryNotInitialized));
+        });
+
+        Object.values(FrameContexts).forEach((context) => {
+          if (context === FrameContexts.content) {
+            it(`marketplace.getCart should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+              expect(marketplace.getCart()).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+          } else {
+            it(`marketplace.getCart should not allow calls from ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              await expect(marketplace.getCart()).rejects.toThrowError(
+                `This call is only allowed in following contexts: ${JSON.stringify([
+                  FrameContexts.content,
+                ])}. Current context: "${context}".`,
+              );
+            });
+          }
+        });
+      });
+
+      describe('Testing marketplace.addOrUpdateCartItems function', () => {
+        const cartItems = [{ id: '1', name: 'Item 1', price: 10, quantity: 1 }];
+
+        it('marketplace.addOrUpdateCartItems should not allow calls before initialization', async () => {
+          await expect(marketplace.addOrUpdateCartItems(cartItems)).rejects.toThrowError(
+            new Error(errorLibraryNotInitialized),
+          );
+        });
+
+        Object.values(FrameContexts).forEach((context) => {
+          if (context === FrameContexts.content) {
+            it(`marketplace.addOrUpdateCartItems should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+              expect(marketplace.addOrUpdateCartItems(cartItems)).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it('marketplace.addOrUpdateCartItems should successfully send the addOrUpdateCartItems message', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+              const promise = marketplace.addOrUpdateCartItems(cartItems);
+              const addOrUpdateCartItemsMessage = utils.findMessageByFunc('marketplace.addOrUpdateCartItems');
+              utils.respondToMessage(addOrUpdateCartItemsMessage!);
+              await promise;
+              await expect(promise).resolves.toBe(undefined);
+            });
+          } else {
+            it(`marketplace.addOrUpdateCartItems should not allow calls from ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              await expect(marketplace.addOrUpdateCartItems(cartItems)).rejects.toThrowError(
+                `This call is only allowed in following contexts: ${JSON.stringify([
+                  FrameContexts.content,
+                ])}. Current context: "${context}".`,
+              );
+            });
+          }
+        });
+      });
+
+      describe('Testing marketplace.removeCartItems function', () => {
+        const cartItemIds = ['001', '002', '003'];
+
+        it('marketplace.removeCartItems should not allow calls before initialization', async () => {
+          await expect(marketplace.removeCartItems(cartItemIds)).rejects.toThrowError(
+            new Error(errorLibraryNotInitialized),
+          );
+        });
+
+        Object.values(FrameContexts).forEach((context) => {
+          if (context === FrameContexts.content) {
+            it(`marketplace.removeCartItems should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+              expect(marketplace.removeCartItems(cartItemIds)).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it('marketplace.removeCartItems should successfully send the removeCartItems message', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+
+              const promise = marketplace.removeCartItems(cartItemIds);
+
+              const removeCartItemsMessage = utils.findMessageByFunc('marketplace.removeCartItems');
+              utils.respondToFramelessMessage({
+                data: {
+                  id: removeCartItemsMessage!.id,
+                  args: [],
+                },
+              } as DOMMessageEvent);
+
+              await promise;
+              await expect(promise).resolves.toBe(undefined);
+            });
+          } else {
+            it(`marketplace.removeCartItems should not allow calls from ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              await expect(marketplace.removeCartItems(cartItemIds)).rejects.toThrowError(
+                `This call is only allowed in following contexts: ${JSON.stringify([
+                  FrameContexts.content,
+                ])}. Current context: "${context}".`,
+              );
+            });
+          }
+        });
+      });
+
+      describe('Testing marketplace.updateCartStatus function', () => {
+        const cartStatusParams = {
+          cartStatus: CartStatus.Processed,
+          message: 'success message',
+        };
+
+        it('marketplace.updateCartStatus should not allow calls before initialization', async () => {
+          await expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toThrowError(
+            new Error(errorLibraryNotInitialized),
+          );
+        });
+
+        Object.values(FrameContexts).forEach((context) => {
+          if (context === FrameContexts.content) {
+            it(`marketplace.updateCartStatus should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+              expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it('marketplace.updateCartStatus should successfully send the updateCartStatus message', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+
+              const promise = marketplace.updateCartStatus(cartStatusParams);
+
+              const updateCartStatusMessage = utils.findMessageByFunc('marketplace.updateCartStatus');
+              utils.respondToFramelessMessage({
+                data: {
+                  id: updateCartStatusMessage!.id,
+                  args: [],
+                },
+              } as DOMMessageEvent);
+
+              await promise;
+              await expect(promise).resolves.toBe(undefined);
+            });
+          } else {
+            it(`marketplace.updateCartStatus should not allow calls from ${context} context`, async () => {
+              await utils.initializeWithContext(context);
+              await expect(marketplace.updateCartStatus(cartStatusParams)).rejects.toThrowError(
+                `This call is only allowed in following contexts: ${JSON.stringify([
+                  FrameContexts.content,
+                ])}. Current context: "${context}".`,
+              );
+            });
+          }
+        });
+      });
+    });
+  });
+});

--- a/packages/teams-js/test/public/marketplace.spec.ts
+++ b/packages/teams-js/test/public/marketplace.spec.ts
@@ -23,6 +23,7 @@ describe('Testing marketplace capability', () => {
     });
     it('should validate price of cart items', () => {
       expect(validatePrice(12.34)).toEqual([true, undefined]);
+      expect(validatePrice(12.346)).toEqual([true, undefined]);
       expect(validatePrice(0)).toEqual([true, undefined]);
       expect(validatePrice(-12.34)).toEqual([false, 'price -12.34 must be a number not less than 0']);
       expect(validatePrice(12.3456)).toEqual([false, 'price 12.3456 must have at most 3 decimal places']);
@@ -166,7 +167,9 @@ describe('Testing marketplace capability', () => {
         it('marketplace.removeCartItems should throw error with empty array input', async () => {
           await utils.initializeWithContext(FrameContexts.content);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
-          expect(marketplace.removeCartItems(cartItemIds)).rejects.toEqual('cartItemIds must be a non-empty array');
+          expect(marketplace.removeCartItems([])).rejects.toThrowError(
+            new Error('cartItemIds must be a non-empty array'),
+          );
         });
 
         Object.values(FrameContexts).forEach((context) => {
@@ -210,8 +213,8 @@ describe('Testing marketplace capability', () => {
 
       describe('Testing marketplace.updateCartStatus function', () => {
         const cartStatusParams = {
-          cartStatus: marketplace.CartStatus.Processed,
-          message: 'success message',
+          cartStatus: marketplace.CartStatus.Error,
+          statusInfo: 'error message',
         };
 
         it('marketplace.updateCartStatus should not allow calls before initialization', async () => {
@@ -374,7 +377,9 @@ describe('Testing marketplace capability', () => {
         it('marketplace.removeCartItems should throw error with empty array input', async () => {
           await utils.initializeWithContext(FrameContexts.content);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
-          expect(marketplace.removeCartItems(cartItemIds)).rejects.toEqual('cartItemIds must be a non-empty array');
+          expect(marketplace.removeCartItems([])).rejects.toThrowError(
+            new Error('cartItemIds must be a non-empty array'),
+          );
         });
 
         Object.values(FrameContexts).forEach((context) => {
@@ -418,8 +423,8 @@ describe('Testing marketplace capability', () => {
 
       describe('Testing marketplace.updateCartStatus function', () => {
         const cartStatusParams = {
-          cartStatus: marketplace.CartStatus.Processed,
-          message: 'success message',
+          cartStatus: marketplace.CartStatus.Error,
+          statusInfo: 'error message',
         };
 
         it('marketplace.updateCartStatus should not allow calls before initialization', async () => {

--- a/packages/teams-js/test/public/marketplace.spec.ts
+++ b/packages/teams-js/test/public/marketplace.spec.ts
@@ -166,25 +166,25 @@ describe('Testing marketplace capability', () => {
           );
         });
 
-        it('marketplace.removeCartItems should throw error with empty cart item array input', async () => {
-          await utils.initializeWithContext(FrameContexts.content);
-          utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
-          const emptyCartItemIds = { cartItemIds: [], cartId: uuid() };
-          expect(marketplace.removeCartItems(emptyCartItemIds)).rejects.toThrowError(
-            new Error('cartItemIds must be a non-empty array'),
-          );
-          const nullRemoveCartItemIds = { cartItemIds: null, cartId: uuid() };
-          expect(
-            marketplace.removeCartItems(nullRemoveCartItemIds as unknown as marketplace.RemoveCartItemsParams),
-          ).rejects.toThrowError(new Error('cartItemIds must be a non-empty array'));
-        });
-
         Object.values(FrameContexts).forEach((context) => {
           if (context === FrameContexts.content || context === FrameContexts.task) {
             it(`marketplace.removeCartItems should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
               expect(marketplace.removeCartItems(removeCartItemsParams)).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it('marketplace.removeCartItems should throw error with invalid cart item array input', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+              const emptyCartItemIds = { cartItemIds: [], cartId: uuid() };
+              expect(marketplace.removeCartItems(emptyCartItemIds)).rejects.toThrowError(
+                new Error('cartItemIds must be a non-empty array'),
+              );
+              const nullRemoveCartItemIds = { cartItemIds: null, cartId: uuid() };
+              expect(
+                marketplace.removeCartItems(nullRemoveCartItemIds as unknown as marketplace.RemoveCartItemsParams),
+              ).rejects.toThrowError(new Error('cartItemIds must be a non-empty array'));
             });
 
             it('marketplace.removeCartItems should successfully send the removeCartItems message', async () => {
@@ -452,25 +452,25 @@ describe('Testing marketplace capability', () => {
           );
         });
 
-        it('marketplace.removeCartItems should throw error with empty cart item array input', async () => {
-          await utils.initializeWithContext(FrameContexts.content);
-          utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
-          const emptyRemoveCartItemIds = { cartItemIds: [], cartId: uuid() };
-          expect(marketplace.removeCartItems(emptyRemoveCartItemIds)).rejects.toThrowError(
-            new Error('cartItemIds must be a non-empty array'),
-          );
-          const nullRemoveCartItemIds = { cartItemIds: null, cartId: uuid() };
-          expect(
-            marketplace.removeCartItems(nullRemoveCartItemIds as unknown as marketplace.RemoveCartItemsParams),
-          ).rejects.toThrowError(new Error('cartItemIds must be a non-empty array'));
-        });
-
         Object.values(FrameContexts).forEach((context) => {
           if (context === FrameContexts.content || context === FrameContexts.task) {
             it(`marketplace.removeCartItems should throw error when marketplace is not supported when initialized with ${context} context`, async () => {
               await utils.initializeWithContext(context);
               utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
               expect(marketplace.removeCartItems(removeCartItemsParams)).rejects.toEqual(errorNotSupportedOnPlatform);
+            });
+
+            it('marketplace.removeCartItems should throw error with empty cart item array input', async () => {
+              await utils.initializeWithContext(context);
+              utils.setRuntimeConfig({ apiVersion: 2, supports: { marketplace: {} } });
+              const emptyRemoveCartItemIds = { cartItemIds: [], cartId: uuid() };
+              expect(marketplace.removeCartItems(emptyRemoveCartItemIds)).rejects.toThrowError(
+                new Error('cartItemIds must be a non-empty array'),
+              );
+              const nullRemoveCartItemIds = { cartItemIds: null, cartId: uuid() };
+              expect(
+                marketplace.removeCartItems(nullRemoveCartItemIds as unknown as marketplace.RemoveCartItemsParams),
+              ).rejects.toThrowError(new Error('cartItemIds must be a non-empty array'));
             });
 
             it('marketplace.removeCartItems should successfully send the removeCartItems message', async () => {


### PR DESCRIPTION
## Description

To enable Teams users a more flexible purchasing experience, we introduce the marketplace capability to make checkout flow can be powered by a Teams app. A Teams app can leverage the marketplace capability to get and update a cart owned by the Teams client.

### Main changes in the PR:

1. add `marketplace` capability.
2. add `getCart`, `addOrUpdateCartItems`, `removeCartItems`, and `updateCartStatus` to interface with `cart` in the host.

## Validation

### Validation performed:

1. Verify  `getCart`, `addOrUpdateCartItems`, `removeCartItems`, and `updateCartStatus` can modify the `cart` object in the MetaOS host.

### Unit Tests added:

Yes

### End-to-end tests added:

Yes

## Additional Requirements

### Change file added:

Yes

### Related PRs:

adding marketplace capability in hub sdk - PR#2001855
[adding marketplace capability in hub sdk - PR#1802](https://github.com/OfficeDev/microsoft-teams-library-js/pull/1802)
