### PR TITLE
add a new test case data for search capability

### DIFF
--- a/apps/teams-test-app/e2e-test-data/search.json
+++ b/apps/teams-test-app/e2e-test-data/search.json
@@ -47,6 +47,13 @@
         }
       ],
       "expectedTestAppValue": "Update your application to handle the search experience being closed. Last query: Hello, world"
+    },
+    {
+      "version": ">=2.12.0",
+      "title": "closeSearch API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_search_closeSearch",
+      "expectedAlertValue": "called"
     }
   ]
 }


### PR DESCRIPTION
## Description

Web Host SDK side just had a change on adding new testing case data for searching capability. Migration is half-way done so I created PR in this place to update testing json data as well.

### Main changes in the PR:

1. a new test case is added in search.json data

## Validation

### Validation performed: Check PR in Web Host SDK side whose name is "Merged PR 2062500: Add closeSearch API..."

Added API and test for closeSearch

### Unit Tests added: No

### End-to-end tests added: No