### PR TITLE
update webpack to enable local self-signed certs to be used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dts/
 # Test App gitignore areas
 yarn-error.log
 *.log
+*.pem
 
 # bundle analysis folders
 /common/*

--- a/apps/teams-test-app/webpack.common.js
+++ b/apps/teams-test-app/webpack.common.js
@@ -10,7 +10,7 @@ try {
   fs.accessSync('localhost.pem', fs.constants.F_OK);
   useLocalCert = true;
 } catch (err) {
-  console.log('Certificates not found, using default https settings...');
+  console.log('Certificates not found: using default https settings...');
 }
 
 module.exports = {

--- a/apps/teams-test-app/webpack.common.js
+++ b/apps/teams-test-app/webpack.common.js
@@ -1,6 +1,17 @@
 /* eslint @typescript-eslint/no-var-requires: off*/
 
 const path = require('path');
+const fs = require('fs');
+
+let useLocalCert = false;
+
+try {
+  fs.accessSync('localhost-key.pem', fs.constants.F_OK);
+  fs.accessSync('localhost.pem', fs.constants.F_OK);
+  useLocalCert = true;
+} catch (err) {
+  console.log('Certificates not found, using default https settings...');
+}
 
 module.exports = {
   mode: 'production',
@@ -39,7 +50,12 @@ module.exports = {
     },
     compress: true,
     port: 4000,
-    https: true,
+    https: useLocalCert
+      ? {
+          key: fs.readFileSync('localhost-key.pem'),
+          cert: fs.readFileSync('localhost.pem'),
+        }
+      : true,
     allowedHosts: 'all',
   },
   performance: { hints: false },


### PR DESCRIPTION
## Description

The changes in this PR enable someone to use self-signed certificates when running the teams test app. The code looks for local certificates and if they exist, uses them when starting the app. 