### PR TITLE
Added permission functions for media capability.

### DIFF
--- a/apps/teams-test-app/src/components/MediaAPIs.tsx
+++ b/apps/teams-test-app/src/components/MediaAPIs.tsx
@@ -220,6 +220,33 @@ const ViewImagesWithUrls = (): React.ReactElement =>
     },
   });
 
+const HasMediaPermission = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'hasMediaPermission',
+    title: 'Has Media Permission',
+    onClick: async () => {
+      const result = await media.hasPermission();
+      return JSON.stringify(result);
+    },
+  });
+
+const RequestMediaPermission = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'requestMediaPermission',
+    title: 'Request Media Permission',
+    onClick: async () => {
+      const result = await media.requestPermission();
+      return JSON.stringify(result);
+    },
+  });
+
+const CheckMediaCapability = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'checkMediaCapability',
+    title: 'Check media Capability',
+    onClick: async () => `media module ${media.isSupported() ? 'is' : 'is not'} supported`,
+  });
+
 const MediaAPIs = (): ReactElement => (
   <ModuleWrapper title="Media">
     <CaptureImage />
@@ -228,6 +255,9 @@ const MediaAPIs = (): ReactElement => (
     <ViewImagesWithId />
     <ViewImagesWithUrls />
     <ScanBarCode />
+    <HasMediaPermission />
+    <RequestMediaPermission />
+    <CheckMediaCapability />
   </ModuleWrapper>
 );
 

--- a/change/@microsoft-teams-js-94b44717-e417-43af-846a-5afe86c8f2bb.json
+++ b/change/@microsoft-teams-js-94b44717-e417-43af-846a-5afe86c8f2bb.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add permission functions for media capability",
+  "comment": "Added permission functions for media capability",
   "packageName": "@microsoft/teams-js",
   "email": "liuella@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-94b44717-e417-43af-846a-5afe86c8f2bb.json
+++ b/change/@microsoft-teams-js-94b44717-e417-43af-846a-5afe86c8f2bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add permission functions for media capability",
+  "packageName": "@microsoft/teams-js",
+  "email": "liuella@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -141,7 +141,6 @@ export namespace media {
   /**
    * Requests user permission for media
    *
-   * @returns true if the user consented permission for media, false otherwise
    * @returns Promise that will resolve with true if the user consented permission for media, or with false otherwise,
    * In case of an error, promise will reject with the error. Function can also throw a NOT_SUPPORTED_ON_PLATFORM error
    */

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -111,6 +111,7 @@ interface IRuntimeV2 extends IBaseRuntime {
     readonly logs?: {};
     readonly mail?: {};
     readonly marketplace?: {};
+    readonly media?: {};
     readonly meetingRoom?: {};
     readonly menus?: {};
     readonly monetization?: {};

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -1,10 +1,11 @@
-import { errorLibraryNotInitialized } from '../../src/internal/constants';
+import { errorLibraryNotInitialized, permissionsAPIsRequiredVersion } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { app } from '../../src/public/app';
-import { FrameContexts, HostClientType } from '../../src/public/constants';
-import { ErrorCode, SdkError } from '../../src/public/interfaces';
+import { errorNotSupportedOnPlatform, FrameContexts, HostClientType } from '../../src/public/constants';
+import { DevicePermission, ErrorCode, SdkError } from '../../src/public/interfaces';
 import { media } from '../../src/public/media';
+import { setUnitializedRuntime } from '../../src/public/runtime';
 import { Utils } from '../utils';
 
 /* eslint-disable */
@@ -22,6 +23,8 @@ describe('media', () => {
   const mediaAPISupportVersion = '1.8.0';
   const nonFullScreenVideoModeAPISupportVersion = '2.0.3';
   const imageOutputFormatsAPISupportVersion = '2.0.4';
+  const allowedContexts = [FrameContexts.content, FrameContexts.task];
+  const minVersionForPermissionsAPIs = permissionsAPIsRequiredVersion;
 
   const emptyCallback = () => {};
   describe('frameless', () => {
@@ -36,6 +39,13 @@ describe('media', () => {
       app._uninitialize();
       jest.clearAllMocks();
       GlobalVars.isFramelessWindow = false;
+    });
+
+    describe('Testing isSupported', () => {
+      it('should not be supported before initialization', () => {
+        setUnitializedRuntime();
+        expect(() => media.isSupported()).toThrowError(new Error(errorLibraryNotInitialized));
+      });
     });
 
     describe('captureImage', () => {
@@ -149,6 +159,200 @@ describe('media', () => {
             args: [{ errorCode: ErrorCode.PERMISSION_DENIED }],
           },
         } as DOMMessageEvent);
+      });
+    });
+
+    describe('Testing HasPermisison API', () => {
+      it('should not allow hasPermission calls before initialization', () => {
+        return expect(() => media.hasPermission()).toThrowError(new Error(errorLibraryNotInitialized));
+      });
+  
+      Object.values(FrameContexts).forEach((context) => {
+        if (allowedContexts.some((allowedContext) => allowedContext === context)) {
+          it(`should throw error when media is not supported in runtime config. context: ${context}`, async () => {
+            await utils.initializeWithContext(context);
+            utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+            expect.assertions(1);
+            try {
+              media.hasPermission();
+            } catch (e) {
+              expect(e).toEqual(errorNotSupportedOnPlatform);
+            }
+          });
+  
+          it(`media should throw error when permissions is not supported in runtime config. context: ${context}`, async () => {
+            await utils.initializeWithContext(context);
+            utils.setRuntimeConfig({ apiVersion: 2, supports: { media: {} } });
+            expect.assertions(1);
+            try {
+              media.hasPermission();
+            } catch (e) {
+              expect(e).toEqual(errorNotSupportedOnPlatform);
+            }
+          });
+  
+          it('hasPermission call in default version of platform support fails', async () => {
+            await utils.initializeWithContext(context);
+            expect.assertions(1);
+            utils.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+            try {
+              media.hasPermission();
+            } catch (e) {
+              expect(e).toEqual(errorNotSupportedOnPlatform);
+            }
+          });
+  
+          it('hasPermission call with successful result', async () => {
+            await utils.initializeWithContext(context);
+            utils.setClientSupportedSDKVersion(minVersionForPermissionsAPIs);
+            utils.setRuntimeConfig({ apiVersion: 1, supports: { media: {}, permissions: {} } });
+  
+            const promise = media.hasPermission();
+  
+            const message = utils.findMessageByFunc('permissions.has');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1);
+            expect(message.args[0]).toEqual(DevicePermission.Media);
+  
+            const callbackId = message.id;
+            utils.respondToFramelessMessage({
+              data: {
+                id: callbackId,
+                args: [undefined, true],
+              },
+            } as DOMMessageEvent);
+  
+            await expect(promise).resolves.toBe(true);
+          });
+  
+          it('HasPermission rejects promise with Error when error received from host', async () => {
+            await utils.initializeWithContext(context);
+            utils.setClientSupportedSDKVersion(minVersionForPermissionsAPIs);
+            utils.setRuntimeConfig({ apiVersion: 1, supports: { media: {}, permissions: {} } });
+  
+            const promise = media.hasPermission();
+  
+            const message = utils.findMessageByFunc('permissions.has');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1);
+  
+            const callbackId = message.id;
+            utils.respondToFramelessMessage({
+              data: {
+                id: callbackId,
+                args: [{ errorCode: ErrorCode.INTERNAL_ERROR }],
+              },
+            } as DOMMessageEvent);
+  
+            await expect(promise).rejects.toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
+          });
+        } else {
+          it(`should not allow hasPermission calls from the wrong context. context: ${context}`, async () => {
+            await utils.initializeWithContext(context);
+            expect(() => media.hasPermission()).toThrowError(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${context}".`,
+            );
+          });
+        }
+      });
+    });
+
+    describe('Testing RequestPermisison API', () => {
+      Object.values(FrameContexts).forEach((context) => {
+        if (allowedContexts.some((allowedContext) => allowedContext === context)) {
+          it('should not allow requestPermission calls before initialization', () => {
+            expect(() => media.requestPermission()).toThrowError(new Error(errorLibraryNotInitialized));
+          });
+  
+          it('requestPermission call in default version of platform support fails', async () => {
+            await utils.initializeWithContext(context);
+            utils.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
+            expect.assertions(1);
+            try {
+              media.requestPermission();
+            } catch (e) {
+              expect(e).toEqual(errorNotSupportedOnPlatform);
+            }
+          });
+  
+          it(`requestPermission should throw error when permissions is not supported in runtime config. context: ${context}`, async () => {
+            await utils.initializeWithContext(context);
+            utils.setRuntimeConfig({ apiVersion: 2, supports: { media: {} } });
+            expect.assertions(1);
+            try {
+              media.requestPermission();
+            } catch (e) {
+              expect(e).toEqual(errorNotSupportedOnPlatform);
+            }
+          });
+  
+          it(`should throw error when media is not supported in runtime config. context: ${context}`, async () => {
+            await utils.initializeWithContext(context);
+            utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+            expect.assertions(1);
+            try {
+              media.hasPermission();
+            } catch (e) {
+              expect(e).toEqual(errorNotSupportedOnPlatform);
+            }
+          });
+  
+          it('requestPermission call with successful result', async () => {
+            await utils.initializeWithContext(context);
+            utils.setClientSupportedSDKVersion(minVersionForPermissionsAPIs);
+            utils.setRuntimeConfig({ apiVersion: 2, supports: { media: {}, permissions: {} } });
+  
+            const promise = media.requestPermission();
+  
+            const message = utils.findMessageByFunc('permissions.request');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1);
+            expect(message.args[0]).toEqual(DevicePermission.Media);
+  
+            const callbackId = message.id;
+            utils.respondToFramelessMessage({
+              data: {
+                id: callbackId,
+                args: [undefined, true],
+              },
+            } as DOMMessageEvent);
+  
+            await expect(promise).resolves.toBe(true);
+          });
+  
+          it('requestPermission rejects promise with Error when error received from host', async () => {
+            await utils.initializeWithContext(context);
+            utils.setClientSupportedSDKVersion(minVersionForPermissionsAPIs);
+            utils.setRuntimeConfig({ apiVersion: 2, supports: { media: {}, permissions: {} } });
+  
+            const promise = media.requestPermission();
+  
+            const message = utils.findMessageByFunc('permissions.request');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(1);
+  
+            const callbackId = message.id;
+            utils.respondToFramelessMessage({
+              data: {
+                id: callbackId,
+                args: [{ errorCode: ErrorCode.INTERNAL_ERROR }],
+              },
+            } as DOMMessageEvent);
+  
+            await expect(promise).rejects.toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
+          });
+        } else {
+          it(`should not allow requestPermission calls from the wrong context. context: ${context}`, async () => {
+            await utils.initializeWithContext(context);
+            expect(() => media.requestPermission()).toThrowError(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${context}".`,
+            );
+          });
+        }
       });
     });
 


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

### Main changes in the PR:

1. Added permission functions(`hasPemrission()`, `requestPermission()` and `isSupported()`) for media capability.
2. Added media permission section test boxes for teams-test-app.
3. Added `readonly media?: {};` in `IRuntimeV2` interface.

## Validation

### Validation performed:

1. Open teams-test-app, we should see three new boxes for testing has media permission, request media Permission, and media capability support check.
![image](https://github.com/OfficeDev/microsoft-teams-library-js/assets/85649572/22b15ed4-e19f-4607-b53f-0e45d1f31c39)


### Unit Tests added:

Yes

### End-to-end tests added:

No, don't have e2e tests.

## Additional Requirements

### Change file added:

Yes

