### PR TITLE
Added beta tags for media permission functions and removed support check for media capability

### DIFF
--- a/apps/teams-test-app/src/components/MediaAPIs.tsx
+++ b/apps/teams-test-app/src/components/MediaAPIs.tsx
@@ -240,13 +240,6 @@ const RequestMediaPermission = (): React.ReactElement =>
     },
   });
 
-const CheckMediaCapability = (): React.ReactElement =>
-  ApiWithoutInput({
-    name: 'checkMediaCapability',
-    title: 'Check media Capability',
-    onClick: async () => `media module ${media.isSupported() ? 'is' : 'is not'} supported`,
-  });
-
 const MediaAPIs = (): ReactElement => (
   <ModuleWrapper title="Media">
     <CaptureImage />
@@ -257,7 +250,6 @@ const MediaAPIs = (): ReactElement => (
     <ScanBarCode />
     <HasMediaPermission />
     <RequestMediaPermission />
-    <CheckMediaCapability />
   </ModuleWrapper>
 );
 

--- a/change/@microsoft-teams-js-2108cec9-a31e-42f0-a93e-23364d5bafaa.json
+++ b/change/@microsoft-teams-js-2108cec9-a31e-42f0-a93e-23364d5bafaa.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Added @Beta tag for media permission functions and remove `isSupported` check for media capability.",
-  "packageName": "@microsoft/teams-js",
-  "email": "liuella@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-2108cec9-a31e-42f0-a93e-23364d5bafaa.json
+++ b/change/@microsoft-teams-js-2108cec9-a31e-42f0-a93e-23364d5bafaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added @Beta tag for media permission functions and remove `isSupported` check for media capability.",
+  "packageName": "@microsoft/teams-js",
+  "email": "liuella@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-teams-js-7c9a6aae-faac-439e-9929-82bb4fb2f573.json
+++ b/change/@microsoft-teams-js-7c9a6aae-faac-439e-9929-82bb4fb2f573.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Added `@beta` tags for media permission functions and removed check for media capability",
+  "comment": "Added `@beta` tags for media permission functions and removed support check for media capability",
   "packageName": "@microsoft/teams-js",
   "email": "liuella@microsoft.com",
   "dependentChangeType": "none"

--- a/change/@microsoft-teams-js-7c9a6aae-faac-439e-9929-82bb4fb2f573.json
+++ b/change/@microsoft-teams-js-7c9a6aae-faac-439e-9929-82bb4fb2f573.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Added `@beta` tags for `media.getPermission` and `media.hasPermission`",
+  "comment": "Added `@beta` tags for `media.requestPermission` and `media.hasPermission`",
   "packageName": "@microsoft/teams-js",
   "email": "liuella@microsoft.com",
   "dependentChangeType": "none"

--- a/change/@microsoft-teams-js-7c9a6aae-faac-439e-9929-82bb4fb2f573.json
+++ b/change/@microsoft-teams-js-7c9a6aae-faac-439e-9929-82bb4fb2f573.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Added `@beta` tags for media permission functions and removed support check for media capability",
+  "comment": "Added `@beta` tags for `media.getPermission` and `media.hasPermission`",
   "packageName": "@microsoft/teams-js",
   "email": "liuella@microsoft.com",
   "dependentChangeType": "none"

--- a/change/@microsoft-teams-js-7c9a6aae-faac-439e-9929-82bb4fb2f573.json
+++ b/change/@microsoft-teams-js-7c9a6aae-faac-439e-9929-82bb4fb2f573.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Added  tags for media permission functions and removed  check for media capability",
+  "comment": "Added `@beta` tags for media permission functions and removed check for media capability",
   "packageName": "@microsoft/teams-js",
   "email": "liuella@microsoft.com",
   "dependentChangeType": "none"

--- a/change/@microsoft-teams-js-7c9a6aae-faac-439e-9929-82bb4fb2f573.json
+++ b/change/@microsoft-teams-js-7c9a6aae-faac-439e-9929-82bb4fb2f573.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added  tags for media permission functions and removed  check for media capability",
+  "packageName": "@microsoft/teams-js",
+  "email": "liuella@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -125,10 +125,12 @@ export namespace media {
    *
    * @returns Promise that will resolve with true if the user had granted the app permission to media information, or with false otherwise,
    * In case of an error, promise will reject with the error. Function can also throw a NOT_SUPPORTED_ON_PLATFORM error
+   *
+   * @beta
    */
   export function hasPermission(): Promise<boolean> {
     ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
-    if (!isSupported()) {
+    if (!isPermissionSupported()) {
       throw errorNotSupportedOnPlatform;
     }
     const permissions: DevicePermission = DevicePermission.Media;
@@ -143,10 +145,12 @@ export namespace media {
    *
    * @returns Promise that will resolve with true if the user consented permission for media, or with false otherwise,
    * In case of an error, promise will reject with the error. Function can also throw a NOT_SUPPORTED_ON_PLATFORM error
+   *
+   * @beta
    */
   export function requestPermission(): Promise<boolean> {
     ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
-    if (!isSupported()) {
+    if (!isPermissionSupported()) {
       throw errorNotSupportedOnPlatform;
     }
     const permissions: DevicePermission = DevicePermission.Media;
@@ -157,13 +161,13 @@ export namespace media {
   }
 
   /**
-   * Checks if media capability is supported by the host
-   * @returns boolean to represent whether media is supported
+   * Checks if permission capability is supported by the host
+   * @returns boolean to represent whether permission is supported
    *
    * @throws Error if {@linkcode app.initialize} has not successfully completed
    */
-  export function isSupported(): boolean {
-    return ensureInitialized(runtime) && runtime.supports.media && runtime.supports.permissions ? true : false;
+  function isPermissionSupported(): boolean {
+    return ensureInitialized(runtime) && runtime.supports.permissions ? true : false;
   }
 
   /**

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -111,7 +111,6 @@ interface IRuntimeV2 extends IBaseRuntime {
     readonly logs?: {};
     readonly mail?: {};
     readonly marketplace?: {};
-    readonly media?: {};
     readonly meetingRoom?: {};
     readonly menus?: {};
     readonly monetization?: {};

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -5,7 +5,6 @@ import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts, HostClientType } from '../../src/public/constants';
 import { DevicePermission, ErrorCode, SdkError } from '../../src/public/interfaces';
 import { media } from '../../src/public/media';
-import { setUnitializedRuntime } from '../../src/public/runtime';
 import { Utils } from '../utils';
 
 /* eslint-disable */
@@ -39,13 +38,6 @@ describe('media', () => {
       app._uninitialize();
       jest.clearAllMocks();
       GlobalVars.isFramelessWindow = false;
-    });
-
-    describe('Testing isSupported', () => {
-      it('should not be supported before initialization', () => {
-        setUnitializedRuntime();
-        expect(() => media.isSupported()).toThrowError(new Error(errorLibraryNotInitialized));
-      });
     });
 
     describe('captureImage', () => {
@@ -169,7 +161,7 @@ describe('media', () => {
   
       Object.values(FrameContexts).forEach((context) => {
         if (allowedContexts.some((allowedContext) => allowedContext === context)) {
-          it(`should throw error when media is not supported in runtime config. context: ${context}`, async () => {
+          it(`media should throw error when permissions is not supported in runtime config. context: ${context}`, async () => {
             await utils.initializeWithContext(context);
             utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
             expect.assertions(1);
@@ -179,18 +171,7 @@ describe('media', () => {
               expect(e).toEqual(errorNotSupportedOnPlatform);
             }
           });
-  
-          it(`media should throw error when permissions is not supported in runtime config. context: ${context}`, async () => {
-            await utils.initializeWithContext(context);
-            utils.setRuntimeConfig({ apiVersion: 2, supports: { media: {} } });
-            expect.assertions(1);
-            try {
-              media.hasPermission();
-            } catch (e) {
-              expect(e).toEqual(errorNotSupportedOnPlatform);
-            }
-          });
-  
+
           it('hasPermission call in default version of platform support fails', async () => {
             await utils.initializeWithContext(context);
             expect.assertions(1);
@@ -205,7 +186,7 @@ describe('media', () => {
           it('hasPermission call with successful result', async () => {
             await utils.initializeWithContext(context);
             utils.setClientSupportedSDKVersion(minVersionForPermissionsAPIs);
-            utils.setRuntimeConfig({ apiVersion: 1, supports: { media: {}, permissions: {} } });
+            utils.setRuntimeConfig({ apiVersion: 2, supports: { permissions: {} } });
   
             const promise = media.hasPermission();
   
@@ -228,7 +209,7 @@ describe('media', () => {
           it('HasPermission rejects promise with Error when error received from host', async () => {
             await utils.initializeWithContext(context);
             utils.setClientSupportedSDKVersion(minVersionForPermissionsAPIs);
-            utils.setRuntimeConfig({ apiVersion: 1, supports: { media: {}, permissions: {} } });
+            utils.setRuntimeConfig({ apiVersion: 2, supports: { permissions: {} } });
   
             const promise = media.hasPermission();
   
@@ -265,7 +246,7 @@ describe('media', () => {
           it('should not allow requestPermission calls before initialization', () => {
             expect(() => media.requestPermission()).toThrowError(new Error(errorLibraryNotInitialized));
           });
-  
+
           it('requestPermission call in default version of platform support fails', async () => {
             await utils.initializeWithContext(context);
             utils.setClientSupportedSDKVersion(originalDefaultPlatformVersion);
@@ -279,7 +260,7 @@ describe('media', () => {
   
           it(`requestPermission should throw error when permissions is not supported in runtime config. context: ${context}`, async () => {
             await utils.initializeWithContext(context);
-            utils.setRuntimeConfig({ apiVersion: 2, supports: { media: {} } });
+            utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
             expect.assertions(1);
             try {
               media.requestPermission();
@@ -287,22 +268,11 @@ describe('media', () => {
               expect(e).toEqual(errorNotSupportedOnPlatform);
             }
           });
-  
-          it(`should throw error when media is not supported in runtime config. context: ${context}`, async () => {
-            await utils.initializeWithContext(context);
-            utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
-            expect.assertions(1);
-            try {
-              media.hasPermission();
-            } catch (e) {
-              expect(e).toEqual(errorNotSupportedOnPlatform);
-            }
-          });
-  
+
           it('requestPermission call with successful result', async () => {
             await utils.initializeWithContext(context);
             utils.setClientSupportedSDKVersion(minVersionForPermissionsAPIs);
-            utils.setRuntimeConfig({ apiVersion: 2, supports: { media: {}, permissions: {} } });
+            utils.setRuntimeConfig({ apiVersion: 2, supports: { permissions: {} } });
   
             const promise = media.requestPermission();
   
@@ -325,7 +295,7 @@ describe('media', () => {
           it('requestPermission rejects promise with Error when error received from host', async () => {
             await utils.initializeWithContext(context);
             utils.setClientSupportedSDKVersion(minVersionForPermissionsAPIs);
-            utils.setRuntimeConfig({ apiVersion: 2, supports: { media: {}, permissions: {} } });
+            utils.setRuntimeConfig({ apiVersion: 2, supports: { permissions: {} } });
   
             const promise = media.requestPermission();
   


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

### Main changes in the PR:

1. Added `@beta` tags for media permission functions 
2. Removed support check for media capability in the teams test app.
3. checked `isPermissionSupported()` before has/request permission in media capability.

## Validation

### Validation performed:

1. <Step 1>
4. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes.

### End-to-end tests added:

No, don't have e2e tests

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes

### Related PR:
https://github.com/OfficeDev/microsoft-teams-library-js/pull/1838
