### PR TITLE
Update video testing json data to support new videoEX API

### DIFF
--- a/apps/teams-test-app/e2e-test-data/video.json
+++ b/apps/teams-test-app/e2e-test-data/video.json
@@ -28,6 +28,7 @@
     },
     {
       "title": "registerForVideoEffect - Handler - Success",
+      "version": ">2.12.0",
       "type": "registerAndRaiseEvent",
       "boxSelector": "#box_registerForVideoEffect",
       "eventName": "videoEffectToApply",
@@ -35,10 +36,11 @@
         "effectId": "nextEffectId"
       },
       "expectedTestAppValue": "video effect changed to \"nextEffectId\"",
-      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: true, effectId: nextEffectId, detail: undefined"
+      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: true, effectId: nextEffectId, detail: undefined, effectParameter: undefined"
     },
     {
       "title": "registerForVideoEffect - Handler - Failed",
+      "version": ">2.12.0",
       "type": "registerAndRaiseEvent",
       "boxSelector": "#box_registerForVideoEffect",
       "eventName": "videoEffectToApply",
@@ -46,7 +48,7 @@
         "effectId": "anInvalidEffectId"
       },
       "expectedTestAppValue": "failed to change effect to \"anInvalidEffectId\"",
-      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: false, effectId: anInvalidEffectId, detail: InvalidEffectId"
+      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: false, effectId: anInvalidEffectId, detail: InvalidEffectId, effectParameter: undefined"
     },
     {
       "title": "updatePersonalizedEffects - Success",
@@ -71,6 +73,7 @@
     },
     {
       "title": "videoEx.registerForVideoEffect - Handler - Success",
+      "version": ">2.12.0",
       "type": "registerAndRaiseEvent",
       "boxSelector": "#box_videoExRegisterForVideoEffect",
       "eventName": "videoEffectToApply",
@@ -79,7 +82,20 @@
         "effectParameter": "nextEffectParam"
       },
       "expectedTestAppValue": "video effect changed to \"nextEffectId\", effect param: \"nextEffectParam\"",
-      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: true, effectId: nextEffectId, detail: undefined"
+      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: true, effectId: nextEffectId, detail: undefined, effectParameter: nextEffectParam"
+    },
+    {
+      "title": "videoEx.registerForVideoEffect - Handler - Failed",
+      "version": ">2.12.0",
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_videoExRegisterForVideoEffect",
+      "eventName": "videoEffectToApply",
+      "eventData": {
+        "effectId": "anInvalidEffectId",
+        "effectParameter": "anInvalidEffectParam"
+      },
+      "expectedTestAppValue": "failed to change effect to \"anInvalidEffectId\", param: \"anInvalidEffectParam\"",
+      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: false, effectId: anInvalidEffectId, detail: InvalidEffectId, effectParameter: anInvalidEffectParam"
     },
     {
       "title": " videoEx.NotifyFatalError - Success",

--- a/apps/teams-test-app/e2e-test-data/video.sharedFrame.json
+++ b/apps/teams-test-app/e2e-test-data/video.sharedFrame.json
@@ -15,7 +15,8 @@
     {
       "title": "videoEx.sharedFrame.registerForVideoFrame - Success",
       "type": "callResponse",
-      "boxSelector": "#box_videoExSharedFrameRegisterForVideoFrame",
+      "version": ">2.12.0",
+      "boxSelector": "#box_videoExSharedFrameRegisterForVideoFrame1",
       "modulesToDisable": ["videoMediaStream"],
       "expectedTestAppValue": "Registration attempt has been initiated. If successful, this message will change when it is invoked on video frame received.",
       "expectedAlertValue": "sharedFrame.registerForVideoFrame called with config: {\"format\":\"NV12\",\"requireCameraStream\":false,\"audioInferenceModel\":{}}"


### PR DESCRIPTION
## Description

Update testing json data under video capability to support videoEX API, which is to keep sync with the change in Web Host SDK for testing.


### Main changes in the PR:

1. Video E2E testing Json data is updated.
2. 
## Validation

### Validation performed:

1. Please search in internal Web Host SDK repo with PR title "support new videoEx API" for validation of the change

### Unit Tests added: No

### End-to-end tests added: Yes

## Additional Requirements

### Change file added: No

### Related PRs: Please search in internal Web Host SDK repo with PR title "support new videoEx API"