### PR TITLE
Update comments referring to AAD to now refer to Microsoft Entra

### DIFF
--- a/apps/blazor-test-app/Interop/TeamsSDK/TeamsContext.cs
+++ b/apps/blazor-test-app/Interop/TeamsSDK/TeamsContext.cs
@@ -99,7 +99,7 @@ public class TeamsContext
     public string Locale { get; set; }
 
     /// <summary>
-    /// A value suitable for use as a login_hint when authenticating with Azure AD. Because a malicious party can run your
+    /// A value suitable for use as a login_hint when authenticating with Microsoft Entra. Because a malicious party can run your
     /// content in a browser, this value should be used only as a hint as to who the user is and never as proof of identity.
     /// This field is available only when the identity permission is requested in the manifest.
     /// </summary>
@@ -183,7 +183,7 @@ public class TeamsContext
     public string Theme { get; set; }
 
     /// <summary>
-    /// The Azure AD tenant ID of the current user. Because a malicious party can run your content in a browser,
+    /// The Microsoft Entra tenant ID of the current user. Because a malicious party can run your content in a browser,
     /// this value should be used only as a hint as to who the user is and never as proof of identity. This field
     /// is available only when the identity permission is requested in the manifest.
     /// </summary>
@@ -200,7 +200,7 @@ public class TeamsContext
     public string UserLicenseType { get; set; }
 
     /// <summary>
-    /// The Azure AD object id of the current user. Because a malicious party run your content in a browser,
+    /// The Microsoft Entra object id of the current user. Because a malicious party run your content in a browser,
     /// this value should be used only as a hint as to who the user is and never as proof of identity. This field
     /// is available only when the identity permission is requested in the manifest.
     /// </summary>

--- a/change/@microsoft-teams-js-33fc2e0b-a980-483b-998c-f0cc73805956.json
+++ b/change/@microsoft-teams-js-33fc2e0b-a980-483b-998c-f0cc73805956.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated documentation to refer to 'Microsoft Entra' instead of 'AAD'",
+  "packageName": "@microsoft/teams-js",
+  "email": "trharris@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -385,7 +385,7 @@ export namespace app {
     licenseType?: string;
 
     /**
-     * A value suitable for use when providing a login_hint to Microsoft Entra for authentication purposes.
+     * A value suitable for use when providing a login_hint to Microsoft Entra ID for authentication purposes.
      * See [Provide optional claims to your app](https://learn.microsoft.com/azure/active-directory/develop/active-directory-optional-claims#v10-and-v20-optional-claims-set)
      * for more information about the use of login_hint
      *

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -239,7 +239,7 @@ export namespace app {
     ownerTenantId?: string;
 
     /**
-     * The AAD group ID of the team which owns the channel.
+     * The Microsoft Entra group ID of the team which owns the channel.
      */
     ownerGroupId?: string;
   }
@@ -351,7 +351,7 @@ export namespace app {
    */
   export interface UserInfo {
     /**
-     * The Azure AD object id of the current user.
+     * The Microsoft Entra object id of the current user.
      *
      * Because a malicious party can run your content in a browser, this value should
      * be used only as a optimization hint as to who the user is and never as proof of identity.
@@ -385,7 +385,7 @@ export namespace app {
     licenseType?: string;
 
     /**
-     * A value suitable for use when providing a login_hint to Azure Active Directory for authentication purposes.
+     * A value suitable for use when providing a login_hint to Microsoft Entra for authentication purposes.
      * See [Provide optional claims to your app](https://learn.microsoft.com/azure/active-directory/develop/active-directory-optional-claims#v10-and-v20-optional-claims-set)
      * for more information about the use of login_hint
      *
@@ -419,7 +419,7 @@ export namespace app {
    */
   export interface TenantInfo {
     /**
-     * The Azure AD tenant ID of the current user.
+     * The Microsoft Entra tenant ID of the current user.
 
      * Because a malicious party can run your content in a browser, this value should
      * be used only as a optimization hint as to who the user is and never as proof of identity.

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -46,7 +46,7 @@ export namespace authentication {
   /**
    * Initiates an authentication flow which requires a new window.
    * There are two primary uses for this function:
-   * 1. When your app needs to authenticate using a 3rd-party identity provider (not Microsoft Entra)
+   * 1. When your app needs to authenticate using a 3rd-party identity provider (not Microsoft Entra ID)
    * 2. When your app needs to show authentication UI that is blocked from being shown in an iframe (e.g., Microsoft Entra consent prompts)
    *
    * For more details, see [Enable authentication using third-party OAuth provider](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/auth-flow-tab)

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -46,12 +46,12 @@ export namespace authentication {
   /**
    * Initiates an authentication flow which requires a new window.
    * There are two primary uses for this function:
-   * 1. When your app needs to authenticate using a 3rd-party identity provider (not Azure Active Directory)
-   * 2. When your app needs to show authentication UI that is blocked from being shown in an iframe (e.g., Azure Active Directory consent prompts)
+   * 1. When your app needs to authenticate using a 3rd-party identity provider (not Microsoft Entra)
+   * 2. When your app needs to show authentication UI that is blocked from being shown in an iframe (e.g., Microsoft Entra consent prompts)
    *
    * For more details, see [Enable authentication using third-party OAuth provider](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/auth-flow-tab)
    *
-   * This function is *not* needed for "standard" Azure SSO usage. Using {@link getAuthToken} is usually sufficient in that case. For more, see
+   * This function is *not* needed for "standard" Microsoft Entra SSO usage. Using {@link getAuthToken} is usually sufficient in that case. For more, see
    * [Enable SSO for tab apps](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/tab-sso-overview))
    *
    * @remarks
@@ -173,8 +173,8 @@ export namespace authentication {
   }
 
   /**
-   * Requests an Azure AD token to be issued on behalf of your app in an SSO flow.
-   * The token is acquired from the cache if it is not expired. Otherwise a request is sent to Azure AD to
+   * Requests an Microsoft Entra token to be issued on behalf of your app in an SSO flow.
+   * The token is acquired from the cache if it is not expired. Otherwise a request is sent to Microsoft Entra to
    * obtain a new token.
    * This function is used to enable SSO scenarios. See [Enable SSO for tab apps](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/tab-sso-overview)
    * for more details.
@@ -237,7 +237,7 @@ export namespace authentication {
 
   /**
    * @hidden
-   * Requests the decoded Azure AD user identity on behalf of the app.
+   * Requests the decoded Microsoft Entra user identity on behalf of the app.
    *
    * @returns Promise that resolves with the {@link UserProfile}.
    *
@@ -250,7 +250,7 @@ export namespace authentication {
    * As of 2.0.0, please use {@link authentication.getUser authentication.getUser(): Promise\<UserProfile\>} instead.
    *
    * @hidden
-   * Requests the decoded Azure AD user identity on behalf of the app.
+   * Requests the decoded Microsoft Entra user identity on behalf of the app.
    *
    * @param userRequest - It passes success/failure callbacks in the userRequest object(deprecated)
    * @internal
@@ -574,7 +574,7 @@ export namespace authentication {
      */
     resources?: string[];
     /**
-     * An optional list of claims which to pass to AAD when requesting the access token.
+     * An optional list of claims which to pass to Microsoft Entra when requesting the access token.
      */
     claims?: string[];
     /**
@@ -623,8 +623,8 @@ export namespace authentication {
     iat: number;
     /**
      * @hidden
-     * Identifies the security token service (STS) that constructs and returns the token. In the tokens that Azure AD
-     * returns, the issuer is sts.windows.net. The GUID in the issuer claim value is the tenant ID of the Azure AD
+     * Identifies the security token service (STS) that constructs and returns the token. In the tokens that Microsoft Entra
+     * returns, the issuer is sts.windows.net. The GUID in the issuer claim value is the tenant ID of the Microsoft Entra
      * directory. The tenant ID is an immutable and reliable identifier of the directory.
      *
      * @internal
@@ -633,7 +633,7 @@ export namespace authentication {
     iss: string;
     /**
      * @hidden
-     * Provides the last name, surname, or family name of the user as defined in the Azure AD user object.
+     * Provides the last name, surname, or family name of the user as defined in the Microsoft Entra user object.
      *
      * @internal
      * Limited to Microsoft-internal use
@@ -641,7 +641,7 @@ export namespace authentication {
     family_name: string;
     /**
      * @hidden
-     * Provides the first or "given" name of the user, as set on the Azure AD user object.
+     * Provides the first or "given" name of the user, as set on the Microsoft Entra user object.
      *
      * @internal
      * Limited to Microsoft-internal use
@@ -658,8 +658,8 @@ export namespace authentication {
     unique_name: string;
     /**
      * @hidden
-     * Contains a unique identifier of an object in Azure AD. This value is immutable and cannot be reassigned or
-     * reused. Use the object ID to identify an object in queries to Azure AD.
+     * Contains a unique identifier of an object in Microsoft Entra. This value is immutable and cannot be reassigned or
+     * reused. Use the object ID to identify an object in queries to Microsoft Entra.
      *
      * @internal
      * Limited to Microsoft-internal use
@@ -669,7 +669,7 @@ export namespace authentication {
      * @hidden
      * Identifies the principal about which the token asserts information, such as the user of an application.
      * This value is immutable and cannot be reassigned or reused, so it can be used to perform authorization
-     * checks safely. Because the subject is always present in the tokens the Azure AD issues, we recommended
+     * checks safely. Because the subject is always present in the tokens the Microsoft Entra issues, we recommended
      * using this value in a general-purpose authorization system.
      *
      * @internal
@@ -691,7 +691,7 @@ export namespace authentication {
      * Defines the end of the time interval within which a token is valid. The service that validates the token
      * should verify that the current date is within the token lifetime; otherwise it should reject the token. The
      * service might allow for up to five minutes beyond the token lifetime to account for any differences in clock
-     * time ("time skew") between Azure AD and the service.
+     * time ("time skew") between Microsoft Entra and the service.
      *
      * @internal
      * Limited to Microsoft-internal use
@@ -702,7 +702,7 @@ export namespace authentication {
      * Defines the start of the time interval within which a token is valid. The service that validates the token
      * should verify that the current date is within the token lifetime; otherwise it should reject the token. The
      * service might allow for up to five minutes beyond the token lifetime to account for any differences in clock
-     * time ("time skew") between Azure AD and the service.
+     * time ("time skew") between Microsoft Entra and the service.
      *
      * @internal
      * Limited to Microsoft-internal use

--- a/packages/teams-js/src/public/call.ts
+++ b/packages/teams-js/src/public/call.ts
@@ -29,7 +29,7 @@ export namespace call {
      * Comma-separated list of user IDs representing the participants of the call.
      *
      * @remarks
-     * Currently the User ID field supports the Azure AD UserPrincipalName,
+     * Currently the User ID field supports the Microsoft Entra UserPrincipalName,
      * typically an email address, or in case of a PSTN call, it supports a pstn
      * mri 4:\<phonenumber>.
      */

--- a/packages/teams-js/src/public/chat.ts
+++ b/packages/teams-js/src/public/chat.ts
@@ -25,7 +25,7 @@ interface OpenChatRequest {
  */
 export interface OpenSingleChatRequest extends OpenChatRequest {
   /**
-   * The Azure Active Directory UPN (e-mail address) of the user to chat with
+   * The Microsoft Entra UPN (e-mail address) of the user to chat with
    */
   user: string;
 }
@@ -39,7 +39,7 @@ export interface OpenSingleChatRequest extends OpenChatRequest {
  */
 export interface OpenGroupChatRequest extends OpenChatRequest {
   /**
-   * Array containing Azure Active Directory UPNs (e-mail addresss) of users to open chat with
+   * Array containing Microsoft Entra UPNs (e-mail addresss) of users to open chat with
    */
   users: string[];
   /**

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -399,7 +399,7 @@ export interface Context {
    * @deprecated
    * As of 2.0.0, please use {@link app.TenantInfo.id | app.Context.user.tenant.id} instead
    *
-   * The Azure AD tenant ID of the current user.
+   * The Microsoft Entra tenant ID of the current user.
    * Because a malicious party can run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
    * This field is available only when the identity permission is requested in the manifest.
@@ -466,7 +466,7 @@ export interface Context {
    * @deprecated
    * As of 2.0.0, please use {@link app.ChannelInfo.ownerGroupId | app.Context.channel.ownerGroupId} instead
    *
-   * The AAD group ID of the host team.
+   * The Microsoft Entra group ID of the host team.
    */
   hostTeamGroupId?: string;
 
@@ -508,7 +508,7 @@ export interface Context {
    * @deprecated
    * As of 2.0.0, please use {@link app.UserInfo.loginHint | app.Context.user.loginHint} instead
    *
-   * A value suitable for use as a login_hint when authenticating with Azure AD.
+   * A value suitable for use as a login_hint when authenticating with Microsoft Entra.
    * Because a malicious party can run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
    * This field is available only when the identity permission is requested in the manifest.
@@ -530,7 +530,7 @@ export interface Context {
    * @deprecated
    * As of 2.0.0, please use {@link app.UserInfo.id | app.Context.user.id} instead
    *
-   * The Azure AD object id of the current user.
+   * The Microsoft Entra object id of the current user.
    * Because a malicious party run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
    * This field is available only when the identity permission is requested in the manifest.

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -508,7 +508,7 @@ export interface Context {
    * @deprecated
    * As of 2.0.0, please use {@link app.UserInfo.loginHint | app.Context.user.loginHint} instead
    *
-   * A value suitable for use as a login_hint when authenticating with Microsoft Entra.
+   * A value suitable for use as a login_hint when authenticating with Microsoft Entra ID.
    * Because a malicious party can run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
    * This field is available only when the identity permission is requested in the manifest.
@@ -530,7 +530,7 @@ export interface Context {
    * @deprecated
    * As of 2.0.0, please use {@link app.UserInfo.id | app.Context.user.id} instead
    *
-   * The Microsoft Entra object id of the current user.
+   * The Microsoft Entra object ID of the current user.
    * Because a malicious party run your content in a browser, this value should
    * be used only as a hint as to who the user is and never as proof of identity.
    * This field is available only when the identity permission is requested in the manifest.

--- a/packages/teams-js/src/public/people.ts
+++ b/packages/teams-js/src/public/people.ts
@@ -14,7 +14,7 @@ export namespace people {
    * Launches a people picker and allows the user to select one or more people from the list
    * If the app is added to personal app scope the people picker launched is org wide and if the app is added to a chat/channel, people picker launched is also limited to the members of chat/channel
    
-   * @param callback - Returns list of JSON object of type PeoplePickerResult which consists of AAD IDs, display names and emails of the selected users
+   * @param callback - Returns list of JSON object of type PeoplePickerResult which consists of Microsoft Entra IDs, display names and emails of the selected users
    * @param peoplePickerInputs - Input parameters to launch customized people picker
    * @returns Promise that will be fulfilled when the operation has completed
    */
@@ -26,7 +26,7 @@ export namespace people {
    * Launches a people picker and allows the user to select one or more people from the list
    * If the app is added to personal app scope the people picker launched is org wide and if the app is added to a chat/channel, people picker launched is also limited to the members of chat/channel
    
-   * @param callback - Returns list of JSON object of type PeoplePickerResult which consists of AAD IDs, display names and emails of the selected users
+   * @param callback - Returns list of JSON object of type PeoplePickerResult which consists of Microsoft Entra IDs, display names and emails of the selected users
    * @param peoplePickerInputs - Input parameters to launch customized people picker
    */
   export function selectPeople(
@@ -96,7 +96,7 @@ export namespace people {
     title?: string;
 
     /**
-     * Optional; AAD ids of the users to be pre-populated in the search box of people picker control
+     * Optional; Microsoft Entra ids of the users to be pre-populated in the search box of people picker control
      * If single select is enabled this value, only the first user in the list will be pre-populated
      * Default value is null
      */
@@ -120,7 +120,7 @@ export namespace people {
    */
   export interface PeoplePickerResult {
     /**
-     * user object Id (also known as aad id) of the selected user
+     * user object Id (also known as Microsoft Entra id) of the selected user
      */
     objectId: string;
 

--- a/packages/teams-js/src/public/people.ts
+++ b/packages/teams-js/src/public/people.ts
@@ -96,7 +96,7 @@ export namespace people {
     title?: string;
 
     /**
-     * Optional; Microsoft Entra ids of the users to be pre-populated in the search box of people picker control
+     * Optional; Microsoft Entra IDs of the users to be pre-populated in the search box of people picker control
      * If single select is enabled this value, only the first user in the list will be pre-populated
      * Default value is null
      */
@@ -120,7 +120,7 @@ export namespace people {
    */
   export interface PeoplePickerResult {
     /**
-     * user object Id (also known as Microsoft Entra id) of the selected user
+     * user object ID (also known as Microsoft Entra ID) of the selected user
      */
     objectId: string;
 

--- a/packages/teams-js/src/public/profile.ts
+++ b/packages/teams-js/src/public/profile.ts
@@ -67,13 +67,13 @@ export namespace profile {
    * The set of identifiers that are supported for resolving the persona.
    *
    * At least one is required, and if multiple are provided then only the highest
-   * priority one will be used (AadObjectId > Upn > Smtp).
+   * priority one will be used (AadObjectId > Upn > Smtp). AAD is now known as "Microsoft Entra"
    *
    * @beta
    */
   export type PersonaIdentifiers = {
     /**
-     * The object id in Azure Active Directory.
+     * The object id in Microsoft Entra.
      *
      * This id is guaranteed to be unique for an object within a tenant,
      * and so if provided will lead to a more performant lookup. It can

--- a/packages/teams-js/src/public/profile.ts
+++ b/packages/teams-js/src/public/profile.ts
@@ -67,7 +67,7 @@ export namespace profile {
    * The set of identifiers that are supported for resolving the persona.
    *
    * At least one is required, and if multiple are provided then only the highest
-   * priority one will be used (AadObjectId > Upn > Smtp). AAD is now known as "Microsoft Entra"
+   * priority one will be used (AadObjectId > Upn > Smtp). AAD is now known as "Microsoft Entra ID"
    *
    * @beta
    */

--- a/tools/bundle-size-tools/src/ADO/AdoArtifactFileProvider.ts
+++ b/tools/bundle-size-tools/src/ADO/AdoArtifactFileProvider.ts
@@ -24,7 +24,7 @@ export function getBundlePathsFromZipObject(jsZip: JSZip): BundleFileData[] {
 }
 
 /**
- * Downloads an Azure Devops artifacts and parses it with the jszip library.
+ * Downloads an Azure Devops Artifacts package and parses it with the JSZip library
  * @param adoConnection - A connection to the ADO api.
  * @param buildNumber - The ADO build number that contains the artifact we wish to fetch
  */


### PR DESCRIPTION
## Description

AAD has been renamed to Microsoft Entra. See [here](https://www.microsoft.com/en-us/security/business/identity-access/azure-active-directory) for more details. I've updated that name in our comments and docs.

### Main changes in the PR:

1. Updated comments/docs to refer to Microsoft Entra instead of AAD.

## Validation

### Validation performed:

None

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes
