### PR TITLE
Baljesingh/add mac os support

### DIFF
--- a/change/@microsoft-teams-js-f0a3858b-d453-42bf-9bbc-255012803b04.json
+++ b/change/@microsoft-teams-js-f0a3858b-d453-42bf-9bbc-255012803b04.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add MacOS support",
+  "packageName": "@microsoft/teams-js",
+  "email": "baljesingh@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -137,6 +137,7 @@ export namespace authentication {
         GlobalVars.hostClientType === HostClientType.android ||
         GlobalVars.hostClientType === HostClientType.ios ||
         GlobalVars.hostClientType === HostClientType.ipados ||
+        GlobalVars.hostClientType === HostClientType.macos ||
         GlobalVars.hostClientType === HostClientType.rigel ||
         GlobalVars.hostClientType === HostClientType.teamsRoomsWindows ||
         GlobalVars.hostClientType === HostClientType.teamsRoomsAndroid ||

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -10,6 +10,8 @@ export enum HostClientType {
   ios = 'ios',
   /** Represents the iPadOS client of host, which runs on iOS devices such as iPads. */
   ipados = 'ipados',
+  /** Represents the macOS client of host, which runs on macOS devices such as Macbook. */
+  macos = 'macos',
   /**
    * @deprecated
    * As of 2.0.0, please use {@link teamsRoomsWindows} instead.

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -10,7 +10,7 @@ export enum HostClientType {
   ios = 'ios',
   /** Represents the iPadOS client of host, which runs on iOS devices such as iPads. */
   ipados = 'ipados',
-  /** Represents the macOS client of host that utilizes MacHubSDK, which runs on macOS devices such as MacBooks. */
+  /** The host is running on a macOS client, which runs on devices such as MacBooks. */
   macos = 'macos',
   /**
    * @deprecated

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -10,7 +10,7 @@ export enum HostClientType {
   ios = 'ios',
   /** Represents the iPadOS client of host, which runs on iOS devices such as iPads. */
   ipados = 'ipados',
-  /** Represents the macOS client of host, which runs on macOS devices such as Macbook. */
+  /** Represents the macOS client of host that utilizes MacHubSDK, which runs on macOS devices such as MacBooks. */
   macos = 'macos',
   /**
    * @deprecated

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -155,7 +155,7 @@ export interface TeamInformation {
  */
 export interface LocaleInfo {
   /** Represents the user's platform on which the app is running. */
-  platform: HostClientType.android | HostClientType.ios | 'macos' | 'windows';
+  platform: HostClientType.android | HostClientType.ios | HostClientType.macos | 'windows';
   /**
    * Represents the regional format used by the user's locale.
    * @example `en-us`.

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -232,6 +232,7 @@ export const v1HostClientTypes = [
   HostClientType.web,
   HostClientType.android,
   HostClientType.ios,
+  HostClientType.macos,
   HostClientType.rigel,
   HostClientType.surfaceHub,
   HostClientType.teamsRoomsWindows,

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -232,7 +232,6 @@ export const v1HostClientTypes = [
   HostClientType.web,
   HostClientType.android,
   HostClientType.ios,
-  HostClientType.macos,
   HostClientType.rigel,
   HostClientType.surfaceHub,
   HostClientType.teamsRoomsWindows,

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -51,6 +51,7 @@ describe('Testing authentication capability', () => {
     HostClientType.desktop,
     HostClientType.android,
     HostClientType.ios,
+    HostClientType.macos,
     HostClientType.rigel,
     HostClientType.teamsDisplays,
     HostClientType.teamsPhones,


### PR DESCRIPTION
## Description

We are introducing host support for Mac, which shares most of its code with iOS host support. However, at the moment, macOS is not included in the host client type check for the auth flow. As a result, when the auth flow is triggered, it opens a browser without any knowledge of its parent window, causing the flows to break.

In this pull request (PR), we will address this issue by adding the macOS client type to the host client list, along with making necessary adjustments in other relevant places. By doing so, the macOS client will be able to leverage the existing auth flow from the iOS host support and function properly.

Reference PR: We added ipados earlier -> https://github.com/OfficeDev/microsoft-teams-library-js/pull/1673

### Main changes in the PR:

1. Adding macOS to the auth flow check in the files authentication.ts and authentication.spec.ts.
2. Defining macOS in the constants.ts file.
3. Replacing 'macos' string in LocaleInfo with 'HostClientType.macos'
4. Including macOS in the v1HostClientTypes list.

## Validation

1. Pull the changes in local and run the library using "pnpm start-test-app"
2. Pull the [app hosting repo]. 
3. Open the app hosting project and run the E2E tests. 

All tests must be succeeded specially auth flows.

### Validation performed: 

Yes (locally, MacOS app hosting SDK E2E tests succeeded)

### Unit Tests added: Yes (added necessary changes)

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

### End-to-end tests added:

Not Needed.

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>


