### PR TITLE
Extend timeout of authentication unit test by 100ms

### DIFF
--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -705,12 +705,12 @@ describe('Testing authentication capability', () => {
         const message = utils.findMessageByFunc('authentication.authenticate.success');
         expect(message).not.toBeNull();
 
-        // Wait 300ms for the close delay
+        // Wait 450ms for the close delay
         await new Promise<void>((resolve) =>
           setTimeout(() => {
             expect(closeWindowSpy).toHaveBeenCalled();
             resolve();
-          }, 350),
+          }, 450),
         );
       });
 


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This test has been a little flaky in the past, primarily because the path we are unit testing has a currently unavoidable 300ms wait in it (100ms from communication.waitForMessageQueue and 200ms from authentication.notifySuccess. There is probably a clever way to track shortening those delays when using unit tests specifically, and we do have that tracked on our backlog. For now, let's extend this timeout so we have more than 50ms of wiggleroom.

### Main changes in the PR:

1. Extend timeout of authentication unit test from 350ms to 400ms so that we have more time to execute the unit tests without timing them out and failing them unnecessarily.

## Validation

### Validation performed:

1. Unit tests run in pipeline

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No, test and comment only
