### PR TITLE
Code update for android and macOS

### DIFF
--- a/apps/teams-test-app/e2e-test-data/clipboard.json
+++ b/apps/teams-test-app/e2e-test-data/clipboard.json
@@ -6,7 +6,7 @@
       "title": "Copy Text - success",
       "type": "callResponse",
       "boxSelector": "#box_copyText",
-      "inputValue": "Hello VSR Team",
+      "inputValue": "Hello Team",
       "expectedTestAppValue": "true"
     },
     {

--- a/apps/teams-test-app/src/components/Clipboard.tsx
+++ b/apps/teams-test-app/src/components/Clipboard.tsx
@@ -1,6 +1,7 @@
 import { clipboard } from '@microsoft/teams-js';
 import React from 'react';
 
+import { noHostSdkMsg } from '../App';
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
 import { ModuleWrapper } from './utils/ModuleWrapper';
 
@@ -56,14 +57,25 @@ const CopyImage = (): React.ReactElement =>
     },
   });
 
+const pasteHelper = (blob: Blob, setResult: (result: string) => void): void => {
+  const reader = new FileReader();
+  reader.readAsText(blob);
+  reader.onloadend = () => {
+    if (reader.result) {
+      setResult(JSON.stringify(reader.result));
+    }
+  };
+};
+
 const Paste = (): React.ReactElement =>
   ApiWithoutInput({
     name: 'paste',
     title: 'Paste',
-    onClick: async () => {
+    onClick: async (setResult) => {
       const result = await clipboard.read();
       if (result.type.startsWith('text')) {
-        return JSON.stringify(await result.text());
+        pasteHelper(result, setResult);
+        return 'clipboard.read()' + noHostSdkMsg;
       } else if (result.type.startsWith('image')) {
         image.src = URL.createObjectURL(result);
         image.style.height = '150px';

--- a/change/@microsoft-teams-js-160c4fe1-6197-4ca0-b2da-23878826bebe.json
+++ b/change/@microsoft-teams-js-160c4fe1-6197-4ca0-b2da-23878826bebe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added macOS to mobile list as macOS is also frameless.",
+  "packageName": "@microsoft/teams-js",
+  "email": "98348000+shrshindeMSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/clipboard.ts
+++ b/packages/teams-js/src/public/clipboard.ts
@@ -1,7 +1,8 @@
 import { sendAndHandleSdkError } from '../internal/communication';
+import { GlobalVars } from '../internal/globalVars';
 import { ensureInitialized, isHostClientMobile } from '../internal/internalAPIs';
 import * as utils from '../internal/utils';
-import { errorNotSupportedOnPlatform, FrameContexts } from './constants';
+import { errorNotSupportedOnPlatform, FrameContexts, HostClientType } from './constants';
 import { ClipboardParams, ClipboardSupportedMimeType } from './interfaces';
 import { runtime } from './runtime';
 
@@ -54,7 +55,7 @@ export namespace clipboard {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-    if (isHostClientMobile()) {
+    if (isHostClientMobile() || GlobalVars.hostClientType === HostClientType.macos) {
       const response = JSON.parse(await sendAndHandleSdkError('clipboard.readFromClipboard')) as ClipboardParams;
       return utils.base64ToBlob(response.mimeType, response.content);
     } else {

--- a/packages/teams-js/test/public/clipboard.spec.ts
+++ b/packages/teams-js/test/public/clipboard.spec.ts
@@ -299,7 +299,12 @@ describe('clipboard', () => {
       });
 
       Object.values(FrameContexts).forEach((context) => {
-        Object.values([HostClientType.android, HostClientType.ios, HostClientType.ipados]).forEach((mobilePlatform) => {
+        Object.values([
+          HostClientType.android,
+          HostClientType.ios,
+          HostClientType.ipados,
+          HostClientType.macos,
+        ]).forEach((mobilePlatform) => {
           if (allowedContexts.some((allowedContext) => allowedContext === context)) {
             it(`clipboard.read should throw error if the clipboard.read capability is not supported in runtime config - Context: ${context}`, async () => {
               try {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

While completing the MacOS and Android feature for clipboard, there were two issues one with `blob` type in Android API 27 as it was not able to read the `blob.text()` function, so this PR resolves it by using `FileReader` instead of blob functions, second one was related to MacOS platform which is the communication should be frameless rather than framed added a check in the `clipboard` api.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Update Test App to use `FileReader` to read data from `blob` type.
2. Add macOS to clipboard api check to receive frameless messages.


### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes

### End-to-end tests added:

N/A

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes

