### PR TITLE
Adding location to teamsRunTimeConfig

### DIFF
--- a/change/@microsoft-teams-js-6a9e9685-b682-40f3-abe9-3a5c94c35f21.json
+++ b/change/@microsoft-teams-js-6a9e9685-b682-40f3-abe9-3a5c94c35f21.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Added `location`, `geoLocation` and `permissions` to `teamsRuntimeConfig` to return true for isSupported in geolocation in v1",
+  "comment": "Added support for `location` to Teams v1",
   "packageName": "@microsoft/teams-js",
   "email": "lakhveerkaur@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-6a9e9685-b682-40f3-abe9-3a5c94c35f21.json
+++ b/change/@microsoft-teams-js-6a9e9685-b682-40f3-abe9-3a5c94c35f21.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added `location`, `geoLocation` and `permissions` to `teamsRuntimeConfig` to return true for isSupported in geolocation in v1",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -264,7 +264,6 @@ export const teamsRuntimeConfig: Runtime = {
     interactive: {},
     logs: {},
     location: {},
-    geoLocation: {},
     meetingRoom: {},
     menus: {},
     monetization: {},
@@ -276,7 +275,6 @@ export const teamsRuntimeConfig: Runtime = {
       backStack: {},
       fullTrust: {},
     },
-    permissions: {},
     remoteCamera: {},
     stageView: {},
     teams: {

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -263,6 +263,8 @@ export const teamsRuntimeConfig: Runtime = {
     },
     interactive: {},
     logs: {},
+    location: {},
+    geoLocation: {},
     meetingRoom: {},
     menus: {},
     monetization: {},
@@ -274,6 +276,7 @@ export const teamsRuntimeConfig: Runtime = {
       backStack: {},
       fullTrust: {},
     },
+    permissions: {},
     remoteCamera: {},
     stageView: {},
     teams: {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.
Teams 1.0 supports the location capability, but the hardcoded teamsRuntimeConfig that Teams v1 uses did not have location, geolocation and permissions. This lead to isSupported returning false for location APIs in Teams v1. This PR adds the location, geolocation and permissions to teamsRunTimeConfig to fix the bug.

### Main changes in the PR:

1. Added `location`, `geolocation` and `permissions` to teamsRunTimeConfig


## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
