### PR TITLE
Lakhveer/uninitialize handlers

### DIFF
--- a/change/@microsoft-teams-js-48e1c129-06b5-414f-baa9-d52bff52751e.json
+++ b/change/@microsoft-teams-js-48e1c129-06b5-414f-baa9-d52bff52751e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reset registered handlers for unit testing ",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -20,26 +20,40 @@ class HandlersPrivate {
   public static themeChangeHandler: (theme: string) => void;
   public static loadHandler: (context: LoadContext) => void;
   public static beforeUnloadHandler: (readyToUnload: () => void) => boolean;
+
+  /**
+   * @internal
+   * Limited to Microsoft-internal use
+   * Initializes the handlers.
+   */
+  public static initializeHandlers(): void {
+    // ::::::::::::::::::::MicrosoftTeams SDK Internal :::::::::::::::::
+    HandlersPrivate.handlers['themeChange'] = handleThemeChange;
+    HandlersPrivate.handlers['load'] = handleLoad;
+    HandlersPrivate.handlers['beforeUnload'] = handleBeforeUnload;
+    pages.backStack._initialize();
+  }
+
+  /**
+   * @internal
+   * Limited to Microsoft-internal use
+   * Uninitializes the handlers.
+   */
+  public static uninitializeHandlers(): void {
+    HandlersPrivate.handlers = {};
+    HandlersPrivate.themeChangeHandler = null;
+    HandlersPrivate.loadHandler = null;
+    HandlersPrivate.beforeUnloadHandler = null;
+  }
 }
 
-/**
- * @internal
- * Limited to Microsoft-internal use
- */
 export function initializeHandlers(): void {
-  // ::::::::::::::::::::MicrosoftTeams SDK Internal :::::::::::::::::
-  HandlersPrivate.handlers['themeChange'] = handleThemeChange;
-  HandlersPrivate.handlers['load'] = handleLoad;
-  HandlersPrivate.handlers['beforeUnload'] = handleBeforeUnload;
-  pages.backStack._initialize();
-}
-export function uninitializeHandlers(): void {
-  HandlersPrivate.handlers = {};
-  HandlersPrivate.themeChangeHandler = null;
-  HandlersPrivate.loadHandler = null;
-  HandlersPrivate.beforeUnloadHandler = null;
+  HandlersPrivate.initializeHandlers();
 }
 
+export function uninitializeHandlers(): void {
+  HandlersPrivate.uninitializeHandlers();
+}
 const callHandlerLogger = handlersLogger.extend('callHandler');
 /**
  * @internal

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -33,6 +33,12 @@ export function initializeHandlers(): void {
   HandlersPrivate.handlers['beforeUnload'] = handleBeforeUnload;
   pages.backStack._initialize();
 }
+export function uninitiliazeHandlers(): void {
+  HandlersPrivate.handlers = {};
+  HandlersPrivate.themeChangeHandler = null;
+  HandlersPrivate.loadHandler = null;
+  HandlersPrivate.beforeUnloadHandler = null;
+}
 
 const callHandlerLogger = handlersLogger.extend('callHandler');
 /**

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -33,7 +33,7 @@ export function initializeHandlers(): void {
   HandlersPrivate.handlers['beforeUnload'] = handleBeforeUnload;
   pages.backStack._initialize();
 }
-export function uninitiliazeHandlers(): void {
+export function uninitializeHandlers(): void {
   HandlersPrivate.handlers = {};
   HandlersPrivate.themeChangeHandler = null;
   HandlersPrivate.loadHandler = null;

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -47,10 +47,18 @@ class HandlersPrivate {
   }
 }
 
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function initializeHandlers(): void {
   HandlersPrivate.initializeHandlers();
 }
 
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export function uninitializeHandlers(): void {
   HandlersPrivate.uninitializeHandlers();
 }

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -685,10 +685,7 @@ export namespace app {
       return;
     }
 
-    if (GlobalVars.frameContext) {
-      /* eslint-disable strict-null-checks/all */ /* Fix tracked by 5730662 */
-      Handlers.uninitiliazeHandlers();
-    }
+    Handlers.uninitiliazeHandlers();
 
     GlobalVars.initializeCalled = false;
     GlobalVars.initializeCompleted = false;

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -16,7 +16,6 @@ import * as Handlers from '../internal/handlers'; // Conflict with some names
 import { ensureInitializeCalled, ensureInitialized, processAdditionalValidOrigins } from '../internal/internalAPIs';
 import { getLogger } from '../internal/telemetry';
 import { compareSDKVersions, inServerSideRenderingEnvironment, runWithTimeout } from '../internal/utils';
-import { logs } from '../private/logs';
 import { authentication } from './authentication';
 import { ChannelType, FrameContexts, HostClientType, HostName, TeamType, UserTeamRole } from './constants';
 import { dialog } from './dialog';
@@ -24,7 +23,6 @@ import { ActionInfo, Context as LegacyContext, FileOpenPreference, LocaleInfo } 
 import { menus } from './menus';
 import { pages } from './pages';
 import { applyRuntimeConfig, generateBackCompatRuntimeConfig, IBaseRuntime, runtime } from './runtime';
-import { teamsCore } from './teamsAPIs';
 import { version } from './version';
 
 /**
@@ -689,23 +687,7 @@ export namespace app {
 
     if (GlobalVars.frameContext) {
       /* eslint-disable strict-null-checks/all */ /* Fix tracked by 5730662 */
-      registerOnThemeChangeHandler(null);
-      pages.backStack.registerBackButtonHandler(null);
-      pages.registerFullScreenHandler(null);
-      teamsCore.registerBeforeUnloadHandler(null);
-      teamsCore.registerOnLoadHandler(null);
-      logs.registerGetLogHandler(null); /* Fix tracked by 5730662 */
-      /* eslint-enable strict-null-checks/all */
-    }
-
-    if (GlobalVars.frameContext === FrameContexts.settings) {
-      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-      pages.config.registerOnSaveHandler(null);
-    }
-
-    if (GlobalVars.frameContext === FrameContexts.remove) {
-      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-      pages.config.registerOnRemoveHandler(null);
+      Handlers.uninitiliazeHandlers();
     }
 
     GlobalVars.initializeCalled = false;

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -685,7 +685,7 @@ export namespace app {
       return;
     }
 
-    Handlers.uninitiliazeHandlers();
+    Handlers.uninitializeHandlers();
 
     GlobalVars.initializeCalled = false;
     GlobalVars.initializeCompleted = false;

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -1254,6 +1254,7 @@ describe('Testing pages module', () => {
 
             it('pages.config.registerOnSaveHandler should proxy to childWindow if no handler in top window', async () => {
               await utils.initializeWithContext(context, null, ['https://teams.microsoft.com']);
+              pages.config.registerOnSaveHandler(undefined);
               utils.processMessage({
                 origin: 'https://outlook.office365.com',
                 source: utils.childWindow,


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

Uninitalize handlers without calling handler APIs with null. 

### Main changes in the PR:

1. Wrote uninitiliazeHandlers function in handlers file to use in UTs
2. changed _uninitialize function to call uninitiliazeHandlers instead of calling handlers with 'null'
3. Reset all the registered handlers
4. Fixed UT in pages

