### PR TITLE
Added a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+* @OfficeDev/teams-client-sdk-approvers


### PR DESCRIPTION
## Description

This will help restrict which people are allowed to approve pull requests in this repository. For now, the rules here are simple: every file in the repository must have an approval from someone in the teams-client-sdk-approvers. This list is much smaller than the contributors team, and we can add people to it in the future as needed. Our main branch was already set up to require approvers from Code owners if there were some.

GitHub determines who codeowners are by looking at the CODEOWNERS file in the upstream branch, so after this checkin is merged we should see this start to take effect. More info here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

### Main changes in the PR:

1. Added a CODEOWNERS file that marked all files as being owned by the teams-client-sdk-approvers team.
