### PR TITLE
Prototype of talking from embedded teamsjs directly to outer host

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -117,10 +117,24 @@ export const generateRegistrationMsg = (changeCause: string): string => {
   return `Registration attempt has been initiated. If successful, this message will change when ${changeCause}.`;
 };
 
+const sandbox =
+  'allow-forms allow-popups allow-popups-to-escape-sandbox allow-pointer-lock allow-scripts allow-same-origin allow-modals';
+
 const App = (): ReactElement => {
   return (
     <div>
       <div className="App-container">
+        {!urlParams.has('appInitializationTest') && (
+          <div>
+            <iframe
+              sandbox={sandbox}
+              src="https://localhost:4000?customInit=true&appInitializationTest=true"
+              style={{ width: 1400, height: 800 }}
+            ></iframe>
+            <iframe sandbox={sandbox} src=""></iframe>
+          </div>
+        )}
+        {urlParams.has('appInitializationTest') && <h1>Embedded App!</h1>}
         <AppAPIs />
         <AppInitializationAPIs />
         <AppInstallDialogAPIs />

--- a/packages/teams-js/src/internal/interfaces.ts
+++ b/packages/teams-js/src/internal/interfaces.ts
@@ -43,7 +43,7 @@ export interface ExtendedWindow extends Window {
  * Limited to Microsoft-internal use
  */
 export interface MessageRequest {
-  id?: number;
+  id?: string;
   func: string;
   timestamp?: number;
   args?: any[];
@@ -54,7 +54,7 @@ export interface MessageRequest {
  * Limited to Microsoft-internal use
  */
 export interface MessageResponse {
-  id: number;
+  id: string;
   args?: any[];
   isPartialResponse?: boolean; // If the message is partial, then there will be more future responses for the given message ID.
 }

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -153,6 +153,9 @@ export function compareSDKVersions(v1: string, v2: string): number {
  * Limited to Microsoft-internal use
  */
 export function generateGUID(): string {
+  if (inServerSideRenderingEnvironment()) {
+    return 'Placeholder id, should only see when used in SSR environment';
+  }
   return uuid.v4();
 }
 

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -5,6 +5,7 @@
 import {
   Communication,
   initializeCommunication,
+  registerWithParentIfNecessary,
   sendAndHandleStatusAndReason,
   sendAndUnwrap,
   sendMessageToParent,
@@ -583,6 +584,11 @@ export namespace app {
       // Just no-op if that happens to make it easier to use.
       if (!GlobalVars.initializeCalled) {
         GlobalVars.initializeCalled = true;
+        // After initialize has succeeded, now check if we are a nested iframe. if we are, send a message up to
+        // our parent letting them know we exist
+        // Race condition here unless we do something like make the parent reply. Would require parent on a specific
+        // version of this sdk
+        registerWithParentIfNecessary();
 
         Handlers.initializeHandlers();
         GlobalVars.initializePromise = initializeCommunication(validMessageOrigins).then(

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -5,7 +5,6 @@
 import {
   Communication,
   initializeCommunication,
-  registerWithParentIfNecessary,
   sendAndHandleStatusAndReason,
   sendAndUnwrap,
   sendMessageToParent,
@@ -584,12 +583,6 @@ export namespace app {
       // Just no-op if that happens to make it easier to use.
       if (!GlobalVars.initializeCalled) {
         GlobalVars.initializeCalled = true;
-        // After initialize has succeeded, now check if we are a nested iframe. if we are, send a message up to
-        // our parent letting them know we exist
-        // Race condition here unless we do something like make the parent reply. Would require parent on a specific
-        // version of this sdk
-        registerWithParentIfNecessary();
-
         Handlers.initializeHandlers();
         GlobalVars.initializePromise = initializeCommunication(validMessageOrigins).then(
           ({ context, clientType, runtimeConfig, clientSupportedSDKVersion = defaultSDKVersionForCompatCheck }) => {


### PR DESCRIPTION
## Description

This is a prototype of letting teams apps that are embedded in other teams apps message directly to the outer host instead of trying to route through their parent and then up to the host.

### Main changes in the PR:

1. Make message ids uuids instead of numbers. This prevents conflicts in ids when messaging directly to the outer host from multiple instances of teamsjs at the same time.
2. Update the test app so it has an embedded iframe hosting the test app again. Makes testing embedded app scenarios easier.
3. Made embedded apps send a dummy message directly to their parent (instead of the outer host) so that the outer host remembered who their child was. This allows the parent to pass responses from the outer host down to the child successfully.
4. Updated communication so that if it received a response from its parent with an id it has never seen before it will just send that response to their child, assuming it's for the child.
5. Made utils.generateGuid not cause errors when called in an SSR environment