### PR TITLE
Update the iOS compact tests

### DIFF
--- a/apps/teams-test-app/e2e-test-data/clipboard.json
+++ b/apps/teams-test-app/e2e-test-data/clipboard.json
@@ -1,6 +1,7 @@
 {
   "name": "Clipboard",
   "version": ">2.14.0",
+  "platforms": "*",
   "testCases": [
     {
       "title": "Copy Text - success",


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Add `platforms` parameter in `Clipboard.json` E2E test file to work with iOS backcompact

### Main changes in the PR:

1. Add `platforms` parameter


## Validation

### Validation performed:
N/A

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

N/A

### End-to-end tests added:

N/A

