### PR TITLE
Rename some functions/structures supporting the Teams back-compat config

### DIFF
--- a/change/@microsoft-teams-js-4dccb2aa-4ca1-4b62-a68b-68237502f40e.json
+++ b/change/@microsoft-teams-js-4dccb2aa-4ca1-4b62-a68b-68237502f40e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Rename Teams back-compat config for clarity",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-6a9e9685-b682-40f3-abe9-3a5c94c35f21.json
+++ b/change/@microsoft-teams-js-6a9e9685-b682-40f3-abe9-3a5c94c35f21.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added support for `location` to Teams v1",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-6a9e9685-b682-40f3-abe9-3a5c94c35f21.json
+++ b/change/@microsoft-teams-js-6a9e9685-b682-40f3-abe9-3a5c94c35f21.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Added support for `location` to Teams v1",
-  "packageName": "@microsoft/teams-js",
-  "email": "lakhveerkaur@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -30,7 +30,7 @@ import { dialog } from './dialog';
 import { ActionInfo, Context as LegacyContext, FileOpenPreference, LocaleInfo, ResumeContext } from './interfaces';
 import { menus } from './menus';
 import { pages } from './pages';
-import { applyRuntimeConfig, generateBackCompatRuntimeConfig, IBaseRuntime, runtime } from './runtime';
+import { applyRuntimeConfig, generateVersionBasedTeamsRuntimeConfig, IBaseRuntime, runtime } from './runtime';
 import { version } from './version';
 
 /**
@@ -640,7 +640,7 @@ export namespace app {
                   }
                 } catch (e) {
                   if (e instanceof SyntaxError) {
-                    applyRuntimeConfig(generateBackCompatRuntimeConfig(GlobalVars.clientSupportedSDKVersion));
+                    applyRuntimeConfig(generateVersionBasedTeamsRuntimeConfig(GlobalVars.clientSupportedSDKVersion));
                   } else {
                     throw e;
                   }

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -247,7 +247,7 @@ export function isRuntimeInitialized(runtime: IBaseRuntime): runtime is Runtime 
 
 export let runtime: Runtime | UninitializedRuntime = _uninitializedRuntime;
 
-export const teamsRuntimeConfig: Runtime = {
+export const versionAndPlatformAgnosticTeamsRuntimeConfig: Runtime = {
   apiVersion: 3,
   hostVersionsInfo: teamsMinAdaptiveCardVersion,
   isLegacyTeams: true,
@@ -395,7 +395,7 @@ export const upgradeChain: IRuntimeUpgrade[] = [
   },
 ];
 
-export const versionConstants: Record<string, Array<ICapabilityReqs>> = {
+export const mapTeamsVersionToSupportedCapabilities: Record<string, Array<ICapabilityReqs>> = {
   '1.9.0': [
     {
       capability: { location: {} },
@@ -444,25 +444,25 @@ const generateBackCompatRuntimeConfigLogger = runtimeLogger.extend('generateBack
  * Limited to Microsoft-internal use
  *
  * Generates and returns a runtime configuration for host clients which are not on the latest host SDK version
- * and do not provide their own runtime config. Their supported capabilities are based on the highest
- * client SDK version that they can support.
+ * and do not provide their own runtime config (this is just older versions of Teams on some platforms).
+ * Their supported capabilities are based on the highest client SDK version that they can support.
  *
  * @param highestSupportedVersion - The highest client SDK version that the host client can support.
  * @returns runtime which describes the APIs supported by the legacy host client.
  */
-export function generateBackCompatRuntimeConfig(highestSupportedVersion: string): Runtime {
+export function generateVersionBasedTeamsRuntimeConfig(highestSupportedVersion: string): Runtime {
   generateBackCompatRuntimeConfigLogger('generating back compat runtime config for %s', highestSupportedVersion);
 
-  let newSupports = { ...teamsRuntimeConfig.supports };
+  let newSupports = { ...versionAndPlatformAgnosticTeamsRuntimeConfig.supports };
 
   generateBackCompatRuntimeConfigLogger(
     'Supported capabilities in config before updating based on highestSupportedVersion: %o',
     newSupports,
   );
 
-  Object.keys(versionConstants).forEach((versionNumber) => {
+  Object.keys(mapTeamsVersionToSupportedCapabilities).forEach((versionNumber) => {
     if (compareSDKVersions(highestSupportedVersion, versionNumber) >= 0) {
-      versionConstants[versionNumber].forEach((capabilityReqs) => {
+      mapTeamsVersionToSupportedCapabilities[versionNumber].forEach((capabilityReqs) => {
         if (capabilityReqs.hostClientTypes.includes(GlobalVars.hostClientType)) {
           newSupports = {
             ...newSupports,
@@ -473,7 +473,7 @@ export function generateBackCompatRuntimeConfig(highestSupportedVersion: string)
     }
   });
 
-  const backCompatRuntimeConfig: Runtime = {
+  const teamsBackCompatRuntimeConfig: Runtime = {
     apiVersion: latestRuntimeApiVersion,
     hostVersionsInfo: teamsMinAdaptiveCardVersion,
     isLegacyTeams: true,
@@ -482,10 +482,10 @@ export function generateBackCompatRuntimeConfig(highestSupportedVersion: string)
 
   generateBackCompatRuntimeConfigLogger(
     'Runtime config after updating based on highestSupportedVersion: %o',
-    backCompatRuntimeConfig,
+    teamsBackCompatRuntimeConfig,
   );
 
-  return backCompatRuntimeConfig;
+  return teamsBackCompatRuntimeConfig;
 }
 
 const applyRuntimeConfigLogger = runtimeLogger.extend('applyRuntimeConfig');

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -23,7 +23,7 @@ import {
   _minRuntimeConfigToUninitialize,
   latestRuntimeApiVersion,
   runtime,
-  teamsRuntimeConfig,
+  versionAndPlatformAgnosticTeamsRuntimeConfig,
 } from '../../src/public/runtime';
 import { version } from '../../src/public/version';
 import { Utils } from '../utils';
@@ -170,7 +170,7 @@ describe('Testing app capability', () => {
         const initMessage = utils.findMessageByFunc('initialize');
         utils.respondToMessage(initMessage, FrameContexts.content, HostClientType.web, '1.6.0');
         await initPromise;
-        expect(runtime).toEqual(teamsRuntimeConfig);
+        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
       });
 
       it('app.initialize should use teams runtime config if an empty runtime config is given', async () => {
@@ -180,7 +180,7 @@ describe('Testing app capability', () => {
         utils.respondToMessage(initMessage, FrameContexts.content, HostClientType.web, '', '1.6.0');
         await initPromise;
 
-        expect(runtime).toEqual(teamsRuntimeConfig);
+        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
       });
 
       it('app.initialize should use teams runtime config if a JSON parsing error is thrown by a given runtime config', async () => {
@@ -190,7 +190,7 @@ describe('Testing app capability', () => {
         utils.respondToMessage(initMessage, FrameContexts.content, HostClientType.web, 'nonJSONStr', '1.6.0');
         await initPromise;
 
-        expect(runtime).toEqual(teamsRuntimeConfig);
+        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
       });
 
       it('app.initialize should throw an error if the given runtime config causes a non parsing related error', async () => {
@@ -214,7 +214,7 @@ describe('Testing app capability', () => {
         );
         await initPromise;
 
-        expect(runtime).not.toEqual(teamsRuntimeConfig);
+        expect(runtime).not.toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
         expect(runtime).toEqual({ apiVersion: latestRuntimeApiVersion, supports: { mail: {} } });
       });
 
@@ -259,7 +259,7 @@ describe('Testing app capability', () => {
         utils.respondToMessage(initMessage, FrameContexts.content, HostClientType.web, '1.6.0', 'nonJSONStr');
         await initPromise;
 
-        expect(runtime).toEqual(teamsRuntimeConfig);
+        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
       });
 
       it('app.initialize should throw an error when "null" runtimeConfig is given, with arguments flipped', async () => {
@@ -1044,7 +1044,7 @@ describe('Testing app capability', () => {
         } as DOMMessageEvent);
         await initPromise;
 
-        expect(runtime).toEqual(teamsRuntimeConfig);
+        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
       });
 
       it('app.initialize should use teams runtime config if an empty runtime config is given', async () => {
@@ -1059,7 +1059,7 @@ describe('Testing app capability', () => {
         } as DOMMessageEvent);
         await initPromise;
 
-        expect(runtime).toEqual(teamsRuntimeConfig);
+        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
       });
 
       it('app.initialize should use teams runtime config if a JSON parsing error is thrown by a given runtime config', async () => {
@@ -1074,7 +1074,7 @@ describe('Testing app capability', () => {
         } as DOMMessageEvent);
         await initPromise;
 
-        expect(runtime).toEqual(teamsRuntimeConfig);
+        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
       });
 
       it('app.initialize should throw an error if the given runtime config causes a non parsing related error', async () => {
@@ -1102,7 +1102,7 @@ describe('Testing app capability', () => {
         } as DOMMessageEvent);
         await initPromise;
 
-        expect(runtime).not.toEqual(teamsRuntimeConfig);
+        expect(runtime).not.toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
         expect(runtime).toEqual({ apiVersion: latestRuntimeApiVersion, supports: { mail: {} } });
       });
 
@@ -1150,7 +1150,7 @@ describe('Testing app capability', () => {
         } as DOMMessageEvent);
         await initPromise;
 
-        expect(runtime).toEqual(teamsRuntimeConfig);
+        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
       });
 
       Object.values(HostClientType).forEach((hostClientType) => {

--- a/packages/teams-js/test/public/runtime.spec.ts
+++ b/packages/teams-js/test/public/runtime.spec.ts
@@ -6,15 +6,15 @@ import { app, HostClientType } from '../../src/public';
 import {
   applyRuntimeConfig,
   fastForwardRuntime,
-  generateBackCompatRuntimeConfig,
+  generateVersionBasedTeamsRuntimeConfig,
   IBaseRuntime,
   isRuntimeInitialized,
   latestRuntimeApiVersion,
+  mapTeamsVersionToSupportedCapabilities,
   Runtime,
   runtime,
   setUnitializedRuntime,
   upgradeChain,
-  versionConstants,
 } from '../../src/public/runtime';
 import { Utils } from '../utils';
 
@@ -132,8 +132,8 @@ describe('runtime', () => {
     });
   });
 
-  describe('generateBackCompatRuntimeConfig', () => {
-    Object.entries(versionConstants).forEach(([version, capabilities]) => {
+  describe('generateVersionBasedTeamsRuntimeConfig', () => {
+    Object.entries(mapTeamsVersionToSupportedCapabilities).forEach(([version, capabilities]) => {
       capabilities.forEach((supportedCapability) => {
         const capability = JSON.stringify(supportedCapability.capability).replace(/[{}]/g, '');
         supportedCapability.hostClientTypes.forEach((clientType) => {
@@ -143,7 +143,7 @@ describe('runtime', () => {
           )} capability`, async () => {
             await utils.initializeWithContext('content', clientType);
             const generatedRuntimeConfigSupportedCapabilities = JSON.stringify(
-              generateBackCompatRuntimeConfig(version).supports,
+              generateVersionBasedTeamsRuntimeConfig(version).supports,
             ).replace(/[{}]/g, '');
             expect(generatedRuntimeConfigSupportedCapabilities.includes(capability)).toBe(true);
           });
@@ -154,23 +154,23 @@ describe('runtime', () => {
           )} capability`, async () => {
             await utils.initializeWithContext('content', clientType);
             const generatedRuntimeConfigSupportedCapabilities = JSON.stringify(
-              generateBackCompatRuntimeConfig('1.4.0').supports,
+              generateVersionBasedTeamsRuntimeConfig('1.4.0').supports,
             ).replace(/[{}]/g, '');
             expect(generatedRuntimeConfigSupportedCapabilities.includes(capability)).toBe(false);
           });
 
-          const lowerVersions = Object.keys(versionConstants).filter(
+          const lowerVersions = Object.keys(mapTeamsVersionToSupportedCapabilities).filter(
             (otherVer) => compareSDKVersions(version, otherVer) >= 0,
           );
 
           lowerVersions.forEach((lowerVersion) => {
-            versionConstants[lowerVersion].forEach((lowerCap) => {
+            mapTeamsVersionToSupportedCapabilities[lowerVersion].forEach((lowerCap) => {
               it(`Back compat host client type ${clientType} supporting up to ${version} should ALSO support ${JSON.stringify(
                 lowerCap.capability,
               ).replace(/[{:}]/g, ' ')} capability`, async () => {
                 await utils.initializeWithContext('content', clientType);
                 const generatedRuntimeConfigSupportedCapabilities = JSON.stringify(
-                  generateBackCompatRuntimeConfig(version).supports,
+                  generateVersionBasedTeamsRuntimeConfig(version).supports,
                 ).replace(/[{}]/g, '');
                 expect(generatedRuntimeConfigSupportedCapabilities.includes(capability)).toBe(true);
               });
@@ -189,7 +189,7 @@ describe('runtime', () => {
           )} capability`, async () => {
             await utils.initializeWithContext('content', clientType);
             const generatedRuntimeConfigSupportedCapabilities = JSON.stringify(
-              generateBackCompatRuntimeConfig(version).supports,
+              generateVersionBasedTeamsRuntimeConfig(version).supports,
             ).replace(/[{}]/g, '');
             expect(generatedRuntimeConfigSupportedCapabilities.includes(capability)).toBe(false);
           });

--- a/packages/teams-js/test/public/sharing.spec.ts
+++ b/packages/teams-js/test/public/sharing.spec.ts
@@ -3,7 +3,7 @@ import { compareSDKVersions } from '../../src/internal/utils';
 import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts, HostClientType } from '../../src/public/constants';
 import { ErrorCode } from '../../src/public/interfaces';
-import { generateBackCompatRuntimeConfig } from '../../src/public/runtime';
+import { generateVersionBasedTeamsRuntimeConfig } from '../../src/public/runtime';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { sharing } from '../../src/public/sharing';
 import { Utils } from '../utils';
@@ -389,13 +389,13 @@ describe('sharing_v2', () => {
           if (compareSDKVersions(version, minDesktopAndWebVersionForSharing) >= 0) {
             it(`sharing.isSupported() should return true for web and desktop when version is greater than supported version ${minDesktopAndWebVersionForSharing}}`, async () => {
               await utils.initializeWithContext(FrameContexts.content, clientType);
-              utils.setRuntimeConfig(generateBackCompatRuntimeConfig(version));
+              utils.setRuntimeConfig(generateVersionBasedTeamsRuntimeConfig(version));
               expect(sharing.isSupported()).toBeTruthy();
             });
           } else {
             it(`sharing.isSupported() should return false for web and desktop when version is lower than supported version ${minDesktopAndWebVersionForSharing}}`, async () => {
               await utils.initializeWithContext(FrameContexts.content, clientType);
-              utils.setRuntimeConfig(generateBackCompatRuntimeConfig(version));
+              utils.setRuntimeConfig(generateVersionBasedTeamsRuntimeConfig(version));
               expect(sharing.isSupported()).toBeFalsy();
             });
           }

--- a/packages/teams-js/test/public/webStorage.spec.ts
+++ b/packages/teams-js/test/public/webStorage.spec.ts
@@ -3,7 +3,7 @@ import { GlobalVars } from '../../src/internal/globalVars';
 import { compareSDKVersions } from '../../src/internal/utils';
 import { app } from '../../src/public/app';
 import { FrameContexts, HostClientType } from '../../src/public/constants';
-import { generateBackCompatRuntimeConfig } from '../../src/public/runtime';
+import { generateVersionBasedTeamsRuntimeConfig } from '../../src/public/runtime';
 import { webStorage } from '../../src/public/webStorage';
 import { Utils } from '../utils';
 
@@ -58,13 +58,13 @@ describe('webStorage', () => {
 
                   it(`webStorage.isWebStorageClearedOnUserLogOut should allow call for context ${frameContext}, hostClientType ${clientType} and version ${version}`, async () => {
                     await utils.initializeWithContext(frameContext, clientType);
-                    utils.setRuntimeConfig(generateBackCompatRuntimeConfig(version));
+                    utils.setRuntimeConfig(generateVersionBasedTeamsRuntimeConfig(version));
                     expect(webStorage.isWebStorageClearedOnUserLogOut()).toBeTruthy();
                   });
                 } else {
                   it(`webStorage.isWebStorageClearedOnUserLogOut should not allow call for context ${frameContext}, hostClientType ${clientType} and version ${version}`, async () => {
                     await utils.initializeWithContext(frameContext, clientType);
-                    utils.setRuntimeConfig(generateBackCompatRuntimeConfig(version));
+                    utils.setRuntimeConfig(generateVersionBasedTeamsRuntimeConfig(version));
                     expect(webStorage.isWebStorageClearedOnUserLogOut()).not.toBeTruthy();
                   });
                 }
@@ -72,7 +72,7 @@ describe('webStorage', () => {
                 // not supported for any client type with invalid version
                 it(`webStorage.isWebStorageClearedOnUserLogOut should not allow call for context ${frameContext}, hostClientType ${clientType} and version ${version}`, async () => {
                   await utils.initializeWithContext(frameContext, clientType);
-                  utils.setRuntimeConfig(generateBackCompatRuntimeConfig(version));
+                  utils.setRuntimeConfig(generateVersionBasedTeamsRuntimeConfig(version));
                   expect(webStorage.isWebStorageClearedOnUserLogOut()).toBeFalsy();
                 });
               }
@@ -125,13 +125,13 @@ describe('webStorage', () => {
                   });
                   it(`webStorage.isWebStorageClearedOnUserLogOut should allow call for context ${frameContext}, hostClientType ${clientType} and version ${version}`, async () => {
                     await utils.initializeWithContext(frameContext, clientType);
-                    utils.setRuntimeConfig(generateBackCompatRuntimeConfig(version));
+                    utils.setRuntimeConfig(generateVersionBasedTeamsRuntimeConfig(version));
                     expect(webStorage.isWebStorageClearedOnUserLogOut()).toBeTruthy();
                   });
                 } else {
                   it(`webStorage.isWebStorageClearedOnUserLogOut should not allow call for context ${frameContext}, hostClientType ${clientType} and version ${version}`, async () => {
                     await utils.initializeWithContext(frameContext, clientType);
-                    utils.setRuntimeConfig(generateBackCompatRuntimeConfig(version));
+                    utils.setRuntimeConfig(generateVersionBasedTeamsRuntimeConfig(version));
                     expect(webStorage.isWebStorageClearedOnUserLogOut()).not.toBeTruthy();
                   });
                 }
@@ -139,7 +139,7 @@ describe('webStorage', () => {
                 // not supported for any client type with invalid version
                 it(`webStorage.isWebStorageClearedOnUserLogOut should not allow call for context ${frameContext}, hostClientType ${clientType} and version ${version}`, async () => {
                   await utils.initializeWithContext(frameContext, clientType);
-                  utils.setRuntimeConfig(generateBackCompatRuntimeConfig(version));
+                  utils.setRuntimeConfig(generateVersionBasedTeamsRuntimeConfig(version));
                   expect(webStorage.isWebStorageClearedOnUserLogOut()).toBeFalsy();
                 });
               }


### PR DESCRIPTION
## Description

When I was investigating an issue, I found that some of the functions and structures that support building a runtime object for Teams back-compat scenarios were confusing and unclear. This change renames some of them to be clearer. No functional changes.

### Validation performed:

Ensure everything still builds and tests pass.

### Unit Tests added:

No, since there is no functional change.

### End-to-end tests added:

No, since there is no functional change.

## Additional Requirements

### Change file added:

Yes