### PR TITLE
Add auto-retry (up to 3) for iOS E2E testing

### DIFF
--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -80,7 +80,10 @@ steps:
       -sdk iphonesimulator
       -parallel-testing-enabled YES
       -parallel-testing-worker-count 2
-      -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2'
+      -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2'
+      -screenshot-enabled="YES"
+      -test-iterations 3
+      -retry-tests-on-failure
       -quiet
       -resultBundlePath TestResults
       test > report.out 2>&1


### PR DESCRIPTION
## Description

Add auto-retry for failed test case in YAML file to make E2E test more stable.

### Unit Tests added: No

### End-to-end tests added: No

## Additional Requirements

### Change file added: No


