### PR TITLE
Auto run tests when starting VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
   "typescript.preferences.quoteStyle": "single",
   "prettier.singleQuote": true,
   "cSpell.words": ["adal", "uninitialize"],
-  "jest.jestCommandLine": "pnpm test -- --"
+  "jest.jestCommandLine": "pnpm test -- --",
+  "jest.autoRun": { "watch": "true", "onStartup": ["all-tests"] }
 }


### PR DESCRIPTION
## Description

This change enables jest to automatically run all tests when VSCode starts, and then watch for any changes thereafter. Without this, it can make it difficult to debug tests because they haven't already run and you have to figure out how to go get them to run, etc. This just makes the experience easier and more instantaneous (with a small perf hit when launching VSCode since the tests run now)

## Validation

### Validation performed:

Ensure that tests pass.

### Unit Tests added:

No, because I'm only changing VSCode environment behavior, not the actual product code being tested.

### End-to-end tests added:

No, because I'm only changing VSCode environment behavior, not the actual product code being tested.

## Additional Requirements

### Change file added:

No, the tool said it was not needed.
