### PR TITLE
Update runtime unit tests to use objects instead of strings

### DIFF
--- a/packages/teams-js/test/public/runtime.spec.ts
+++ b/packages/teams-js/test/public/runtime.spec.ts
@@ -132,31 +132,92 @@ describe('runtime', () => {
     });
   });
 
+  // Determines whether the given "subset" runtime object is a subset of the given "superset" runtime object.
+  // This is used to determine whether all capabilities supported in "subset" are also supported in "superset"
+  function isSubset(subset: object, superset: object): boolean {
+    for (const key in subset) {
+      if (typeof subset[key] === 'object' && typeof superset[key] === 'object') {
+        if (!isSubset(subset[key], superset[key])) {
+          return false;
+        }
+      } else if (superset[key] === undefined) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Can recursively decompose an object into an array of objects, where each object in the array is a path to a leaf
+  // node in the original object.
+  // For example,
+  // {
+  //     pages: {
+  //         appButton: {},
+  //         tabs: {},
+  //     }
+  // }
+  // would be decomposed into
+  // [
+  //     { pages: { appButton: {} } },
+  //     { pages: { tabs: {} } }
+  // ]
+  // This can be a useful helper when identifying which capability defined in 'obj' is not defined in a runtime (because
+  // you can decompose a runtime object using this function, then compare each capability/subcapability one at a time to find
+  // any that are missing)
+  function decomposeObject(obj: object): object[] {
+    const result: object[] = [];
+
+    function recurse(current: object, path: string[] = []): void {
+      for (const key in current) {
+        const newPath = [...path, key];
+        if (typeof current[key] === 'object' && Object.keys(current[key]).length > 0) {
+          recurse(current[key], newPath);
+        } else {
+          const entry: object = {};
+          let temp = entry;
+          for (const [i, prop] of newPath.entries()) {
+            temp[prop] = i === newPath.length - 1 ? current[key] : {};
+            temp = temp[prop];
+          }
+          result.push(entry);
+        }
+      }
+    }
+
+    recurse(obj);
+    return result;
+  }
+
   describe('generateVersionBasedTeamsRuntimeConfig', () => {
-    Object.entries(mapTeamsVersionToSupportedCapabilities).forEach(([version, capabilities]) => {
-      capabilities.forEach((supportedCapability) => {
-        const capability = JSON.stringify(supportedCapability.capability).replace(/[{}]/g, '');
-        supportedCapability.hostClientTypes.forEach((clientType) => {
-          it(`Back compat host client type ${clientType} supporting up to ${version} should support ${capability.replace(
-            /:/g,
-            ' ',
-          )} capability`, async () => {
+    Object.entries(mapTeamsVersionToSupportedCapabilities).forEach(([version, capabilityAdditionsForEachVersion]) => {
+      capabilityAdditionsForEachVersion.forEach((capabilityAdditionsForClientTypesInASpecificVersion) => {
+        const capabilityAdditionsForThisVersion = capabilityAdditionsForClientTypesInASpecificVersion.capability;
+        capabilityAdditionsForClientTypesInASpecificVersion.hostClientTypes.forEach((clientType) => {
+          it(`Back compat host client type ${clientType} supporting up to ${version} should support ${JSON.stringify(
+            capabilityAdditionsForThisVersion,
+          )}`, async () => {
             await utils.initializeWithContext('content', clientType);
-            const generatedRuntimeConfigSupportedCapabilities = JSON.stringify(
-              generateVersionBasedTeamsRuntimeConfig(version).supports,
-            ).replace(/[{}]/g, '');
-            expect(generatedRuntimeConfigSupportedCapabilities.includes(capability)).toBe(true);
+            const generatedCapabilityObjectForThisVersion = generateVersionBasedTeamsRuntimeConfig(version).supports;
+            expect(isSubset(capabilityAdditionsForThisVersion, generatedCapabilityObjectForThisVersion)).toBe(true);
           });
 
-          it(`Back compat host client type ${clientType} supporting lower than up to ${version} should NOT support ${capability.replace(
-            /:/g,
-            ' ',
+          it(`Back compat host client type ${clientType} supporting lower than up to ${version} should NOT support ${JSON.stringify(
+            capabilityAdditionsForThisVersion,
           )} capability`, async () => {
+            const individualCapabilityAdditionsForThisVersion: object[] = decomposeObject(
+              capabilityAdditionsForThisVersion,
+            );
+
             await utils.initializeWithContext('content', clientType);
-            const generatedRuntimeConfigSupportedCapabilities = JSON.stringify(
-              generateVersionBasedTeamsRuntimeConfig('1.4.0').supports,
-            ).replace(/[{}]/g, '');
-            expect(generatedRuntimeConfigSupportedCapabilities.includes(capability)).toBe(false);
+
+            const generatedRuntimeConfigSupportedCapabilities =
+              generateVersionBasedTeamsRuntimeConfig('1.4.0').supports;
+
+            individualCapabilityAdditionsForThisVersion.forEach((capabilityAdditionForThisVersion) => {
+              expect(isSubset(capabilityAdditionForThisVersion, generatedRuntimeConfigSupportedCapabilities)).toBe(
+                false,
+              );
+            });
           });
 
           const lowerVersions = Object.keys(mapTeamsVersionToSupportedCapabilities).filter(
@@ -165,33 +226,46 @@ describe('runtime', () => {
 
           lowerVersions.forEach((lowerVersion) => {
             mapTeamsVersionToSupportedCapabilities[lowerVersion].forEach((lowerCap) => {
-              it(`Back compat host client type ${clientType} supporting up to ${version} should ALSO support ${JSON.stringify(
-                lowerCap.capability,
-              ).replace(/[{:}]/g, ' ')} capability`, async () => {
-                await utils.initializeWithContext('content', clientType);
-                const generatedRuntimeConfigSupportedCapabilities = JSON.stringify(
-                  generateVersionBasedTeamsRuntimeConfig(version).supports,
-                ).replace(/[{}]/g, '');
-                expect(generatedRuntimeConfigSupportedCapabilities.includes(capability)).toBe(true);
-              });
+              if (lowerCap.hostClientTypes.includes(clientType)) {
+                const capabilityAdditionsForThisVersion = lowerCap.capability;
+                it(`Back compat host client type ${clientType} supporting up to ${version} should ALSO support ${JSON.stringify(
+                  capabilityAdditionsForThisVersion,
+                )} capability`, async () => {
+                  await utils.initializeWithContext('content', clientType);
+                  expect(
+                    isSubset(
+                      capabilityAdditionsForThisVersion,
+                      generateVersionBasedTeamsRuntimeConfig(version).supports,
+                    ),
+                  ).toBe(true);
+                });
+              }
             });
           });
         });
 
         const notSupportedHostClientTypes = Object.values(HostClientType).filter(
-          (type) => !supportedCapability.hostClientTypes.includes(type),
+          (type) => !capabilityAdditionsForClientTypesInASpecificVersion.hostClientTypes.includes(type),
+        );
+
+        const individualCapabilityAdditionsForThisVersion: object[] = decomposeObject(
+          capabilityAdditionsForThisVersion,
         );
 
         notSupportedHostClientTypes.forEach((clientType) => {
-          it(`Back compat host client type ${clientType} supporting up to ${version} should NOT support ${capability.replace(
-            /[{:}]/g,
-            ' ',
+          it(`Back compat host client type ${clientType} supporting up to ${version} should NOT support ${JSON.stringify(
+            capabilityAdditionsForThisVersion,
           )} capability`, async () => {
             await utils.initializeWithContext('content', clientType);
-            const generatedRuntimeConfigSupportedCapabilities = JSON.stringify(
-              generateVersionBasedTeamsRuntimeConfig(version).supports,
-            ).replace(/[{}]/g, '');
-            expect(generatedRuntimeConfigSupportedCapabilities.includes(capability)).toBe(false);
+
+            individualCapabilityAdditionsForThisVersion.forEach((singleCapabilityAdditionForThisVersion) => {
+              expect(
+                isSubset(
+                  singleCapabilityAdditionForThisVersion,
+                  generateVersionBasedTeamsRuntimeConfig(version).supports,
+                ),
+              ).toBe(false);
+            });
           });
         });
       });


### PR DESCRIPTION
## Description

Today, the runtime unit tests validate that the Teams default runtime gets applied by using strings and regex on the objects. This was fine for the need at the time, but it has limitations. In particular, the code does not support subcapabilities, only comparing top level capabilities (foreshadowing).

Before adding subcapabilities to the runtime objects in a subsequent change, I'm updating this code to use the actual objects when doing comparisons (rather than trying to extend the string-based comparisons) so that it can now support subcapabilities (to any level of nesting).

### Main changes in the PR:

Update the runtime tests to use object comparisons rather than strings and regex

## Validation

### Validation performed:

* Ensure tests continued to pass
* Broke something to ensure the tests failed when they should

### Unit Tests added:

No new unit tests were added since this change only focuses on changing the implementation of the current unit tests.

### End-to-end tests added:

No; this change is limited to unit test implementation.

## Additional Requirements

### Change file added:

No, the tool said no changefile was required.

### Next/remaining steps:

1. My subsequent PR will update how the version tests are handled in this file to ensure they're always using a lower version and not just hardcoding 1.4.0 and assuming it is the lowest version
2. Subsequent to that, I will be creating another PR to update the default Teams config to indicate that Teams Mobile does not support various subcapabilities (e.g., pages.tabs)
