### PR TITLE
Fix unit tests that assume the runtime always supports them

### DIFF
--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -21,6 +21,7 @@ import {
 } from '../../src/public/interfaces';
 import {
   _minRuntimeConfigToUninitialize,
+  generateVersionBasedTeamsRuntimeConfig,
   latestRuntimeApiVersion,
   runtime,
   versionAndPlatformAgnosticTeamsRuntimeConfig,
@@ -164,33 +165,42 @@ describe('Testing app capability', () => {
         expect(callbackInvoked).toBe(true);
       });
 
-      it('app.initialize should use teams runtime config if no runtime config is given', async () => {
+      it('app.initialize should use version and platform-specific Teams runtime config if no runtime config is given', async () => {
         const initPromise = app.initialize();
 
         const initMessage = utils.findMessageByFunc('initialize');
-        utils.respondToMessage(initMessage, FrameContexts.content, HostClientType.web, '1.6.0');
+        const highestSupportedVersion: string = '1.6.0';
+        utils.respondToMessage(initMessage, FrameContexts.content, HostClientType.web, highestSupportedVersion);
         await initPromise;
-        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
+        expect(runtime).toEqual(generateVersionBasedTeamsRuntimeConfig(highestSupportedVersion));
       });
 
-      it('app.initialize should use teams runtime config if an empty runtime config is given', async () => {
+      it('app.initialize should use version and platform-specific Teams runtime config if an empty runtime config is given', async () => {
         const initPromise = app.initialize();
 
         const initMessage = utils.findMessageByFunc('initialize');
-        utils.respondToMessage(initMessage, FrameContexts.content, HostClientType.web, '', '1.6.0');
+        const highestSupportedVersion: string = '1.6.0';
+        utils.respondToMessage(initMessage, FrameContexts.content, HostClientType.web, '', highestSupportedVersion);
         await initPromise;
 
-        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
+        expect(runtime).toEqual(generateVersionBasedTeamsRuntimeConfig(highestSupportedVersion));
       });
 
       it('app.initialize should use teams runtime config if a JSON parsing error is thrown by a given runtime config', async () => {
         const initPromise = app.initialize();
 
         const initMessage = utils.findMessageByFunc('initialize');
-        utils.respondToMessage(initMessage, FrameContexts.content, HostClientType.web, 'nonJSONStr', '1.6.0');
+        const highestSupportedVersion: string = '1.6.0';
+        utils.respondToMessage(
+          initMessage,
+          FrameContexts.content,
+          HostClientType.web,
+          'nonJSONStr',
+          highestSupportedVersion,
+        );
         await initPromise;
 
-        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
+        expect(runtime).toEqual(generateVersionBasedTeamsRuntimeConfig(highestSupportedVersion));
       });
 
       it('app.initialize should throw an error if the given runtime config causes a non parsing related error', async () => {
@@ -256,10 +266,17 @@ describe('Testing app capability', () => {
         const initPromise = app.initialize();
 
         const initMessage = utils.findMessageByFunc('initialize');
-        utils.respondToMessage(initMessage, FrameContexts.content, HostClientType.web, '1.6.0', 'nonJSONStr');
+        const highestSupportedVersion: string = '1.6.0';
+        utils.respondToMessage(
+          initMessage,
+          FrameContexts.content,
+          HostClientType.web,
+          highestSupportedVersion,
+          'nonJSONStr',
+        );
         await initPromise;
 
-        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
+        expect(runtime).toEqual(generateVersionBasedTeamsRuntimeConfig(highestSupportedVersion));
       });
 
       it('app.initialize should throw an error when "null" runtimeConfig is given, with arguments flipped', async () => {
@@ -1036,45 +1053,48 @@ describe('Testing app capability', () => {
         const initPromise = app.initialize();
         const initMessage = utils.findMessageByFunc('initialize');
 
+        const highestSupportedVersion = '1.6.0';
         utils.respondToFramelessMessage({
           data: {
             id: initMessage.id,
-            args: [FrameContexts.content, HostClientType.web, '1.6.0'],
+            args: [FrameContexts.content, HostClientType.web, highestSupportedVersion],
           },
         } as DOMMessageEvent);
         await initPromise;
 
-        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
+        expect(runtime).toEqual(generateVersionBasedTeamsRuntimeConfig(highestSupportedVersion));
       });
 
       it('app.initialize should use teams runtime config if an empty runtime config is given', async () => {
         const initPromise = app.initialize();
 
+        const highestSupportedVersion = '1.6.0';
         const initMessage = utils.findMessageByFunc('initialize');
         utils.respondToFramelessMessage({
           data: {
             id: initMessage.id,
-            args: [FrameContexts.content, HostClientType.web, '', '1.6.0'],
+            args: [FrameContexts.content, HostClientType.web, '', highestSupportedVersion],
           },
         } as DOMMessageEvent);
         await initPromise;
 
-        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
+        expect(runtime).toEqual(generateVersionBasedTeamsRuntimeConfig(highestSupportedVersion));
       });
 
       it('app.initialize should use teams runtime config if a JSON parsing error is thrown by a given runtime config', async () => {
         const initPromise = app.initialize();
 
+        const highestSupportedVersion = '1.6.0';
         const initMessage = utils.findMessageByFunc('initialize');
         utils.respondToFramelessMessage({
           data: {
             id: initMessage.id,
-            args: [FrameContexts.content, HostClientType.web, 'nonJSONStr', '1.6.0'],
+            args: [FrameContexts.content, HostClientType.web, 'nonJSONStr', highestSupportedVersion],
           },
         } as DOMMessageEvent);
         await initPromise;
 
-        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
+        expect(runtime).toEqual(generateVersionBasedTeamsRuntimeConfig(highestSupportedVersion));
       });
 
       it('app.initialize should throw an error if the given runtime config causes a non parsing related error', async () => {
@@ -1141,16 +1161,17 @@ describe('Testing app capability', () => {
       it('app.initialize should initialize with teams config when an invalid runtimeConfig is given, with arguments flipped', async () => {
         const initPromise = app.initialize();
 
+        const highestSupportedVersion = '1.6.0';
         const initMessage = utils.findMessageByFunc('initialize');
         utils.respondToFramelessMessage({
           data: {
             id: initMessage.id,
-            args: [FrameContexts.content, HostClientType.web, '1.6.0', 'nonJSONStr'],
+            args: [FrameContexts.content, HostClientType.web, highestSupportedVersion, 'nonJSONStr'],
           },
         } as DOMMessageEvent);
         await initPromise;
 
-        expect(runtime).toEqual(versionAndPlatformAgnosticTeamsRuntimeConfig);
+        expect(runtime).toEqual(generateVersionBasedTeamsRuntimeConfig(highestSupportedVersion));
       });
 
       Object.values(HostClientType).forEach((hostClientType) => {

--- a/packages/teams-js/test/public/navigation.spec.ts
+++ b/packages/teams-js/test/public/navigation.spec.ts
@@ -70,21 +70,27 @@ describe('MicrosoftTeams-Navigation', () => {
 
     Object.values(FrameContexts).forEach((context) => {
       it(`navigation.navigateToTab should successfully call pages.tabs.nagivateToTab when initialized with ${context} context`, async () => {
-        await utils.initializeWithContext(context, 'desktop');
+        await utils.initializeWithContext(context);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: { tabs: {} } } });
+
         const pagesNavigateToTabs = jest.spyOn(pages.tabs, 'navigateToTab');
         navigateToTab(null);
         expect(pagesNavigateToTabs).toHaveBeenCalled();
       });
 
       it.skip(`navigation.navigateToTab should register the navigateToTab action when initialized with ${context} context`, async () => {
-        await utils.initializeWithContext(context, 'desktop');
+        await utils.initializeWithContext(context);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: { tabs: {} } } });
+
         navigateToTab(null);
         const navigateToTabMsg = utils.findMessageByFunc('navigateToTab');
         expect(navigateToTabMsg).not.toBeNull();
       });
 
       it.skip(`navigation.navigateToTab should not navigate to tab action when set to false and initialized with ${context} context`, async () => {
-        await utils.initializeWithContext(context, 'desktop');
+        await utils.initializeWithContext(context);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: { tabs: {} } } });
+
         jest.spyOn(utilFunc, 'getGenericOnCompleteHandler').mockImplementation(() => {
           return (success: boolean, reason: string): void => {
             if (!success) {

--- a/packages/teams-js/test/public/navigation.spec.ts
+++ b/packages/teams-js/test/public/navigation.spec.ts
@@ -78,7 +78,7 @@ describe('MicrosoftTeams-Navigation', () => {
         expect(pagesNavigateToTabs).toHaveBeenCalled();
       });
 
-      it.skip(`navigation.navigateToTab should register the navigateToTab action when initialized with ${context} context`, async () => {
+      it(`navigation.navigateToTab should register the navigateToTab action when initialized with ${context} context`, async () => {
         await utils.initializeWithContext(context);
         utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: { tabs: {} } } });
 
@@ -87,7 +87,7 @@ describe('MicrosoftTeams-Navigation', () => {
         expect(navigateToTabMsg).not.toBeNull();
       });
 
-      it.skip(`navigation.navigateToTab should not navigate to tab action when set to false and initialized with ${context} context`, async () => {
+      it(`navigation.navigateToTab should not navigate to tab action when set to false and initialized with ${context} context`, async () => {
         await utils.initializeWithContext(context);
         utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: { tabs: {} } } });
 

--- a/packages/teams-js/test/public/navigation.spec.ts
+++ b/packages/teams-js/test/public/navigation.spec.ts
@@ -12,6 +12,10 @@ describe('MicrosoftTeams-Navigation', () => {
   // Use to send a mock message from the app.
   const utils = new Utils();
 
+  function makeRuntimeSupportNavigationCapability() {
+    utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: { tabs: {} } } });
+  }
+
   beforeEach(() => {
     utils.processMessage = null;
     utils.messages = [];
@@ -71,7 +75,7 @@ describe('MicrosoftTeams-Navigation', () => {
     Object.values(FrameContexts).forEach((context) => {
       it(`navigation.navigateToTab should successfully call pages.tabs.nagivateToTab when initialized with ${context} context`, async () => {
         await utils.initializeWithContext(context);
-        utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: { tabs: {} } } });
+        makeRuntimeSupportNavigationCapability();
 
         const pagesNavigateToTabs = jest.spyOn(pages.tabs, 'navigateToTab');
         navigateToTab(null);
@@ -80,7 +84,7 @@ describe('MicrosoftTeams-Navigation', () => {
 
       it(`navigation.navigateToTab should register the navigateToTab action when initialized with ${context} context`, async () => {
         await utils.initializeWithContext(context);
-        utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: { tabs: {} } } });
+        makeRuntimeSupportNavigationCapability();
 
         navigateToTab(null);
         const navigateToTabMsg = utils.findMessageByFunc('navigateToTab');
@@ -89,7 +93,7 @@ describe('MicrosoftTeams-Navigation', () => {
 
       it(`navigation.navigateToTab should not navigate to tab action when set to false and initialized with ${context} context`, async () => {
         await utils.initializeWithContext(context);
-        utils.setRuntimeConfig({ apiVersion: 1, supports: { pages: { tabs: {} } } });
+        makeRuntimeSupportNavigationCapability();
 
         jest.spyOn(utilFunc, 'getGenericOnCompleteHandler').mockImplementation(() => {
           return (success: boolean, reason: string): void => {

--- a/packages/teams-js/test/public/navigation.spec.ts
+++ b/packages/teams-js/test/public/navigation.spec.ts
@@ -70,21 +70,21 @@ describe('MicrosoftTeams-Navigation', () => {
 
     Object.values(FrameContexts).forEach((context) => {
       it(`navigation.navigateToTab should successfully call pages.tabs.nagivateToTab when initialized with ${context} context`, async () => {
-        await utils.initializeWithContext(context);
+        await utils.initializeWithContext(context, 'desktop');
         const pagesNavigateToTabs = jest.spyOn(pages.tabs, 'navigateToTab');
         navigateToTab(null);
         expect(pagesNavigateToTabs).toHaveBeenCalled();
       });
 
-      it(`navigation.navigateToTab should register the navigateToTab action when initialized with ${context} context`, async () => {
-        await utils.initializeWithContext(context);
+      it.skip(`navigation.navigateToTab should register the navigateToTab action when initialized with ${context} context`, async () => {
+        await utils.initializeWithContext(context, 'desktop');
         navigateToTab(null);
         const navigateToTabMsg = utils.findMessageByFunc('navigateToTab');
         expect(navigateToTabMsg).not.toBeNull();
       });
 
-      it(`navigation.navigateToTab should not navigate to tab action when set to false and initialized with ${context} context`, async () => {
-        await utils.initializeWithContext(context);
+      it.skip(`navigation.navigateToTab should not navigate to tab action when set to false and initialized with ${context} context`, async () => {
+        await utils.initializeWithContext(context, 'desktop');
         jest.spyOn(utilFunc, 'getGenericOnCompleteHandler').mockImplementation(() => {
           return (success: boolean, reason: string): void => {
             if (!success) {

--- a/packages/teams-js/test/public/stageView.spec.ts
+++ b/packages/teams-js/test/public/stageView.spec.ts
@@ -75,7 +75,9 @@ describe('stageView', () => {
     });
 
     it('should pass along entire StageViewParams parameter in content context', async () => {
-      await utils.initializeWithContext(FrameContexts.content, 'desktop');
+      await utils.initializeWithContext(FrameContexts.content);
+      utils.setRuntimeConfig({ apiVersion: 1, supports: { stageView: {} } });
+
       const promise = stageView.open(stageViewParams);
 
       const openStageViewMessage = utils.findMessageByFunc('stageView.open');

--- a/packages/teams-js/test/public/stageView.spec.ts
+++ b/packages/teams-js/test/public/stageView.spec.ts
@@ -68,12 +68,12 @@ describe('stageView', () => {
 
     it('should not allow a null StageViewParams parameter', async () => {
       expect.assertions(1);
-      await utils.initializeWithContext(FrameContexts.content);
+      await utils.initializeWithContext(FrameContexts.content, 'desktop');
       expect(() => stageView.open(null)).rejects.toThrowError('[stageView.open] Stage view params cannot be null');
     });
 
     it('should pass along entire StageViewParams parameter in content context', async () => {
-      await utils.initializeWithContext(FrameContexts.content);
+      await utils.initializeWithContext(FrameContexts.content, 'desktop');
       const promise = stageView.open(stageViewParams);
 
       const openStageViewMessage = utils.findMessageByFunc('stageView.open');
@@ -84,7 +84,7 @@ describe('stageView', () => {
     });
 
     it('should return promise and resolve', async () => {
-      await utils.initializeWithContext(FrameContexts.content);
+      await utils.initializeWithContext(FrameContexts.content, 'desktop');
 
       const promise = stageView.open(stageViewParams);
 
@@ -97,7 +97,7 @@ describe('stageView', () => {
     });
 
     it('should properly handle errors', async () => {
-      await utils.initializeWithContext(FrameContexts.content);
+      await utils.initializeWithContext(FrameContexts.content, 'desktop');
 
       const promise = stageView.open(stageViewParams);
 
@@ -111,7 +111,7 @@ describe('stageView', () => {
     });
 
     it('should throw error when stageView is not supported.', async () => {
-      await utils.initializeWithContext(FrameContexts.content);
+      await utils.initializeWithContext(FrameContexts.content, 'ios');
       utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
 
       expect.assertions(1);

--- a/packages/teams-js/test/public/stageView.spec.ts
+++ b/packages/teams-js/test/public/stageView.spec.ts
@@ -12,8 +12,11 @@ import { Utils } from '../utils';
 
 describe('stageView', () => {
   const utils = new Utils();
-
   const allowedContexts = [FrameContexts.content];
+
+  function makeRuntimeSupportStageViewCapability() {
+    utils.setRuntimeConfig({ apiVersion: 1, supports: { stageView: {} } });
+  }
 
   beforeEach(() => {
     utils.processMessage = null;
@@ -69,14 +72,14 @@ describe('stageView', () => {
     it('should not allow a null StageViewParams parameter', async () => {
       expect.assertions(1);
       await utils.initializeWithContext(FrameContexts.content);
-      utils.setRuntimeConfig({ apiVersion: 1, supports: { stageView: {} } });
+      makeRuntimeSupportStageViewCapability();
 
       expect(() => stageView.open(null)).rejects.toThrowError('[stageView.open] Stage view params cannot be null');
     });
 
     it('should pass along entire StageViewParams parameter in content context', async () => {
       await utils.initializeWithContext(FrameContexts.content);
-      utils.setRuntimeConfig({ apiVersion: 1, supports: { stageView: {} } });
+      makeRuntimeSupportStageViewCapability();
 
       const promise = stageView.open(stageViewParams);
 
@@ -89,7 +92,7 @@ describe('stageView', () => {
 
     it('should return promise and resolve', async () => {
       await utils.initializeWithContext(FrameContexts.content);
-      utils.setRuntimeConfig({ apiVersion: 1, supports: { stageView: {} } });
+      makeRuntimeSupportStageViewCapability();
 
       const promise = stageView.open(stageViewParams);
 
@@ -103,7 +106,7 @@ describe('stageView', () => {
 
     it('should properly handle errors', async () => {
       await utils.initializeWithContext(FrameContexts.content);
-      utils.setRuntimeConfig({ apiVersion: 1, supports: { stageView: {} } });
+      makeRuntimeSupportStageViewCapability();
 
       const promise = stageView.open(stageViewParams);
 

--- a/packages/teams-js/test/public/stageView.spec.ts
+++ b/packages/teams-js/test/public/stageView.spec.ts
@@ -68,7 +68,9 @@ describe('stageView', () => {
 
     it('should not allow a null StageViewParams parameter', async () => {
       expect.assertions(1);
-      await utils.initializeWithContext(FrameContexts.content, 'desktop');
+      await utils.initializeWithContext(FrameContexts.content);
+      utils.setRuntimeConfig({ apiVersion: 1, supports: { stageView: {} } });
+
       expect(() => stageView.open(null)).rejects.toThrowError('[stageView.open] Stage view params cannot be null');
     });
 
@@ -84,7 +86,8 @@ describe('stageView', () => {
     });
 
     it('should return promise and resolve', async () => {
-      await utils.initializeWithContext(FrameContexts.content, 'desktop');
+      await utils.initializeWithContext(FrameContexts.content);
+      utils.setRuntimeConfig({ apiVersion: 1, supports: { stageView: {} } });
 
       const promise = stageView.open(stageViewParams);
 
@@ -97,7 +100,8 @@ describe('stageView', () => {
     });
 
     it('should properly handle errors', async () => {
-      await utils.initializeWithContext(FrameContexts.content, 'desktop');
+      await utils.initializeWithContext(FrameContexts.content);
+      utils.setRuntimeConfig({ apiVersion: 1, supports: { stageView: {} } });
 
       const promise = stageView.open(stageViewParams);
 
@@ -111,7 +115,7 @@ describe('stageView', () => {
     });
 
     it('should throw error when stageView is not supported.', async () => {
-      await utils.initializeWithContext(FrameContexts.content, 'ios');
+      await utils.initializeWithContext(FrameContexts.content);
       utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
 
       expect.assertions(1);


### PR DESCRIPTION
## Description

Some of the unit tests make assumptions that the capability they are testing will always be supported (i.e., they don't explicitly ensure it is supported as part of their set up). This is fine today, when the default runtime does support them. But it's not fine tomorrow when I update the default runtime to no longer support them (i.e., a future change will remove pages.tabs and from being default supported, since it's not correct for it to be supported on Teams mobile).

This change makes their assumptions explicit by ensuring they are always setting that their capability is supported (in the case of navigation and stageView) and ensuring that the default runtime being tested against is actually specific to the version and platform being specified (in the case of app).

### Main changes in the PR:

1. Update navigation and stageView unit tests to explicitly set their dependent capability as supported
2. Update app unit tests to compare against the appropriate version and platform runtime object, rather than assuming the version and platform agnostic one is correct

## Validation

### Validation performed:

- Ensured unit tests continued to pass

### Unit Tests added:

No, not changing or adding functionality, just updating the implementation of existing unit tests.

### End-to-end tests added:

No.

## Additional Requirements

### Change file added:

The tool said it wasn't needed.

### Related PRs:

#1952 
#1953 

### Next/remaining steps:

- In addition to merging the above PRs, I believe the only remaining step to complete this journey will be to update the Teams fallback runtime to properly indicate that capabilities like pages.tabs are not supported on Teams Mobile