### PR TITLE
Fix ts-jest globals deprecation warning

### DIFF
--- a/jest.config.common.js
+++ b/jest.config.common.js
@@ -1,6 +1,6 @@
 module.exports = {
   transform: {
-    '.(ts|tsx)': 'ts-jest',
+    '.(ts|tsx)': ['ts-jest', { tsconfig: { downlevelIteration: true } }],
   },
   testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$',
   testEnvironment: 'jsdom',

--- a/packages/teams-js/jest.config.js
+++ b/packages/teams-js/jest.config.js
@@ -5,11 +5,6 @@ const packageVersion = require('./package.json').version;
 module.exports = {
   ...commonSettings,
   globals: {
-    'ts-jest': {
-      tsconfig: {
-        downlevelIteration: true,
-      },
-    },
     PACKAGE_VERSION: packageVersion,
   },
 };

--- a/tools/bundle-size-tools/jest.config.js
+++ b/tools/bundle-size-tools/jest.config.js
@@ -6,11 +6,6 @@ const packageVersion = require('./package.json').version;
 module.exports = {
   ...commonSettings,
   globals: {
-    'ts-jest': {
-      tsconfig: {
-        downlevelIteration: true,
-      },
-    },
     PACKAGE_VERSION: packageVersion,
   },
 };


### PR DESCRIPTION
## Description

When running jest tests in this repo, this warning would show up multiple times:
```
@microsoft/teams-js: ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
@microsoft/teams-js: transform: {
@microsoft/teams-js:     <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
@microsoft/teams-js: },
```

When you are investigating unit test failures, noise like this can make it hard to track down issues.

### Main changes in the PR:

Move the ts-jest config from the `globals` section to the `transform` section, as the warning indicates.

## Validation

### Validation performed:

Verified that all jest tests still pass and that the warning is now gone.

### Unit Tests added:

No.

### End-to-end tests added:

No.

## Additional Requirements

### Change file added:

None needed.

### Next/remaining steps:

There's one remaining warning
```
@microsoft/teams-js: ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting `esModuleInterop` to `true` in your TypeScript configuration file (usually `tsconfig.json`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
```
...that I will fix in a subsequent PR.