### PR TITLE
Fix ts-jest warning about esModuleInterop not being true

### DIFF
--- a/jest.config.common.js
+++ b/jest.config.common.js
@@ -1,6 +1,6 @@
 module.exports = {
   transform: {
-    '.(ts|tsx)': ['ts-jest', { tsconfig: { downlevelIteration: true } }],
+    '.(ts|tsx)': ['ts-jest', { tsconfig: { downlevelIteration: true, esModuleInterop: true } }],
   },
   testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$',
   testEnvironment: 'jsdom',


### PR DESCRIPTION
## Description

The last remaining jest warning in the teams-js repo was this:
```
@microsoft/teams-js: ts-jest[config] (WARN) message TS151001: If you have issues related to imports, you should consider setting `esModuleInterop` to `true` in your TypeScript configuration file (usually `tsconfig.json`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
```

It would show several times when running jest tests, adding noise to any attempt to debug issues. With this change, I am fixing that warning and there are now no longer any warnings showing when running jest tests.

Note: I haven't yet figured out if there is a way to make ts-jest warnings show up as errors, to prevent anything like this from being reintroduced. I haven't found any documentation about it. I have [a post](https://stackoverflow.com/questions/77219016/is-there-a-way-to-make-ts-jest-treat-warnings-as-errors) out on StackOverflow to see if there are any pointers.

### Main changes in the PR:

Make the suggested configuration change (set `esModuleInterop` to `true`) in the jest configuration. I'm not aware of any actual import problems caused by not having this, but [the docs](https://devblogs.microsoft.com/typescript/announcing-typescript-2-7/#easier-ecmascript-module-interoperability) make it sound like a reasonable thing to enable, and enabling it seems like the only way to fix the warning.

## Validation

### Validation performed:

Ensure tests still pass and no warnings are emitted.

### Unit Tests added:

No.

### End-to-end tests added:

No.

## Additional Requirements

### Change file added:

Was not required.

### Related PRs:

#1956 