### PR TITLE
Magli/openchatfix

### DIFF
--- a/change/@microsoft-teams-js-23b47bb4-1712-4f2d-80e1-07d270a51f0c.json
+++ b/change/@microsoft-teams-js-23b47bb4-1712-4f2d-80e1-07d270a51f0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed the bug that openchat doesn't allow users to pass string for single user",
+  "packageName": "@microsoft/teams-js",
+  "email": "magli@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/chat.ts
+++ b/packages/teams-js/src/public/chat.ts
@@ -79,7 +79,7 @@ export namespace chat {
         );
       } else {
         const sendPromise = sendAndHandleStatusAndReason('chat.openChat', {
-          members: openChatRequest.user,
+          members: [openChatRequest.user],
           message: openChatRequest.message,
         });
         resolve(sendPromise);

--- a/packages/teams-js/test/public/chat.spec.ts
+++ b/packages/teams-js/test/public/chat.spec.ts
@@ -86,7 +86,7 @@ describe('chat', () => {
           chat.openChat(chatRequest);
 
           const chatResponse = {
-            members: 'someUPN',
+            members: ['someUPN'],
             message: 'someMessage',
           };
 


### PR DESCRIPTION
This PR is to address the github issue: https://github.com/OfficeDev/microsoft-teams-library-js/issues/1964

## Description
Currently, teamsjs supports both single chat and group chat. For single chat, according to the public document, developers can pass user as OpenSingleChatRequest object which holds user as a string https://learn.microsoft.com/en-us/javascript/api/@microsoft/teams-js/opensinglechatrequest?view=msteams-client-js-latest. However, teams client is expecting app sdk passing in an user array for both single and group chat. That causes the issue that if developers are passing in user as a string as part of opensinglechatrequest object, they will encounter the error: "members.map is not a function".

The fix in this PR is to convert the user string as user array in teams js.

### Main changes in the PR:

1. Convert user string to be user array for single chat 
2. Update the test

## Validation
Validated with local test app. After the updating, developer are able to pass parameters like 
![image](https://github.com/OfficeDev/microsoft-teams-library-js/assets/8062622/2dfa0ec5-b164-415f-b18e-7a70ff43e0b6)
 for single chat.
Without this fix, it will repro the error "members.map is not a function".

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
