### PR TITLE
Clipboard Test Data fix

### DIFF
--- a/apps/teams-test-app/e2e-test-data/clipboard.json
+++ b/apps/teams-test-app/e2e-test-data/clipboard.json
@@ -14,7 +14,7 @@
       "title": "Copy Text - failure",
       "type": "callResponse",
       "boxSelector": "#box_copyText",
-      "inputValue": "\"\"",
+      "inputValue": {},
       "skipJsonStringifyOnInputValue": true,
       "expectedTestAppValue": "Error: String can't be empty"
     },
@@ -36,7 +36,7 @@
       "title": "Copy Image - failure",
       "type": "callResponse",
       "boxSelector": "#box_copyImage",
-      "inputValue": "\"\"",
+      "inputValue": {},
       "skipJsonStringifyOnInputValue": true,
       "expectedTestAppValue": "Error: mimeType can't be empty"
     }


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description
This PR is to change the input type in clipboard json file for e2e test cases from `""` to `{}`.


### Main changes in the PR:

1. Change the input type in clipboard

## Validation

### Validation performed:

N/A

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

N/A

### End-to-end tests added:

N/A

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

N/A

### Related PRs:

N/A