### PR TITLE
Fix local typedoc generation and export unexported referenced types

### DIFF
--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -14,7 +14,7 @@
     "build": "pnpm lint && webpack && pnpm docs:validate",
     "clean": "rimraf ./dist",
     "docs": "pnpm typedoc",
-    "docs:validate": "pnpm typedoc --plugin typedoc-plugin-missing-exports --emit none",
+    "docs:validate": "pnpm typedoc --emit none",
     "lint": "pnpm eslint ./src ./test --max-warnings 0 --fix --ext .ts",
     "prettier": "prettier --write '**/*.{ts,js,css,html}'",
     "test": "jest"

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -535,7 +535,7 @@ export namespace app {
   /**
    * This function is passed to registerOnThemeHandler. It is called every time the user changes their theme.
    */
-  type themeHandler = (theme: string) => void;
+  export type themeHandler = (theme: string) => void;
 
   /**
    * Checks whether the Teams client SDK has been initialized.
@@ -808,14 +808,14 @@ export namespace app {
      *
      * @param context - Data structure to be used to pass the context to the app.
      */
-    type registerOnResumeHandlerFunctionType = (context: ResumeContext) => void;
+    export type registerOnResumeHandlerFunctionType = (context: ResumeContext) => void;
 
     /**
      * Register before suspendOrTerminate handler function type
      *
      * @returns void
      */
-    type registerBeforeSuspendOrTerminateHandlerFunctionType = () => void;
+    export type registerBeforeSuspendOrTerminateHandlerFunctionType = () => void;
 
     /**
      * Registers a handler to be called before the page is suspended or terminated. Once a user navigates away from an app,

--- a/packages/teams-js/src/public/appWindow.ts
+++ b/packages/teams-js/src/public/appWindow.ts
@@ -10,9 +10,9 @@ import { FrameContexts } from './constants';
 import { runtime } from './runtime';
 
 /** onComplete function type */
-type onCompleteFunctionType = (status: boolean, reason?: string) => void;
+export type onCompleteFunctionType = (status: boolean, reason?: string) => void;
 /** addEventListner function type */
-type addEventListnerFunctionType = (message: any) => void;
+export type addEventListnerFunctionType = (message: any) => void;
 
 /** Represents a window or frame within the host app. */
 export interface IAppWindow {

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -28,6 +28,7 @@ export {
   LoadContext,
   LocaleInfo,
   M365ContentAction,
+  ResumeContext,
   SdkError,
   SecondaryId,
   SecondaryM365ContentIdName,
@@ -71,6 +72,7 @@ export { appInitialization } from './appInitialization';
 export {
   enablePrintCapability,
   executeDeepLink,
+  executeDeepLinkOnCompleteFunctionType,
   getContext,
   getMruTabInstances,
   getTabInstances,

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -49,7 +49,13 @@ export { dialog } from './dialog';
 export { geoLocation } from './geoLocation';
 export { getAdaptiveCardSchemaVersion } from './adaptiveCards';
 export { pages } from './pages';
-export { ChildAppWindow, IAppWindow, ParentAppWindow } from './appWindow';
+export {
+  addEventListnerFunctionType,
+  ChildAppWindow,
+  IAppWindow,
+  onCompleteFunctionType,
+  ParentAppWindow,
+} from './appWindow';
 export { menus } from './menus';
 export { media } from './media';
 export { secondaryBrowser } from './secondaryBrowser';
@@ -70,29 +76,41 @@ export { webStorage } from './webStorage';
 export { call } from './call';
 export { appInitialization } from './appInitialization';
 export {
+  callbackFunctionType,
   enablePrintCapability,
   executeDeepLink,
   executeDeepLinkOnCompleteFunctionType,
   getContext,
+  getContextCallbackFunctionType,
   getMruTabInstances,
   getTabInstances,
+  getTabInstancesCallbackFunctionType,
   initialize,
   initializeWithFrameContext,
   print,
-  registerBackButtonHandler,
-  registerBeforeUnloadHandler,
-  registerFocusEnterHandler,
-  registerChangeSettingsHandler,
-  registerFullScreenHandler,
-  registerOnLoadHandler,
-  registerOnThemeChangeHandler,
   registerAppButtonClickHandler,
   registerAppButtonHoverEnterHandler,
   registerAppButtonHoverLeaveHandler,
+  registerBackButtonHandler,
+  registerBackButtonHandlerFunctionType,
+  registerBeforeUnloadHandler,
+  registerChangeSettingsHandler,
+  registerFocusEnterHandler,
+  registerFullScreenHandler,
+  registerFullScreenHandlerFunctionType,
+  registerOnLoadHandler,
+  registerOnThemeChangeHandler,
+  registerOnThemeChangeHandlerFunctionType,
   setFrameContext,
   shareDeepLink,
 } from './publicAPIs';
-export { returnFocus, navigateBack, navigateCrossDomain, navigateToTab } from './navigation';
+export {
+  navigateBack,
+  navigateCrossDomain,
+  navigateToTab,
+  onCompleteHandlerFunctionType,
+  returnFocus,
+} from './navigation';
 export { settings } from './settings';
 export { tasks } from './tasks';
 export { liveShare, LiveShareHost } from './liveShareHost';

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -938,7 +938,7 @@ export interface ResumeContext {
 
 /**
  * @deprecated
- * As of 2.14.1, please use ResumeContext instead.
+ * As of 2.14.1, please use {@link ResumeContext} instead.
  */
 export type LoadContext = ResumeContext;
 

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -13,9 +13,9 @@ import { runtime } from './runtime';
  */
 export namespace location {
   /** Get location callback function type */
-  type getLocationCallbackFunctionType = (error: SdkError, location: Location) => void;
+  export type getLocationCallbackFunctionType = (error: SdkError, location: Location) => void;
   /** Show location callback function type */
-  type showLocationCallbackFunctionType = (error: SdkError, status: boolean) => void;
+  export type showLocationCallbackFunctionType = (error: SdkError, status: boolean) => void;
 
   /**
    * @deprecated

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -35,13 +35,13 @@ import { runtime } from './runtime';
  */
 export namespace media {
   /** Capture image callback function type. */
-  type captureImageCallbackFunctionType = (error: SdkError, files: File[]) => void;
+  export type captureImageCallbackFunctionType = (error: SdkError, files: File[]) => void;
   /** Select media callback function type. */
-  type selectMediaCallbackFunctionType = (error: SdkError, attachments: Media[]) => void;
+  export type selectMediaCallbackFunctionType = (error: SdkError, attachments: Media[]) => void;
   /** Error callback function type. */
-  type errorCallbackFunctionType = (error?: SdkError) => void;
+  export type errorCallbackFunctionType = (error?: SdkError) => void;
   /** Scan BarCode callback function type. */
-  type scanBarCodeCallbackFunctionType = (error: SdkError, decodedText: string) => void;
+  export type scanBarCodeCallbackFunctionType = (error: SdkError, decodedText: string) => void;
   /** Get media callback function type. */
   type getMediaCallbackFunctionType = (error: SdkError, blob: Blob) => void;
 

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -43,7 +43,7 @@ export namespace media {
   /** Scan BarCode callback function type. */
   export type scanBarCodeCallbackFunctionType = (error: SdkError, decodedText: string) => void;
   /** Get media callback function type. */
-  type getMediaCallbackFunctionType = (error: SdkError, blob: Blob) => void;
+  export type getMediaCallbackFunctionType = (error: SdkError, blob: Blob) => void;
 
   /**
    * Enum for file formats supported

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -14,28 +14,28 @@ import { runtime } from './runtime';
  */
 export namespace meeting {
   /** Error callback function type */
-  type errorCallbackFunctionType = (error: SdkError | null, result: boolean | null) => void;
+  export type errorCallbackFunctionType = (error: SdkError | null, result: boolean | null) => void;
   /** Get live stream state callback function type */
-  type getLiveStreamStateCallbackFunctionType = (
+  export type getLiveStreamStateCallbackFunctionType = (
     error: SdkError | null,
     liveStreamState: LiveStreamState | null,
   ) => void;
   /** Live stream error callback function type */
-  type liveStreamErrorCallbackFunctionType = (error: SdkError | null) => void;
+  export type liveStreamErrorCallbackFunctionType = (error: SdkError | null) => void;
   /** Register live stream changed handler function type */
-  type registerLiveStreamChangedHandlerFunctionType = (liveStreamState: LiveStreamState) => void;
+  export type registerLiveStreamChangedHandlerFunctionType = (liveStreamState: LiveStreamState) => void;
   /** Get app content stage sharing capabilities callback function type */
-  type getAppContentCallbackFunctionType = (
+  export type getAppContentCallbackFunctionType = (
     error: SdkError | null,
     appContentStageSharingCapabilities: IAppContentStageSharingCapabilities | null,
   ) => void;
   /** Get app content stage sharing state callback function type */
-  type getAppContentStageCallbackFunctionType = (
+  export type getAppContentStageCallbackFunctionType = (
     error: SdkError | null,
     appContentStageSharingState: IAppContentStageSharingState | null,
   ) => void;
   /** Register speaking state change handler function type */
-  type registerSpeakingStateChangeHandlerFunctionType = (speakingState: ISpeakingState) => void;
+  export type registerSpeakingStateChangeHandlerFunctionType = (speakingState: ISpeakingState) => void;
   /**
    * @hidden
    * Data structure to represent meeting details

--- a/packages/teams-js/src/public/navigation.ts
+++ b/packages/teams-js/src/public/navigation.ts
@@ -9,7 +9,7 @@ import { runtime } from './runtime';
  */
 
 /** Navigation on complete handler function type */
-type onCompleteHandlerFunctionType = (status: boolean, reason?: string) => void;
+export type onCompleteHandlerFunctionType = (status: boolean, reason?: string) => void;
 /**
  * @deprecated
  * As of 2.0.0, please use {@link pages.returnFocus pages.returnFocus(navigateForward?: boolean): void} instead.

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -24,11 +24,11 @@ export namespace pages {
   /** Full screen function */
   export type fullScreenChangeFunctionType = (isFullScreen: boolean) => void;
   /** Back button handler function */
-  type backButtonHandlerFunctionType = () => boolean;
+  export type backButtonHandlerFunctionType = () => boolean;
   /** Save event function */
-  type saveEventType = (evt: pages.config.SaveEvent) => void;
+  export type saveEventType = (evt: pages.config.SaveEvent) => void;
   /** Remove event function */
-  type removeEventType = (evt: pages.config.RemoveEvent) => void;
+  export type removeEventType = (evt: pages.config.RemoveEvent) => void;
 
   /**
    * Return focus to the host. Will move focus forward or backward based on where the application container falls in

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -20,9 +20,9 @@ import { runtime } from './runtime';
  */
 export namespace pages {
   /** Callback function */
-  type handlerFunctionType = () => void;
+  export type handlerFunctionType = () => void;
   /** Full screen function */
-  type fullScreenChangeFunctionType = (isFullScreen: boolean) => void;
+  export type fullScreenChangeFunctionType = (isFullScreen: boolean) => void;
   /** Back button handler function */
   type backButtonHandlerFunctionType = () => boolean;
   /** Save event function */

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -20,17 +20,17 @@ import { teamsCore } from './teamsAPIs';
 /** Execute deep link on complete function type */
 export type executeDeepLinkOnCompleteFunctionType = (status: boolean, reason?: string) => void;
 /** Callback function type */
-type callbackFunctionType = () => void;
+export type callbackFunctionType = () => void;
 /** Get context callback function type */
-type getContextCallbackFunctionType = (context: Context) => void;
+export type getContextCallbackFunctionType = (context: Context) => void;
 /** Get tab instances callback function type */
-type getTabInstancesCallbackFunctionType = (tabInfo: TabInformation) => void;
+export type getTabInstancesCallbackFunctionType = (tabInfo: TabInformation) => void;
 /** Register back button handler function type */
-type registerBackButtonHandlerFunctionType = () => boolean;
+export type registerBackButtonHandlerFunctionType = () => boolean;
 /** Register full screen handler function type */
-type registerFullScreenHandlerFunctionType = (isFullScreen: boolean) => void;
+export type registerFullScreenHandlerFunctionType = (isFullScreen: boolean) => void;
 /** Register on theme change handler function type */
-type registerOnThemeChangeHandlerFunctionType = (theme: string) => void;
+export type registerOnThemeChangeHandlerFunctionType = (theme: string) => void;
 /**
  * @deprecated
  * As of 2.0.0, please use {@link app.initialize app.initialize(validMessageOrigins?: string[]): Promise\<void\>} instead.

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -18,7 +18,7 @@ import { runtime } from './runtime';
 import { teamsCore } from './teamsAPIs';
 
 /** Execute deep link on complete function type */
-type executeDeepLinkOnCompleteFunctionType = (status: boolean, reason?: string) => void;
+export type executeDeepLinkOnCompleteFunctionType = (status: boolean, reason?: string) => void;
 /** Callback function type */
 type callbackFunctionType = () => void;
 /** Get context callback function type */

--- a/packages/teams-js/src/public/settings.ts
+++ b/packages/teams-js/src/public/settings.ts
@@ -13,13 +13,13 @@ import { runtime } from './runtime';
  */
 export namespace settings {
   /** Register on remove handler function type */
-  type registerOnRemoveHandlerFunctionType = (evt: RemoveEvent) => void;
+  export type registerOnRemoveHandlerFunctionType = (evt: RemoveEvent) => void;
   /** Register on save handler function type */
-  type registerOnSaveHandlerFunctionType = (evt: SaveEvent) => void;
+  export type registerOnSaveHandlerFunctionType = (evt: SaveEvent) => void;
   /** Set settings on complete function type */
-  type setSettingsOnCompleteFunctionType = (status: boolean, reason?: string) => void;
+  export type setSettingsOnCompleteFunctionType = (status: boolean, reason?: string) => void;
   /** Get settings callback function type */
-  type getSettingsCallbackFunctionType = (instanceSettings: Settings) => void;
+  export type getSettingsCallbackFunctionType = (instanceSettings: Settings) => void;
 
   /**
    * @deprecated

--- a/packages/teams-js/src/public/sharing.ts
+++ b/packages/teams-js/src/public/sharing.ts
@@ -11,7 +11,7 @@ import { runtime } from './runtime';
  */
 export namespace sharing {
   /** shareWebContent callback function type */
-  type shareWebContentCallbackFunctionType = (err?: SdkError) => void;
+  export type shareWebContentCallbackFunctionType = (err?: SdkError) => void;
 
   /** Type of message that can be sent or received by the sharing APIs */
   export const SharingAPIMessages = {

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -18,7 +18,7 @@ import { runtime } from './runtime';
  */
 export namespace tasks {
   /** Start task submit handler function type.  */
-  type startTaskSubmitHandlerFunctionType = (err: string, result: string | object) => void;
+  export type startTaskSubmitHandlerFunctionType = (err: string, result: string | object) => void;
 
   /**
    * @deprecated

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -11,7 +11,7 @@ import { runtime } from './runtime';
  */
 export namespace teamsCore {
   /** Ready to unload function type */
-  type readyToUnloadFunctionType = () => void;
+  export type readyToUnloadFunctionType = () => void;
   /** Register on load handler function type */
   export type registerOnLoadHandlerFunctionType = (context: LoadContext) => void;
   /** Register before unload handler function type */

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -13,9 +13,9 @@ export namespace teamsCore {
   /** Ready to unload function type */
   type readyToUnloadFunctionType = () => void;
   /** Register on load handler function type */
-  type registerOnLoadHandlerFunctionType = (context: LoadContext) => void;
+  export type registerOnLoadHandlerFunctionType = (context: LoadContext) => void;
   /** Register before unload handler function type */
-  type registerBeforeUnloadHandlerFunctionType = (readyToUnload: readyToUnloadFunctionType) => boolean;
+  export type registerBeforeUnloadHandlerFunctionType = (readyToUnload: readyToUnloadFunctionType) => boolean;
   /**
    * Enable print capability to support printing page using Ctrl+P and cmd+P
    */

--- a/packages/teams-js/src/public/videoEffects.ts
+++ b/packages/teams-js/src/public/videoEffects.ts
@@ -17,9 +17,9 @@ export namespace videoEffects {
     : new VideoPerformanceMonitor(sendMessageToParent);
 
   /** Notify video frame processed function type */
-  type notifyVideoFrameProcessedFunctionType = () => void;
+  export type notifyVideoFrameProcessedFunctionType = () => void;
   /** Notify error function type */
-  type notifyErrorFunctionType = (errorMessage: string) => void;
+  export type notifyErrorFunctionType = (errorMessage: string) => void;
 
   /**
    * Represents a video frame


### PR DESCRIPTION
## Description

Running `pnpm run docs` to generate docs locally on a dev box was broken. I discovered this was because the command run as part of the build to prevent it breaking was `pnpm run docs:validate` which runs typedoc in a similar way to `pnpm run docs` except that it uses an extra plugin which suppresses certain warnings.

The warnings that are suppressed are warnings about documented types referencing other types that aren't exported. E.g., if you had
```
export function foo(myBar: Bar): void;

type Bar = string;
```
It would show a warning because you were exporting a function that referenced a type which was not exported. This is a problem because if you are exporting a function, you will want all the types referenced as part of the function's definition to be exported (so others can use them and, for the purposes of typedoc, see their published documentation).

There are two primary changes in this PR:
1. Remove the reference to the typedoc plugin which suppressed these warnings
2. Fix all the non-exported types referenced by exported functions to be exported

Note that #1 also fixes the problem where `pnpm run docs` doesn't do the same thing as `pnpm run docs:validate` and therefore also makes `pnpm run docs` work again on your local dev box (so you can see and validate doc changes you make).

## Validation

### Validation performed:

Ensured that `pnpm run docs` and `pnpm run docs:validate` both function and that the former successfully generates docs locally.