### PR TITLE
Timeout install Android emulator task after 10 minutes

### DIFF
--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -49,8 +49,7 @@ steps:
   - bash: 'chmod u+x install_emulator.sh && ./install_emulator.sh'
     displayName: 'Install Emulator'
     workingDirectory: '$(Agent.BuildDirectory)/androidHost/devtools/ci'
-    timeoutInMinutes: 2
-    retryCountOnTaskFailure: 1
+    timeoutInMinutes: 10
 
   - task: JavaToolInstaller@0
     inputs:

--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -49,6 +49,8 @@ steps:
   - bash: 'chmod u+x install_emulator.sh && ./install_emulator.sh'
     displayName: 'Install Emulator'
     workingDirectory: '$(Agent.BuildDirectory)/androidHost/devtools/ci'
+    timeoutInMinutes: 2
+    retryCountOnTaskFailure: 1
 
   - task: JavaToolInstaller@0
     inputs:

--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -49,6 +49,8 @@ steps:
   - bash: 'chmod u+x install_emulator.sh && ./install_emulator.sh'
     displayName: 'Install Emulator'
     workingDirectory: '$(Agent.BuildDirectory)/androidHost/devtools/ci'
+    # This task is flaky, but when it works it almost always completes in under 5 minutes.
+    # Setting the timeout to 10 minutes so we can fail faster when it fails.
     timeoutInMinutes: 10
 
   - task: JavaToolInstaller@0


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

The "Install emulator" task on the Android E2E testing pipeline is a bit flaky. When it succeeds, it usually takes under 5 minutes, but if it fails it will take the entire 60 minutes allotted to the pipeline. This PR just adds a 10 minute timeout to the task so we can fail this task faster when it doesn't succeed.

### Main changes in the PR:

1. Add 10 minute timeout to the install emulator task on the Android test pipeline

## Validation

### Validation performed:

1. Android E2E tests continue to pass when emulator installs successfully

### Unit Tests added:

No, no code changes

### End-to-end tests added:

No, no code changes

## Additional Requirements

### Change file added:

No, pipeline change only

### Next/remaining steps:

I think we can retry starting the emulator in a separate task after the initial task times out. I'm going to work on this as a separate PR, but I think failing the task in 10 minutes vs. 60 is enough of an improvement to check in on its own for now.
