### PR TITLE
Add version control for data testing on stringified error

### DIFF
--- a/apps/teams-test-app/e2e-test-data/barCode.json
+++ b/apps/teams-test-app/e2e-test-data/barCode.json
@@ -42,6 +42,7 @@
     {
       "title": "scanBarCode API Call - Failure",
       "type": "callResponse",
+      "version": ">2.16.0",
       "boxSelector": "#box_scanBarCode",
       "requestPermissionBeforeThisCall": {
         "boxSelector": "#box_requestBarCodePermission",

--- a/apps/teams-test-app/e2e-test-data/geoLocation.json
+++ b/apps/teams-test-app/e2e-test-data/geoLocation.json
@@ -42,6 +42,7 @@
     {
       "title": "getCurrentLocation API Call - Failure",
       "type": "callResponse",
+      "version": ">2.16.0",
       "boxSelector": "#box_getCurrentLocation",
       "requestPermissionBeforeThisCall": {
         "boxSelector": "#box_requestGeoLocationPermission",

--- a/apps/teams-test-app/e2e-test-data/geoLocation.map.json
+++ b/apps/teams-test-app/e2e-test-data/geoLocation.map.json
@@ -20,6 +20,7 @@
     {
       "title": "chooseLocationOnMap API Call - Failure",
       "type": "callResponse",
+      "version": ">2.16.0",
       "boxSelector": "#box_chooseLocationOnMap",
       "requestPermissionBeforeThisCall": {
         "boxSelector": "#box_requestGeoLocationPermission",


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

E2E test run against on corresponding teams-js library and test app. For example, E2E test on Teams-Js library V2.4.0 will use that version's test app for running tests. The issue is that the backward test apps have problems on formatting errors for some of cases so we need to excludes those versions if we want to test with correct input and output for handling errors.

Future discussion is to see if it is possible to run each version of teams-js library on latest test app. Otherwise, web host sdk might need to tolerate faulty json data.

### Main changes in the PR:

1. Version control on some of data which is to trigger error handling test cases.

## Validation

### Validation performed:

1. Nothing will change for latest teams-js library main branch but in web host sdk sides, those three cases will be excluded from V2.1.0 after this change.

### Unit Tests added: No

### End-to-end tests added: No