### PR TITLE
Start logging name of script currently executing when teamsjs is first loaded

### DIFF
--- a/change/@microsoft-teams-js-063ed744-1e82-4803-8244-c2acd5aeeb43.json
+++ b/change/@microsoft-teams-js-063ed744-1e82-4803-8244-c2acd5aeeb43.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Start logging name of script currently executing when teamsjs is first loaded",
+  "packageName": "@microsoft/teams-js",
+  "email": "trharris@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -565,6 +565,26 @@ export namespace app {
    */
   const initializationTimeoutInMs = 5000;
 
+  function logWhereTeamsJsIsBeingUsed(): void {
+    if (inServerSideRenderingEnvironment()) {
+      return;
+    }
+    const scripts = document.getElementsByTagName('script');
+    // This will always be the current script because browsers load and execute scripts in order.
+    // Whenever a script is executing for the first time it will be the last script in this array.
+    const currentScriptSrc = scripts[scripts.length - 1].src;
+    const scriptUsageWarning =
+      'Today, teamsjs can only be used from a single script or you may see undefined behavior. If you would like to use teamjs from more than one script at the same time, please open an issue at https://github.com/OfficeDev/microsoft-teams-library-js/issues';
+    if (!currentScriptSrc || currentScriptSrc.length === 0) {
+      appLogger('teamsjs is being used from a script tag embedded directly in your html. %s', scriptUsageWarning);
+    } else {
+      appLogger('teamsjs is being used from %s. %s', currentScriptSrc, scriptUsageWarning);
+    }
+  }
+
+  // This is called right away to make sure that we capture which script is being executed correctly
+  logWhereTeamsJsIsBeingUsed();
+
   /**
    * Initializes the library.
    *


### PR DESCRIPTION
## Description

Currently, teamsjs does not support being used from more than one script at the same time. Doing so will result in undefined behavior from the library. Currently, this restriction is not well publicized and can be very difficult to track down by people helping users of the library. With this change, the first time a script using teamsjs is loaded we will log out the name of the script file using teamsjs (or the fact that teamsjs is being used by script embedded directly into the html). If you see more than one of these log statements at the same time, that means that your app is using teamsjs in a way that is currently unsupported.

The log statement also includes a link to where developers can open a GitHub issues if they would like to be able to use teamsjs from more than one place at the same time. We already have that work on our backlog, but hopefully that will help us gauge the demand and importance of fixing this (which is a more intricate change)

### Main changes in the PR:

1. Start logging the name of the script using teamsjs when that script is first loaded.

## Validation

### Validation performed:

1. Ran the test app and made sure the log statement was being written correctly

### Unit Tests added:

No, logging change only

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes
