### PR TITLE
Fix strictNullChecks violations in media.ts and mediaUtil.ts

### DIFF
--- a/change/@microsoft-teams-js-9e85c1d2-7ae8-4f04-8fb5-867873552c98.json
+++ b/change/@microsoft-teams-js-9e85c1d2-7ae8-4f04-8fb5-867873552c98.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix strictNullChecks violations in media files",
+  "comment": "Fixed strictNullChecks violations in `media.ts` and `mediaUtil.ts` files",
   "packageName": "@microsoft/teams-js",
   "email": "36546967+AE-MS@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-9e85c1d2-7ae8-4f04-8fb5-867873552c98.json
+++ b/change/@microsoft-teams-js-9e85c1d2-7ae8-4f04-8fb5-867873552c98.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix strictNullChecks violations in media files",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/mediaUtil.ts
+++ b/packages/teams-js/src/internal/mediaUtil.ts
@@ -14,11 +14,11 @@ import { throwExceptionIfMobileApiIsNotSupported } from './internalAPIs';
  * @internal
  * Limited to Microsoft-internal use
  */
-export function createFile(assembleAttachment: media.AssembleAttachment[], mimeType: string): Blob {
+export function createFile(assembleAttachment: media.AssembleAttachment[], mimeType: string): Blob | null {
   if (assembleAttachment == null || mimeType == null || assembleAttachment.length <= 0) {
     return null;
   }
-  let file: Blob | undefined;
+  let file: Blob | null = null;
   let sequence = 1;
   assembleAttachment.sort((a, b) => (a.sequence > b.sequence ? 1 : -1));
   assembleAttachment.forEach((item) => {
@@ -42,7 +42,7 @@ export function createFile(assembleAttachment: media.AssembleAttachment[], mimeT
  * @internal
  * Limited to Microsoft-internal use
  */
-export function decodeAttachment(attachment: media.MediaChunk, mimeType: string): media.AssembleAttachment {
+export function decodeAttachment(attachment: media.MediaChunk, mimeType: string): media.AssembleAttachment | null {
   if (attachment == null || mimeType == null) {
     return null;
   }
@@ -188,10 +188,10 @@ export function validateViewImagesInput(uriList: media.ImageUri[]): boolean {
  *
  * @internal
  */
-export function validateScanBarCodeInput(barCodeConfig: media.BarCodeConfig): boolean {
+export function validateScanBarCodeInput(barCodeConfig?: media.BarCodeConfig): boolean {
   if (barCodeConfig) {
     if (
-      barCodeConfig.timeOutIntervalInSec === null ||
+      !barCodeConfig.timeOutIntervalInSec ||
       barCodeConfig.timeOutIntervalInSec <= 0 ||
       barCodeConfig.timeOutIntervalInSec > 60
     ) {

--- a/packages/teams-js/src/internal/mediaUtil.ts
+++ b/packages/teams-js/src/internal/mediaUtil.ts
@@ -191,9 +191,9 @@ export function validateViewImagesInput(uriList: media.ImageUri[]): boolean {
 export function validateScanBarCodeInput(barCodeConfig?: media.BarCodeConfig): boolean {
   if (barCodeConfig) {
     if (
-      !barCodeConfig.timeOutIntervalInSec ||
-      barCodeConfig.timeOutIntervalInSec <= 0 ||
-      barCodeConfig.timeOutIntervalInSec > 60
+      barCodeConfig.timeOutIntervalInSec === null ||
+      (barCodeConfig.timeOutIntervalInSec != undefined && barCodeConfig.timeOutIntervalInSec <= 0) ||
+      (barCodeConfig.timeOutIntervalInSec != undefined && barCodeConfig.timeOutIntervalInSec > 60)
     ) {
       return false;
     }

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -25,6 +25,7 @@ import {
   validateSelectMediaInputs,
   validateViewImagesInput,
 } from '../internal/mediaUtil';
+import { isNullOrUndefined } from '../internal/typeCheckUtilities';
 import { generateGUID } from '../internal/utils';
 import { errorNotSupportedOnPlatform, FrameContexts, HostClientType } from './constants';
 import { DevicePermission, ErrorCode, SdkError } from './interfaces';
@@ -34,15 +35,38 @@ import { runtime } from './runtime';
  * Interact with media, including capturing and viewing images.
  */
 export namespace media {
-  /** Capture image callback function type. */
+  /**
+   * Function callback type used when calling {@link media.captureImage}.
+   *
+   * @param error - Error encountered during the API call, if any, {@link SdkError}
+   * @param files - Collection of File objects (images) captured by the user. Will be an empty array in the case of an error.
+   * */
   export type captureImageCallbackFunctionType = (error: SdkError, files: File[]) => void;
-  /** Select media callback function type. */
+
+  /**
+   * Function callback type used when calling {@link media.selectMedia}.
+   *
+   * @param error - Error encountered during the API call, if any, {@link SdkError}
+   * @param attachments - Collection of {@link Media} objects selected by the user. Will be an empty array in the case of an error.
+   * */
   export type selectMediaCallbackFunctionType = (error: SdkError, attachments: Media[]) => void;
+
   /** Error callback function type. */
   export type errorCallbackFunctionType = (error?: SdkError) => void;
-  /** Scan BarCode callback function type. */
+  /**
+   * Function callback type used when calling {@link media.scanBarCode}.
+   *
+   * @param error - Error encountered during the API call, if any, {@link SdkError}
+   * @param decodedText - Decoded text from the barcode, if any. In the case of an error, this will be the empty string.
+   * */
   export type scanBarCodeCallbackFunctionType = (error: SdkError, decodedText: string) => void;
-  /** Get media callback function type. */
+
+  /**
+   * Function callback type used when calling {@link media.Media.getMedia}
+   *
+   * @param error - Error encountered during the API call, if any, {@link SdkError}
+   * @param blob - Blob of media returned. Will be a blob with no BlobParts, in the case of an error.
+   * */
   export type getMediaCallbackFunctionType = (error: SdkError, blob: Blob) => void;
 
   /**
@@ -106,14 +130,14 @@ export namespace media {
     if (!GlobalVars.isFramelessWindow) {
       const notSupportedError: SdkError = { errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM };
       /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-      callback(notSupportedError, undefined);
+      callback(notSupportedError, []);
       return;
     }
 
     if (!isCurrentSDKVersionAtLeast(captureImageMobileSupportVersion)) {
       const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
       /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-      callback(oldPlatformError, undefined);
+      callback(oldPlatformError, []);
       return;
     }
 
@@ -174,7 +198,7 @@ export namespace media {
    * Media object returned by the select Media API
    */
   export class Media extends File {
-    constructor(that: Media = null) {
+    constructor(that?: Media) {
       super();
       if (that) {
         this.content = that.content;
@@ -204,14 +228,12 @@ export namespace media {
       ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
       if (!isCurrentSDKVersionAtLeast(mediaAPISupportVersion)) {
         const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
-        /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-        callback(oldPlatformError, null);
+        callback(oldPlatformError, new Blob());
         return;
       }
       if (!validateGetMediaInputs(this.mimeType, this.format, this.content)) {
         const invalidInput: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
-        /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-        callback(invalidInput, null);
+        callback(invalidInput, new Blob());
         return;
       }
       // Call the new get media implementation via callbacks if the client version is greater than or equal to '2.0.0'
@@ -232,23 +254,26 @@ export namespace media {
       function handleGetMediaCallbackRequest(mediaResult: MediaResult): void {
         if (callback) {
           if (mediaResult && mediaResult.error) {
-            /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-            callback(mediaResult.error, null);
+            callback(mediaResult.error, new Blob());
           } else {
             if (mediaResult && mediaResult.mediaChunk) {
               // If the chunksequence number is less than equal to 0 implies EOF
               // create file/blob when all chunks have arrived and we get 0/-1 as chunksequence number
               if (mediaResult.mediaChunk.chunkSequence <= 0) {
                 const file = createFile(helper.assembleAttachment, helper.mediaMimeType);
-                callback(mediaResult.error, file);
+                callback(mediaResult.error, file ?? new Blob());
               } else {
                 // Keep pushing chunks into assemble attachment
-                const assemble: AssembleAttachment = decodeAttachment(mediaResult.mediaChunk, helper.mediaMimeType);
-                helper.assembleAttachment.push(assemble);
+                const assemble: AssembleAttachment | null = decodeAttachment(
+                  mediaResult.mediaChunk,
+                  helper.mediaMimeType,
+                );
+                if (assemble) {
+                  helper.assembleAttachment.push(assemble);
+                }
               }
             } else {
-              /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-              callback({ errorCode: ErrorCode.INTERNAL_ERROR, message: 'data received is null' }, null);
+              callback({ errorCode: ErrorCode.INTERNAL_ERROR, message: 'data received is null' }, new Blob());
             }
           }
         }
@@ -264,14 +289,13 @@ export namespace media {
         assembleAttachment: [],
       };
       const params = [actionName, this.content];
-      this.content && callback && sendMessageToParent('getMedia', params);
+      this.content && !isNullOrUndefined(callback) && sendMessageToParent('getMedia', params);
       function handleGetMediaRequest(response: string): void {
         if (callback) {
           /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
           const mediaResult: MediaResult = JSON.parse(response);
           if (mediaResult.error) {
-            /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-            callback(mediaResult.error, null);
+            callback(mediaResult.error, new Blob());
             removeHandler('getMedia' + actionName);
           } else {
             if (mediaResult.mediaChunk) {
@@ -279,16 +303,20 @@ export namespace media {
               // create file/blob when all chunks have arrived and we get 0/-1 as chunksequence number
               if (mediaResult.mediaChunk.chunkSequence <= 0) {
                 const file = createFile(helper.assembleAttachment, helper.mediaMimeType);
-                callback(mediaResult.error, file);
+                callback(mediaResult.error, file ?? new Blob());
                 removeHandler('getMedia' + actionName);
               } else {
                 // Keep pushing chunks into assemble attachment
-                const assemble: AssembleAttachment = decodeAttachment(mediaResult.mediaChunk, helper.mediaMimeType);
-                helper.assembleAttachment.push(assemble);
+                const assemble: AssembleAttachment | null = decodeAttachment(
+                  mediaResult.mediaChunk,
+                  helper.mediaMimeType,
+                );
+                if (assemble) {
+                  helper.assembleAttachment.push(assemble);
+                }
               }
             } else {
-              /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-              callback({ errorCode: ErrorCode.INTERNAL_ERROR, message: 'data received is null' }, null);
+              callback({ errorCode: ErrorCode.INTERNAL_ERROR, message: 'data received is null' }, new Blob());
               removeHandler('getMedia' + actionName);
             }
           }
@@ -446,7 +474,7 @@ export namespace media {
    */
   abstract class MediaController<T> {
     /** Callback that can be registered to handle events related to the playback and control of video content. */
-    protected controllerCallback: T;
+    protected controllerCallback?: T;
 
     public constructor(controllerCallback?: T) {
       this.controllerCallback = controllerCallback;
@@ -695,23 +723,20 @@ export namespace media {
     ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
     if (!isCurrentSDKVersionAtLeast(mediaAPISupportVersion)) {
       const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
-      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-      callback(oldPlatformError, null);
+      callback(oldPlatformError, []);
       return;
     }
 
     try {
       throwExceptionIfMediaCallIsNotSupportedOnMobile(mediaInputs);
     } catch (err) {
-      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-      callback(err, null);
+      callback(err, []);
       return;
     }
 
     if (!validateSelectMediaInputs(mediaInputs)) {
       const invalidInput: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
-      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-      callback(invalidInput, null);
+      callback(invalidInput, []);
       return;
     }
 
@@ -724,16 +749,14 @@ export namespace media {
         // MediaControllerEvent response is used to notify the app about events and is a partial response to selectMedia
         if (mediaEvent) {
           if (isVideoControllerRegistered(mediaInputs)) {
-            /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-            mediaInputs.videoProps.videoController.notifyEventToApp(mediaEvent);
+            mediaInputs?.videoProps?.videoController?.notifyEventToApp(mediaEvent);
           }
           return;
         }
 
         // Media Attachments are final response to selectMedia
         if (!localAttachments) {
-          /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-          callback(err, null);
+          callback(err, []);
           return;
         }
 
@@ -813,23 +836,19 @@ export namespace media {
       GlobalVars.hostClientType === HostClientType.teamsDisplays
     ) {
       const notSupportedError: SdkError = { errorCode: ErrorCode.NOT_SUPPORTED_ON_PLATFORM };
-      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-      callback(notSupportedError, null);
+      callback(notSupportedError, '');
       return;
     }
 
     if (!isCurrentSDKVersionAtLeast(scanBarCodeAPIMobileSupportVersion)) {
       const oldPlatformError: SdkError = { errorCode: ErrorCode.OLD_PLATFORM };
-      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-      callback(oldPlatformError, null);
+      callback(oldPlatformError, '');
       return;
     }
 
-    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
     if (!validateScanBarCodeInput(config)) {
       const invalidInput: SdkError = { errorCode: ErrorCode.INVALID_ARGUMENTS };
-      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-      callback(invalidInput, null);
+      callback(invalidInput, '');
       return;
     }
 

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -25,11 +25,14 @@ import {
   validateSelectMediaInputs,
   validateViewImagesInput,
 } from '../internal/mediaUtil';
+import { getLogger } from '../internal/telemetry';
 import { isNullOrUndefined } from '../internal/typeCheckUtilities';
 import { generateGUID } from '../internal/utils';
 import { errorNotSupportedOnPlatform, FrameContexts, HostClientType } from './constants';
 import { DevicePermission, ErrorCode, SdkError } from './interfaces';
 import { runtime } from './runtime';
+
+const mediaLogger = getLogger('media');
 
 /**
  * Interact with media, including capturing and viewing images.
@@ -270,6 +273,10 @@ export namespace media {
                 );
                 if (assemble) {
                   helper.assembleAttachment.push(assemble);
+                } else {
+                  mediaLogger(
+                    `Received a null assemble attachment for when decoding chunk sequence ${mediaResult.mediaChunk.chunkSequence}; not including the chunk in the assembled file.`,
+                  );
                 }
               }
             } else {

--- a/packages/teams-js/src/public/secondaryBrowser.ts
+++ b/packages/teams-js/src/public/secondaryBrowser.ts
@@ -14,9 +14,9 @@ import { runtime } from './runtime';
 export namespace secondaryBrowser {
   /**
    * Open a URL in the secondary browser.
-   *  
+   *
    * On mobile, this is the in-app browser.
-   * 
+   *
    * On web and desktop, please use the `window.open()` method or other native external browser methods.
    *
    * @param url Url to open in the browser

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -158,7 +158,7 @@ describe('media', () => {
       it('should not allow hasPermission calls before initialization', () => {
         return expect(() => media.hasPermission()).toThrowError(new Error(errorLibraryNotInitialized));
       });
-  
+
       Object.values(FrameContexts).forEach((context) => {
         if (allowedContexts.some((allowedContext) => allowedContext === context)) {
           it(`media should throw error when permissions is not supported in runtime config. context: ${context}`, async () => {
@@ -182,19 +182,19 @@ describe('media', () => {
               expect(e).toEqual(errorNotSupportedOnPlatform);
             }
           });
-  
+
           it('hasPermission call with successful result', async () => {
             await utils.initializeWithContext(context);
             utils.setClientSupportedSDKVersion(minVersionForPermissionsAPIs);
             utils.setRuntimeConfig({ apiVersion: 2, supports: { permissions: {} } });
-  
+
             const promise = media.hasPermission();
-  
+
             const message = utils.findMessageByFunc('permissions.has');
             expect(message).not.toBeNull();
             expect(message.args.length).toBe(1);
             expect(message.args[0]).toEqual(DevicePermission.Media);
-  
+
             const callbackId = message.id;
             utils.respondToFramelessMessage({
               data: {
@@ -202,21 +202,21 @@ describe('media', () => {
                 args: [undefined, true],
               },
             } as DOMMessageEvent);
-  
+
             await expect(promise).resolves.toBe(true);
           });
-  
+
           it('HasPermission rejects promise with Error when error received from host', async () => {
             await utils.initializeWithContext(context);
             utils.setClientSupportedSDKVersion(minVersionForPermissionsAPIs);
             utils.setRuntimeConfig({ apiVersion: 2, supports: { permissions: {} } });
-  
+
             const promise = media.hasPermission();
-  
+
             const message = utils.findMessageByFunc('permissions.has');
             expect(message).not.toBeNull();
             expect(message.args.length).toBe(1);
-  
+
             const callbackId = message.id;
             utils.respondToFramelessMessage({
               data: {
@@ -224,7 +224,7 @@ describe('media', () => {
                 args: [{ errorCode: ErrorCode.INTERNAL_ERROR }],
               },
             } as DOMMessageEvent);
-  
+
             await expect(promise).rejects.toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
           });
         } else {
@@ -257,7 +257,7 @@ describe('media', () => {
               expect(e).toEqual(errorNotSupportedOnPlatform);
             }
           });
-  
+
           it(`requestPermission should throw error when permissions is not supported in runtime config. context: ${context}`, async () => {
             await utils.initializeWithContext(context);
             utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
@@ -273,14 +273,14 @@ describe('media', () => {
             await utils.initializeWithContext(context);
             utils.setClientSupportedSDKVersion(minVersionForPermissionsAPIs);
             utils.setRuntimeConfig({ apiVersion: 2, supports: { permissions: {} } });
-  
+
             const promise = media.requestPermission();
-  
+
             const message = utils.findMessageByFunc('permissions.request');
             expect(message).not.toBeNull();
             expect(message.args.length).toBe(1);
             expect(message.args[0]).toEqual(DevicePermission.Media);
-  
+
             const callbackId = message.id;
             utils.respondToFramelessMessage({
               data: {
@@ -288,21 +288,21 @@ describe('media', () => {
                 args: [undefined, true],
               },
             } as DOMMessageEvent);
-  
+
             await expect(promise).resolves.toBe(true);
           });
-  
+
           it('requestPermission rejects promise with Error when error received from host', async () => {
             await utils.initializeWithContext(context);
             utils.setClientSupportedSDKVersion(minVersionForPermissionsAPIs);
             utils.setRuntimeConfig({ apiVersion: 2, supports: { permissions: {} } });
-  
+
             const promise = media.requestPermission();
-  
+
             const message = utils.findMessageByFunc('permissions.request');
             expect(message).not.toBeNull();
             expect(message.args.length).toBe(1);
-  
+
             const callbackId = message.id;
             utils.respondToFramelessMessage({
               data: {
@@ -310,7 +310,7 @@ describe('media', () => {
                 args: [{ errorCode: ErrorCode.INTERNAL_ERROR }],
               },
             } as DOMMessageEvent);
-  
+
             await expect(promise).rejects.toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
           });
         } else {
@@ -548,7 +548,7 @@ describe('media', () => {
           maxMediaCount: 10,
         };
         media.selectMedia(mediaInputs, (mediaError: SdkError, mediaAttachments: media.Media[]) => {
-          expect(mediaAttachments).toBeFalsy();
+          expect(mediaAttachments).toHaveLength(0);
           expect(mediaError).toEqual({ errorCode: ErrorCode.SIZE_EXCEEDED });
         });
         const message = utils.findMessageByFunc('selectMedia');


### PR DESCRIPTION
## Description

Continuing down the path of fixing more violations of `strictNullChecks` violations across teamsjs, this change fixes the violations in the media*.ts family of files.

I've annotated the PR with specific comments at the areas where the changes are made. That said, the general theme of the changes is to just update the code/types to reflect what the code is already doing -- e.g., the code is already returning `null` in places where it's not allowed, just update the code to reflect that said value is allowed and how it handles it, documenting appropriately.

## Validation

### Validation performed:

Ensure all tests continue to pass.

## Additional Requirements

### Change file added:

Yes.

### Related PRs:

#2012 

### Next/remaining steps:

Fix more violations of `strictNullChecks` across the next set of files.