### PR TITLE
Fix runtime interface for app.lifecycle

### DIFF
--- a/change/@microsoft-teams-js-2fa564a4-011e-483c-b49f-4f2d2405da60.json
+++ b/change/@microsoft-teams-js-2fa564a4-011e-483c-b49f-4f2d2405da60.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Deleted unnecessary subcapability named `caching` from `app.lifecycle` from runtime ",
+  "comment": "Deleted unnecessary subcapability named `caching` from `app.lifecycle` in runtime",
   "packageName": "@microsoft/teams-js",
   "email": "lakhveerkaur@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-2fa564a4-011e-483c-b49f-4f2d2405da60.json
+++ b/change/@microsoft-teams-js-2fa564a4-011e-483c-b49f-4f2d2405da60.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Deleted unnecessary subcapability named `caching` from `app.lifecycle` from runtime ",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -151,9 +151,7 @@ interface IRuntimeV3 extends IBaseRuntime {
   readonly isLegacyTeams?: boolean;
   readonly supports: {
     readonly app?: {
-      readonly lifecycle?: {
-        readonly caching?: {};
-      };
+      readonly lifecycle?: {};
     };
     readonly appEntity?: {};
     readonly appInstallDialog?: {};
@@ -256,9 +254,7 @@ export const versionAndPlatformAgnosticTeamsRuntimeConfig: Runtime = {
   isLegacyTeams: true,
   supports: {
     app: {
-      lifecycle: {
-        caching: {},
-      },
+      lifecycle: {},
     },
     appInstallDialog: {},
     appEntity: {},


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

In my previous [PR](https://github.com/OfficeDev/microsoft-teams-library-js/pull/1878/files#diff-85dddae2b8eeec9b3e380ecace89b971146adc53725c2dbf478591f5c5c7730d), we decided to combine two handlers (beforeSuspendOrTerminateHandler and onResumeHandler) into app.lifecyle instead of having a subsubcapability (caching). The runtime file was left unchanged by mistake. This PR update the runtime file to indicate there is no subsubcapability called `caching`


> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Updating runtime file to correctly indicate there is no sub-sub-capability named `caching`

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No> Yes

### Related PRs:
https://github.com/OfficeDev/microsoft-teams-library-js/pull/1878/files#diff-85dddae2b8eeec9b3e380ecace89b971146adc53725c2dbf478591f5c5c7730d

