### PR TITLE
Fix more "easy" strictNullChecks violations -- ones which just require adding already in-use types

### DIFF
--- a/change/@microsoft-teams-js-0b842417-16fe-4c54-b9f5-70f530257d55.json
+++ b/change/@microsoft-teams-js-0b842417-16fe-4c54-b9f5-70f530257d55.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix more strictNullChecks violations",
+  "comment": "Fixed more strictNullChecks violations",
   "packageName": "@microsoft/teams-js",
   "email": "36546967+AE-MS@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-0b842417-16fe-4c54-b9f5-70f530257d55.json
+++ b/change/@microsoft-teams-js-0b842417-16fe-4c54-b9f5-70f530257d55.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix more strictNullChecks violations",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -19,10 +19,10 @@ const communicationLogger = getLogger('communication');
  */
 export class Communication {
   public static currentWindow: Window | any;
-  public static parentOrigin: string;
+  public static parentOrigin: string | null;
   public static parentWindow: Window | any;
-  public static childWindow: Window;
-  public static childOrigin: string;
+  public static childWindow: Window | null;
+  public static childOrigin: string | null;
 }
 
 /**
@@ -176,7 +176,7 @@ export function sendAndHandleSdkError<T>(actionName: string, ...args: any[]): Pr
  * @internal
  * Limited to Microsoft-internal use
  */
-export function sendMessageToParentAsync<T>(actionName: string, args: any[] = undefined): Promise<T> {
+export function sendMessageToParentAsync<T>(actionName: string, args: any[] | undefined = undefined): Promise<T> {
   return new Promise((resolve) => {
     const request = sendMessageToParentHelper(actionName, args);
     /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
@@ -234,7 +234,7 @@ const sendMessageToParentHelperLogger = communicationLogger.extend('sendMessageT
  * @internal
  * Limited to Microsoft-internal use
  */
-function sendMessageToParentHelper(actionName: string, args: any[]): MessageRequest {
+function sendMessageToParentHelper(actionName: string, args: any[] | undefined): MessageRequest {
   const logger = sendMessageToParentHelperLogger;
 
   const targetWindow = Communication.parentWindow;
@@ -451,7 +451,7 @@ function handleChildMessage(evt: DOMMessageEvent): void {
  * @internal
  * Limited to Microsoft-internal use
  */
-function getTargetMessageQueue(targetWindow: Window): MessageRequest[] {
+function getTargetMessageQueue(targetWindow: Window | null): MessageRequest[] {
   return targetWindow === Communication.parentWindow
     ? CommunicationPrivate.parentMessageQueue
     : targetWindow === Communication.childWindow
@@ -463,7 +463,7 @@ function getTargetMessageQueue(targetWindow: Window): MessageRequest[] {
  * @internal
  * Limited to Microsoft-internal use
  */
-function getTargetOrigin(targetWindow: Window): string {
+function getTargetOrigin(targetWindow: Window | null): string | null {
   return targetWindow === Communication.parentWindow
     ? Communication.parentOrigin
     : targetWindow === Communication.childWindow
@@ -483,7 +483,7 @@ function flushMessageQueue(targetWindow: Window | any): void {
   while (targetWindow && targetOrigin && targetMessageQueue.length > 0) {
     const request = targetMessageQueue.shift();
     /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
-    flushMessageQueueLogger('Flushing message %i from ' + target + ' message queue via postMessage.', request.id);
+    flushMessageQueueLogger('Flushing message %i from ' + target + ' message queue via postMessage.', request?.id);
     targetWindow.postMessage(request, targetOrigin);
   }
 }
@@ -545,7 +545,7 @@ export function sendMessageEventToChild(actionName: string, args?: any[]): void 
  * @internal
  * Limited to Microsoft-internal use
  */
-function createMessageRequest(func: string, args: any[]): MessageRequest {
+function createMessageRequest(func: string, args: any[] | undefined): MessageRequest {
   return {
     id: CommunicationPrivate.nextMessageId++,
     func: func,
@@ -558,7 +558,7 @@ function createMessageRequest(func: string, args: any[]): MessageRequest {
  * @internal
  * Limited to Microsoft-internal use
  */
-function createMessageResponse(id: number, args: any[], isPartialResponse: boolean): MessageResponse {
+function createMessageResponse(id: number, args: any[] | undefined, isPartialResponse?: boolean): MessageResponse {
   return {
     id: id,
     args: args || [],
@@ -573,7 +573,7 @@ function createMessageResponse(id: number, args: any[], isPartialResponse: boole
  * @internal
  * Limited to Microsoft-internal use
  */
-function createMessageEvent(func: string, args: any[]): MessageRequest {
+function createMessageEvent(func: string, args?: any[]): MessageRequest {
   return {
     func: func,
     args: args || [],

--- a/packages/teams-js/src/internal/videoFrameTick.ts
+++ b/packages/teams-js/src/internal/videoFrameTick.ts
@@ -36,7 +36,7 @@ export class VideoFrameTick {
    */
   public static tick(): void {
     const now = performance.now();
-    const timeoutIds = [];
+    const timeoutIds: string[] = [];
     // find all the timeouts that are due,
     // not to invoke them in the loop to avoid modifying the collection while iterating
     for (const key in VideoFrameTick.setTimeoutCallbacks) {

--- a/packages/teams-js/src/internal/videoPerformanceMonitor.ts
+++ b/packages/teams-js/src/internal/videoPerformanceMonitor.ts
@@ -11,13 +11,13 @@ export class VideoPerformanceMonitor {
   private isFirstFrameProcessed = false;
 
   // The effect that the user last selected:
-  private applyingEffect: {
+  private applyingEffect?: {
     effectId: string;
     effectParam?: string;
   };
 
   // The effect that is currently applied to the video:
-  private appliedEffect: {
+  private appliedEffect?: {
     effectId: string;
     effectParam?: string;
   };

--- a/packages/teams-js/src/internal/videoPerformanceStatistics.ts
+++ b/packages/teams-js/src/internal/videoPerformanceStatistics.ts
@@ -68,7 +68,7 @@ export class VideoPerformanceStatistics {
     this.sampleCount += 1;
   }
 
-  private getStatistics(): VideoPerformanceStatisticsResult {
+  private getStatistics(): VideoPerformanceStatisticsResult | null {
     if (!this.currentSession) {
       return null;
     }

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -112,7 +112,7 @@ export namespace authentication {
           return value;
         } finally {
           if (!isDifferentParamsInCall) {
-            authParams = null;
+            authParams = undefined;
           }
         }
       })
@@ -125,7 +125,7 @@ export namespace authentication {
           throw err;
         } finally {
           if (!isDifferentParamsInCall) {
-            authParams = null;
+            authParams = undefined;
           }
         }
       });
@@ -260,7 +260,7 @@ export namespace authentication {
    * Limited to Microsoft-internal use
    */
   export function getUser(userRequest: UserRequest): void;
-  export function getUser(userRequest?: UserRequest): Promise<UserProfile> {
+  export function getUser(userRequest?: UserRequest): Promise<UserProfile | null> {
     ensureInitializeCalled();
     return getUserHelper()
       .then((value: UserProfile) => {
@@ -444,7 +444,7 @@ export namespace authentication {
         authHandlers.success(result);
       }
     } finally {
-      authHandlers = null;
+      authHandlers = undefined;
       closeAuthenticationWindow();
     }
   }
@@ -455,7 +455,7 @@ export namespace authentication {
         authHandlers.fail(new Error(reason));
       }
     } finally {
-      authHandlers = null;
+      authHandlers = undefined;
       closeAuthenticationWindow();
     }
   }

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -171,6 +171,7 @@ describe('Testing communication', () => {
 
         await initPromise;
 
+        /* eslint-disable-next-line strict-null-checks/all */
         expect(communication.Communication.parentOrigin).toBeNull();
       });
     });
@@ -231,11 +232,13 @@ describe('Testing communication', () => {
 
       it('should set Communication.parentOrigin to null and then update to the message origin once a response is received', async () => {
         const initPromise = communication.initializeCommunication(undefined);
+        /* eslint-disable-next-line strict-null-checks/all */
         expect(communication.Communication.parentOrigin).toBeNull();
         const initMessage = utils.findInitializeMessageOrThrow();
 
         utils.respondToMessage(initMessage, FrameContexts.content);
         await initPromise;
+        /* eslint-disable-next-line strict-null-checks/all */
         expect(communication.Communication.parentOrigin).toBe(utils.validOrigin);
       });
 
@@ -252,6 +255,7 @@ describe('Testing communication', () => {
         */
         communication.initializeCommunication(undefined);
 
+        /* eslint-disable-next-line strict-null-checks/all */
         expect(communication.Communication.parentOrigin).toBeNull();
         expect(communication.Communication.parentWindow).not.toBeNull();
 
@@ -261,6 +265,7 @@ describe('Testing communication', () => {
         utils.respondToMessage(initMessage, FrameContexts.content);
 
         expect(communication.Communication.parentWindow).toBeNull();
+        /* eslint-disable-next-line strict-null-checks/all */
         expect(communication.Communication.parentOrigin).toBeNull();
       });
 
@@ -323,24 +328,30 @@ describe('Testing communication', () => {
     it('should set Communication.parentOrigin to null', () => {
       app._initialize(utils.mockWindow);
       communication.Communication.parentOrigin = utils.mockWindow.parentOrigin;
+      /* eslint-disable-next-line strict-null-checks/all */
       expect(communication.Communication.parentOrigin).not.toBeNull();
       communication.uninitializeCommunication();
+      /* eslint-disable-next-line strict-null-checks/all */
       expect(communication.Communication.parentOrigin).toBeNull();
     });
 
     it('should set Communication.childWindow to null', () => {
       app._initialize(utils.mockWindow);
       communication.Communication.childWindow = utils.mockWindow;
+      /* eslint-disable-next-line strict-null-checks/all */
       expect(communication.Communication.childWindow).not.toBeNull();
       communication.uninitializeCommunication();
+      /* eslint-disable-next-line strict-null-checks/all */
       expect(communication.Communication.childWindow).toBeNull();
     });
 
     it('should set Communication.childOrigin to null', () => {
       app._initialize(utils.mockWindow);
       communication.Communication.childOrigin = utils.mockWindow.origin;
+      /* eslint-disable-next-line strict-null-checks/all */
       expect(communication.Communication.childOrigin).not.toBeNull();
       communication.uninitializeCommunication();
+      /* eslint-disable-next-line strict-null-checks/all */
       expect(communication.Communication.childOrigin).toBeNull();
     });
 
@@ -378,6 +389,7 @@ describe('Testing communication', () => {
       communication.Communication.currentWindow.setInterval = (fn) => {
         fn();
       };
+      /* eslint-disable-next-line strict-null-checks/all */
       communication.waitForMessageQueue(communication.Communication.childWindow, () => {
         // this callback only ever fires if the message queue associated with the passed in window is empty
         expect(true).toBeTruthy();
@@ -1163,10 +1175,12 @@ describe('Testing communication', () => {
       communication.Communication.currentWindow.setInterval = (fn) => {
         fn();
       };
+      /* eslint-disable-next-line strict-null-checks/all */
       communication.waitForMessageQueue(communication.Communication.childWindow, () => {
         expect(false).toBeFalsy();
       });
       communication.sendMessageEventToChild('testAction', ['arg zero']);
+      /* eslint-disable-next-line strict-null-checks/all */
       communication.waitForMessageQueue(communication.Communication.childWindow, () => {
         expect(true).toBeFalsy();
       });
@@ -1179,10 +1193,12 @@ describe('Testing communication', () => {
       communication.Communication.currentWindow.setInterval = (fn) => {
         fn();
       };
+      /* eslint-disable-next-line strict-null-checks/all */
       communication.waitForMessageQueue(communication.Communication.childWindow, () => {
         expect(false).toBeFalsy();
       });
       communication.sendMessageEventToChild('testAction', ['arg zero']);
+      /* eslint-disable-next-line strict-null-checks/all */
       communication.waitForMessageQueue(communication.Communication.childWindow, () => {
         expect(true).toBeFalsy();
       });


### PR DESCRIPTION
## Description

Continuing the journey of fixing `strictNullChecks` violations...

In this change I am mostly just updating the stated types to match the types actually being used. E.g., if the code is actually returning `null` or `undefined` in places, then the type signature should now reflect that.

There are two places (in `authentication.ts`) where I updated the return value to be set to `undefined` instead of `null` because the actual return type was already defined to allow for `undefined` -- so we should just actually use that! I added comments inline in the code review to point these out.

Because of this new, correct, types, some of the communication unit tests now started to trigger violations of `strictNullChecks` because the compiler now realizes that the now-correctly-annotated types might be being misused. For now, I have just silenced these violations. Again, nothing about how the code actually works/runs is changing, the compiler just now realizes that there are potential problems here (which is why it's important to actually have `strictNullChecks` enabled!). These new violations will be fixed as part of the overall journey to get this enabled.

## Validation

### Validation performed:

Ensured all existing tests continued to pass.

## Additional Requirements

### Change file added:

Yes.

### Related PRs:

#2012 
#2014 

### Next/remaining steps:

Continue to fix violations in future PRs