### PR TITLE
Remove isSupported from load/unload handlers

### DIFF
--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -58,7 +58,7 @@ export namespace teamsCore {
    */
   export function registerOnLoadHandler(handler: registerOnLoadHandlerFunctionType): void {
     registerOnLoadHandlerHelper(handler, () => {
-      if (!isNullOrUndefined(handler) && !isSupported()) {
+      if (!isNullOrUndefined(handler)) {
         throw errorNotSupportedOnPlatform;
       }
     });
@@ -103,7 +103,7 @@ export namespace teamsCore {
    */
   export function registerBeforeUnloadHandler(handler: registerBeforeUnloadHandlerFunctionType): void {
     registerBeforeUnloadHandlerHelper(handler, () => {
-      if (!isNullOrUndefined(handler) && !isSupported()) {
+      if (!isNullOrUndefined(handler)) {
         throw errorNotSupportedOnPlatform;
       }
     });


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

This removes isSupported checks in registerLoad/registerUnload handlers for Teams.

Fix current issue where this returns as false in certain scenarios, throwing an error unnecessarily.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. isSupported removed from registerOnLoadHandler
2. sSupported removed from registerBeforeUnloadHandler

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
