### PR TITLE
Fix the last of the remaining "easy" strictNullChecks violations

### DIFF
--- a/change/@microsoft-teams-js-e65900ef-5cbc-4129-a931-b3443a53b827.json
+++ b/change/@microsoft-teams-js-e65900ef-5cbc-4129-a931-b3443a53b827.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed more `strictNullChecks` violations",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -207,7 +207,7 @@ export function sendMessageToParent(actionName: string, callback?: Function): vo
  * @internal
  * Limited to Microsoft-internal use
  */
-export function sendMessageToParent(actionName: string, args: any[], callback?: Function): void;
+export function sendMessageToParent(actionName: string, args: any[] | undefined, callback?: Function): void;
 
 /**
  * @internal

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -19,17 +19,17 @@ class HandlersPrivate {
   public static handlers: {
     [func: string]: Function;
   } = {};
-  public static themeChangeHandler: null | ((theme: string) => void);
+  public static themeChangeHandler: null | ((theme: string) => void) = null;
   /**
    * @deprecated
    */
-  public static loadHandler: null | ((context: LoadContext) => void);
+  public static loadHandler: null | ((context: LoadContext) => void) = null;
   /**
    * @deprecated
    */
-  public static beforeUnloadHandler: null | ((readyToUnload: () => void) => boolean);
-  public static beforeSuspendOrTerminateHandler: null | (() => void);
-  public static resumeHandler: null | ((context: ResumeContext) => void);
+  public static beforeUnloadHandler: null | ((readyToUnload: () => void) => boolean) = null;
+  public static beforeSuspendOrTerminateHandler: null | (() => void) = null;
+  public static resumeHandler: null | ((context: ResumeContext) => void) = null;
 
   /**
    * @internal

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -19,17 +19,17 @@ class HandlersPrivate {
   public static handlers: {
     [func: string]: Function;
   } = {};
-  public static themeChangeHandler: (theme: string) => void;
+  public static themeChangeHandler: null | ((theme: string) => void);
   /**
    * @deprecated
    */
-  public static loadHandler: (context: LoadContext) => void;
+  public static loadHandler: null | ((context: LoadContext) => void);
   /**
    * @deprecated
    */
-  public static beforeUnloadHandler: (readyToUnload: () => void) => boolean;
-  public static beforeSuspendOrTerminateHandler: () => void;
-  public static resumeHandler: (context: ResumeContext) => void;
+  public static beforeUnloadHandler: null | ((readyToUnload: () => void) => boolean);
+  public static beforeSuspendOrTerminateHandler: null | (() => void);
+  public static resumeHandler: null | ((context: ResumeContext) => void);
 
   /**
    * @internal

--- a/packages/teams-js/src/private/conversations.ts
+++ b/packages/teams-js/src/private/conversations.ts
@@ -155,7 +155,7 @@ export namespace conversations {
         registerHandler(
           'startConversation',
           (subEntityId: string, conversationId: string, channelId: string, entityId: string) =>
-            openConversationRequest.onStartConversation({
+            openConversationRequest.onStartConversation?.({
               subEntityId,
               conversationId,
               channelId,
@@ -167,7 +167,7 @@ export namespace conversations {
         registerHandler(
           'closeConversation',
           (subEntityId: string, conversationId?: string, channelId?: string, entityId?: string) =>
-            openConversationRequest.onCloseConversation({
+            openConversationRequest.onCloseConversation?.({
               subEntityId,
               conversationId,
               channelId,


### PR DESCRIPTION
## Description

This fixes the last of the "easy" fixes of `strictNullChecks` violations in the product code.

### Main changes in the PR:

The code is directly annotated in this PR to describe the individual fixes.

## Validation

### Validation performed:

Ensured all existing tests continued to pass.

## Additional Requirements

### Change file added:

Yes

### Related PRs:

#2012, #2014, #2020, #2024

### Next/remaining steps:

There still remain a few violations in the product code that will be more invasive to fix and will come next. They will require some refactoring or other functionality changes (or changes that are theoretical functionality changes but likely never get hit in production)).

There are also still a ton of violations in the test code that will also be fixed, but likely not until the product code is fully clean.

In case you're curious, here are the stats for the remaining violations in the product code:
```
Errors  Files
     5  src/internal/communication.ts:183
     1  src/public/app.ts:938
```