### PR TITLE
Enable strictNullChecks for product code!

### DIFF
--- a/change/@microsoft-teams-js-54e1bba3-9307-4dd5-bbab-e3c92d531d39.json
+++ b/change/@microsoft-teams-js-54e1bba3-9307-4dd5-bbab-e3c92d531d39.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Enabled strictNullChecks on product code, suppressed on test code (for now)",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/jest.config.common.js
+++ b/jest.config.common.js
@@ -1,6 +1,9 @@
 module.exports = {
   transform: {
-    '.(ts|tsx)': ['ts-jest', { tsconfig: { downlevelIteration: true, esModuleInterop: true } }],
+    '.(ts|tsx)': [
+      'ts-jest',
+      { tsconfig: { downlevelIteration: true, esModuleInterop: true, strictNullChecks: false } },
+    ],
   },
   testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$',
   testEnvironment: 'jsdom',

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -179,7 +179,8 @@ export function sendAndHandleSdkError<T>(actionName: string, ...args: any[]): Pr
 export function sendMessageToParentAsync<T>(actionName: string, args: any[] | undefined = undefined): Promise<T> {
   return new Promise((resolve) => {
     const request = sendMessageToParentHelper(actionName, args);
-    /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     resolve(waitForResponse<T>(request.id));
   });
 }
@@ -224,6 +225,8 @@ export function sendMessageToParent(actionName: string, argsOrCallback?: any[] |
   /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
   const request = sendMessageToParentHelper(actionName, args);
   if (callback) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     CommunicationPrivate.callbacks[request.id] = callback;
   }
 }
@@ -388,6 +391,8 @@ function handleParentMessage(evt: DOMMessageEvent): void {
     logger('Received a response from parent for message %i', message.id);
     if (callback) {
       logger('Invoking the registered callback for message %i with arguments %o', message.id, message.args);
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       callback.apply(null, [...message.args, message.isPartialResponse]);
 
       // Remove the callback to ensure that the callback is called only once and to free up memory if response is a complete response
@@ -432,14 +437,16 @@ function handleChildMessage(evt: DOMMessageEvent): void {
     const message = evt.data as MessageRequest;
     const [called, result] = callHandler(message.func, message.args);
     if (called && typeof result !== 'undefined') {
-      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       sendMessageResponseToChild(message.id, Array.isArray(result) ? result : [result]);
     } else {
       // No handler, proxy to parent
       sendMessageToParent(message.func, message.args, (...args: any[]): void => {
         if (Communication.childWindow) {
           const isPartialResponse = args.pop();
-          /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
           sendMessageResponseToChild(message.id, args, isPartialResponse);
         }
       });

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable strict-null-checks/all */
 
 import { FrameContexts } from '../public/constants';
 import { SdkError } from '../public/interfaces';

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -935,6 +935,8 @@ function transformLegacyContextToAppContext(legacyContext: LegacyContext): app.C
     },
     page: {
       id: legacyContext.entityId,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       frameContext: legacyContext.frameContext ? legacyContext.frameContext : GlobalVars.frameContext,
       subPageId: legacyContext.subEntityId,
       isFullScreen: legacyContext.isFullScreen,

--- a/packages/teams-js/tsconfig.json
+++ b/packages/teams-js/tsconfig.json
@@ -12,7 +12,8 @@
     "noEmitOnError": false,
     "noImplicitReturns": true,
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "strictNullChecks": true
   },
   "exclude": ["node_modules", "./test", "./webpack.config.ts"]
 }


### PR DESCRIPTION
## Description

After all the recent PRs to fix violations of `strictNullChecks`, the product code is now down to only 6 remaining violations. These are more invasive to fix and so not to be taken lightly. There are also still a ton of violations in the test code.

However! There are so few violations now that I am comfortable actually enabling `strictNullChecks` for the product code and just suppressing the compiler warning for the specific remaining violating lines! This is a big step forward because it will prevent any new code from adding new violations!

### Main changes in the PR:

1. Enable `strictNullChecks` in the `tsconfig.json` file for the product code -- this will ensure the compiler now enforces `strictNullChecks` for all product code.
2. Suppress the remaining violations of this in `communication.ts` and `app.ts`. Note that there is currently no way to only suppress specific TS compiler errors for a line, you have to suppress all TS errors for that line. I am comfortable with this, given how few locations this includes.
3. Suppress the eslint warning that tells you not to use `@ts-ignore` for all the lines in number 2 above
4. Disable `strictNullChecks` for the unit test files. Note that this is not fundamentally changing behavior: the unit tests, by default, inherit the same tsconfig settings from the product. Prior to this change, `strictNullChecks` was not enabled. Now that I'm enabling it for the product code, I have to override it for the unit tests to put it back to disabled (for just the unit tests).

## Validation

### Validation performed:

Ensured that all existing builds and tests pass.

## Additional Requirements

### Change file added:

Yes.

### Related PRs:

#2012, #2014, #2020, #2024, #2025

### Next/remaining steps:

Enabling this compiler flag is a big step forward. The next steps will be to actually start fixing some of the remaining violations that are suppressed, along with working to enable the `strictNullChecks` flag for the test code.