### PR TITLE
Extend RequestAppAudioHandling to support for audio device selection sync

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.16.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-v6djPeImSC5Pb0IvhWyq/XY8It8EYt0U00nPlcodpX/RN5KgChhoqkKEZs5kX5hr"
+      src="https://res.cdn.office.net/teams-js/2.17.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-xp55t/129OsN192JZYLP0rGhzjCF9aYtjY0LVtXvolkDrBe4Jchylp56NrUYJ4S2"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm lint && webpack",

--- a/change/@microsoft-teams-js-04cac70a-42d1-49ad-a0d1-b008d3e03c1d.json
+++ b/change/@microsoft-teams-js-04cac70a-42d1-49ad-a0d1-b008d3e03c1d.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added optional field `openMode` to open `stageView` in new modes if supported by host",
-  "packageName": "@microsoft/teams-js",
-  "email": "astripa@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-063ed744-1e82-4803-8244-c2acd5aeeb43.json
+++ b/change/@microsoft-teams-js-063ed744-1e82-4803-8244-c2acd5aeeb43.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Start logging name of script currently executing when teamsjs is first loaded",
-  "packageName": "@microsoft/teams-js",
-  "email": "trharris@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-14cf15d3-97d3-400f-a8a9-b40ea99f56a4.json
+++ b/change/@microsoft-teams-js-14cf15d3-97d3-400f-a8a9-b40ea99f56a4.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Exported all publicly referenced but unexported types",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-1f9bb602-83c2-4b09-a307-176491fe5051.json
+++ b/change/@microsoft-teams-js-1f9bb602-83c2-4b09-a307-176491fe5051.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fixed some locations violating `strictNullChecks`",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-252e0ab1-300c-4234-8b5c-76c706f3edec.json
+++ b/change/@microsoft-teams-js-252e0ab1-300c-4234-8b5c-76c706f3edec.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Updated default runtime for Teams Mobile to indicate that `pages.appButton`, `pages.tabs`, and `stageView` are not supported.",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-2fa564a4-011e-483c-b49f-4f2d2405da60.json
+++ b/change/@microsoft-teams-js-2fa564a4-011e-483c-b49f-4f2d2405da60.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Deleted unnecessary subcapability named `caching` from `app.lifecycle` in runtime",
-  "packageName": "@microsoft/teams-js",
-  "email": "lakhveerkaur@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-39cb25bf-5581-473d-b98e-3567c5cd61f5.json
+++ b/change/@microsoft-teams-js-39cb25bf-5581-473d-b98e-3567c5cd61f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed more violations of strictNullChecks",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-693e5412-2ef1-43d1-8121-788dbcc3db99.json
+++ b/change/@microsoft-teams-js-693e5412-2ef1-43d1-8121-788dbcc3db99.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Updated documentation for `teamsSku` context property to list possible values",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-79b01e32-a70f-4798-9d2a-8112e7c5495f.json
+++ b/change/@microsoft-teams-js-79b01e32-a70f-4798-9d2a-8112e7c5495f.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Updated app.lifecycle handlers, registerBeforeSuspendOrTerminateHandler and registerOnResumeHandler, so that they will overwrite teamsCore's registered handlers, registerBeforeUnloadHandler and registerOnLoadHandler, respectively.",
-  "packageName": "@microsoft/teams-js",
-  "email": "lakhveerkaur@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-7ebef344-0a7e-4f6d-8a75-7adec5ad1f57.json
+++ b/change/@microsoft-teams-js-7ebef344-0a7e-4f6d-8a75-7adec5ad1f57.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Updated documentation for `secondaryBrowser` capability",
-  "packageName": "@microsoft/teams-js",
-  "email": "mobajemu@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-c7d07f0d-ee14-4921-af8d-6750b0307503.json
+++ b/change/@microsoft-teams-js-c7d07f0d-ee14-4921-af8d-6750b0307503.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Added teams.cloud.microsoft, outlook.cloud.microsoft, m365.cloud.microsoft, www.bing.com and www.staging-bing-int.com to the `validOrigins` list",
-  "packageName": "@microsoft/teams-js",
-  "email": "jadahiya@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-ddc6ef24-fe31-47d9-a089-01c2d08090ac.json
+++ b/change/@microsoft-teams-js-ddc6ef24-fe31-47d9-a089-01c2d08090ac.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Released 2.16.0",
+  "comment": "Released version 2.17.0",
   "packageName": "@microsoft/teams-js",
   "email": "jadahiya@microsoft.com",
   "dependentChangeType": "none"

--- a/change/@microsoft-teams-js-e65900ef-5cbc-4129-a931-b3443a53b827.json
+++ b/change/@microsoft-teams-js-e65900ef-5cbc-4129-a931-b3443a53b827.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed more `strictNullChecks` violations",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-f497aa57-1549-40c6-a0f7-89b4c59a2e1f.json
+++ b/change/@microsoft-teams-js-f497aa57-1549-40c6-a0f7-89b4c59a2e1f.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added a new capability `visualMedia` and subcapability `visualMedia.image` for capturing images from device camera and gallery",
-  "packageName": "@microsoft/teams-js",
-  "email": "maggiegong@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-fd2fe2b1-7f23-493a-8cad-78ced187ec23.json
+++ b/change/@microsoft-teams-js-fd2fe2b1-7f23-493a-8cad-78ced187ec23.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Updated capability merging code to support properly merging subcapabilities",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,27 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Wed, 11 Oct 2023 16:51:27 GMT and should not be manually modified.
+This log was last generated on Wed, 01 Nov 2023 18:15:02 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.17.0
+
+Wed, 01 Nov 2023 18:15:02 GMT
+
+### Minor changes
+
+- Added optional field `openMode` to open `stageView` in new modes if supported by host
+- Updated app.lifecycle handlers, registerBeforeSuspendOrTerminateHandler and registerOnResumeHandler, so that they will overwrite teamsCore's registered handlers, registerBeforeUnloadHandler and registerOnLoadHandler, respectively.
+- Added a new capability `visualMedia` and subcapability `visualMedia.image` for capturing images from device camera and gallery
+
+### Patches
+
+- Started logging name of script currently executing when teamsjs is first loaded
+- Exported all publicly referenced but unexported types
+- Fixed some locations violating `strictNullChecks`
+- Updated default runtime for Teams Mobile to indicate that `pages.appButton`, `pages.tabs`, and `stageView` are not supported.
+- Deleted unnecessary subcapability named `caching` from `app.lifecycle` in runtime
+- Updated capability merging code to support properly merging subcapabilities
 
 ## 2.16.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.16.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.17.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.16.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-v6djPeImSC5Pb0IvhWyq/XY8It8EYt0U00nPlcodpX/RN5KgChhoqkKEZs5kX5hr"
+  src="https://res.cdn.office.net/teams-js/2.17.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-xp55t/129OsN192JZYLP0rGhzjCF9aYtjY0LVtXvolkDrBe4Jchylp56NrUYJ4S2"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.16.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.17.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -207,7 +207,7 @@ export function sendMessageToParent(actionName: string, callback?: Function): vo
  * @internal
  * Limited to Microsoft-internal use
  */
-export function sendMessageToParent(actionName: string, args: any[], callback?: Function): void;
+export function sendMessageToParent(actionName: string, args: any[] | undefined, callback?: Function): void;
 
 /**
  * @internal

--- a/packages/teams-js/src/internal/globalVars.ts
+++ b/packages/teams-js/src/internal/globalVars.ts
@@ -3,10 +3,10 @@ export class GlobalVars {
   public static initializeCalled = false;
   public static initializeCompleted = false;
   public static additionalValidOrigins: string[] = [];
-  public static initializePromise: Promise<void>;
+  public static initializePromise: Promise<void> | undefined = undefined;
   public static isFramelessWindow = false;
-  public static frameContext: FrameContexts;
-  public static hostClientType: string;
+  public static frameContext: FrameContexts | undefined = undefined;
+  public static hostClientType: string | undefined = undefined;
   public static clientSupportedSDKVersion: string;
   public static printCapabilityEnabled = false;
 }

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -19,17 +19,17 @@ class HandlersPrivate {
   public static handlers: {
     [func: string]: Function;
   } = {};
-  public static themeChangeHandler: (theme: string) => void;
+  public static themeChangeHandler: null | ((theme: string) => void) = null;
   /**
    * @deprecated
    */
-  public static loadHandler: (context: LoadContext) => void;
+  public static loadHandler: null | ((context: LoadContext) => void) = null;
   /**
    * @deprecated
    */
-  public static beforeUnloadHandler: (readyToUnload: () => void) => boolean;
-  public static beforeSuspendOrTerminateHandler: () => void;
-  public static resumeHandler: (context: ResumeContext) => void;
+  public static beforeUnloadHandler: null | ((readyToUnload: () => void) => boolean) = null;
+  public static beforeSuspendOrTerminateHandler: null | (() => void) = null;
+  public static resumeHandler: null | ((context: ResumeContext) => void) = null;
 
   /**
    * @internal

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -7,6 +7,7 @@ import { runtime } from '../public/runtime';
 import { Communication, sendMessageEventToChild, sendMessageToParent } from './communication';
 import { ensureInitialized } from './internalAPIs';
 import { getLogger } from './telemetry';
+import { isNullOrUndefined } from './typeCheckUtilities';
 
 const handlersLogger = getLogger('handlers');
 
@@ -155,7 +156,7 @@ export function registerHandlerHelper(
  */
 export function registerOnThemeChangeHandler(handler: (theme: string) => void): void {
   HandlersPrivate.themeChangeHandler = handler;
-  handler && sendMessageToParent('registerHandler', ['themeChange']);
+  !isNullOrUndefined(handler) && sendMessageToParent('registerHandler', ['themeChange']);
 }
 
 /**
@@ -180,7 +181,7 @@ export function handleThemeChange(theme: string): void {
  */
 export function registerOnLoadHandler(handler: (context: LoadContext) => void): void {
   HandlersPrivate.loadHandler = handler;
-  handler && sendMessageToParent('registerHandler', ['load']);
+  !isNullOrUndefined(handler) && sendMessageToParent('registerHandler', ['load']);
 }
 
 /**
@@ -207,7 +208,7 @@ function handleLoad(context: LoadContext): void {
  */
 export function registerBeforeUnloadHandler(handler: (readyToUnload: () => void) => boolean): void {
   HandlersPrivate.beforeUnloadHandler = handler;
-  handler && sendMessageToParent('registerHandler', ['beforeUnload']);
+  !isNullOrUndefined(handler) && sendMessageToParent('registerHandler', ['beforeUnload']);
 }
 
 /**
@@ -241,7 +242,7 @@ function handleBeforeUnload(): void {
  */
 export function registerBeforeSuspendOrTerminateHandler(handler: () => void): void {
   HandlersPrivate.beforeSuspendOrTerminateHandler = handler;
-  handler && sendMessageToParent('registerHandler', ['beforeUnload']);
+  !isNullOrUndefined(handler) && sendMessageToParent('registerHandler', ['beforeUnload']);
 }
 
 /**
@@ -250,5 +251,5 @@ export function registerBeforeSuspendOrTerminateHandler(handler: () => void): vo
  */
 export function registerOnResumeHandler(handler: (context: LoadContext) => void): void {
   HandlersPrivate.resumeHandler = handler;
-  handler && sendMessageToParent('registerHandler', ['load']);
+  !isNullOrUndefined(handler) && sendMessageToParent('registerHandler', ['load']);
 }

--- a/packages/teams-js/src/private/conversations.ts
+++ b/packages/teams-js/src/private/conversations.ts
@@ -155,7 +155,7 @@ export namespace conversations {
         registerHandler(
           'startConversation',
           (subEntityId: string, conversationId: string, channelId: string, entityId: string) =>
-            openConversationRequest.onStartConversation({
+            openConversationRequest.onStartConversation?.({
               subEntityId,
               conversationId,
               channelId,
@@ -167,7 +167,7 @@ export namespace conversations {
         registerHandler(
           'closeConversation',
           (subEntityId: string, conversationId?: string, channelId?: string, entityId?: string) =>
-            openConversationRequest.onCloseConversation({
+            openConversationRequest.onCloseConversation?.({
               subEntityId,
               conversationId,
               channelId,

--- a/packages/teams-js/src/private/files.ts
+++ b/packages/teams-js/src/private/files.ts
@@ -799,7 +799,10 @@ export namespace files {
    * @internal
    * Limited to Microsoft-internal use
    */
-  export function openDownloadFolder(fileObjectId: string = undefined, callback: (error?: SdkError) => void): void {
+  export function openDownloadFolder(
+    fileObjectId: string | undefined = undefined,
+    callback: (error?: SdkError) => void,
+  ): void {
     ensureInitialized(runtime, FrameContexts.content);
 
     if (!callback) {

--- a/packages/teams-js/src/private/logs.ts
+++ b/packages/teams-js/src/private/logs.ts
@@ -1,6 +1,7 @@
 import { sendMessageToParent } from '../internal/communication';
 import { registerHandler, removeHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
+import { isNullOrUndefined } from '../internal/typeCheckUtilities';
 import { errorNotSupportedOnPlatform } from '../public/constants';
 import { runtime } from '../public/runtime';
 
@@ -25,8 +26,8 @@ export namespace logs {
    */
   export function registerGetLogHandler(handler: () => string): void {
     // allow for registration cleanup even when not finished initializing
-    handler && ensureInitialized(runtime);
-    if (handler && !isSupported()) {
+    !isNullOrUndefined(handler) && ensureInitialized(runtime);
+    if (!isNullOrUndefined(handler) && !isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
 

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -512,7 +512,10 @@ export function generateVersionBasedTeamsRuntimeConfig(
   Object.keys(mapVersionToSupportedCapabilities).forEach((versionNumber) => {
     if (compareSDKVersions(highestSupportedVersion, versionNumber) >= 0) {
       mapVersionToSupportedCapabilities[versionNumber].forEach((capabilityReqs) => {
-        if (capabilityReqs.hostClientTypes.includes(GlobalVars.hostClientType)) {
+        if (
+          GlobalVars.hostClientType !== undefined &&
+          capabilityReqs.hostClientTypes.includes(GlobalVars.hostClientType)
+        ) {
           newSupports = mergeRuntimeCapabilities(newSupports, capabilityReqs.capability);
         }
       });


### PR DESCRIPTION
## Description

This is a continuous PR of the original [PR](https://github.com/OfficeDev/microsoft-teams-library-js/pull/1931) by [shilcare](https://github.com/shilcare). There is another outdated PR from a fork [here](https://github.com/OfficeDev/microsoft-teams-library-js/pull/2008), change to this branch PR because of security issues.

### Purpose

Give Teams apps the ability to use Teams' audio devices settings, like play audio on the device that user selected in Teams.

### Details

Add a callback method to `RequestAppAudioHandling`.
- When App first call `RequestAppAudioHandling` with this callback, the callback will be called immediately with Teams' current audio device labels. The app can use this info to initialize and select the corresponding audio devices.
- This callback will also be called when user changes audio devices in Teams, app can update its audio devices accordingly.

### Main changes in the PR:

1. add optional `audioDeviceSelectionChangedCallback` to `RequestAppAudioHandlingParams` which is used in `meeting.requestAppAudioHandling`
2. register event handler in `startAppAudioHandling`
3. unregister event handler in `stopAppAudioHandling`

## Validation

### Validation performed:

To make this work properly, we also need code changes in some internal repos. We have built a Teams container with those changes.

1. Use Teams 2.1 with the custom container
2. Create a test Teams app, add some test code like
```typescript
  meeting.requestAppAudioHandling(
    {
      //...
      audioDeviceSelectionChangedCallback: (selectedDevices) => {
        console.log('audioDeviceSelectionChangedCallback');
        console.log(selectedDevices);
        return Promise.resolve();
      },
    },
   //...
  );
```
3. Replace an existing meeting app, redirect to the local test app
4. Open the modified meeting app.
5. The callback will be called after `meeting.requestAppAudioHandling` is called. And also get called after device is changed in Teams settings. The payload is correct too.

### Unit Tests added:

Yes

### End-to-end tests added:

`requestAppAudioHandling API Call - register audioDeviceSelectionChanged Handler`

## Additional Requirements

### Change file added:

No. `pnpm changefile` says No change files are needed.

### Related PRs:

- <https://github.com/OfficeDev/microsoft-teams-library-js/pull/1931>

### Next/remaining steps:

Close [original PR](https://github.com/OfficeDev/microsoft-teams-library-js/pull/1931) because duplicated and outdated.
Close [fork PR](https://github.com/OfficeDev/microsoft-teams-library-js/pull/2008) because duplicated and outdated.