### PR TITLE
Add test tab module for custom message api

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -12,6 +12,7 @@ import BarCodeAPIs from './components/BarCodeAPIs';
 import CalendarAPIs from './components/CalendarAPIs';
 import CallAPIs from './components/CallAPIs';
 import ClipboardAPIs from './components/Clipboard';
+import CustomAPIs from './components/Custom';
 import DialogAPIs from './components/DialogAPIs';
 import DialogCardAPIs from './components/DialogCardAPIs';
 import DialogCardBotAPIs from './components/DialogCardBotAPIs';
@@ -132,6 +133,7 @@ const App = (): ReactElement => {
         <CallAPIs />
         <ChatAPIs />
         <ClipboardAPIs />
+        <CustomAPIs />
         <DialogAPIs />
         <DialogCardAPIs />
         <DialogCardBotAPIs />

--- a/apps/teams-test-app/src/components/Custom.tsx
+++ b/apps/teams-test-app/src/components/Custom.tsx
@@ -1,0 +1,38 @@
+import { registerCustomHandler, sendCustomMessage } from '@microsoft/teams-js';
+import React from 'react';
+
+import { ApiWithoutInput } from './utils';
+import { ModuleWrapper } from './utils/ModuleWrapper';
+
+const CustomApi = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'customAPI',
+    title: 'Call Custom API',
+    onClick: async () => {
+      await sendCustomMessage('custom-service-test');
+      return '';
+    },
+  });
+
+const RegisterCustomHandler = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'registerCustomHandler',
+    title: 'Register Custom Handler',
+    onClick: async (setResult) => {
+      registerCustomHandler('custom-service-test', (result: string) => {
+        setResult(result);
+        return [];
+      });
+
+      return 'registered';
+    },
+  });
+
+const CustomAPIs: React.FC = () => (
+  <ModuleWrapper title="Custom">
+    <CustomApi />
+    <RegisterCustomHandler />
+  </ModuleWrapper>
+);
+
+export default CustomAPIs;


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Adding a module for custom API in the test app which will facilitate e2e testing for the custom message service that is being added to the host SDK. 

### Unit Tests added:

N/A Test tab update

### End-to-end tests added:

N/A
## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

