### PR TITLE
Create new, alternate, MessageRequest structure with expected required properties

### DIFF
--- a/change/@microsoft-teams-js-26de76b6-42fd-440a-a405-705efdaf1089.json
+++ b/change/@microsoft-teams-js-26de76b6-42fd-440a-a405-705efdaf1089.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Created new `MessageRequest` interface with required properties to enhance type-safety",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable strict-null-checks/all */
-/* eslint-disable strict-null-checks/all */
 
 import { FrameContexts } from '../public/constants';
 import { SdkError } from '../public/interfaces';

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable strict-null-checks/all */
+/* eslint-disable strict-null-checks/all */
 
 import { FrameContexts } from '../public/constants';
 import { SdkError } from '../public/interfaces';
@@ -8,7 +9,8 @@ import { latestRuntimeApiVersion } from '../public/runtime';
 import { version } from '../public/version';
 import { GlobalVars } from './globalVars';
 import { callHandler } from './handlers';
-import { DOMMessageEvent, ExtendedWindow, MessageRequest, MessageResponse } from './interfaces';
+import { DOMMessageEvent, ExtendedWindow } from './interfaces';
+import { MessageRequest, MessageRequestWithRequiredProperties, MessageResponse } from './messageObjects';
 import { getLogger } from './telemetry';
 import { ssrSafeWindow, validateOrigin } from './utils';
 
@@ -180,8 +182,6 @@ export function sendAndHandleSdkError<T>(actionName: string, ...args: any[]): Pr
 export function sendMessageToParentAsync<T>(actionName: string, args: any[] | undefined = undefined): Promise<T> {
   return new Promise((resolve) => {
     const request = sendMessageToParentHelper(actionName, args);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     resolve(waitForResponse<T>(request.id));
   });
 }
@@ -223,7 +223,6 @@ export function sendMessageToParent(actionName: string, argsOrCallback?: any[] |
     args = argsOrCallback;
   }
 
-  /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
   const request = sendMessageToParentHelper(actionName, args);
   if (callback) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -238,18 +237,16 @@ const sendMessageToParentHelperLogger = communicationLogger.extend('sendMessageT
  * @internal
  * Limited to Microsoft-internal use
  */
-function sendMessageToParentHelper(actionName: string, args: any[] | undefined): MessageRequest {
+function sendMessageToParentHelper(actionName: string, args: any[] | undefined): MessageRequestWithRequiredProperties {
   const logger = sendMessageToParentHelperLogger;
 
   const targetWindow = Communication.parentWindow;
   const request = createMessageRequest(actionName, args);
 
-  /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
   logger('Message %i information: %o', request.id, { actionName, args });
 
   if (GlobalVars.isFramelessWindow) {
     if (Communication.currentWindow && Communication.currentWindow.nativeInterface) {
-      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       logger('Sending message %i to parent via framelessPostMessage interface', request.id);
       (Communication.currentWindow as ExtendedWindow).nativeInterface.framelessPostMessage(JSON.stringify(request));
     }
@@ -259,11 +256,9 @@ function sendMessageToParentHelper(actionName: string, args: any[] | undefined):
     // If the target window isn't closed and we already know its origin, send the message right away; otherwise,
     // queue the message and send it after the origin is established
     if (targetWindow && targetOrigin) {
-      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       logger('Sending message %i to parent via postMessage', request.id);
       targetWindow.postMessage(request, targetOrigin);
     } else {
-      /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
       logger('Adding message %i to parent message queue', request.id);
       getTargetMessageQueue(targetWindow).push(request);
     }
@@ -553,7 +548,7 @@ export function sendMessageEventToChild(actionName: string, args?: any[]): void 
  * @internal
  * Limited to Microsoft-internal use
  */
-function createMessageRequest(func: string, args: any[] | undefined): MessageRequest {
+function createMessageRequest(func: string, args: any[] | undefined): MessageRequestWithRequiredProperties {
   return {
     id: CommunicationPrivate.nextMessageId++,
     func: func,

--- a/packages/teams-js/src/internal/interfaces.ts
+++ b/packages/teams-js/src/internal/interfaces.ts
@@ -39,27 +39,6 @@ export interface ExtendedWindow extends Window {
 }
 
 /**
- * @internal
- * Limited to Microsoft-internal use
- */
-export interface MessageRequest {
-  id?: number;
-  func: string;
-  timestamp?: number;
-  args?: any[];
-}
-
-/**
- * @internal
- * Limited to Microsoft-internal use
- */
-export interface MessageResponse {
-  id: number;
-  args?: any[];
-  isPartialResponse?: boolean; // If the message is partial, then there will be more future responses for the given message ID.
-}
-
-/**
  * @hidden
  * Meant for Message objects that are sent to children without id
  *

--- a/packages/teams-js/src/internal/messageObjects.ts
+++ b/packages/teams-js/src/internal/messageObjects.ts
@@ -1,0 +1,38 @@
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export interface MessageRequest {
+  id?: number;
+  func: string;
+  timestamp?: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args?: any[];
+}
+
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export interface MessageResponse {
+  id: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args?: any[];
+  isPartialResponse?: boolean; // If the message is partial, then there will be more future responses for the given message ID.
+}
+
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ *
+ * For reasons that are unclear at this time, some MessageRequest objects can exist without an id or timestamp, even though
+ * many parts of code assume that they are defined.
+ * To enable type-safety in some scenarios, this new interface can be used where these properties are required. Because it
+ * derives from the original interface, objects of this type can be user interchangeably with the original interface.
+ * As the required messaging scenarios are better understood, the interfaces will eventually be updated and
+ * merged. However, it's a journey.
+ */
+export interface MessageRequestWithRequiredProperties extends MessageRequest {
+  id: number;
+  timestamp: number;
+}

--- a/packages/teams-js/test/private/privateAPIs.spec.ts
+++ b/packages/teams-js/test/private/privateAPIs.spec.ts
@@ -1,4 +1,4 @@
-import { MessageResponse } from '../../src/internal/interfaces';
+import { MessageResponse } from '../../src/internal/messageObjects';
 import { UserSettingTypes, ViewerActionTypes } from '../../src/private/interfaces';
 import {
   openFilePreview,

--- a/packages/teams-js/test/private/videoEffectsEx.spec.ts
+++ b/packages/teams-js/test/private/videoEffectsEx.spec.ts
@@ -1,5 +1,6 @@
 import { GlobalVars } from '../../src/internal/globalVars';
-import { DOMMessageEvent, MessageRequest } from '../../src/internal/interfaces';
+import { DOMMessageEvent } from '../../src/internal/interfaces';
+import { MessageRequest } from '../../src/internal/messageObjects';
 import { VideoPerformanceMonitor } from '../../src/internal/videoPerformanceMonitor';
 import { videoEffectsEx } from '../../src/private/videoEffectsEx';
 import { app } from '../../src/public/app';

--- a/packages/teams-js/test/public/meeting.spec.ts
+++ b/packages/teams-js/test/public/meeting.spec.ts
@@ -1,6 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
-import { DOMMessageEvent, MessageRequest } from '../../src/internal/interfaces';
+import { DOMMessageEvent } from '../../src/internal/interfaces';
+import { MessageRequest } from '../../src/internal/messageObjects';
 import { FrameContexts } from '../../src/public';
 import { app } from '../../src/public/app';
 import { ErrorCode, SdkError } from '../../src/public/interfaces';
@@ -1654,4 +1655,3 @@ describe('meeting', () => {
     });
   });
 });
-

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -1,6 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
-import { DOMMessageEvent, MessageResponse } from '../../src/internal/interfaces';
+import { DOMMessageEvent } from '../../src/internal/interfaces';
+import { MessageResponse } from '../../src/internal/messageObjects';
 import { getGenericOnCompleteHandler } from '../../src/internal/utils';
 import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -1,6 +1,7 @@
 import { defaultSDKVersionForCompatCheck } from '../src/internal/constants';
 import { GlobalVars } from '../src/internal/globalVars';
-import { DOMMessageEvent, ExtendedWindow, MessageResponse } from '../src/internal/interfaces';
+import { DOMMessageEvent, ExtendedWindow } from '../src/internal/interfaces';
+import { MessageResponse } from '../src/internal/messageObjects';
 import { app } from '../src/public/app';
 import { applyRuntimeConfig, IBaseRuntime, setUnitializedRuntime } from '../src/public/runtime';
 


### PR DESCRIPTION
## Description

There are some violations of `structNullChecks` remaining in `communication.ts` that are fundamentally unfixable without program flow changes. For example, the `MessageRequest` structure has some properties which are optional, but there is code in `communication.ts` that assumes they are always defined. Generally speaking, fixing these will require one-by-one incremental changes to the code structure.

This first change is the easiest. 😜 

### Main changes in the PR:

1. Create a new message request interface, `MessageRequestWithRequiredProperties`, which derives from the old interface (`MessageRequest`) that marks the previously optional properties as requred. Since this new interface derives from the old, it can be used interchangeably in any place the old interface was used.
2. Update the `createMessageRequest` function in `communication.ts` to return a `MessageRequestWithRequiredProperties` object (instead of a `MessageRequest` object) and pass that around in as many places as possible. This function already populated all the properties, so using the new type recognizes that.
3. Remove violations of `strictNullChecks` (those that are suppressed with `@ts-ignore`) which are no longer violations because they are using the new type which guarantees the properties are defined
4. I also took this opportunity to move the existing `MessageRequest` and `MessageResponse` interfaces, as well as the new interface, into a separate file used just to hold the message objects. This will help ensure that `interfaces.ts` doesn't continue to be an ever-growing file of every interface in the product. These interfaces will now be logically grouped into their own file. (It's possible that in the future these interfaces should live in `communication.ts`, but that file is also huge and complex so I didn't want to exacerbate that problem by putting them in there now).

## Validation

### Validation performed:

This is a typing-only / refactoring change so I ensured that all existing validation continued to pass.

## Additional Requirements

### Change file added:

Yes

### Next/remaining steps:

`MessageRequest` objects are created in many other ways besides just calling `createMessageRequest`. Future changes will have to work on updating these other ways to also create objects with all required properties. This will be less straightforward as the exact scenarios when these other use cases occur will need to be understood more deeply and will result in control flow changes in the code.

Eventually I expect that they can all be converted to always using the required properties and then `MessageRequestWithRequiredProperties` can go away and `MessageRequest` can remain the single interface used everywhere, now with the properties required.