### PR TITLE
Fix calls to chat capability when only a single user is specified

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/ChatAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/ChatAPIs.tsx
@@ -41,8 +41,8 @@ const OpenChat = (): React.ReactElement =>
     title: 'Open Chat',
     onClick: {
       validateInput: (input) => {
-        if (!input.user || !input.message) {
-          throw new Error('Both user and message are required on the input');
+        if (!input.user) {
+          throw new Error('User is required on the input');
         }
       },
       submit: async (input) => {

--- a/change/@microsoft-teams-js-aae140c3-b4de-4ac4-b3cc-e590c4af6bc5.json
+++ b/change/@microsoft-teams-js-aae140c3-b4de-4ac4-b3cc-e590c4af6bc5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed calls to `chat.openChat` and `chat.openGroupChat` when only a single user is specified",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/chat.ts
+++ b/packages/teams-js/src/public/chat.ts
@@ -25,7 +25,8 @@ interface OpenChatRequest {
  */
 export interface OpenSingleChatRequest extends OpenChatRequest {
   /**
-   * The Microsoft Entra UPN (e-mail address) of the user to chat with
+   * The [Microsoft Entra UPNs](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/plan-connect-userprincipalname) (usually but not always an e-mail address)
+   * of the user with whom to begin a chat
    */
   user: string;
 }
@@ -39,7 +40,8 @@ export interface OpenSingleChatRequest extends OpenChatRequest {
  */
 export interface OpenGroupChatRequest extends OpenChatRequest {
   /**
-   * Array containing Microsoft Entra UPNs (e-mail addresss) of users to open chat with
+   * Array containing [Microsoft Entra UPNs](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/plan-connect-userprincipalname) (usually but not always an e-mail address)
+   * of users with whom to begin a chat
    */
   users: string[];
   /**
@@ -79,7 +81,7 @@ export namespace chat {
         );
       } else {
         const sendPromise = sendAndHandleStatusAndReason('chat.openChat', {
-          members: openChatRequest.user,
+          members: [openChatRequest.user],
           message: openChatRequest.message,
         });
         resolve(sendPromise);
@@ -107,7 +109,7 @@ export namespace chat {
           user: openChatRequest.users[0],
           message: openChatRequest.message,
         };
-        openChat(chatRequest);
+        resolve(openChat(chatRequest));
       } else {
         ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
         if (!isSupported()) {

--- a/packages/teams-js/test/promiseTester.ts
+++ b/packages/teams-js/test/promiseTester.ts
@@ -1,0 +1,24 @@
+export enum PromiseState {
+  Pending = 'pending',
+  Resolved = 'resolved',
+  Rejected = 'rejected',
+}
+
+export async function getPromiseState<T>(promiseInQuestion: Promise<T>): Promise<PromiseState> {
+  const objectThatActsLikeAResolvedPromise = {};
+  try {
+    const firstPromiseNotPending = await Promise.race([promiseInQuestion, objectThatActsLikeAResolvedPromise]);
+
+    if (firstPromiseNotPending === objectThatActsLikeAResolvedPromise) {
+      return PromiseState.Pending;
+    } else {
+      return PromiseState.Resolved;
+    }
+  } catch (e) {
+    return PromiseState.Rejected;
+  }
+}
+
+export async function isPromiseStillPending<T>(promiseInQuestion: Promise<T>): Promise<boolean> {
+  return (await getPromiseState(promiseInQuestion)) === PromiseState.Pending;
+}

--- a/packages/teams-js/test/promiseTester.ts
+++ b/packages/teams-js/test/promiseTester.ts
@@ -10,11 +10,14 @@ export async function getPromiseState<T>(promiseInQuestion: Promise<T>): Promise
     const firstPromiseNotPending = await Promise.race([promiseInQuestion, objectThatActsLikeAResolvedPromise]);
 
     if (firstPromiseNotPending === objectThatActsLikeAResolvedPromise) {
+      // Promise.race will return the first promise in the given iterable that has settled (either resolved or rejected).
+      // If the promise it returned is objectThatActsLikeAResolvedPromise, then we know that the promiseInQuestion is still pending.
       return PromiseState.Pending;
     } else {
       return PromiseState.Resolved;
     }
   } catch (e) {
+    // If the promiseInQuestion is rejected, then Promise.race will reject.
     return PromiseState.Rejected;
   }
 }

--- a/packages/teams-js/test/public/chat.spec.ts
+++ b/packages/teams-js/test/public/chat.spec.ts
@@ -9,6 +9,7 @@ import {
   validateChatDeepLinkTopic,
   validateDeepLinkUsers,
 } from '../internal/deepLinkUtilities.spec';
+import { isPromiseStillPending } from '../promiseTester';
 import { Utils } from '../utils';
 
 /* eslint-disable */
@@ -83,16 +84,34 @@ describe('chat', () => {
             message: 'someMessage',
           };
 
-          chat.openChat(chatRequest);
-
-          const chatResponse = {
-            members: 'someUPN',
+          const normalizedChatRequest = {
+            members: ['someUPN'],
             message: 'someMessage',
           };
 
+          chat.openChat(chatRequest);
+
           const openChatMessage = utils.findMessageByFunc('chat.openChat');
           expect(openChatMessage).not.toBeNull();
-          expect(openChatMessage.args).toEqual([chatResponse]);
+          expect(openChatMessage.args).toEqual([normalizedChatRequest]);
+        });
+
+        it(`should wait until response is received from non-legacy Teams host before resolving promise - Context: ${context}`, async () => {
+          await utils.initializeWithContext(context);
+          utils.setRuntimeConfig({ apiVersion: 1, isLegacyTeams: false, supports: { chat: {} } });
+
+          const chatRequest: OpenSingleChatRequest = {
+            user: 'someUPN',
+            message: 'someMessage',
+          };
+
+          const promise: Promise<void> = chat.openChat(chatRequest);
+          expect(await isPromiseStillPending(promise)).toBe(true);
+
+          const openChatMessage = utils.findMessageByFunc('chat.openChat');
+          utils.respondToMessage(openChatMessage, true);
+
+          await expect(promise).resolves.not.toThrow();
         });
 
         it(`should successfully pass chatRequest to legacy Teams host - Context: ${context}`, async () => {
@@ -174,7 +193,7 @@ describe('chat', () => {
             topic: 'someTopic',
           };
 
-          const chatResponse = {
+          const normalizedChatRequest = {
             members: ['someUPN', 'someUPN2'],
             message: 'someMessage',
             topic: 'someTopic',
@@ -184,8 +203,50 @@ describe('chat', () => {
 
           const openChatMessage = utils.findMessageByFunc('chat.openChat');
           expect(openChatMessage).not.toBeNull();
-          expect(openChatMessage.args).toEqual([chatResponse]);
+          expect(openChatMessage.args).toEqual([normalizedChatRequest]);
         });
+
+        it(`should successfully pass chatRequest to non-legacy Teams host when only one UPN is specified - Context: ${context}`, async () => {
+          await utils.initializeWithContext(context);
+          utils.setRuntimeConfig({ apiVersion: 1, isLegacyTeams: false, supports: { chat: {} } });
+
+          const chatRequest: OpenGroupChatRequest = {
+            users: ['someUPN'],
+            message: 'someMessage',
+            topic: 'someTopic',
+          };
+
+          const normalizedChatRequestForASingleUser = {
+            members: ['someUPN'],
+            message: 'someMessage',
+          };
+
+          chat.openGroupChat(chatRequest);
+
+          const openChatMessage = utils.findMessageByFunc('chat.openChat');
+          expect(openChatMessage).not.toBeNull();
+          expect(openChatMessage.args).toEqual([normalizedChatRequestForASingleUser]);
+        });
+
+        it(`should wait until response is received from non-legacy Teams host before resolving promise  - Context: ${context}`, async () => {
+          await utils.initializeWithContext(context);
+          utils.setRuntimeConfig({ apiVersion: 1, isLegacyTeams: false, supports: { chat: {} } });
+
+          const chatRequest: OpenGroupChatRequest = {
+            users: ['someUPN'],
+            message: 'someMessage',
+            topic: 'someTopic',
+          };
+
+          const chatPromise = chat.openGroupChat(chatRequest);
+          expect(await isPromiseStillPending(chatPromise)).toBe(true);
+
+          const openChatMessage = utils.findMessageByFunc('chat.openChat');
+          utils.respondToMessage(openChatMessage, true);
+
+          await expect(chatPromise).resolves.not.toThrow();
+        });
+
         it(`should successfully pass chatRequest to legacy Teams host - Context:${context}`, async () => {
           await utils.initializeWithContext(context);
           utils.setRuntimeConfig({ apiVersion: 1, isLegacyTeams: true, supports: { chat: {} } });

--- a/packages/teams-js/test/public/chat.spec.ts
+++ b/packages/teams-js/test/public/chat.spec.ts
@@ -84,7 +84,7 @@ describe('chat', () => {
             message: 'someMessage',
           };
 
-          const normalizedChatRequest = {
+          const normalizedChatRequestArguments = {
             members: ['someUPN'],
             message: 'someMessage',
           };
@@ -93,7 +93,7 @@ describe('chat', () => {
 
           const openChatMessage = utils.findMessageByFunc('chat.openChat');
           expect(openChatMessage).not.toBeNull();
-          expect(openChatMessage.args).toEqual([normalizedChatRequest]);
+          expect(openChatMessage.args).toEqual([normalizedChatRequestArguments]);
         });
 
         it(`should wait until response is received from non-legacy Teams host before resolving promise - Context: ${context}`, async () => {
@@ -193,7 +193,7 @@ describe('chat', () => {
             topic: 'someTopic',
           };
 
-          const normalizedChatRequest = {
+          const normalizedChatRequestArguments = {
             members: ['someUPN', 'someUPN2'],
             message: 'someMessage',
             topic: 'someTopic',
@@ -203,7 +203,7 @@ describe('chat', () => {
 
           const openChatMessage = utils.findMessageByFunc('chat.openChat');
           expect(openChatMessage).not.toBeNull();
-          expect(openChatMessage.args).toEqual([normalizedChatRequest]);
+          expect(openChatMessage.args).toEqual([normalizedChatRequestArguments]);
         });
 
         it(`should successfully pass chatRequest to non-legacy Teams host when only one UPN is specified - Context: ${context}`, async () => {
@@ -216,7 +216,7 @@ describe('chat', () => {
             topic: 'someTopic',
           };
 
-          const normalizedChatRequestForASingleUser = {
+          const normalizedChatRequestArgumentsForASingleUser = {
             members: ['someUPN'],
             message: 'someMessage',
           };
@@ -225,7 +225,7 @@ describe('chat', () => {
 
           const openChatMessage = utils.findMessageByFunc('chat.openChat');
           expect(openChatMessage).not.toBeNull();
-          expect(openChatMessage.args).toEqual([normalizedChatRequestForASingleUser]);
+          expect(openChatMessage.args).toEqual([normalizedChatRequestArgumentsForASingleUser]);
         });
 
         it(`should wait until response is received from non-legacy Teams host before resolving promise  - Context: ${context}`, async () => {


### PR DESCRIPTION
## Description

The contract for communicating between teams-js and the host library for opening chat requests (`chat.openChat` message) is that the desired users will be passed as an array in the `members` property. The `chat.openChat` function, used when only a single user is intended to be specified, was not doing that. It was passing the single user as a string. Consequently, when the host library (and/or the host) received the message, it could not handle it correctly because it was expecting `members` to be an array of strings and not a single string.

Relatedly, the `chat.openGroupChat` function was similarly broken when a single user was passed to it, since it deferred to `chat.openChat` in that case.

As part of testing, I also discovered these issues:
- When `chat.openGroupChat` defers to `chat.openChat` in the single user case, it was ignore the promise returned from `chat.openChat`, so `chat.openGroupChat` would return immediately rather than waiting for the response from the host library
- The documentation incorrectly stated that UPNs are e-mail addresses. They are frequently e-mail addresses, but not always.
- The test app UX (`ChatAPIs.tsx`) for validating `chat.openChat` was incorrectly saying that `message` was required, when the `OpenSingleChatRequest` type passed to `chat.openChat` clearing indicates that it is optional.
- The same test app file (`ChatAPIs.tsx`) is incorrectly located the "private" directory even though the `chat` capability is public.
- There were no unit tests to cover any of these cases.

### Main changes in the PR:

1. Fix `chat.openChat` to pass the single user as an array with a single element
2. Fix `chat.openGroupChat` to leverage the `Promise` returned by `chat.openChat` when it defers to that function in the single user case
3. Update the documentation to link to the Microsoft Entra ID page describing UPNs
4. Update the test app's chat functionality to not require the `message` property
5. Add unit tests to cover all these fixed cases

Note: The incorrect location of `ChatAPIs.tsx` was not fixed in this change as it would likely have made the diff harder to read (it would have been more difficult to see that the file was both relocated and modified). I will move the file in a later change.

## Validation

### Validation performed:

1. Validate that all existing unit tests pass
2. Validated that all new unit tests failed before the fixes and passed after the fixes
3. Validate that all E2E tests pass as part of this PR
4. Validate that the exact error message reported in #1964 (and #2035) could be reproed in the test host before the fix and would no longer repro after the fix

### Unit Tests added:

Yes

### End-to-end tests added:

No.

## Additional Requirements

### Change file added:

Indeed.