### PR TITLE
Make composeExtension a required property on query message extension response in external app auth capability

### DIFF
--- a/change/@microsoft-teams-js-ffdf93d1-4a5d-4c9c-abbd-620b88478b53.json
+++ b/change/@microsoft-teams-js-ffdf93d1-4a5d-4c9c-abbd-620b88478b53.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Made composeExtension a required field on IQueryMessageExtensionResponse",
+  "packageName": "@microsoft/teams-js",
+  "email": "jeklouda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/externalAppAuthentication.ts
+++ b/packages/teams-js/src/private/externalAppAuthentication.ts
@@ -149,7 +149,7 @@ export namespace externalAppAuthentication {
    */
   export interface IQueryMessageExtensionResponse {
     responseType: InvokeResponseType.QueryMessageExtensionResponse;
-    composeExtension?: ComposeExtensionResponse;
+    composeExtension: ComposeExtensionResponse;
   }
 
   /**


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Make composeExtension a required property on `IQeuryMessageExtensionResponse`

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
