### PR TITLE
Adding E2E Testing Json files for external app Capabilities

### DIFF
--- a/apps/teams-test-app/e2e-test-data/externalAppAuthentication.json
+++ b/apps/teams-test-app/e2e-test-data/externalAppAuthentication.json
@@ -1,0 +1,7 @@
+{
+  "name": "ExternalAppAuthentication",
+  "version": ">2.18.0",
+  "platform": "Web",
+  "checkIsSupported": {},
+  "testCases": []
+}

--- a/apps/teams-test-app/e2e-test-data/externalAppAuthentication.json
+++ b/apps/teams-test-app/e2e-test-data/externalAppAuthentication.json
@@ -2,6 +2,5 @@
   "name": "ExternalAppAuthentication",
   "version": ">2.18.0",
   "platform": "Web",
-  "checkIsSupported": {},
   "testCases": []
 }

--- a/apps/teams-test-app/e2e-test-data/externalAppCardActions.json
+++ b/apps/teams-test-app/e2e-test-data/externalAppCardActions.json
@@ -1,0 +1,32 @@
+{
+  "name": "ExternalAppCardActions",
+  "version": ">2.18.0",
+  "platform": "Web",
+  "checkIsSupported": {},
+  "testCases": [
+    {
+      "title": "processActionSubmit API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_processActionSubmit",
+      "inputValue": {
+        "appId": "testId",
+        "actionSubmitPayload": {
+          "id": "mockId",
+          "data": {}
+        }
+      },
+      "expectedAlertValue": "processActionSubmit called with ##JSON_INPUT_VALUE##",
+      "expectedTestAppValue": "Completed"
+    },
+    {
+      "title": "processActionOpenUrl API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_processActionOpenUrl",
+      "inputValue": {
+        "appId": "testId",
+        "url": "https://example.com"
+      },
+      "expectedTestAppValue": "something GenericUrl type value?"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/externalAppCardActions.json
+++ b/apps/teams-test-app/e2e-test-data/externalAppCardActions.json
@@ -2,31 +2,5 @@
   "name": "ExternalAppCardActions",
   "version": ">2.18.0",
   "platform": "Web",
-  "checkIsSupported": {},
-  "testCases": [
-    {
-      "title": "processActionSubmit API Call - Success",
-      "type": "callResponse",
-      "boxSelector": "#box_processActionSubmit",
-      "inputValue": {
-        "appId": "testId",
-        "actionSubmitPayload": {
-          "id": "mockId",
-          "data": {}
-        }
-      },
-      "expectedAlertValue": "processActionSubmit called with ##JSON_INPUT_VALUE##",
-      "expectedTestAppValue": "Completed"
-    },
-    {
-      "title": "processActionOpenUrl API Call - Success",
-      "type": "callResponse",
-      "boxSelector": "#box_processActionOpenUrl",
-      "inputValue": {
-        "appId": "testId",
-        "url": "https://example.com"
-      },
-      "expectedTestAppValue": "something GenericUrl type value?"
-    }
-  ]
+  "testCases": []
 }


### PR DESCRIPTION
## Description


Nothing will be added here because we need to let test app to be presented as external app without exposing appId. So we will add all of test cases in web host sdk side.

### Main changes in the PR:

1. Add testing json file for compiling