### PR TITLE
Remove isSupported checking

### DIFF
--- a/change/@microsoft-teams-js-6947d1b0-af04-49ac-9cdc-01faca53672c.json
+++ b/change/@microsoft-teams-js-6947d1b0-af04-49ac-9cdc-01faca53672c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "remove isSupported checking",
+  "packageName": "@microsoft/teams-js",
+  "email": "kaelapolnitz@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -57,11 +57,7 @@ export namespace teamsCore {
    * @beta
    */
   export function registerOnLoadHandler(handler: registerOnLoadHandlerFunctionType): void {
-    registerOnLoadHandlerHelper(handler, () => {
-      if (!isNullOrUndefined(handler) && !isSupported()) {
-        throw errorNotSupportedOnPlatform;
-      }
-    });
+    registerOnLoadHandlerHelper(handler);
   }
 
   /**
@@ -102,11 +98,7 @@ export namespace teamsCore {
    * @beta
    */
   export function registerBeforeUnloadHandler(handler: registerBeforeUnloadHandlerFunctionType): void {
-    registerBeforeUnloadHandlerHelper(handler, () => {
-      if (!isNullOrUndefined(handler) && !isSupported()) {
-        throw errorNotSupportedOnPlatform;
-      }
-    });
+    registerBeforeUnloadHandlerHelper(handler);
   }
 
   /**

--- a/packages/teams-js/test/public/teamsAPIs.spec.ts
+++ b/packages/teams-js/test/public/teamsAPIs.spec.ts
@@ -142,19 +142,6 @@ describe('Testing TeamsCore Capability', () => {
       });
 
       Object.values(FrameContexts).forEach((context) => {
-        it(`teamsCore.registerOnLoadHandler should throw error when teamsCore is not supported. context: ${context}`, async () => {
-          await utils.initializeWithContext(context);
-          utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
-          expect.assertions(1);
-          try {
-            teamsCore.registerOnLoadHandler(() => {
-              return false;
-            });
-          } catch (e) {
-            expect(e).toEqual(errorNotSupportedOnPlatform);
-          }
-        });
-
         it(`teamsCore.registerOnLoadHandler should successfully register handler. context: ${context}`, async () => {
           await utils.initializeWithContext(context);
 
@@ -181,19 +168,6 @@ describe('Testing TeamsCore Capability', () => {
       });
 
       Object.values(FrameContexts).forEach((context) => {
-        it(`teamsCore.registerBeforeUnloadHandler should throw error when teamsCore is not supported. context:${context}`, async () => {
-          await utils.initializeWithContext(context);
-          utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
-          expect.assertions(1);
-          try {
-            teamsCore.registerBeforeUnloadHandler(() => {
-              return false;
-            });
-          } catch (e) {
-            expect(e).toEqual(errorNotSupportedOnPlatform);
-          }
-        });
-
         it(`teamsCore.registerBeforeUnloadHandler should successfully register a before unload handler. context: ${context}`, async () => {
           await utils.initializeWithContext(context);
 


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

This removes isSupported checks in registerLoad/registerUnload handlers for Teams.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. isSupported check removed from registerOnLoadHandler
2. sSupported check removed from registerBeforeUnloadHandler

## Validation

### Validation performed:

1. Can successfully register handler in pop-out windows
2. Can successfully register handler in app caching contexts 

### Unit Tests added:

Yes, teamsAPIs.spec.ts updated

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes

### Next/remaining steps: To be made available to apps 

### Screenshots:

> When app wants to register load/beforeUnload hander in pop-out
Before: Would throw error due to isSupported being false.
<img width="366" alt="image" src="https://github.com/OfficeDev/microsoft-teams-library-js/assets/20099584/ad9d9fb1-c856-4870-b7f3-f03355b0d3bd">

<img width="491" alt="image" src="https://github.com/OfficeDev/microsoft-teams-library-js/assets/20099584/9708826a-8430-4be0-93c1-92f17c3e26c7">

After: Does not throw. Successfully allows registration.
<img width="358" alt="image" src="https://github.com/OfficeDev/microsoft-teams-library-js/assets/20099584/318712e9-0d3a-4ecc-8c65-3e138c467c21">

