### PR TITLE
Add optional parameter to initialize call

### DIFF
--- a/change/@microsoft-teams-js-2105a377-282c-452d-bb03-208852fcc2dd.json
+++ b/change/@microsoft-teams-js-2105a377-282c-452d-bb03-208852fcc2dd.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Added optional `customeMessageIdStarter` parameter to `app.initialize` call to give an option to developers to set the starting number for messageIds",
+  "comment": "Added optional `customeMessageIdStarter` parameter to `app.initialize` call to give an option to developers to set the starting number for messageIds. \\nHaving a high seed value for this field results in generating messageIds that have a less change of collision when there are multiple instances of teamsJS running by the application",
   "packageName": "@microsoft/teams-js",
   "email": "lakhveerkaur@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-2105a377-282c-452d-bb03-208852fcc2dd.json
+++ b/change/@microsoft-teams-js-2105a377-282c-452d-bb03-208852fcc2dd.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Added optional `customeMessageIdStarter` parameter to `app.initialize` call to give an option to developers to set teh starting number fr messageIds",
+  "comment": "Added optional `customeMessageIdStarter` parameter to `app.initialize` call to give an option to developers to set the starting number for messageIds",
   "packageName": "@microsoft/teams-js",
   "email": "lakhveerkaur@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-2105a377-282c-452d-bb03-208852fcc2dd.json
+++ b/change/@microsoft-teams-js-2105a377-282c-452d-bb03-208852fcc2dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added optional `customeMessageIdStarter` parameter to `app.initialize` call to give an option to developers to set teh starting number fr messageIds",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-2105a377-282c-452d-bb03-208852fcc2dd.json
+++ b/change/@microsoft-teams-js-2105a377-282c-452d-bb03-208852fcc2dd.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Added optional `customeMessageIdStarter` parameter to `app.initialize` call to give an option to developers to set the starting number for messageIds. \\nHaving a high seed value for this field results in generating messageIds that have a less change of collision when there are multiple instances of teamsJS running by the application",
+  "comment": "Added optional `customeMessageIdStarter` parameter to `app.initialize` call to give an option to developers to set the starting number for messageIds. \\nHaving a high seed value for this field results in generating messageIds that have a less chances of collision when there are multiple instances of teamsJS running by the application",
   "packageName": "@microsoft/teams-js",
   "email": "lakhveerkaur@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -63,7 +63,9 @@ interface InitializeResponse {
 export function initializeCommunication(
   validMessageOrigins: string[] | undefined,
   apiVersionTag: string,
+  customMessageIdStarter?: number,
 ): Promise<InitializeResponse> {
+  CommunicationPrivate.nextMessageId = customMessageIdStarter ?? CommunicationPrivate.nextMessageId;
   // Listen for messages post to our window
   CommunicationPrivate.messageListener = (evt: DOMMessageEvent): void => processMessage(evt);
 

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -46,10 +46,14 @@ const initializationTimeoutInMs = 5000;
 
 const appLogger = getLogger('app');
 
-export function appInitializeHelper(apiVersionTag: string, validMessageOrigins?: string[]): Promise<void> {
+export function appInitializeHelper(
+  apiVersionTag: string,
+  validMessageOrigins?: string[],
+  customMessageIdStarter?: number,
+): Promise<void> {
   if (!inServerSideRenderingEnvironment()) {
     return runWithTimeout(
-      () => initializeHelper(apiVersionTag, validMessageOrigins),
+      () => initializeHelper(apiVersionTag, validMessageOrigins, customMessageIdStarter),
       initializationTimeoutInMs,
       new Error('SDK initialization timed out.'),
     );
@@ -63,87 +67,89 @@ export function appInitializeHelper(apiVersionTag: string, validMessageOrigins?:
 }
 
 const initializeHelperLogger = appLogger.extend('initializeHelper');
-function initializeHelper(apiVersionTag: string, validMessageOrigins?: string[]): Promise<void> {
+function initializeHelper(
+  apiVersionTag: string,
+  validMessageOrigins?: string[],
+  customMessageIdStarter?: number,
+): Promise<void> {
   return new Promise<void>((resolve) => {
     // Independent components might not know whether the SDK is initialized so might call it to be safe.
     // Just no-op if that happens to make it easier to use.
-    if (!GlobalVars.initializeCalled) {
-      GlobalVars.initializeCalled = true;
+    GlobalVars.initializeCalled = true;
 
-      Handlers.initializeHandlers();
-      GlobalVars.initializePromise = initializeCommunication(validMessageOrigins, apiVersionTag).then(
-        ({ context, clientType, runtimeConfig, clientSupportedSDKVersion = defaultSDKVersionForCompatCheck }) => {
-          GlobalVars.frameContext = context;
-          GlobalVars.hostClientType = clientType;
-          GlobalVars.clientSupportedSDKVersion = clientSupportedSDKVersion;
-          // Temporary workaround while the Host is updated with the new argument order.
-          // For now, we might receive any of these possibilities:
-          // - `runtimeConfig` in `runtimeConfig` and `clientSupportedSDKVersion` in `clientSupportedSDKVersion`.
-          // - `runtimeConfig` in `clientSupportedSDKVersion` and `clientSupportedSDKVersion` in `runtimeConfig`.
-          // - `clientSupportedSDKVersion` in `runtimeConfig` and no `clientSupportedSDKVersion`.
-          // This code supports any of these possibilities
+    Handlers.initializeHandlers();
+    GlobalVars.initializePromise = initializeCommunication(
+      validMessageOrigins,
+      apiVersionTag,
+      customMessageIdStarter,
+    ).then(({ context, clientType, runtimeConfig, clientSupportedSDKVersion = defaultSDKVersionForCompatCheck }) => {
+      GlobalVars.frameContext = context;
+      GlobalVars.hostClientType = clientType;
+      GlobalVars.clientSupportedSDKVersion = clientSupportedSDKVersion;
+      // Temporary workaround while the Host is updated with the new argument order.
+      // For now, we might receive any of these possibilities:
+      // - `runtimeConfig` in `runtimeConfig` and `clientSupportedSDKVersion` in `clientSupportedSDKVersion`.
+      // - `runtimeConfig` in `clientSupportedSDKVersion` and `clientSupportedSDKVersion` in `runtimeConfig`.
+      // - `clientSupportedSDKVersion` in `runtimeConfig` and no `clientSupportedSDKVersion`.
+      // This code supports any of these possibilities
 
-          // Teams AppHost won't provide this runtime config
-          // so we assume that if we don't have it, we must be running in Teams.
-          // After Teams updates its client code, we can remove this default code.
+      // Teams AppHost won't provide this runtime config
+      // so we assume that if we don't have it, we must be running in Teams.
+      // After Teams updates its client code, we can remove this default code.
+      try {
+        initializeHelperLogger('Parsing %s', runtimeConfig);
+        const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(runtimeConfig);
+        initializeHelperLogger('Checking if %o is a valid runtime object', givenRuntimeConfig ?? 'null');
+        // Check that givenRuntimeConfig is a valid instance of IBaseRuntime
+        if (!givenRuntimeConfig || !givenRuntimeConfig.apiVersion) {
+          throw new Error('Received runtime config is invalid');
+        }
+        runtimeConfig && applyRuntimeConfig(givenRuntimeConfig);
+      } catch (e) {
+        if (e instanceof SyntaxError) {
           try {
-            initializeHelperLogger('Parsing %s', runtimeConfig);
-            const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(runtimeConfig);
-            initializeHelperLogger('Checking if %o is a valid runtime object', givenRuntimeConfig ?? 'null');
-            // Check that givenRuntimeConfig is a valid instance of IBaseRuntime
-            if (!givenRuntimeConfig || !givenRuntimeConfig.apiVersion) {
-              throw new Error('Received runtime config is invalid');
+            initializeHelperLogger('Attempting to parse %s as an SDK version', runtimeConfig);
+            // if the given runtime config was actually meant to be a SDK version, store it as such.
+            // TODO: This is a temporary workaround to allow Teams to store clientSupportedSDKVersion even when
+            // it doesn't provide the runtimeConfig. After Teams updates its client code, we should
+            // remove this feature.
+            if (!isNaN(compareSDKVersions(runtimeConfig, defaultSDKVersionForCompatCheck))) {
+              GlobalVars.clientSupportedSDKVersion = runtimeConfig;
             }
-            runtimeConfig && applyRuntimeConfig(givenRuntimeConfig);
+            const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(clientSupportedSDKVersion);
+            initializeHelperLogger('givenRuntimeConfig parsed to %o', givenRuntimeConfig ?? 'null');
+
+            if (!givenRuntimeConfig) {
+              throw new Error('givenRuntimeConfig string was successfully parsed. However, it parsed to value of null');
+            } else {
+              applyRuntimeConfig(givenRuntimeConfig);
+            }
           } catch (e) {
             if (e instanceof SyntaxError) {
-              try {
-                initializeHelperLogger('Attempting to parse %s as an SDK version', runtimeConfig);
-                // if the given runtime config was actually meant to be a SDK version, store it as such.
-                // TODO: This is a temporary workaround to allow Teams to store clientSupportedSDKVersion even when
-                // it doesn't provide the runtimeConfig. After Teams updates its client code, we should
-                // remove this feature.
-                if (!isNaN(compareSDKVersions(runtimeConfig, defaultSDKVersionForCompatCheck))) {
-                  GlobalVars.clientSupportedSDKVersion = runtimeConfig;
-                }
-                const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(clientSupportedSDKVersion);
-                initializeHelperLogger('givenRuntimeConfig parsed to %o', givenRuntimeConfig ?? 'null');
-
-                if (!givenRuntimeConfig) {
-                  throw new Error(
-                    'givenRuntimeConfig string was successfully parsed. However, it parsed to value of null',
-                  );
-                } else {
-                  applyRuntimeConfig(givenRuntimeConfig);
-                }
-              } catch (e) {
-                if (e instanceof SyntaxError) {
-                  applyRuntimeConfig(
-                    generateVersionBasedTeamsRuntimeConfig(
-                      GlobalVars.clientSupportedSDKVersion,
-                      versionAndPlatformAgnosticTeamsRuntimeConfig,
-                      mapTeamsVersionToSupportedCapabilities,
-                    ),
-                  );
-                } else {
-                  throw e;
-                }
-              }
+              applyRuntimeConfig(
+                generateVersionBasedTeamsRuntimeConfig(
+                  GlobalVars.clientSupportedSDKVersion,
+                  versionAndPlatformAgnosticTeamsRuntimeConfig,
+                  mapTeamsVersionToSupportedCapabilities,
+                ),
+              );
             } else {
-              // If it's any error that's not a JSON parsing error, we want the program to fail.
               throw e;
             }
           }
+        } else {
+          // If it's any error that's not a JSON parsing error, we want the program to fail.
+          throw e;
+        }
+      }
 
-          GlobalVars.initializeCompleted = true;
-        },
-      );
+      GlobalVars.initializeCompleted = true;
+    });
 
-      authentication.initialize();
-      menus.initialize();
-      pages.config.initialize();
-      dialog.initialize();
-    }
+    authentication.initialize();
+    menus.initialize();
+    pages.config.initialize();
+    dialog.initialize();
 
     // Handle additional valid message origins if specified
     if (Array.isArray(validMessageOrigins)) {
@@ -729,10 +735,11 @@ export namespace app {
    * https: protocol otherwise they will be ignored. Example: https://www.example.com
    * @returns Promise that will be fulfilled when initialization has completed, or rejected if the initialization fails or times out
    */
-  export function initialize(validMessageOrigins?: string[]): Promise<void> {
+  export function initialize(validMessageOrigins?: string[], customMessageIdStarter?: number): Promise<void> {
     return appInitializeHelper(
       getApiVersionTag(appTelemetryVersionNumber, ApiName.App_Initialize),
       validMessageOrigins,
+      customMessageIdStarter,
     );
   }
 

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -737,6 +737,8 @@ export namespace app {
    * @param validMessageOrigins - Optionally specify a list of cross frame message origins. They must have
    * https: protocol otherwise they will be ignored. Example: https://www.example.com
    *
+   * @hidden
+   * @internal
    * @param customMessageIdStarter - a starting number from where the sequence of messageIds begin that we use to match the requests and responses from teams-js to host sdk.
    * The default value is zero. A higher seed value reduces the chance of collisions in messageIds when multiple teamsJS instances are running concurrently
    *

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -737,7 +737,9 @@ export namespace app {
    * @param validMessageOrigins - Optionally specify a list of cross frame message origins. They must have
    * https: protocol otherwise they will be ignored. Example: https://www.example.com
    *
-   * @param customMessageIdStarter -
+   * @param customMessageIdStarter - a starting number from where the sequence of messageIds begin that we use to match the requests and responses from teams-js to host sdk.
+   * The default value is zero. A higher seed value reduces the chance of collisions in messageIds when multiple teamsJS instances are running concurrently
+   *
    * @returns Promise that will be fulfilled when initialization has completed, or rejected if the initialization fails or times out
    */
   export function initialize(validMessageOrigins?: string[], customMessageIdStarter?: number): Promise<void> {

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -75,82 +75,85 @@ function initializeHelper(
   return new Promise<void>((resolve) => {
     // Independent components might not know whether the SDK is initialized so might call it to be safe.
     // Just no-op if that happens to make it easier to use.
-    GlobalVars.initializeCalled = true;
+    if (!GlobalVars.initializeCalled) {
+      GlobalVars.initializeCalled = true;
 
-    Handlers.initializeHandlers();
-    GlobalVars.initializePromise = initializeCommunication(
-      validMessageOrigins,
-      apiVersionTag,
-      customMessageIdStarter,
-    ).then(({ context, clientType, runtimeConfig, clientSupportedSDKVersion = defaultSDKVersionForCompatCheck }) => {
-      GlobalVars.frameContext = context;
-      GlobalVars.hostClientType = clientType;
-      GlobalVars.clientSupportedSDKVersion = clientSupportedSDKVersion;
-      // Temporary workaround while the Host is updated with the new argument order.
-      // For now, we might receive any of these possibilities:
-      // - `runtimeConfig` in `runtimeConfig` and `clientSupportedSDKVersion` in `clientSupportedSDKVersion`.
-      // - `runtimeConfig` in `clientSupportedSDKVersion` and `clientSupportedSDKVersion` in `runtimeConfig`.
-      // - `clientSupportedSDKVersion` in `runtimeConfig` and no `clientSupportedSDKVersion`.
-      // This code supports any of these possibilities
+      Handlers.initializeHandlers();
+      GlobalVars.initializePromise = initializeCommunication(
+        validMessageOrigins,
+        apiVersionTag,
+        customMessageIdStarter,
+      ).then(({ context, clientType, runtimeConfig, clientSupportedSDKVersion = defaultSDKVersionForCompatCheck }) => {
+        GlobalVars.frameContext = context;
+        GlobalVars.hostClientType = clientType;
+        GlobalVars.clientSupportedSDKVersion = clientSupportedSDKVersion;
+        // Temporary workaround while the Host is updated with the new argument order.
+        // For now, we might receive any of these possibilities:
+        // - `runtimeConfig` in `runtimeConfig` and `clientSupportedSDKVersion` in `clientSupportedSDKVersion`.
+        // - `runtimeConfig` in `clientSupportedSDKVersion` and `clientSupportedSDKVersion` in `runtimeConfig`.
+        // - `clientSupportedSDKVersion` in `runtimeConfig` and no `clientSupportedSDKVersion`.
+        // This code supports any of these possibilities
 
-      // Teams AppHost won't provide this runtime config
-      // so we assume that if we don't have it, we must be running in Teams.
-      // After Teams updates its client code, we can remove this default code.
-      try {
-        initializeHelperLogger('Parsing %s', runtimeConfig);
-        const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(runtimeConfig);
-        initializeHelperLogger('Checking if %o is a valid runtime object', givenRuntimeConfig ?? 'null');
-        // Check that givenRuntimeConfig is a valid instance of IBaseRuntime
-        if (!givenRuntimeConfig || !givenRuntimeConfig.apiVersion) {
-          throw new Error('Received runtime config is invalid');
-        }
-        runtimeConfig && applyRuntimeConfig(givenRuntimeConfig);
-      } catch (e) {
-        if (e instanceof SyntaxError) {
-          try {
-            initializeHelperLogger('Attempting to parse %s as an SDK version', runtimeConfig);
-            // if the given runtime config was actually meant to be a SDK version, store it as such.
-            // TODO: This is a temporary workaround to allow Teams to store clientSupportedSDKVersion even when
-            // it doesn't provide the runtimeConfig. After Teams updates its client code, we should
-            // remove this feature.
-            if (!isNaN(compareSDKVersions(runtimeConfig, defaultSDKVersionForCompatCheck))) {
-              GlobalVars.clientSupportedSDKVersion = runtimeConfig;
-            }
-            const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(clientSupportedSDKVersion);
-            initializeHelperLogger('givenRuntimeConfig parsed to %o', givenRuntimeConfig ?? 'null');
-
-            if (!givenRuntimeConfig) {
-              throw new Error('givenRuntimeConfig string was successfully parsed. However, it parsed to value of null');
-            } else {
-              applyRuntimeConfig(givenRuntimeConfig);
-            }
-          } catch (e) {
-            if (e instanceof SyntaxError) {
-              applyRuntimeConfig(
-                generateVersionBasedTeamsRuntimeConfig(
-                  GlobalVars.clientSupportedSDKVersion,
-                  versionAndPlatformAgnosticTeamsRuntimeConfig,
-                  mapTeamsVersionToSupportedCapabilities,
-                ),
-              );
-            } else {
-              throw e;
-            }
+        // Teams AppHost won't provide this runtime config
+        // so we assume that if we don't have it, we must be running in Teams.
+        // After Teams updates its client code, we can remove this default code.
+        try {
+          initializeHelperLogger('Parsing %s', runtimeConfig);
+          const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(runtimeConfig);
+          initializeHelperLogger('Checking if %o is a valid runtime object', givenRuntimeConfig ?? 'null');
+          // Check that givenRuntimeConfig is a valid instance of IBaseRuntime
+          if (!givenRuntimeConfig || !givenRuntimeConfig.apiVersion) {
+            throw new Error('Received runtime config is invalid');
           }
-        } else {
-          // If it's any error that's not a JSON parsing error, we want the program to fail.
-          throw e;
+          runtimeConfig && applyRuntimeConfig(givenRuntimeConfig);
+        } catch (e) {
+          if (e instanceof SyntaxError) {
+            try {
+              initializeHelperLogger('Attempting to parse %s as an SDK version', runtimeConfig);
+              // if the given runtime config was actually meant to be a SDK version, store it as such.
+              // TODO: This is a temporary workaround to allow Teams to store clientSupportedSDKVersion even when
+              // it doesn't provide the runtimeConfig. After Teams updates its client code, we should
+              // remove this feature.
+              if (!isNaN(compareSDKVersions(runtimeConfig, defaultSDKVersionForCompatCheck))) {
+                GlobalVars.clientSupportedSDKVersion = runtimeConfig;
+              }
+              const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(clientSupportedSDKVersion);
+              initializeHelperLogger('givenRuntimeConfig parsed to %o', givenRuntimeConfig ?? 'null');
+
+              if (!givenRuntimeConfig) {
+                throw new Error(
+                  'givenRuntimeConfig string was successfully parsed. However, it parsed to value of null',
+                );
+              } else {
+                applyRuntimeConfig(givenRuntimeConfig);
+              }
+            } catch (e) {
+              if (e instanceof SyntaxError) {
+                applyRuntimeConfig(
+                  generateVersionBasedTeamsRuntimeConfig(
+                    GlobalVars.clientSupportedSDKVersion,
+                    versionAndPlatformAgnosticTeamsRuntimeConfig,
+                    mapTeamsVersionToSupportedCapabilities,
+                  ),
+                );
+              } else {
+                throw e;
+              }
+            }
+          } else {
+            // If it's any error that's not a JSON parsing error, we want the program to fail.
+            throw e;
+          }
         }
-      }
 
-      GlobalVars.initializeCompleted = true;
-    });
+        GlobalVars.initializeCompleted = true;
+      });
 
-    authentication.initialize();
-    menus.initialize();
-    pages.config.initialize();
-    dialog.initialize();
-
+      authentication.initialize();
+      menus.initialize();
+      pages.config.initialize();
+      dialog.initialize();
+    }
     // Handle additional valid message origins if specified
     if (Array.isArray(validMessageOrigins)) {
       processAdditionalValidOrigins(validMessageOrigins);

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -46,10 +46,14 @@ const initializationTimeoutInMs = 5000;
 
 const appLogger = getLogger('app');
 
-export function appInitializeHelper(apiVersionTag: string, validMessageOrigins?: string[]): Promise<void> {
+export function appInitializeHelper(
+  apiVersionTag: string,
+  validMessageOrigins?: string[],
+  customMessageIdStarter?: number,
+): Promise<void> {
   if (!inServerSideRenderingEnvironment()) {
     return runWithTimeout(
-      () => initializeHelper(apiVersionTag, validMessageOrigins),
+      () => initializeHelper(apiVersionTag, validMessageOrigins, customMessageIdStarter),
       initializationTimeoutInMs,
       new Error('SDK initialization timed out.'),
     );
@@ -63,7 +67,11 @@ export function appInitializeHelper(apiVersionTag: string, validMessageOrigins?:
 }
 
 const initializeHelperLogger = appLogger.extend('initializeHelper');
-function initializeHelper(apiVersionTag: string, validMessageOrigins?: string[]): Promise<void> {
+function initializeHelper(
+  apiVersionTag: string,
+  validMessageOrigins?: string[],
+  customMessageIdStarter?: number,
+): Promise<void> {
   return new Promise<void>((resolve) => {
     // Independent components might not know whether the SDK is initialized so might call it to be safe.
     // Just no-op if that happens to make it easier to use.
@@ -71,73 +79,75 @@ function initializeHelper(apiVersionTag: string, validMessageOrigins?: string[])
       GlobalVars.initializeCalled = true;
 
       Handlers.initializeHandlers();
-      GlobalVars.initializePromise = initializeCommunication(validMessageOrigins, apiVersionTag).then(
-        ({ context, clientType, runtimeConfig, clientSupportedSDKVersion = defaultSDKVersionForCompatCheck }) => {
-          GlobalVars.frameContext = context;
-          GlobalVars.hostClientType = clientType;
-          GlobalVars.clientSupportedSDKVersion = clientSupportedSDKVersion;
-          // Temporary workaround while the Host is updated with the new argument order.
-          // For now, we might receive any of these possibilities:
-          // - `runtimeConfig` in `runtimeConfig` and `clientSupportedSDKVersion` in `clientSupportedSDKVersion`.
-          // - `runtimeConfig` in `clientSupportedSDKVersion` and `clientSupportedSDKVersion` in `runtimeConfig`.
-          // - `clientSupportedSDKVersion` in `runtimeConfig` and no `clientSupportedSDKVersion`.
-          // This code supports any of these possibilities
+      GlobalVars.initializePromise = initializeCommunication(
+        validMessageOrigins,
+        apiVersionTag,
+        customMessageIdStarter,
+      ).then(({ context, clientType, runtimeConfig, clientSupportedSDKVersion = defaultSDKVersionForCompatCheck }) => {
+        GlobalVars.frameContext = context;
+        GlobalVars.hostClientType = clientType;
+        GlobalVars.clientSupportedSDKVersion = clientSupportedSDKVersion;
+        // Temporary workaround while the Host is updated with the new argument order.
+        // For now, we might receive any of these possibilities:
+        // - `runtimeConfig` in `runtimeConfig` and `clientSupportedSDKVersion` in `clientSupportedSDKVersion`.
+        // - `runtimeConfig` in `clientSupportedSDKVersion` and `clientSupportedSDKVersion` in `runtimeConfig`.
+        // - `clientSupportedSDKVersion` in `runtimeConfig` and no `clientSupportedSDKVersion`.
+        // This code supports any of these possibilities
 
-          // Teams AppHost won't provide this runtime config
-          // so we assume that if we don't have it, we must be running in Teams.
-          // After Teams updates its client code, we can remove this default code.
-          try {
-            initializeHelperLogger('Parsing %s', runtimeConfig);
-            const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(runtimeConfig);
-            initializeHelperLogger('Checking if %o is a valid runtime object', givenRuntimeConfig ?? 'null');
-            // Check that givenRuntimeConfig is a valid instance of IBaseRuntime
-            if (!givenRuntimeConfig || !givenRuntimeConfig.apiVersion) {
-              throw new Error('Received runtime config is invalid');
-            }
-            runtimeConfig && applyRuntimeConfig(givenRuntimeConfig);
-          } catch (e) {
-            if (e instanceof SyntaxError) {
-              try {
-                initializeHelperLogger('Attempting to parse %s as an SDK version', runtimeConfig);
-                // if the given runtime config was actually meant to be a SDK version, store it as such.
-                // TODO: This is a temporary workaround to allow Teams to store clientSupportedSDKVersion even when
-                // it doesn't provide the runtimeConfig. After Teams updates its client code, we should
-                // remove this feature.
-                if (!isNaN(compareSDKVersions(runtimeConfig, defaultSDKVersionForCompatCheck))) {
-                  GlobalVars.clientSupportedSDKVersion = runtimeConfig;
-                }
-                const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(clientSupportedSDKVersion);
-                initializeHelperLogger('givenRuntimeConfig parsed to %o', givenRuntimeConfig ?? 'null');
-
-                if (!givenRuntimeConfig) {
-                  throw new Error(
-                    'givenRuntimeConfig string was successfully parsed. However, it parsed to value of null',
-                  );
-                } else {
-                  applyRuntimeConfig(givenRuntimeConfig);
-                }
-              } catch (e) {
-                if (e instanceof SyntaxError) {
-                  applyRuntimeConfig(
-                    generateVersionBasedTeamsRuntimeConfig(
-                      GlobalVars.clientSupportedSDKVersion,
-                      versionAndPlatformAgnosticTeamsRuntimeConfig,
-                      mapTeamsVersionToSupportedCapabilities,
-                    ),
-                  );
-                } else {
-                  throw e;
-                }
-              }
-            } else {
-              // If it's any error that's not a JSON parsing error, we want the program to fail.
-              throw e;
-            }
+        // Teams AppHost won't provide this runtime config
+        // so we assume that if we don't have it, we must be running in Teams.
+        // After Teams updates its client code, we can remove this default code.
+        try {
+          initializeHelperLogger('Parsing %s', runtimeConfig);
+          const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(runtimeConfig);
+          initializeHelperLogger('Checking if %o is a valid runtime object', givenRuntimeConfig ?? 'null');
+          // Check that givenRuntimeConfig is a valid instance of IBaseRuntime
+          if (!givenRuntimeConfig || !givenRuntimeConfig.apiVersion) {
+            throw new Error('Received runtime config is invalid');
           }
+          runtimeConfig && applyRuntimeConfig(givenRuntimeConfig);
+        } catch (e) {
+          if (e instanceof SyntaxError) {
+            try {
+              initializeHelperLogger('Attempting to parse %s as an SDK version', runtimeConfig);
+              // if the given runtime config was actually meant to be a SDK version, store it as such.
+              // TODO: This is a temporary workaround to allow Teams to store clientSupportedSDKVersion even when
+              // it doesn't provide the runtimeConfig. After Teams updates its client code, we should
+              // remove this feature.
+              if (!isNaN(compareSDKVersions(runtimeConfig, defaultSDKVersionForCompatCheck))) {
+                GlobalVars.clientSupportedSDKVersion = runtimeConfig;
+              }
+              const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(clientSupportedSDKVersion);
+              initializeHelperLogger('givenRuntimeConfig parsed to %o', givenRuntimeConfig ?? 'null');
 
-          GlobalVars.initializeCompleted = true;
-        },
-      );
+              if (!givenRuntimeConfig) {
+                throw new Error(
+                  'givenRuntimeConfig string was successfully parsed. However, it parsed to value of null',
+                );
+              } else {
+                applyRuntimeConfig(givenRuntimeConfig);
+              }
+            } catch (e) {
+              if (e instanceof SyntaxError) {
+                applyRuntimeConfig(
+                  generateVersionBasedTeamsRuntimeConfig(
+                    GlobalVars.clientSupportedSDKVersion,
+                    versionAndPlatformAgnosticTeamsRuntimeConfig,
+                    mapTeamsVersionToSupportedCapabilities,
+                  ),
+                );
+              } else {
+                throw e;
+              }
+            }
+          } else {
+            // If it's any error that's not a JSON parsing error, we want the program to fail.
+            throw e;
+          }
+        }
+
+        GlobalVars.initializeCompleted = true;
+      });
 
       authentication.initialize();
       menus.initialize();
@@ -727,12 +737,22 @@ export namespace app {
    *
    * @param validMessageOrigins - Optionally specify a list of cross frame message origins. They must have
    * https: protocol otherwise they will be ignored. Example: https://www.example.com
+   *
+   * @hidden
+   * @internal
+   * @param customMessageIdStarter - a starting number from where the sequence of messageIds begin that we use to match the requests and responses from teams-js to host sdk.
+   * The default value is zero. A higher seed value reduces the chance of collisions in messageIds when multiple teamsJS instances are running concurrently
+   *
    * @returns Promise that will be fulfilled when initialization has completed, or rejected if the initialization fails or times out
    */
-  export function initialize(validMessageOrigins?: string[]): Promise<void> {
+  export function initialize(validMessageOrigins?: string[], customMessageIdStarter?: number): Promise<void> {
+    if (customMessageIdStarter && customMessageIdStarter < 0) {
+      throw 'customMessageIdStarter cannot be a negative number';
+    }
     return appInitializeHelper(
       getApiVersionTag(appTelemetryVersionNumber, ApiName.App_Initialize),
       validMessageOrigins,
+      customMessageIdStarter,
     );
   }
 

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -733,9 +733,14 @@ export namespace app {
    *
    * @param validMessageOrigins - Optionally specify a list of cross frame message origins. They must have
    * https: protocol otherwise they will be ignored. Example: https://www.example.com
+   *
+   * @param customMessageIdStarter -
    * @returns Promise that will be fulfilled when initialization has completed, or rejected if the initialization fails or times out
    */
   export function initialize(validMessageOrigins?: string[], customMessageIdStarter?: number): Promise<void> {
+    if (customMessageIdStarter && customMessageIdStarter < 0) {
+      throw 'customMessageIdStarter cannot be a negative number';
+    }
     return appInitializeHelper(
       getApiVersionTag(appTelemetryVersionNumber, ApiName.App_Initialize),
       validMessageOrigins,

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -112,6 +112,18 @@ describe('Testing app capability', () => {
         expect(initMessage.timestamp).not.toBeNull();
       });
 
+      it('app.initialize message will start messageId from provided customeMessageIdStarter', () => {
+        app.initialize(undefined, 1000);
+
+        expect(utils.processMessage).toBeDefined();
+        expect(utils.messages.length).toBe(1);
+
+        const initMessage = utils.findMessageByFunc('initialize');
+        expect(initMessage).not.toBeNull();
+        expect(initMessage.id).toBe(1000);
+        expect(initMessage.func).toBe('initialize');
+      });
+
       it('app.initialize should allow multiple initialize calls', () => {
         for (let i = 0; i < 2; i++) {
           app.initialize();


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

Adding optional `customMessageIdStarter` parameter to initialize call. If there are more than one teams-js instants, and there can be a problem that both instants are making call to host with the same message IDs. customMessageIdStarter parameter gives app developer an option start the messageIDs from a different number, so they don't conflict. 

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
