### PR TITLE
Magli/add sharing support for mobile

### DIFF
--- a/change/@microsoft-teams-js-134533ca-fcbe-44f6-a617-de49c1129126.json
+++ b/change/@microsoft-teams-js-134533ca-fcbe-44f6-a617-de49c1129126.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added sharing support in runtime for mobile platform",
+  "packageName": "@microsoft/teams-js",
+  "email": "magli@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-134533ca-fcbe-44f6-a617-de49c1129126.json
+++ b/change/@microsoft-teams-js-134533ca-fcbe-44f6-a617-de49c1129126.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Added sharing support in runtime for mobile platform",
+  "comment": "Added support for `sharing` capability in default runtime for Teams mobile platform",
   "packageName": "@microsoft/teams-js",
   "email": "magli@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -440,6 +440,12 @@ export const mapTeamsVersionToSupportedCapabilities: Record<string, Array<ICapab
       hostClientTypes: [HostClientType.android, HostClientType.desktop, HostClientType.ios],
     },
   ],
+  '2.0.8': [
+    {
+      capability: { sharing: {} },
+      hostClientTypes: [HostClientType.android, HostClientType.ios],
+    },
+  ],
 };
 
 const generateBackCompatRuntimeConfigLogger = runtimeLogger.extend('generateBackCompatRuntimeConfig');

--- a/packages/teams-js/test/public/sharing.spec.ts
+++ b/packages/teams-js/test/public/sharing.spec.ts
@@ -386,7 +386,7 @@ describe('sharing_v2', () => {
   const testVersions = ['1.8.0', '1.9.0', '2.0.2'];
   const minDesktopAndWebVersionForSharing = '2.0.0';
   const supportedClientTypes = [HostClientType.web, HostClientType.desktop];
-  describe('Testing sharing.isSupported() on different platforms', () => {
+  describe('Testing sharing.isSupported() on web and desktop platforms', () => {
     Object.values(HostClientType).forEach((clientType) => {
       if (supportedClientTypes.some((supportedClientTypes) => supportedClientTypes == clientType)) {
         Object.values(testVersions).forEach((version) => {
@@ -416,10 +416,42 @@ describe('sharing_v2', () => {
             });
           }
         });
-      } else {
-        it(`sharing.isSupported() should return false for platforms other than desktop and web, regardless version`, async () => {
-          await utils.initializeWithContext(FrameContexts.content, clientType);
-          expect(sharing.isSupported()).toBeFalsy();
+      }
+    });
+  });
+
+  const testVersionsForMobile = ['2.0.2', '2.0.8', '2.0.9'];
+  const minMobileVersionForSharing = '2.0.8';
+  const supportedMobileClientTypes = [HostClientType.ios, HostClientType.android];
+  describe('Testing sharing.isSupported() on mobile platforms', () => {
+    Object.values(HostClientType).forEach((clientType) => {
+      if (supportedMobileClientTypes.some((supportedMobileClientTypes) => supportedMobileClientTypes == clientType)) {
+        Object.values(testVersionsForMobile).forEach((version) => {
+          if (compareSDKVersions(version, minMobileVersionForSharing) >= 0) {
+            it(`sharing.isSupported() should return true for mobile when version is greater than supported version ${minMobileVersionForSharing}}`, async () => {
+              await utils.initializeWithContext(FrameContexts.content, clientType);
+              utils.setRuntimeConfig(
+                generateVersionBasedTeamsRuntimeConfig(
+                  version,
+                  versionAndPlatformAgnosticTeamsRuntimeConfig,
+                  mapTeamsVersionToSupportedCapabilities,
+                ),
+              );
+              expect(sharing.isSupported()).toBeTruthy();
+            });
+          } else {
+            it(`sharing.isSupported() should return false for mobile when version is lower than supported version ${minMobileVersionForSharing}}`, async () => {
+              await utils.initializeWithContext(FrameContexts.content, clientType);
+              utils.setRuntimeConfig(
+                generateVersionBasedTeamsRuntimeConfig(
+                  version,
+                  versionAndPlatformAgnosticTeamsRuntimeConfig,
+                  mapTeamsVersionToSupportedCapabilities,
+                ),
+              );
+              expect(sharing.isSupported()).toBeFalsy();
+            });
+          }
         });
       }
     });


### PR DESCRIPTION
Teams mobile will start to support shareWebContent api from version 2.0.8. While they are working on a long term solution which is to send runtime object, teamsjs is providing a default configuration to unblock them. This PR is for this purpose.

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
