### PR TITLE
Fix and enhance readability (hopefully) of unit tests for versioned runtime 

### DIFF
--- a/change/@microsoft-teams-js-17e23500-2b46-429a-83cc-62548c0a1e5e.json
+++ b/change/@microsoft-teams-js-17e23500-2b46-429a-83cc-62548c0a1e5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated runtime capabilities for webStorage to avoid duplicate entry",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -437,7 +437,7 @@ export const mapTeamsVersionToSupportedCapabilities: Record<string, Array<ICapab
   '2.0.5': [
     {
       capability: { webStorage: {} },
-      hostClientTypes: [HostClientType.android, HostClientType.desktop, HostClientType.ios],
+      hostClientTypes: [HostClientType.android, HostClientType.ios],
     },
   ],
 };
@@ -513,6 +513,11 @@ export function generateVersionBasedTeamsRuntimeConfig(
           GlobalVars.hostClientType !== undefined &&
           capabilityReqs.hostClientTypes.includes(GlobalVars.hostClientType)
         ) {
+          console.log(
+            `Adding capabilities from version ${versionNumber} for host client ${
+              GlobalVars.hostClientType
+            }:  ${JSON.stringify(capabilityReqs.capability)}`,
+          );
           newSupports = mergeRuntimeCapabilities(newSupports, capabilityReqs.capability);
         }
       });

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -513,11 +513,6 @@ export function generateVersionBasedTeamsRuntimeConfig(
           GlobalVars.hostClientType !== undefined &&
           capabilityReqs.hostClientTypes.includes(GlobalVars.hostClientType)
         ) {
-          console.log(
-            `Adding capabilities from version ${versionNumber} for host client ${
-              GlobalVars.hostClientType
-            }:  ${JSON.stringify(capabilityReqs.capability)}`,
-          );
           newSupports = mergeRuntimeCapabilities(newSupports, capabilityReqs.capability);
         }
       });

--- a/packages/teams-js/test/public/runtime.spec.ts
+++ b/packages/teams-js/test/public/runtime.spec.ts
@@ -329,7 +329,7 @@ describe('runtime', () => {
   // and Android report it as unsupported in versions OLDER than 1.5.0 and also ensure that Desktop and Android report it as SUPPORTED in versions
   // NEWER than (or equal to) 1.5.0. However, those tests will not validate that iOS reports it as UNSUPPORTED in all versions, since the tests
   // are based on the platforms listed in the map and not on the platforms absent from the map.
-  describe('generateVersionBasedTeamsRuntimeConfig ensure only platforms ', () => {
+  describe('generateVersionBasedTeamsRuntimeConfig ensure only platform support is consistent', () => {
     const mapCapabilityAsStringToPlatformsListedInMap: Map<string, Set<string>> = new Map();
 
     const allAddedCapabilityReqsInAnyVersion: Array<Array<ICapabilityReqs>> = Object.values(

--- a/packages/teams-js/test/public/runtime.spec.ts
+++ b/packages/teams-js/test/public/runtime.spec.ts
@@ -237,18 +237,27 @@ describe('runtime', () => {
         }
       }
     });
+  });
 
-    it('Validate that all client types for a version EARLIER than when a capability began to be supported report that capability is NOT supported ', async () => {
+  describe('generateVersionBasedTeamsRuntimeConfig older and newer version tests', () => {
+    it('Validate that all client types for a version OLDER than when a capability began to be supported report that capability is NOT supported ', async () => {
       for (const [version, capabilityAdditionsForEachVersion] of Object.entries(
         mapTeamsVersionToSupportedCapabilities,
       )) {
+        console.log(`version: ${version}`);
         for (const capabilityAdditionsInASpecificVersion of capabilityAdditionsForEachVersion) {
           const capabilityAdditionsForThisVersion = capabilityAdditionsInASpecificVersion.capability;
           const individualCapabilityAdditionsForThisVersion: object[] = decomposeObject(
             capabilityAdditionsForThisVersion,
           );
+          console.log(
+            `individualCapabilityAdditionsForThisVersion: ${JSON.stringify(
+              individualCapabilityAdditionsForThisVersion,
+            )}`,
+          );
 
           for (const clientType of capabilityAdditionsInASpecificVersion.hostClientTypes) {
+            console.log(`clientType: ${clientType}`);
             const olderVersionsInCapabilityMap = getVersionsFromCapabilityMapOlderThanGivenVersion(version);
             const versionOlderThanAllVersionsInCapabilityMap =
               generateVersionOlderThanGivenVersion(oldestVersionInCapabilityMap);
@@ -256,8 +265,11 @@ describe('runtime', () => {
               ...olderVersionsInCapabilityMap,
               versionOlderThanAllVersionsInCapabilityMap,
             ];
+            console.log(`oldVersionsToTestAgainst: ${oldVersionsToTestAgainst}`);
 
             for (const olderVersion of oldVersionsToTestAgainst) {
+              console.log(`olderVersion: ${olderVersion}`);
+
               await utils.initializeWithContext('content', clientType);
 
               const generatedRuntimeConfigSupportedCapabilities = generateVersionBasedTeamsRuntimeConfig(
@@ -266,7 +278,14 @@ describe('runtime', () => {
                 mapTeamsVersionToSupportedCapabilities,
               ).supports;
 
+              console.log(
+                `generatedRuntimeConfigSupportedCapabilities: ${JSON.stringify(
+                  generatedRuntimeConfigSupportedCapabilities,
+                )}`,
+              );
+
               individualCapabilityAdditionsForThisVersion.forEach((capabilityAdditionForThisVersion) => {
+                console.log(`capabilityAdditionForThisVersion: ${JSON.stringify(capabilityAdditionForThisVersion)}`);
                 expect(isSubset(capabilityAdditionForThisVersion, generatedRuntimeConfigSupportedCapabilities)).toBe(
                   false,
                 );
@@ -277,44 +296,44 @@ describe('runtime', () => {
       }
     });
 
-    it('Validate that all client types for a version NEWER than when a capability began to be supported report that capability IS supported ', async () => {
-      for (const [version, capabilityAdditionsForEachVersion] of Object.entries(
-        mapTeamsVersionToSupportedCapabilities,
-      )) {
-        for (const capabilityAdditionsInASpecificVersion of capabilityAdditionsForEachVersion) {
-          const capabilityAdditionsForThisVersion = capabilityAdditionsInASpecificVersion.capability;
-          const individualCapabilityAdditionsForThisVersion: object[] = decomposeObject(
-            capabilityAdditionsForThisVersion,
-          );
+    // it('Validate that all client types for a version NEWER than when a capability began to be supported report that capability IS supported ', async () => {
+    //   for (const [version, capabilityAdditionsForEachVersion] of Object.entries(
+    //     mapTeamsVersionToSupportedCapabilities,
+    //   )) {
+    //     for (const capabilityAdditionsInASpecificVersion of capabilityAdditionsForEachVersion) {
+    //       const capabilityAdditionsForThisVersion = capabilityAdditionsInASpecificVersion.capability;
+    //       const individualCapabilityAdditionsForThisVersion: object[] = decomposeObject(
+    //         capabilityAdditionsForThisVersion,
+    //       );
 
-          for (const clientType of capabilityAdditionsInASpecificVersion.hostClientTypes) {
-            const newerVersionsInCapabilityMap = getVersionsFromCapabilityMapOlderThanGivenVersion(version);
-            const versionNewerThanAllVersionsInCapabilityMap =
-              generateVersionNewerThanGivenVersion(newestVersionInCapabilityMap);
-            const newVersionsToTestAgainst = [
-              ...newerVersionsInCapabilityMap,
-              versionNewerThanAllVersionsInCapabilityMap,
-            ];
+    //       for (const clientType of capabilityAdditionsInASpecificVersion.hostClientTypes) {
+    //         const newerVersionsInCapabilityMap = getVersionsFromCapabilityMapOlderThanGivenVersion(version);
+    //         const versionNewerThanAllVersionsInCapabilityMap =
+    //           generateVersionNewerThanGivenVersion(newestVersionInCapabilityMap);
+    //         const newVersionsToTestAgainst = [
+    //           ...newerVersionsInCapabilityMap,
+    //           versionNewerThanAllVersionsInCapabilityMap,
+    //         ];
 
-            for (const newerVersion of newVersionsToTestAgainst) {
-              await utils.initializeWithContext('content', clientType);
+    //         for (const newerVersion of newVersionsToTestAgainst) {
+    //           await utils.initializeWithContext('content', clientType);
 
-              const generatedRuntimeConfigSupportedCapabilities = generateVersionBasedTeamsRuntimeConfig(
-                newerVersion,
-                versionAndPlatformAgnosticTeamsRuntimeConfig,
-                mapTeamsVersionToSupportedCapabilities,
-              ).supports;
+    //           const generatedRuntimeConfigSupportedCapabilities = generateVersionBasedTeamsRuntimeConfig(
+    //             newerVersion,
+    //             versionAndPlatformAgnosticTeamsRuntimeConfig,
+    //             mapTeamsVersionToSupportedCapabilities,
+    //           ).supports;
 
-              individualCapabilityAdditionsForThisVersion.forEach((capabilityAdditionForThisVersion) => {
-                expect(isSubset(capabilityAdditionForThisVersion, generatedRuntimeConfigSupportedCapabilities)).toBe(
-                  true,
-                );
-              });
-            }
-          }
-        }
-      }
-    });
+    //           individualCapabilityAdditionsForThisVersion.forEach((capabilityAdditionForThisVersion) => {
+    //             expect(isSubset(capabilityAdditionForThisVersion, generatedRuntimeConfigSupportedCapabilities)).toBe(
+    //               true,
+    //             );
+    //           });
+    //         }
+    //       }
+    //     }
+    //   }
+    // });
   });
 
   // for (const [version, capabilityAdditionsForEachVersion] of Object.entries(mapTeamsVersionToSupportedCapabilities)) {

--- a/packages/teams-js/test/public/runtime.spec.ts
+++ b/packages/teams-js/test/public/runtime.spec.ts
@@ -190,6 +190,28 @@ describe('runtime', () => {
     return result;
   }
 
+  describe('generateVersionBasedTeamsRuntimeConfig tests based on Teams default configuration', () => {
+    it('Validate that all client types where a capability began to be supported report that capability IS supported in that version', async () => {
+      for (const [version, capabilityAdditionsForEachVersion] of Object.entries(
+        mapTeamsVersionToSupportedCapabilities,
+      )) {
+        for (const capabilityAdditionsInASpecificVersion of capabilityAdditionsForEachVersion) {
+          const capabilityAdditionsForThisVersion = capabilityAdditionsInASpecificVersion.capability;
+
+          for (const clientType of capabilityAdditionsInASpecificVersion.hostClientTypes) {
+            await utils.initializeWithContext('content', clientType);
+            const generatedCapabilityObjectForThisVersion = generateVersionBasedTeamsRuntimeConfig(
+              version,
+              versionAndPlatformAgnosticTeamsRuntimeConfig,
+              mapTeamsVersionToSupportedCapabilities,
+            ).supports;
+            expect(isSubset(capabilityAdditionsForThisVersion, generatedCapabilityObjectForThisVersion)).toBe(true);
+          }
+        }
+      }
+    });
+  });
+
   function getVersionsFromCapabilityMapOlderThanGivenVersion(version: string): string[] {
     return Object.keys(mapTeamsVersionToSupportedCapabilities).filter(
       (otherVer) => compareSDKVersions(otherVer, version) < 0,
@@ -217,222 +239,178 @@ describe('runtime', () => {
     return `${version}.1`;
   }
 
-  describe('generateVersionBasedTeamsRuntimeConfig tests based on Teams default configuration', () => {
-    it('Validate that all client types where a capability began to be supported report that capability IS supported in that version', async () => {
-      for (const [version, capabilityAdditionsForEachVersion] of Object.entries(
-        mapTeamsVersionToSupportedCapabilities,
-      )) {
-        for (const capabilityAdditionsInASpecificVersion of capabilityAdditionsForEachVersion) {
-          const capabilityAdditionsForThisVersion = capabilityAdditionsInASpecificVersion.capability;
+  enum OlderOrNewerVersions {
+    OlderVersions,
+    NewerVersions,
+  }
 
-          for (const clientType of capabilityAdditionsInASpecificVersion.hostClientTypes) {
-            await utils.initializeWithContext('content', clientType);
-            const generatedCapabilityObjectForThisVersion = generateVersionBasedTeamsRuntimeConfig(
-              version,
+  function getOlderOrNewerVersionsToUseForTest(olderOrNewer: OlderOrNewerVersions, version: string): string[] {
+    if (olderOrNewer === OlderOrNewerVersions.OlderVersions) {
+      const olderVersionsInCapabilityMap = getVersionsFromCapabilityMapOlderThanGivenVersion(version);
+      const versionOlderThanAllVersionsInCapabilityMap =
+        generateVersionOlderThanGivenVersion(oldestVersionInCapabilityMap);
+      const oldVersionsToTestAgainst = [...olderVersionsInCapabilityMap, versionOlderThanAllVersionsInCapabilityMap];
+      return oldVersionsToTestAgainst;
+    } else {
+      const newVersionsInCapabilityMap = getVersionsFromCapabilityMapNewerThanGivenVersion(version);
+      const versionNewerThanAllVersionsInCapabilityMap =
+        generateVersionNewerThanGivenVersion(newestVersionInCapabilityMap);
+      const newVersionsToTestAgainst = [...newVersionsInCapabilityMap, versionNewerThanAllVersionsInCapabilityMap];
+      return newVersionsToTestAgainst;
+    }
+  }
+
+  async function testVersionsForPresenceOrAbsenceOfCapabilitySupport(
+    olderOrNewerVersions: OlderOrNewerVersions,
+    versionWhereCapabilityWasAdded: string,
+    individualCapabilityAdditionsForThisVersion: object[],
+    clientType: string,
+  ): Promise<void> {
+    const versionsToTestAgainst = getOlderOrNewerVersionsToUseForTest(
+      olderOrNewerVersions,
+      versionWhereCapabilityWasAdded,
+    );
+    for (const versionToTest of versionsToTestAgainst) {
+      await utils.initializeWithContext('content', clientType);
+
+      const generatedRuntimeConfigSupportedCapabilities = generateVersionBasedTeamsRuntimeConfig(
+        versionToTest,
+        versionAndPlatformAgnosticTeamsRuntimeConfig,
+        mapTeamsVersionToSupportedCapabilities,
+      ).supports;
+
+      const shouldCapabilityBeSupported = olderOrNewerVersions === OlderOrNewerVersions.NewerVersions;
+
+      individualCapabilityAdditionsForThisVersion.forEach((capabilityAdditionForThisVersion) => {
+        expect(isSubset(capabilityAdditionForThisVersion, generatedRuntimeConfigSupportedCapabilities)).toBe(
+          shouldCapabilityBeSupported,
+        );
+      });
+    }
+  }
+
+  describe('generateVersionBasedTeamsRuntimeConfig older and newer version tests', () => {
+    for (const [versionWhereCapabilitySupportWasAdded, capabilityAdditionsForEachVersion] of Object.entries(
+      mapTeamsVersionToSupportedCapabilities,
+    )) {
+      for (const capabilityAdditionsInASpecificVersion of capabilityAdditionsForEachVersion) {
+        const capabilityAdditionsForThisVersion = capabilityAdditionsInASpecificVersion.capability;
+        const individualCapabilityAdditionsForThisVersion: object[] = decomposeObject(
+          capabilityAdditionsForThisVersion,
+        );
+
+        for (const clientType of capabilityAdditionsInASpecificVersion.hostClientTypes) {
+          it('Validate that all client types for a version OLDER than when a capability began to be supported report that capability is NOT supported ', async () => {
+            await testVersionsForPresenceOrAbsenceOfCapabilitySupport(
+              OlderOrNewerVersions.OlderVersions,
+              versionWhereCapabilitySupportWasAdded,
+              individualCapabilityAdditionsForThisVersion,
+              clientType,
+            );
+          });
+          it('Validate that all client types for a version NEWER than when a capability began to be supported report that capability IS supported ', async () => {
+            await testVersionsForPresenceOrAbsenceOfCapabilitySupport(
+              OlderOrNewerVersions.NewerVersions,
+              versionWhereCapabilitySupportWasAdded,
+              individualCapabilityAdditionsForThisVersion,
+              clientType,
+            );
+          });
+        }
+      }
+    }
+  });
+
+  // For any capability which begins to be supported on some version for some platform, the above tests will validate that it's NOT reported
+  // in any version OLDER than its entry and IS supported in all versions NEWER than its entry
+  // This test will validate that for any capability in the map, if there's a platform for that capability that does NOT appear in the map, it
+  // is always reported as unsupported.
+  // E.g., if the "sharing" capability is supported on Desktop and Android in version 1.5.0, the above tests will make sure that both Desktop
+  // and Android report it as unsupported in versions OLDER than 1.5.0 and also ensure that Desktop and Android report it as SUPPORTED in versions
+  // NEWER than (or equal to) 1.5.0. However, those tests will not validate that iOS reports it as UNSUPPORTED in all versions, since the tests
+  // are based on the platforms listed in the map and not on the platforms absent from the map.
+  describe('generateVersionBasedTeamsRuntimeConfig ensure only platforms ', () => {
+    const mapCapabilityAsStringToPlatformsListedInMap: Map<string, Set<string>> = new Map();
+
+    const allAddedCapabilityReqsInAnyVersion: Array<Array<ICapabilityReqs>> = Object.values(
+      mapTeamsVersionToSupportedCapabilities,
+    );
+
+    for (const addedCapabilityReqsInAVersion of allAddedCapabilityReqsInAnyVersion) {
+      for (const addedCapabilityReqInAVersion of addedCapabilityReqsInAVersion) {
+        const individualCapabilities: object[] = decomposeObject(addedCapabilityReqInAVersion.capability);
+
+        for (const individualCapability of individualCapabilities) {
+          const individualCapabilityAsString: string = JSON.stringify(individualCapability);
+          const clientTypesToWhichCapabilityHasBeenAddedSoFar: Set<string> | undefined =
+            mapCapabilityAsStringToPlatformsListedInMap.get(individualCapabilityAsString);
+
+          const updatedClientTypesToWhichCapabilityHasBeenAdded: Set<string> =
+            clientTypesToWhichCapabilityHasBeenAddedSoFar
+              ? new Set([
+                  ...clientTypesToWhichCapabilityHasBeenAddedSoFar,
+                  ...addedCapabilityReqInAVersion.hostClientTypes,
+                ])
+              : new Set(addedCapabilityReqInAVersion.hostClientTypes);
+
+          mapCapabilityAsStringToPlatformsListedInMap.set(
+            individualCapabilityAsString,
+            updatedClientTypesToWhichCapabilityHasBeenAdded,
+          );
+        }
+      }
+    }
+
+    // Now that we have all the capabilities from the map and the platforms that they are added to (for any version) in the map, we
+    // can generate the map of capabilities to platforms that are NOT listed in the map anywhere for each capability.
+    const mapCapabilityAsStringToPlatformsNotListedForItEverInMap: Map<string, string[]> = new Map();
+    for (const [
+      capabilityAsString,
+      clientTypesEverListedInMapForThisCapability,
+    ] of mapCapabilityAsStringToPlatformsListedInMap) {
+      const notSupportedHostClientTypes = Object.values(HostClientType).filter(
+        (clientType) => !clientTypesEverListedInMapForThisCapability.has(clientType),
+      );
+
+      mapCapabilityAsStringToPlatformsNotListedForItEverInMap.set(capabilityAsString, notSupportedHostClientTypes);
+    }
+
+    // Finally, we can test that for every capability in the map, platforms that don't appear ever for that capability are always reported as unsupported
+    for (const [
+      capabilityAsString,
+      notSupportedHostClientTypes,
+    ] of mapCapabilityAsStringToPlatformsNotListedForItEverInMap) {
+      // For all versions in the map plus ones older than it and newer than it
+      const allVersionsInCapabilityMap = Object.keys(mapTeamsVersionToSupportedCapabilities);
+      const versionOlderThanCapabilityMap = generateVersionOlderThanGivenVersion(oldestVersionInCapabilityMap);
+      const versionNewerThanCapabilityMap = generateVersionNewerThanGivenVersion(newestVersionInCapabilityMap);
+      const versionsToTestAgainst = [
+        ...allVersionsInCapabilityMap,
+        versionOlderThanCapabilityMap,
+        versionNewerThanCapabilityMap,
+      ];
+
+      const capabilityAdditionThatShouldBeUnsupported = JSON.parse(capabilityAsString);
+
+      for (const versionToTest of versionsToTestAgainst) {
+        for (const unsupportedClientType of notSupportedHostClientTypes) {
+          it(`Validate that ${capabilityAsString} is NOT supported for clientType ${unsupportedClientType} on version ${versionToTest}`, async () => {
+            await utils.initializeWithContext('content', unsupportedClientType);
+
+            const generatedRuntimeConfigSupportedCapabilities = generateVersionBasedTeamsRuntimeConfig(
+              versionToTest,
               versionAndPlatformAgnosticTeamsRuntimeConfig,
               mapTeamsVersionToSupportedCapabilities,
             ).supports;
-            expect(isSubset(capabilityAdditionsForThisVersion, generatedCapabilityObjectForThisVersion)).toBe(true);
-          }
+
+            expect(
+              isSubset(capabilityAdditionThatShouldBeUnsupported, generatedRuntimeConfigSupportedCapabilities),
+            ).toBe(false);
+          });
         }
       }
-    });
+    }
   });
-
-  describe('generateVersionBasedTeamsRuntimeConfig older and newer version tests', () => {
-    it('Validate that all client types for a version OLDER than when a capability began to be supported report that capability is NOT supported ', async () => {
-      for (const [version, capabilityAdditionsForEachVersion] of Object.entries(
-        mapTeamsVersionToSupportedCapabilities,
-      )) {
-        console.log(`version: ${version}`);
-        for (const capabilityAdditionsInASpecificVersion of capabilityAdditionsForEachVersion) {
-          const capabilityAdditionsForThisVersion = capabilityAdditionsInASpecificVersion.capability;
-          const individualCapabilityAdditionsForThisVersion: object[] = decomposeObject(
-            capabilityAdditionsForThisVersion,
-          );
-          console.log(
-            `individualCapabilityAdditionsForThisVersion: ${JSON.stringify(
-              individualCapabilityAdditionsForThisVersion,
-            )}`,
-          );
-
-          for (const clientType of capabilityAdditionsInASpecificVersion.hostClientTypes) {
-            console.log(`clientType: ${clientType}`);
-            const olderVersionsInCapabilityMap = getVersionsFromCapabilityMapOlderThanGivenVersion(version);
-            const versionOlderThanAllVersionsInCapabilityMap =
-              generateVersionOlderThanGivenVersion(oldestVersionInCapabilityMap);
-            const oldVersionsToTestAgainst = [
-              ...olderVersionsInCapabilityMap,
-              versionOlderThanAllVersionsInCapabilityMap,
-            ];
-            console.log(`oldVersionsToTestAgainst: ${oldVersionsToTestAgainst}`);
-
-            for (const olderVersion of oldVersionsToTestAgainst) {
-              console.log(`olderVersion: ${olderVersion}`);
-
-              await utils.initializeWithContext('content', clientType);
-
-              const generatedRuntimeConfigSupportedCapabilities = generateVersionBasedTeamsRuntimeConfig(
-                olderVersion,
-                versionAndPlatformAgnosticTeamsRuntimeConfig,
-                mapTeamsVersionToSupportedCapabilities,
-              ).supports;
-
-              console.log(
-                `generatedRuntimeConfigSupportedCapabilities: ${JSON.stringify(
-                  generatedRuntimeConfigSupportedCapabilities,
-                )}`,
-              );
-
-              individualCapabilityAdditionsForThisVersion.forEach((capabilityAdditionForThisVersion) => {
-                console.log(`capabilityAdditionForThisVersion: ${JSON.stringify(capabilityAdditionForThisVersion)}`);
-                expect(isSubset(capabilityAdditionForThisVersion, generatedRuntimeConfigSupportedCapabilities)).toBe(
-                  false,
-                );
-              });
-            }
-          }
-        }
-      }
-    });
-
-    // it('Validate that all client types for a version NEWER than when a capability began to be supported report that capability IS supported ', async () => {
-    //   for (const [version, capabilityAdditionsForEachVersion] of Object.entries(
-    //     mapTeamsVersionToSupportedCapabilities,
-    //   )) {
-    //     for (const capabilityAdditionsInASpecificVersion of capabilityAdditionsForEachVersion) {
-    //       const capabilityAdditionsForThisVersion = capabilityAdditionsInASpecificVersion.capability;
-    //       const individualCapabilityAdditionsForThisVersion: object[] = decomposeObject(
-    //         capabilityAdditionsForThisVersion,
-    //       );
-
-    //       for (const clientType of capabilityAdditionsInASpecificVersion.hostClientTypes) {
-    //         const newerVersionsInCapabilityMap = getVersionsFromCapabilityMapOlderThanGivenVersion(version);
-    //         const versionNewerThanAllVersionsInCapabilityMap =
-    //           generateVersionNewerThanGivenVersion(newestVersionInCapabilityMap);
-    //         const newVersionsToTestAgainst = [
-    //           ...newerVersionsInCapabilityMap,
-    //           versionNewerThanAllVersionsInCapabilityMap,
-    //         ];
-
-    //         for (const newerVersion of newVersionsToTestAgainst) {
-    //           await utils.initializeWithContext('content', clientType);
-
-    //           const generatedRuntimeConfigSupportedCapabilities = generateVersionBasedTeamsRuntimeConfig(
-    //             newerVersion,
-    //             versionAndPlatformAgnosticTeamsRuntimeConfig,
-    //             mapTeamsVersionToSupportedCapabilities,
-    //           ).supports;
-
-    //           individualCapabilityAdditionsForThisVersion.forEach((capabilityAdditionForThisVersion) => {
-    //             expect(isSubset(capabilityAdditionForThisVersion, generatedRuntimeConfigSupportedCapabilities)).toBe(
-    //               true,
-    //             );
-    //           });
-    //         }
-    //       }
-    //     }
-    //   }
-    // });
-  });
-
-  // for (const [version, capabilityAdditionsForEachVersion] of Object.entries(mapTeamsVersionToSupportedCapabilities)) {
-  //   for (const capabilityAdditionsForClientTypesInASpecificVersion of capabilityAdditionsForEachVersion) {
-  //     const capabilityAdditionsForThisVersion = capabilityAdditionsForClientTypesInASpecificVersion.capability;
-  //     capabilityAdditionsForClientTypesInASpecificVersion.hostClientTypes.forEach((clientType) => {
-  // it(`Back compat host client type ${clientType} supporting up to ${version} should support ${JSON.stringify(
-  //   capabilityAdditionsForThisVersion,
-  // )}`, async () => {
-  //   await utils.initializeWithContext('content', clientType);
-  //   const generatedCapabilityObjectForThisVersion = generateVersionBasedTeamsRuntimeConfig(
-  //     version,
-  //     versionAndPlatformAgnosticTeamsRuntimeConfig,
-  //     mapTeamsVersionToSupportedCapabilities,
-  //   ).supports;
-  //   expect(isSubset(capabilityAdditionsForThisVersion, generatedCapabilityObjectForThisVersion)).toBe(true);
-  // });
-
-  // it(`Back compat host client type ${clientType} supporting lower than up to ${version} should NOT support ${JSON.stringify(
-  //   capabilityAdditionsForThisVersion,
-  // )} capability`, async () => {
-  //   const individualCapabilityAdditionsForThisVersion: object[] = decomposeObject(
-  //     capabilityAdditionsForThisVersion,
-  //   );
-
-  //   await utils.initializeWithContext('content', clientType);
-
-  //   const generatedRuntimeConfigSupportedCapabilities = generateVersionBasedTeamsRuntimeConfig(
-  //     generateVersionNumberOlderThanGivenVersion(version),
-  //     versionAndPlatformAgnosticTeamsRuntimeConfig,
-  //     mapTeamsVersionToSupportedCapabilities,
-  //   ).supports;
-
-  //   individualCapabilityAdditionsForThisVersion.forEach((capabilityAdditionForThisVersion) => {
-  //     expect(isSubset(capabilityAdditionForThisVersion, generatedRuntimeConfigSupportedCapabilities)).toBe(
-  //       false,
-  //     );
-  //   });
-  // });
-
-  //   const lowerVersions = Object.keys(mapTeamsVersionToSupportedCapabilities).filter(
-  //     (otherVer) => compareSDKVersions(version, otherVer) >= 0,
-  //   );
-
-  //   lowerVersions.forEach((lowerVersion) => {
-  //     mapTeamsVersionToSupportedCapabilities[lowerVersion].forEach((lowerCap) => {
-  //       if (lowerCap.hostClientTypes.includes(clientType)) {
-  //         const capabilityAdditionsForThisVersion = lowerCap.capability;
-  //         it(`Back compat host client type ${clientType} supporting up to ${version} should ALSO support ${JSON.stringify(
-  //           capabilityAdditionsForThisVersion,
-  //         )} capability`, async () => {
-  //           await utils.initializeWithContext('content', clientType);
-  //           expect(
-  //             isSubset(
-  //               capabilityAdditionsForThisVersion,
-  //               generateVersionBasedTeamsRuntimeConfig(
-  //                 version,
-  //                 versionAndPlatformAgnosticTeamsRuntimeConfig,
-  //                 mapTeamsVersionToSupportedCapabilities,
-  //               ).supports,
-  //             ),
-  //           ).toBe(true);
-  //         });
-  //       }
-  //     });
-  //   });
-  // });
-
-  //   const notSupportedHostClientTypes = Object.values(HostClientType).filter(
-  //     (type) => !capabilityAdditionsForClientTypesInASpecificVersion.hostClientTypes.includes(type),
-  //   );
-
-  //   const individualCapabilityAdditionsForThisVersion: object[] = decomposeObject(
-  //     capabilityAdditionsForThisVersion,
-  //   );
-
-  //   notSupportedHostClientTypes.forEach((clientType) => {
-  //     it(`Back compat host client type ${clientType} supporting up to ${version} should NOT support ${JSON.stringify(
-  //       capabilityAdditionsForThisVersion,
-  //     )} capability`, async () => {
-  //       await utils.initializeWithContext('content', clientType);
-
-  //       individualCapabilityAdditionsForThisVersion.forEach((singleCapabilityAdditionForThisVersion) => {
-  //         expect(
-  //           isSubset(
-  //             singleCapabilityAdditionForThisVersion,
-  //             generateVersionBasedTeamsRuntimeConfig(
-  //               version,
-  //               versionAndPlatformAgnosticTeamsRuntimeConfig,
-  //               mapTeamsVersionToSupportedCapabilities,
-  //             ).supports,
-  //           ),
-  //         ).toBe(false);
-  //       });
-  //     });
-  //   });
-  // });
-  //   });
-  // });
 
   const runtimeWithNestedPagesCapability: Runtime = {
     apiVersion: latestRuntimeApiVersion,


### PR DESCRIPTION
## Description

The unit tests for versioned runtime application function (`generateVersionBasedTeamsRuntimeConfig`) were confusing to understand, wrong, and incomplete.

- There was a lot of nesting both inside and outside of the tests, making it hard to read and understand.
- The tests only tested for one version lower, and not all versions in the map
- The tests which tried to validate that unsupported platforms were always unsupported were broken in the case where one capability was supported on some platforms and then later that same capability was added for other platforms.
 
### Main changes in the PR:

1. Refactor and rewrite the tests to, hopefully, be more readable.
2. Write a new test that properly validates the unsupportedness of platforms

Reviewers may find it easier to ignore the diff and just look at the "right side" (e.g. the contents of the updated file without reference to what it used to look like)

## Validation

### Validation performed:

1. Tests pass
2. Tests pass even if I make @maglims's change (which was failing the tests in the PR #2112 and alerted me to these issues)
4. Tests fail when I intentionally introduce bugs into `generateVersionBasedTeamsRuntimeConfig`