### PR TITLE
Moving validDomains into a separate artifact for new release pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,6 +92,11 @@ extends:
                   artifactName: 'CDNFeed'
 
                 - output: pipelineArtifact
+                  displayName: 'Publish validDomains to Build Artifacts'
+                  targetPath: '$(Build.ArtifactStagingDirectory)\validDomains'
+                  artifactName: 'validDomains'
+
+                - output: pipelineArtifact
                   displayName: 'Publish NPM feed to Build Artifacts'
                   targetPath: '$(Build.ArtifactStagingDirectory)\NPMFeed'
                   artifactName: 'NPMFeed'

--- a/tools/yaml-templates/build-test-publish.yml
+++ b/tools/yaml-templates/build-test-publish.yml
@@ -102,7 +102,7 @@ steps:
     inputs:
       Contents: |
         packages\teams-js\src\artifactsForCDN\validDomains.json
-      TargetFolder: '$(Build.ArtifactStagingDirectory)\CDNFeed\validDomains\json'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)\validDomains\json'
       flattenFolders: true
     displayName: 'Copy validDomains for CDN'
 


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Separating validDomains from CDNFeed to allow us to decouple validDomains list being updated on every PROD/SDF release

## Validation

### Validation performed:

1. Artifact generated by build pipeline creates a new validDomains artifact in the top level and removes it from the CDNFeed