### PR TITLE
Add PUID to context in userprofile to be fetch in getContextAPI

### DIFF
--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -517,7 +517,7 @@ export namespace app {
     /**
      * PUID of the current user.
      */
-    id: string;
+    puid?: string;
 
     /**
      * The address book name of the current user.

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -515,6 +515,11 @@ export namespace app {
     id: string;
 
     /**
+     * PUID of the current user.
+     */
+    id: string;
+
+    /**
      * The address book name of the current user.
      */
     displayName?: string;


### PR DESCRIPTION
## Overview
Add PUID to context in userprofile to be fetch in getContextAPI

We need PUID to access the IDB for M365 Calendar
<img width="1728" alt="Screenshot 2024-01-11 at 10 51 05 AM" src="https://github.com/OfficeDev/microsoft-teams-library-js/assets/9450414/e8441cab-c62e-47e6-8d5a-4c704efd3a1a">


Why the PUID cannot be fetched as a part of outlook APIs in the iframe?
We need PUID to access the IDB even before any API call is made to fetch the user profile infor such that we can extract the calendar events from the data store