### PR TITLE
Minor change to set the helper values in ThirdPartyCloudStorageAPIs

### DIFF
--- a/change/@microsoft-teams-js-6a7d3368-138b-40f7-86c3-0d9e78441ff5.json
+++ b/change/@microsoft-teams-js-6a7d3368-138b-40f7-86c3-0d9e78441ff5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Minor change in helper values",
+  "packageName": "@microsoft/teams-js",
+  "email": "mahimashuklaMSFT@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/thirdPartyCloudStorage.ts
+++ b/packages/teams-js/src/public/thirdPartyCloudStorage.ts
@@ -193,6 +193,7 @@ export namespace thirdPartyCloudStorage {
             const assemble: AssembleAttachment | null = decodeAttachment(fileResult.fileChunk, fileResult.fileType);
             if (assemble) {
               helper.assembleAttachment.push(assemble);
+              helper.fileType = fileResult.fileType;
             } else {
               Files3PLogger(
                 `Received a null assemble attachment for when decoding chunk sequence ${fileResult.fileChunk.chunkSequence}; not including the chunk in the assembled file.`,


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

[https://github.com/OfficeDev/microsoft-teams-library-js/pull/1903/files#diff-ec0b521b72add73ea784045aa2a4fd63089f0352ada767a1cac53e707089e0ca](url)
In above PR, in apps/teams-test-app/src/components/ThirdPartyCloudStorageAPIs.tsx helper was not having the fileType value because of which createFile function was failing.
Have assigned the fileType value to the helper


> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
