### PR TITLE
Allow underscore for unused parameters

### DIFF
--- a/change/@microsoft-teams-js-d1b21769-c65c-4536-a016-0f0231541e66.json
+++ b/change/@microsoft-teams-js-d1b21769-c65c-4536-a016-0f0231541e66.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Allow unused variables if they are prefixed with underscore",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/.eslintrc.js
+++ b/packages/teams-js/.eslintrc.js
@@ -5,13 +5,12 @@ module.exports = {
   },
   plugins: ['strict-null-checks'],
   rules: {
-    // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
+    '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',
       { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_', varsIgnorePattern: '^_' },
     ],
-    '@typescript-eslint/interface-name-prefix': 'off',
     'no-inner-declarations': 'off',
     'strict-null-checks/all': 'warn',
   },

--- a/packages/teams-js/.eslintrc.js
+++ b/packages/teams-js/.eslintrc.js
@@ -7,6 +7,10 @@ module.exports = {
   rules: {
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
     '@typescript-eslint/no-namespace': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+    ],
     '@typescript-eslint/interface-name-prefix': 'off',
     'no-inner-declarations': 'off',
     'strict-null-checks/all': 'warn',


### PR DESCRIPTION
## Description

Prefixing unused parameters/variables with underscore is a very common convention to indicate "this parameter is intentionally not used." Our own tooling in VSCode even auto-suggests doing it as a "fix" for unused parameters when it sees them. Unfortunately, our linting rules do not recognize the leading-underscore as meaning anything special and still errors about unused parameters.

This change updates our lint rules to allow for a leading underscore and ignores any unused violations in those specific cases.
## Validation

### Validation performed:

Make a parameter unused with a leading underscore and validate that no lint error is triggered.

### Change file added:

Yes.