### PR TITLE
Gate specific e2e tests by hostSdkVersion

### DIFF
--- a/apps/teams-test-app/e2e-test-data/meeting.json
+++ b/apps/teams-test-app/e2e-test-data/meeting.json
@@ -224,7 +224,7 @@
       "title": "requestAppAudioHandling API Call - register audioDeviceSelectionChanged Handler - Success",
       "type": "registerAndRaiseEvent",
       "version": ">2.17.0",
-      "hostSDKsVersion": {
+      "hostSdksVersion": {
         "web": ">=2.8.0"
       },
       "boxSelector": "#box_registerAudioDeviceSelectionChangedHandler",
@@ -240,7 +240,7 @@
       "title": "requestAppAudioHandling API Call - register audioDeviceSelectionChanged Handler - Error",
       "type": "registerAndRaiseEvent",
       "version": ">2.17.0",
-      "hostSDKsVersion": {
+      "hostSdksVersion": {
         "web": ">=2.8.0"
       },
       "boxSelector": "#box_registerAudioDeviceSelectionChangedHandler",

--- a/apps/teams-test-app/e2e-test-data/meeting.json
+++ b/apps/teams-test-app/e2e-test-data/meeting.json
@@ -1,12 +1,7 @@
 {
   "name": "Meeting",
   "platforms": "Web",
-  "testUrlParams": [
-    [
-      "frameContext",
-      "sidePanel"
-    ]
-  ],
+  "testUrlParams": [["frameContext", "sidePanel"]],
   "testCases": [
     {
       "title": "getIncomingClientAudioState API Call - Success",
@@ -229,6 +224,9 @@
       "title": "requestAppAudioHandling API Call - register audioDeviceSelectionChanged Handler - Success",
       "type": "registerAndRaiseEvent",
       "version": ">2.17.0",
+      "hostSDKsVersion": {
+        "web": ">=2.8.0"
+      },
       "boxSelector": "#box_registerAudioDeviceSelectionChangedHandler",
       "eventName": "audioDeviceSelectionChanged",
       "eventData": {
@@ -242,6 +240,9 @@
       "title": "requestAppAudioHandling API Call - register audioDeviceSelectionChanged Handler - Error",
       "type": "registerAndRaiseEvent",
       "version": ">2.17.0",
+      "hostSDKsVersion": {
+        "web": ">=2.8.0"
+      },
       "boxSelector": "#box_registerAudioDeviceSelectionChangedHandler",
       "eventName": "audioDeviceSelectionChanged",
       "eventData": {

--- a/apps/teams-test-app/e2e-test-data/video.json
+++ b/apps/teams-test-app/e2e-test-data/video.json
@@ -29,6 +29,24 @@
     {
       "title": "registerForVideoEffect - Handler - Success",
       "version": ">2.12.0",
+      "hostSDKsVersion": {
+        "web": "<2.3.0"
+      },
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerForVideoEffect",
+      "eventName": "videoEffectToApply",
+      "eventData": {
+        "effectId": "nextEffectId"
+      },
+      "expectedTestAppValue": "video effect changed to \"nextEffectId\"",
+      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: true, effectId: nextEffectId, detail: undefined"
+    },
+    {
+      "title": "registerForVideoEffect - Handler - Success",
+      "version": ">2.12.0",
+      "hostSDKsVersion": {
+        "web": ">=2.3.0"
+      },
       "type": "registerAndRaiseEvent",
       "boxSelector": "#box_registerForVideoEffect",
       "eventName": "videoEffectToApply",
@@ -41,6 +59,24 @@
     {
       "title": "registerForVideoEffect - Handler - Failed",
       "version": ">2.12.0",
+      "hostSDKsVersion": {
+        "web": "<2.3.0"
+      },
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_registerForVideoEffect",
+      "eventName": "videoEffectToApply",
+      "eventData": {
+        "effectId": "anInvalidEffectId"
+      },
+      "expectedTestAppValue": "failed to change effect to \"anInvalidEffectId\"",
+      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: false, effectId: anInvalidEffectId, detail: InvalidEffectId"
+    },
+    {
+      "title": "registerForVideoEffect - Handler - Failed",
+      "version": ">2.12.0",
+      "hostSDKsVersion": {
+        "web": ">=2.3.0"
+      },
       "type": "registerAndRaiseEvent",
       "boxSelector": "#box_registerForVideoEffect",
       "eventName": "videoEffectToApply",
@@ -74,6 +110,25 @@
     {
       "title": "videoEx.registerForVideoEffect - Handler - Success",
       "version": ">2.12.0",
+      "hostSDKsVersion": {
+        "web": "<2.3.0"
+      },
+      "type": "registerAndRaiseEvent",
+      "boxSelector": "#box_videoExRegisterForVideoEffect",
+      "eventName": "videoEffectToApply",
+      "eventData": {
+        "effectId": "nextEffectId",
+        "effectParameter": "nextEffectParam"
+      },
+      "expectedTestAppValue": "video effect changed to \"nextEffectId\", effect param: \"nextEffectParam\"",
+      "expectedAlertValue": "setVideoEffectAppliedResult called with isReady: true, effectId: nextEffectId, detail: undefined"
+    },
+    {
+      "title": "videoEx.registerForVideoEffect - Handler - Success",
+      "version": ">2.12.0",
+      "hostSDKsVersion": {
+        "web": ">=2.3.0"
+      },
       "type": "registerAndRaiseEvent",
       "boxSelector": "#box_videoExRegisterForVideoEffect",
       "eventName": "videoEffectToApply",
@@ -87,6 +142,9 @@
     {
       "title": "videoEx.registerForVideoEffect - Handler - Failed",
       "version": ">2.12.0",
+      "hostSDKsVersion": {
+        "web": ">=2.3.0"
+      },
       "type": "registerAndRaiseEvent",
       "boxSelector": "#box_videoExRegisterForVideoEffect",
       "eventName": "videoEffectToApply",

--- a/apps/teams-test-app/e2e-test-data/video.json
+++ b/apps/teams-test-app/e2e-test-data/video.json
@@ -29,7 +29,7 @@
     {
       "title": "registerForVideoEffect - Handler - Success",
       "version": ">2.12.0",
-      "hostSDKsVersion": {
+      "hostSdksVersion": {
         "web": "<2.3.0"
       },
       "type": "registerAndRaiseEvent",
@@ -44,7 +44,7 @@
     {
       "title": "registerForVideoEffect - Handler - Success",
       "version": ">2.12.0",
-      "hostSDKsVersion": {
+      "hostSdksVersion": {
         "web": ">=2.3.0"
       },
       "type": "registerAndRaiseEvent",
@@ -59,7 +59,7 @@
     {
       "title": "registerForVideoEffect - Handler - Failed",
       "version": ">2.12.0",
-      "hostSDKsVersion": {
+      "hostSdksVersion": {
         "web": "<2.3.0"
       },
       "type": "registerAndRaiseEvent",
@@ -74,7 +74,7 @@
     {
       "title": "registerForVideoEffect - Handler - Failed",
       "version": ">2.12.0",
-      "hostSDKsVersion": {
+      "hostSdksVersion": {
         "web": ">=2.3.0"
       },
       "type": "registerAndRaiseEvent",
@@ -110,7 +110,7 @@
     {
       "title": "videoEx.registerForVideoEffect - Handler - Success",
       "version": ">2.12.0",
-      "hostSDKsVersion": {
+      "hostSdksVersion": {
         "web": "<2.3.0"
       },
       "type": "registerAndRaiseEvent",
@@ -126,7 +126,7 @@
     {
       "title": "videoEx.registerForVideoEffect - Handler - Success",
       "version": ">2.12.0",
-      "hostSDKsVersion": {
+      "hostSdksVersion": {
         "web": ">=2.3.0"
       },
       "type": "registerAndRaiseEvent",
@@ -142,7 +142,7 @@
     {
       "title": "videoEx.registerForVideoEffect - Handler - Failed",
       "version": ">2.12.0",
-      "hostSDKsVersion": {
+      "hostSdksVersion": {
         "web": ">=2.3.0"
       },
       "type": "registerAndRaiseEvent",


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.
We currently don't test all supported versions of TeamsJS against all supported host SDK versions. A need arose to be able to run e2e tests against an older version of Web host SDK, which highlighted some incompatibilities in expected test behavior. We are introducing the ability on the host SDK e2e test engine to conditionally skip e2e tests for which the behavior has changed on the host SDK side.

This change will skip particular tests (or adjust expectations based on the host SDK behavior) for v2.2.0 of the web host SDK.

### Main changes in the PR:

1. Adjust expectations for specific video capability E2E tests.
2. Adjust expectations for specific meeting capability E2E tests.

## Validation

### Validation performed:

1. Ran the E2E tests locally with the specific configuration.

### Unit Tests added:

No. These are E2E tests.

### End-to-end tests added:

Not added but adjusted.

## Additional Requirements

### Change file added:

Not required for test data files.

### Next/remaining steps:

Once we have validated this change works with the changes on the Host SDK side, we'll be able to merge both PRs.
