### PR TITLE
Add Blazor solution to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log
 lerna-debug.log
 
 # Blazor Test App
+microsoft-teams-library-js.sln
 *.binlog
 *.user
 .dotnet/


### PR DESCRIPTION
## Description

VSCode will (often? usually?) suggest you install the C# tools because it sees the Blazor app. If you accept (and why would one know any better?), it causes a VS solution file to be put at the root of the repo. This file does not exist in the repo, so it means everyone will have it showing up in their PRs until it either gets added or ignored. @noahdarveau-MSFT, the resident Blazor expert, says the right thing to do is to .gitignore it.

### Main changes in the PR:

Add the .SLN file to the .gitignore file

## Additional Requirements

### Change file added:

No, not required.