### PR TITLE
Trharris/filesdocupdate

### DIFF
--- a/change/@microsoft-teams-js-6a7d8dc2-3cbe-416f-a18f-d5f187d613ec.json
+++ b/change/@microsoft-teams-js-6a7d8dc2-3cbe-416f-a18f-d5f187d613ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated documentation for `files.getCloudStorageFolders`",
+  "packageName": "@microsoft/teams-js",
+  "email": "trharris@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/private/files.ts
+++ b/packages/teams-js/src/private/files.ts
@@ -557,7 +557,9 @@ export namespace files {
    * @hidden
    * Hide from docs
    *
-   * Gets a list of cloud storage folders added to the channel
+   * Gets a list of cloud storage folders added to the channel. This function will not timeout;
+   * the callback will only return when the host responds with a list of folders or error.
+   *
    * @param channelId - ID of the channel whose cloud storage folders should be retrieved
    * @param callback - Callback that will be triggered post folders load
    *


### PR DESCRIPTION
## Description

Updated documentation for `files.getCloudStorageFolders` to make it explicit that the callback has no timeout.

### Main changes in the PR:

1. Updated documentation on the aforementioned function

## Validation

### Validation performed:

None

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes