### PR TITLE
Add Loop domains to the list of valid origins

### DIFF
--- a/packages/teams-js/src/artifactsForCDN/validDomains.json
+++ b/packages/teams-js/src/artifactsForCDN/validDomains.json
@@ -35,6 +35,9 @@
     "outlook.cloud.microsoft",
     "m365.cloud.microsoft",
     "copilot.microsoft.com",
-    "windows.msn.com"
+    "windows.msn.com",
+    "*.loop.microsoft.com",
+    "loop.cloud.microsoft",
+    "loop.cloud-dev.microsoft"
   ]
 }


### PR DESCRIPTION
I'm from the Microsoft Loop team. We're working on standing up Loop App as a MetaOS Hub. According to the onboarding documentation, we need to add our app domains to the list of valid origins. 