### PR TITLE
Updated the beachball experience to encourage more consistent changefile messages

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 
 const postbump = (packagePath, packageName, packageVersion) => {
-  fs.rm(`${packagePath}/CHANGELOG.json`, err => {
+  fs.rm(`${packagePath}/CHANGELOG.json`, (err) => {
     if (err) {
       console.log(err.message);
       return;
@@ -11,11 +11,14 @@ const postbump = (packagePath, packageName, packageVersion) => {
 };
 
 // Overriding the default entry renderer so that it just shows the comment without the author.
-const customRenderEntry = ChangelogEntry => new Promise(res => res(`- ${ChangelogEntry.comment}`));
+const customRenderEntry = (ChangelogEntry) => new Promise((res) => res(`- ${ChangelogEntry.comment}`));
 
 module.exports = {
   branch: 'origin/main',
   bumpDeps: false,
+  changeFilePrompt: {
+    changePrompt: 'Testing 1, 2, 3',
+  },
   disallowedChangeTypes: ['prerelease'],
   generateChangelog: true,
   hooks: { postbump },

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -12,12 +12,36 @@ const postbump = (packagePath, packageName, packageVersion) => {
 
 // Overriding the default entry renderer so that it just shows the comment without the author.
 const customRenderEntry = (ChangelogEntry) => new Promise((res) => res(`- ${ChangelogEntry.comment}`));
+const changePromptFunction = (DefaultPrompt, string) => new Promise((res) => res(`- ${ChangelogEntry.comment}`));
 
 module.exports = {
   branch: 'origin/main',
   bumpDeps: false,
   changeFilePrompt: {
-    changePrompt: 'Testing 1, 2, 3',
+    changePrompt: (prompt) => {
+      // see https://github.com/microsoft/beachball/blob/master/src/types/ChangeFilePrompt.ts
+      const { changeType } = prompt;
+      changeType.choices &&
+        changeType.choices.forEach((choice) => {
+          if (choice.value === 'patch') {
+            choice.title = ' �[1mPatch�[22m      - Changes that bumps packge with patch version.';
+          } else if (choice.value === 'minor') {
+            choice.title = ' �[1mMinor�[22m      - Changes that bumps packge with minor version.';
+          }
+        });
+
+      const changeAreaPrompt = {
+        type: 'select',
+        name: 'area',
+        message: 'Change area',
+        choices: [
+          { value: 'fix', title: 'Bug fix' },
+          { value: 'perf', title: 'Performance' },
+          { value: 'doc', title: 'Documentation' },
+        ],
+      };
+      return [prompt.changeType, changeAreaPrompt, prompt.description];
+    },
   },
   disallowedChangeTypes: ['prerelease'],
   generateChangelog: true,

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -12,7 +12,6 @@ const postbump = (packagePath, packageName, packageVersion) => {
 
 // Overriding the default entry renderer so that it just shows the comment without the author.
 const customRenderEntry = (ChangelogEntry) => new Promise((res) => res(`- ${ChangelogEntry.comment}`));
-const changePromptFunction = (DefaultPrompt, string) => new Promise((res) => res(`- ${ChangelogEntry.comment}`));
 
 module.exports = {
   branch: 'origin/main',
@@ -20,27 +19,35 @@ module.exports = {
   changeFilePrompt: {
     changePrompt: (prompt) => {
       // see https://github.com/microsoft/beachball/blob/master/src/types/ChangeFilePrompt.ts
-      const { changeType } = prompt;
-      changeType.choices &&
-        changeType.choices.forEach((choice) => {
-          if (choice.value === 'patch') {
-            choice.title = ' �[1mPatch�[22m      - Changes that bumps packge with patch version.';
-          } else if (choice.value === 'minor') {
-            choice.title = ' �[1mMinor�[22m      - Changes that bumps packge with minor version.';
-          }
-        });
+      const { description } = prompt;
 
-      const changeAreaPrompt = {
-        type: 'select',
-        name: 'area',
-        message: 'Change area',
-        choices: [
-          { value: 'fix', title: 'Bug fix' },
-          { value: 'perf', title: 'Performance' },
-          { value: 'doc', title: 'Documentation' },
-        ],
-      };
-      return [prompt.changeType, changeAreaPrompt, prompt.description];
+      description.message =
+        'Describe changes (type or choose one). Afterwards, make sure to fill in any placeholder values in your created changefile.';
+      if (description.choices) {
+        while (description.choices.length > 0) {
+          description.choices.pop();
+        }
+        description.choices.push({
+          value: 'Updated documentation for `{namespace}` capability.',
+          title: 'Updating documentation',
+        });
+        description.choices.push({
+          value:
+            'Added `{namespace}` capability that will {explain capability}. The capability is still awaiting support in one or most host applications. To track availability of this capability across different hosts see https://aka.ms/capmatrix',
+          title: 'Initial release of alpha or beta capability',
+        });
+        description.choices.push({
+          value:
+            'Removed hidden tag on `{namespace}` capability as it is available on at least one host. To track availability of this capability across different hosts see https://aka.ms/capmatrix',
+          title: 'Removing hidden tag from capability because it is now supported in at least one host',
+        });
+        description.choices.push({
+          value:
+            'Removed Beta/Preview tag on `{namespace}` capability. To track availability of this capability across different hosts see https://aka.ms/capmatrix',
+          title: 'Releasing capability that is stable and fully supported',
+        });
+      }
+      return [prompt.changeType, description];
     },
   },
   disallowedChangeTypes: ['prerelease'],

--- a/change/@microsoft-teams-js-8fa5d255-6960-4bce-a06f-19369f4b72c7.json
+++ b/change/@microsoft-teams-js-8fa5d255-6960-4bce-a06f-19369f4b72c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated how beachball works to encourage people to use a pre-existing change message if possible so that our patch notes will be more consistent.",
+  "packageName": "@microsoft/teams-js",
+  "email": "trharris@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-test-app-CDN": "pnpm --filter teams-test-app build:CDN",
     "build-test-app-local": "pnpm --filter teams-test-app build:local",
     "build-test-app-V1": "pnpm --filter teams-test-app build:CDNV1",
-    "changefile": "pnpm beachball",
+    "changefile": "pnpm beachball --no-commit",
     "clean": "lerna run clean --stream",
     "clean:full": "pnpm clean && pnpm clean:modules",
     "clean:modules": "lerna clean -y && rimraf node_modules",

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -271,7 +271,7 @@ export namespace dialog {
       }
 
       /**
-       *  Send message to the dialog from the parent
+       *  Send message to the dialog from the parent, DO NOT CHECK IN
        *
        * @param message - The message to send
        *

--- a/packages/teams-js/src/public/dialog.ts
+++ b/packages/teams-js/src/public/dialog.ts
@@ -271,7 +271,7 @@ export namespace dialog {
       }
 
       /**
-       *  Send message to the dialog from the parent, DO NOT CHECK IN
+       *  Send message to the dialog from the parent
        *
        * @param message - The message to send
        *


### PR DESCRIPTION
## Description

Updated the beachball experience for changefile creation so that *common* types of changes now have easy options developers can pick which will add standardized changefile descriptions to your the changefile in your branch. This will hopefully encourage more consistent patch notes for external developers.
### Main changes in the PR:

1. Added 4 common options to the beachball change description field, as seen below:
![image](https://github.com/OfficeDev/microsoft-teams-library-js/assets/18446904/55704968-ea8a-45a0-8676-81a781272ec5)
Choosing one of these options will add a description to your changefile that may have simple placeholders you need to fill in manually.
2. Updated the beachball description prompt so that it encourages developers to fill in placeholders.
3. Made it so the `pnpm changefile` command no longer auto commits changefiles and instead just puts them in your branch's uncommitted files (which will hopefully encourage developers to read the changefiles, fill in placeholders, etc.)

## Validation

### Validation performed:

1. Ran `pnpm changefile` a billion times.

### Unit Tests added:

No

### End-to-end tests added:

No
