### PR TITLE
Update README.md with new pnpm installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following guide references steps to build the entire project including Teams
 
 Please look through our [Contributing Guide](CONTRIBUTING.md) for important details on how to submit a pull request and contribute to this repository.
 
-NOTE: Make sure `pnpm@7.30.1` is installed as a global tool, by running `npm install -g pnpm@7.30.1`.
+NOTE: Make sure `pnpm@7.30.1` or greater is installed as a global tool, by running `npm install -g pnpm`.
 
 TIP: whenever building or testing the Teams client library, you can run `pnpm build` or `pnpm test` from the `packages/teams-js` directory.
 


### PR DESCRIPTION
## Description

We used to require *exactly* pnpm version 7.30.1. Now we require 7.30.1 _or greater_. I've updated the README to reflect this change.

### Main changes in the PR:

1. Updated README

## Validation

### Validation performed:

None

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No, README only change doesn't require changefile