### PR TITLE
Fix meeting tests so they are version-aware

### DIFF
--- a/apps/teams-test-app/e2e-test-data/meeting.json
+++ b/apps/teams-test-app/e2e-test-data/meeting.json
@@ -281,7 +281,7 @@
     {
       "title": "updateMicState API Call - Success",
       "type": "callResponse",
-      "version": ">2.7.1 && <2.19.0",
+      "version": ">2.7.1 && <=2.20.0",
       "boxSelector": "#box_updateMicState",
       "inputValue": {
         "isMicMuted": true

--- a/apps/teams-test-app/e2e-test-data/meeting.json
+++ b/apps/teams-test-app/e2e-test-data/meeting.json
@@ -166,8 +166,20 @@
       "expectedTestAppValue": "Receieved error {\"errorCode\":1000,\"message\":\"Encountered an error\"}"
     },
     {
-      "title": "shareAppContentToStage API Call - Success",
+      "title": "shareAppContentToStage API Call (<2.19.0) - Success",
       "type": "callResponse",
+      "version": "<2.19.0",
+      "boxSelector": "#box_shareAppContentToStage",
+      "inputValue": {
+        "appContentUrl": "www.someUrl.com"
+      },
+      "expectedAlertValue": "shareAppContentToStage called with [object Object] + undefined",
+      "expectedTestAppValue": "shareAppContentToStage() succeeded"
+    },
+    {
+      "title": "shareAppContentToStage API Call (>=2.19.0) - Success",
+      "type": "callResponse",
+      "version": ">=2.19.0",
       "boxSelector": "#box_shareAppContentToStage",
       "inputValue": {
         "appContentUrl": "www.someUrl.com"
@@ -178,6 +190,21 @@
     {
       "title": "shareAppContentToStage API Call with shareOptions - Success",
       "type": "callResponse",
+      "version": "<2.19.0",
+      "boxSelector": "#box_shareAppContentToStage",
+      "inputValue": {
+        "appContentUrl": "www.someUrl.com",
+        "shareOptions": {
+          "sharingProtocol": "ScreenShare"
+        }
+      },
+      "expectedAlertValue": "shareAppContentToStage called with [object Object] + undefined",
+      "expectedTestAppValue": "shareAppContentToStage() succeeded"
+    },
+    {
+      "title": "shareAppContentToStage API Call with shareOptions - Success",
+      "type": "callResponse",
+      "version": ">=2.19.0",
       "boxSelector": "#box_shareAppContentToStage",
       "inputValue": {
         "appContentUrl": "www.someUrl.com",
@@ -254,7 +281,18 @@
     {
       "title": "updateMicState API Call - Success",
       "type": "callResponse",
-      "version": ">2.7.1",
+      "version": ">2.7.1 && <2.19.0",
+      "boxSelector": "#box_updateMicState",
+      "inputValue": {
+        "isMicMuted": true
+      },
+      "expectedAlertValue": "updateMicState called with micState: isMicMuted:true, reason:1",
+      "expectedTestAppValue": "updateMicState called with micState: isMicMuted:[object Object]"
+    },
+    {
+      "title": "updateMicState API Call - Success",
+      "type": "callResponse",
+      "version": ">2.20.0",
       "boxSelector": "#box_updateMicState",
       "inputValue": {
         "isMicMuted": true

--- a/apps/teams-test-app/e2e-test-data/meeting.json
+++ b/apps/teams-test-app/e2e-test-data/meeting.json
@@ -188,7 +188,7 @@
       "expectedTestAppValue": "shareAppContentToStage() succeeded"
     },
     {
-      "title": "shareAppContentToStage API Call with shareOptions - Success",
+      "title": "shareAppContentToStage API Call with shareOptions (<2.19.0) - Success",
       "type": "callResponse",
       "version": "<2.19.0",
       "boxSelector": "#box_shareAppContentToStage",
@@ -202,7 +202,7 @@
       "expectedTestAppValue": "shareAppContentToStage() succeeded"
     },
     {
-      "title": "shareAppContentToStage API Call with shareOptions - Success",
+      "title": "shareAppContentToStage API Call with shareOptions (>=2.19.0) - Success",
       "type": "callResponse",
       "version": ">=2.19.0",
       "boxSelector": "#box_shareAppContentToStage",

--- a/apps/teams-test-app/e2e-test-data/meeting.json
+++ b/apps/teams-test-app/e2e-test-data/meeting.json
@@ -279,7 +279,7 @@
       "expectedTestAppValue": "Received audioDeviceSelectionChanged event: ##JSON_EVENT_DATA##"
     },
     {
-      "title": "updateMicState API Call - Success",
+      "title": "updateMicState API Call (<=2.20.0) - Success",
       "type": "callResponse",
       "version": ">2.7.1 && <=2.20.0",
       "boxSelector": "#box_updateMicState",
@@ -290,7 +290,7 @@
       "expectedTestAppValue": "updateMicState called with micState: isMicMuted:[object Object]"
     },
     {
-      "title": "updateMicState API Call - Success",
+      "title": "updateMicState API Call (>2.20.0) - Success",
       "type": "callResponse",
       "version": ">2.20.0",
       "boxSelector": "#box_updateMicState",


### PR DESCRIPTION
## Description

Recent PR #2158 added some expected values that are only valid in the most recent teamsjs source. Those expected values are not correct for earlier versions. This is my attempt at properly versioning the expected values.

Note: this problem is currently breaking all check-ins to a certain other unnamed repo

### Change file added:

Beachball says none is required.