### PR TITLE
Disabling unit test publishing temporarily

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,20 +65,20 @@ jobs:
           name: Unit Test Results (Jest ${{ matrix.node-version }})
           path: packages/*/test-results/unit/unit-tests-report.xml
 
-  publish-test-results:
-    name: 'Publish Unit Tests Results'
-    needs: build
-    runs-on: ubuntu-latest
-    if: always()
+  # publish-test-results:
+  #   name: 'Publish Unit Tests Results'
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   if: always()
 
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: artifacts
+  #   steps:
+  #     - name: Download Artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         path: artifacts
 
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          files: artifacts/**/*.xml
-          comment_mode: off
+  #     - name: Publish Unit Test Results
+  #       uses: EnricoMi/publish-unit-test-result-action@v2
+  #       with:
+  #         files: artifacts/**/*.xml
+  #         comment_mode: off


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

All unit test publishing steps are failing now; it looks like this is related to the recent token changes. I am going to disable the publish UT step for now (so we don't train people to get used to ignoring failures) and in parallel investigate how to fix/re-enable it


### Main changes in the PR:

1. Commenting out the Publish UT step from our build pipelines temporarily
