### PR TITLE
Updated Publish Unit Test Results with permissions to write to Pull R…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,20 +65,23 @@ jobs:
           name: Unit Test Results (Jest ${{ matrix.node-version }})
           path: packages/*/test-results/unit/unit-tests-report.xml
 
-  # publish-test-results:
-  #   name: 'Publish Unit Tests Results'
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   if: always()
+  publish-test-results:
+    name: 'Publish Unit Tests Results'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+    if: always()
 
-  #   steps:
-  #     - name: Download Artifacts
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         path: artifacts
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
 
-  #     - name: Publish Unit Test Results
-  #       uses: EnricoMi/publish-unit-test-result-action@v2
-  #       with:
-  #         files: artifacts/**/*.xml
-  #         comment_mode: off
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: artifacts/**/*.xml
+          comment_mode: off


### PR DESCRIPTION
…equests

For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

All unit test publishing steps were failing due to the recent token changes. Following new guidance to add extra permissions directly to the YAML script should resolve this issue

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Adding `pull-request` and `checks` permissions to Publish Unit Test step to allow this YAML job to write to PRs and update checks on Github
