### PR TITLE
Fix a few doc bugs I discovered

### DIFF
--- a/change/@microsoft-teams-js-50106ba4-7db7-4113-ae30-1fa99d4cc0b3.json
+++ b/change/@microsoft-teams-js-50106ba4-7db7-4113-ae30-1fa99d4cc0b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated documentation on `OpenSingleChatRequest` interface and updated all URLs to remove locale-specific portions.",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/videoEffectsUtils.ts
+++ b/packages/teams-js/src/internal/videoEffectsUtils.ts
@@ -383,7 +383,7 @@ class TransformerWithMetadata {
     // The rectangle of pixels to copy from the texture. The first two rows are the header.
     const headerRect = { x: 0, y: 0, width: texture.codedWidth, height: 2 };
     // allocate buffer for the header
-    // The texture is in NV12 format (https://learn.microsoft.com/en-us/windows/win32/medfound/recommended-8-bit-yuv-formats-for-video-rendering#nv12).
+    // The texture is in NV12 format (https://learn.microsoft.com/windows/win32/medfound/recommended-8-bit-yuv-formats-for-video-rendering#nv12).
     // NV12 has one luma "luminance" plane Y and one UV plane with U and V values interleaved.
     // In NV12, chroma planes (blue and red) are subsampled in both the horizontal and vertical dimensions by a factor of 2.
     // So for a 2×2 group of pixels, you have 4 Y samples and 1 U and 1 V sample, each sample being 1 byte.

--- a/packages/teams-js/src/private/externalAppAuthentication.ts
+++ b/packages/teams-js/src/private/externalAppAuthentication.ts
@@ -77,7 +77,7 @@ export namespace externalAppAuthentication {
 
   /**
    * @hidden
-   * Information about the message extension request that should be resent by the host. Corresponds to request schema in https://learn.microsoft.com/en-us/microsoftteams/platform/resources/messaging-extension-v3/search-extensions#receive-user-requests
+   * Information about the message extension request that should be resent by the host. Corresponds to request schema in https://learn.microsoft.com/microsoftteams/platform/resources/messaging-extension-v3/search-extensions#receive-user-requests
    * @internal
    * Limited to Microsoft-internal use
    */

--- a/packages/teams-js/src/public/chat.ts
+++ b/packages/teams-js/src/public/chat.ts
@@ -32,7 +32,7 @@ interface OpenChatRequest {
  */
 export interface OpenSingleChatRequest extends OpenChatRequest {
   /**
-   * The [Microsoft Entra UPN](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/plan-connect-userprincipalname) (usually but not always an e-mail address)
+   * The [Microsoft Entra UPN](https://learn.microsoft.com/entra/identity/hybrid/connect/plan-connect-userprincipalname) (usually but not always an e-mail address)
    * of the user with whom to begin a chat
    */
   user: string;
@@ -47,7 +47,7 @@ export interface OpenSingleChatRequest extends OpenChatRequest {
  */
 export interface OpenGroupChatRequest extends OpenChatRequest {
   /**
-   * Array containing [Microsoft Entra UPNs](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/plan-connect-userprincipalname) (usually but not always an e-mail address)
+   * Array containing [Microsoft Entra UPNs](https://learn.microsoft.com/entra/identity/hybrid/connect/plan-connect-userprincipalname) (usually but not always an e-mail address)
    * of users with whom to begin a chat
    */
   users: string[];

--- a/packages/teams-js/src/public/chat.ts
+++ b/packages/teams-js/src/public/chat.ts
@@ -32,7 +32,7 @@ interface OpenChatRequest {
  */
 export interface OpenSingleChatRequest extends OpenChatRequest {
   /**
-   * The [Microsoft Entra UPNs](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/plan-connect-userprincipalname) (usually but not always an e-mail address)
+   * The [Microsoft Entra UPN](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/plan-connect-userprincipalname) (usually but not always an e-mail address)
    * of the user with whom to begin a chat
    */
   user: string;

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -247,7 +247,7 @@ export interface SecondaryId {
 
 /**
  * These correspond with field names in the MSGraph.
- * See (commonly accessed resources)[https://learn.microsoft.com/graph/api/resources/onedrive?view=graph-rest-1.0#commonly-accessed-resources].
+ * See [commonly accessed resources](https://learn.microsoft.com/graph/api/resources/onedrive?view=graph-rest-1.0#commonly-accessed-resources).
  * @beta
  */
 export enum SecondaryM365ContentIdName {

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -247,7 +247,7 @@ export interface SecondaryId {
 
 /**
  * These correspond with field names in the MSGraph.
- * See (commonly accessed resources)[https://learn.microsoft.com/en-us/graph/api/resources/onedrive?view=graph-rest-1.0#commonly-accessed-resources].
+ * See (commonly accessed resources)[https://learn.microsoft.com/graph/api/resources/onedrive?view=graph-rest-1.0#commonly-accessed-resources].
  * @beta
  */
 export enum SecondaryM365ContentIdName {

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -54,7 +54,7 @@ export namespace teamsCore {
   /**
    * Registers a handler to be called when the page has been requested to load.
    *
-   * @remarks Check out [App Caching in Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/app-caching)
+   * @remarks Check out [App Caching in Teams](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/app-caching)
    * for a more detailed explanation about using this API.
    *
    * @param handler - The handler to invoke when the page is loaded.
@@ -104,7 +104,7 @@ export namespace teamsCore {
   /**
    * Registers a handler to be called before the page is unloaded.
    *
-   * @remarks Check out [App Caching in Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/app-caching)
+   * @remarks Check out [App Caching in Teams](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/app-caching)
    * for a more detailed explanation about using this API.
    *
    * @param handler - The handler to invoke before the page is unloaded. If this handler returns true the page should


### PR DESCRIPTION
## Description

### Main changes in the PR:

1. Fix doc URL links to remove hardcoded locale (en-us) and allow the docs site to redirect to the current user's locale. This is a best practice from the docs team
2. Fix the documentation on the `user` property of `OpenSingleChatRequest` to reflect that it's only a single UPN
3. Fix the markdown on the URL in the documentation for `SecondaryM365ContentIdName` which had reversed brackets/parentheses

### Change file added:

Yuppers