### PR TITLE
Remove valid origin that is no longer needed

### DIFF
--- a/change/@microsoft-teams-js-5cc77b90-8226-4b99-8dd7-e9f697b4c5d9.json
+++ b/change/@microsoft-teams-js-5cc77b90-8226-4b99-8dd7-e9f697b4c5d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed one default valid origin",
+  "packageName": "@microsoft/teams-js",
+  "email": "trharris@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/artifactsForCDN/validDomains.json
+++ b/packages/teams-js/src/artifactsForCDN/validDomains.json
@@ -5,7 +5,6 @@
     "gov.teams.microsoft.us",
     "dod.teams.microsoft.us",
     "int.teams.microsoft.com",
-    "*.teams.microsoft.com",
     "outlook.office.com",
     "outlook-sdf.office.com",
     "outlook.office365.com",

--- a/packages/teams-js/test/internal/validOrigins.spec.ts
+++ b/packages/teams-js/test/internal/validOrigins.spec.ts
@@ -30,7 +30,7 @@ describe('validOrigins', () => {
       expect(result).toBe(true);
     });
     it('validateOrigin returns true if origin for subdomains in teams pre-known allowlist', async () => {
-      const messageOrigin = new URL('https://subdomain.teams.microsoft.com');
+      const messageOrigin = new URL('https://test.www.office.com');
       const result = await validateOrigin(messageOrigin);
       expect(result).toBe(true);
     });
@@ -158,7 +158,7 @@ describe('validOrigins', () => {
       expect(result).toBe(true);
     });
     it('validateOrigin returns true if origin for subdomains in teams pre-known allowlist', async () => {
-      const messageOrigin = new URL('https://subdomain.teams.microsoft.com');
+      const messageOrigin = new URL('https://test.www.office.com');
       const result = await validateOrigin(messageOrigin);
       expect(result).toBe(true);
     });
@@ -279,7 +279,7 @@ describe('validOrigins', () => {
       expect(result).toBe(true);
     });
     it('validateOrigin returns true if origin for subdomains in teams pre-known allowlist', async () => {
-      const messageOrigin = new URL('https://subdomain.teams.microsoft.com');
+      const messageOrigin = new URL('https://test.www.office.com');
       const result = await validateOrigin(messageOrigin);
       expect(result).toBe(true);
     });
@@ -400,7 +400,7 @@ describe('validOrigins', () => {
       expect(result).toBe(true);
     });
     it('validateOrigin returns true if origin for subdomains in teams pre-known allowlist', async () => {
-      const messageOrigin = new URL('https://subdomain.teams.microsoft.com');
+      const messageOrigin = new URL('https://test.www.office.com');
       const result = await validateOrigin(messageOrigin);
       expect(result).toBe(true);
     });

--- a/packages/teams-js/test/private/privateAPIs.spec.ts
+++ b/packages/teams-js/test/private/privateAPIs.spec.ts
@@ -108,7 +108,6 @@ describe('AppSDK-privateAPIs', () => {
     'https://outlook.live.com',
     'https://outlook.office365.com',
     'https://outlook-sdf.office365.com',
-    'https://retailservices.teams.microsoft.com',
     'https://test.www.office.com',
     'https://www.office.com',
     'https://word.office.com',


### PR DESCRIPTION
## Description

No longer need one of the valid origins.

### Main changes in the PR:

1. Removed `*.teams.microsoft.com` from the list of valid origins we store. (`teams.microsoft.com` is still there though)
2. Updated unit tests.

## Validation

### Validation performed:

1. Ran unit tests

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes