### PR TITLE
Bug Fix:  Clipboard capability throwing error `DOMException: Document not focused` 

### DIFF
--- a/change/@microsoft-teams-js-1f05f3e0-286f-4831-8747-649c0e47e551.json
+++ b/change/@microsoft-teams-js-1f05f3e0-286f-4831-8747-649c0e47e551.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed clipboard issue for desktop client to resolve DOMExecption:Document not focused",
+  "packageName": "@microsoft/teams-js",
+  "email": "98348000+shrshindeMSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-1f05f3e0-286f-4831-8747-649c0e47e551.json
+++ b/change/@microsoft-teams-js-1f05f3e0-286f-4831-8747-649c0e47e551.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fixed clipboard issue for desktop client to resolve DOMExecption:Document not focused",
+  "comment": "Fixed `clipboard` issue for desktop client to resolve 'DOMExecption: Document not focused' error",
   "packageName": "@microsoft/teams-js",
   "email": "98348000+shrshindeMSFT@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/public/clipboard.ts
+++ b/packages/teams-js/src/public/clipboard.ts
@@ -82,7 +82,11 @@ export namespace clipboard {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-    if (isHostClientMobile() || GlobalVars.hostClientType === HostClientType.macos) {
+    if (
+      isHostClientMobile() ||
+      GlobalVars.hostClientType === HostClientType.macos ||
+      GlobalVars.hostClientType === HostClientType.desktop
+    ) {
       const response = JSON.parse(
         await sendAndHandleSdkError(apiVersionTag, 'clipboard.readFromClipboard'),
       ) as ClipboardParams;

--- a/packages/teams-js/src/public/clipboard.ts
+++ b/packages/teams-js/src/public/clipboard.ts
@@ -1,9 +1,8 @@
 import { sendAndHandleSdkError } from '../internal/communication';
-import { GlobalVars } from '../internal/globalVars';
-import { ensureInitialized, isHostClientMobile } from '../internal/internalAPIs';
+import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
 import * as utils from '../internal/utils';
-import { errorNotSupportedOnPlatform, FrameContexts, HostClientType } from './constants';
+import { errorNotSupportedOnPlatform, FrameContexts } from './constants';
 import { ClipboardParams, ClipboardSupportedMimeType } from './interfaces';
 import { runtime } from './runtime';
 
@@ -82,17 +81,12 @@ export namespace clipboard {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-    if (
-      isHostClientMobile() ||
-      GlobalVars.hostClientType === HostClientType.macos ||
-      GlobalVars.hostClientType === HostClientType.desktop
-    ) {
-      const response = JSON.parse(
-        await sendAndHandleSdkError(apiVersionTag, 'clipboard.readFromClipboard'),
-      ) as ClipboardParams;
-      return utils.base64ToBlob(response.mimeType, response.content);
+    const response = await sendAndHandleSdkError(apiVersionTag, 'clipboard.readFromClipboard');
+    if (typeof response === 'string') {
+      const data = JSON.parse(response) as ClipboardParams;
+      return utils.base64ToBlob(data.mimeType, data.content);
     } else {
-      return sendAndHandleSdkError(apiVersionTag, 'clipboard.readFromClipboard');
+      return response as Blob;
     }
   }
 

--- a/packages/teams-js/test/public/clipboard.spec.ts
+++ b/packages/teams-js/test/public/clipboard.spec.ts
@@ -308,6 +308,7 @@ describe('clipboard', () => {
       Object.values(FrameContexts).forEach((context) => {
         Object.values([
           HostClientType.android,
+          HostClientType.desktop,
           HostClientType.ios,
           HostClientType.ipados,
           HostClientType.macos,


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Currently developers are facing [issue ](https://github.com/OfficeDev/microsoft-teams-library-js/issues/2196) in desktop clients on clipboard capability. This PR adds changes to how `App` interacts with parent window over JSON string rather than `blob`.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Added desktop to use JSON string to read response from clipboard.
2. Added desktop to unit tests.

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes

### End-to-end tests added:

N/A

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes

Issue Link:[ Clipboard api throws 'NotAllowedError: Failed to execute 'write' on 'Clipboard': Document is not focused](https://github.com/OfficeDev/microsoft-teams-library-js/issues/2196)