### PR TITLE
Updated version spec on new joinMeeting tests to be correct

### DIFF
--- a/apps/teams-test-app/e2e-test-data/meeting.json
+++ b/apps/teams-test-app/e2e-test-data/meeting.json
@@ -353,7 +353,7 @@
       "type": "callResponse",
       "version": ">2.20.0",
       "hostSdkVersion": {
-        "web": ">=2.12.0"
+        "web": ">2.12.0"
       },
       "boxSelector": "#box_joinMeeting",
       "inputValue": {
@@ -368,7 +368,7 @@
       "type": "callResponse",
       "version": ">2.20.0",
       "hostSdkVersion": {
-        "web": ">=2.12.0"
+        "web": ">2.12.0"
       },
       "boxSelector": "#box_joinMeeting",
       "inputValue": {


### PR DESCRIPTION
## Description

When the `meeting.joinMeeting` tests were added in 2203, the new tests were set to run on any version of the host runtime >= 2.12.0. This was done due to a problem with how tests are run in these pipelines:
- The most recently released version of the host runtime is 2.12.0.
- The code in the host runtime that knows how to run these tests was checked in after 2.12.0 is released, therefore, these tests cannot run against 2.12.0 or anything earlier
- However, due to a problem in the test infrastructure, the "latest" version of the host runtime always thinks it is the last released version, EVEN when new code has been added to "latest" (but not yet released).
- Consequently, if I restricted the new tests to ">2.12.0", they would not have run during check-in because the latest host runtime code thinks it is 2.12.0 and therefore not eligible to run the tests (even though it is)
This problem is tracked to be fixed in bug 8812392.

I checked in the tests with the restriction set to ">=2.12.0" so the tests would run as part of checkin and ensure they worked. Now that we know they work, I'm updating the restriction to correctly be >2.12.0. There is a small risk in doing this, as it means these tests will stop running until a version after 2.12.0 actually gets released, at which point they will "magically" start running again on latest. However, the likelihood of this happening is low and it's more important for this restriction to be accurate than for us to accidentally forget to change it and (incorrectly) run the tests against any attempted 2.12.0 branch releases.

