### PR TITLE
Implementing the externalAppCommands API

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -38,6 +38,7 @@ import PeopleAPIs from './components/PeopleAPIs';
 import ChatAPIs from './components/privateApis/ChatAPIs';
 import ExternalAppAuthenticationAPIs from './components/privateApis/ExternalAppAuthenticationAPIs';
 import ExternalAppCardActionsAPIs from './components/privateApis/ExternalAppCardActionsAPIs';
+import ExternalAppCommandsAPIs from './components/privateApis/ExternalAppCommandsAPIs';
 import FilesAPIs from './components/privateApis/FilesAPIs';
 import FullTrustAPIs from './components/privateApis/FullTrustAPIs';
 import MeetingRoomAPIs from './components/privateApis/MeetingRoomAPIs';
@@ -146,6 +147,7 @@ const App = (): ReactElement => {
         <DialogUrlBotAPIs />
         <ExternalAppAuthenticationAPIs />
         <ExternalAppCardActionsAPIs />
+        <ExternalAppCommandsAPIs />
         <FilesAPIs />
         <FullTrustAPIs />
         <GeoLocationAPIs />

--- a/apps/teams-test-app/src/components/privateApis/ExternalAppCommandsAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/ExternalAppCommandsAPIs.tsx
@@ -1,0 +1,58 @@
+import { externalAppCommands } from '@microsoft/teams-js';
+import React from 'react';
+
+import { ApiWithoutInput, ApiWithTextInput } from '../utils';
+import { ModuleWrapper } from '../utils/ModuleWrapper';
+
+const CheckExternalAppCommandsCapability = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'checkExternalAppCommandsCapability',
+    title: 'Check External App Commands Capability',
+    onClick: async () =>
+      `External App Commands module ${externalAppCommands.isSupported() ? 'is' : 'is not'} supported`,
+  });
+
+const ProcessActionCommand = (): React.ReactElement =>
+  ApiWithTextInput<{
+    appId: string;
+    commandId: string;
+    extractedParameters: Record<string, string>;
+  }>({
+    name: 'processActionCommand',
+    title: 'Process Action Command',
+    onClick: {
+      validateInput: (input) => {
+        if (!input.appId) {
+          throw new Error('appId is required');
+        }
+        if (!input.commandId) {
+          throw new Error('commandId is required');
+        }
+        if (!input.extractedParameters) {
+          throw new Error('extractedParameters is required');
+        }
+      },
+      submit: async (input) => {
+        const result = await externalAppCommands.processActionCommand(
+          input.appId,
+          input.commandId,
+          input.extractedParameters,
+        );
+        return JSON.stringify(result);
+      },
+    },
+    defaultInput: JSON.stringify({
+      appId: 'b7f8c0a0-6c1d-4a9a-9c0a-2c3f1c0a3b0a',
+      commandId: 'testCommandId',
+      extractedParameters: { key: 'value-string' },
+    }),
+  });
+
+const ExternalAppCommandsAPIs = (): React.ReactElement => (
+  <ModuleWrapper title="External App Commands">
+    <CheckExternalAppCommandsCapability />
+    <ProcessActionCommand />
+  </ModuleWrapper>
+);
+
+export default ExternalAppCommandsAPIs;

--- a/change/@microsoft-teams-js-2759cb8f-9b8e-42d5-91f1-9328285f396e.json
+++ b/change/@microsoft-teams-js-2759cb8f-9b8e-42d5-91f1-9328285f396e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added `externalAppCommands` 1P internal-only capability",
+  "packageName": "@microsoft/teams-js",
+  "email": "maggiegong@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -111,6 +111,7 @@ export enum ApiName {
   ExternalAppAuthentication_AuthenticateWithSSOAndResendRequest = 'externalAppAuthentication.authenticateWithSSOAndResendRequest',
   ExternalAppCardActions_ProcessActionOpenUrl = 'externalAppCardActions.processActionOpenUrl',
   ExternalAppCardActions_ProcessActionSubmit = 'externalAppCardActions.processActionSubmit',
+  ExternalAppCommands_ProcessActionCommands = 'externalAppCommands.processActionCommand',
   Files_AddCloudStorageFolder = 'files.addCloudStorageFolder',
   Files_AddCloudStorageProvider = 'files.addCloudStorageProvider',
   Files_AddCloudStorageProviderFile = 'files.addCloudStorageProviderFile',

--- a/packages/teams-js/src/private/constants.ts
+++ b/packages/teams-js/src/private/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * @hidden
+ * Error codes that can be thrown from externalAppCommands and externalAppCardCommands Action Submit specifically
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export enum ExternalAppErrorCode {
+  INTERNAL_ERROR = 'INTERNAL_ERROR', // Generic error
+}

--- a/packages/teams-js/src/private/externalAppCardActions.ts
+++ b/packages/teams-js/src/private/externalAppCardActions.ts
@@ -4,6 +4,7 @@ import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemet
 import { FrameContexts } from '../public';
 import { errorNotSupportedOnPlatform } from '../public/constants';
 import { runtime } from '../public/runtime';
+import { ExternalAppErrorCode } from './constants';
 
 /**
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
@@ -74,18 +75,8 @@ export namespace externalAppCardActions {
    * Limited to Microsoft-internal use
    */
   export interface ActionSubmitError {
-    errorCode: ActionSubmitErrorCode;
+    errorCode: ExternalAppErrorCode;
     message?: string;
-  }
-
-  /**
-   * @hidden
-   * Error codes that can be thrown from IExternalAppCardActionService.handleActionSubmit
-   * @internal
-   * Limited to Microsoft-internal use
-   */
-  export enum ActionSubmitErrorCode {
-    INTERNAL_ERROR = 'INTERNAL_ERROR', // Generic error
   }
 
   /**

--- a/packages/teams-js/src/private/externalAppCommands.ts
+++ b/packages/teams-js/src/private/externalAppCommands.ts
@@ -1,0 +1,166 @@
+import { sendMessageToParentAsync } from '../internal/communication';
+import { ensureInitialized } from '../internal/internalAPIs';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
+import { FrameContexts } from '../public';
+import { errorNotSupportedOnPlatform } from '../public/constants';
+import { runtime } from '../public/runtime';
+import { ExternalAppErrorCode } from './constants';
+import { externalAppAuthentication } from './externalAppAuthentication';
+
+/**
+ * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
+ */
+const externalAppCommandsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
+
+/**
+ * @hidden
+ * Namespace to delegate the ActionCommand to the host
+ * @internal
+ * Limited to Microsoft-internal use
+ *
+ * @beta
+ */
+export namespace externalAppCommands {
+  /**
+   * @hidden
+   * The payload of IActionCommandResponse
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
+   * @beta
+   */
+  export type IActionCommandResponse = ITextActionCommandResponse | ICardActionCommandResponse;
+
+  /**
+   * @hidden
+   * The payload of IBaseActionCommandResponse
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
+   * @beta
+   */
+  export interface IBaseActionCommandResponse {
+    taskModuleClosedReason: TaskModuleClosedReason;
+  }
+
+  /**
+   * @hidden
+   * The text result type
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
+   * @beta
+   */
+  export interface ITextActionCommandResponse extends IBaseActionCommandResponse {
+    resultType: 'text';
+    text: string | undefined;
+  }
+
+  /**
+   * @hidden
+   * The card result type
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
+   * @beta
+   */
+  export interface ICardActionCommandResponse extends IBaseActionCommandResponse {
+    resultType: 'card';
+    attachmentLayout: externalAppAuthentication.AttachmentLayout;
+    attachments: externalAppAuthentication.QueryMessageExtensionAttachment[];
+  }
+
+  /**
+   * @hidden
+   * The result type for the ActionCommandResultType
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
+   * @beta
+   */
+  export type ActionCommandResultType = 'card' | 'text';
+
+  /**
+   * @hidden
+   * The reason for the TaskModuleClosedReason
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
+   * @beta
+   */
+  export type TaskModuleClosedReason = 'Done' | 'CancelledByUser';
+
+  /**
+   *
+   * @hidden
+   * Error that can be thrown from IExternalAppCommandsService.processActionCommand
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
+   * @beta
+   */
+  export interface ActionCommandError {
+    errorCode: ExternalAppErrorCode;
+    message?: string;
+  }
+
+  /**
+   * @internal
+   * Limited to Microsoft-internal use
+   * @hidden
+   * This API delegates an ActionCommand request to the host for the application with the provided following parameters:
+   *
+   * @param appId ID of the application the request is intended for. This must be a UUID
+   * @param commandId extensibilityProvider use this ID to look up the command declared by ActionME
+   * @param extractedParameters are the key-value pairs that the dialog will be prepopulated with
+   *
+   * @returns Promise that resolves with the {@link IActionCommandResponse} when the request is completed and rejects with {@link ActionCommandError} if the request fails
+   *
+   * @beta
+   */
+  export async function processActionCommand(
+    appId: string,
+    commandId: string,
+    extractedParameters: Record<string, string>,
+  ): Promise<IActionCommandResponse> {
+    ensureInitialized(runtime, FrameContexts.content);
+
+    if (!isSupported()) {
+      throw errorNotSupportedOnPlatform;
+    }
+
+    const [error, response] = await sendMessageToParentAsync<[ActionCommandError, IActionCommandResponse]>(
+      getApiVersionTag(externalAppCommandsTelemetryVersionNumber, ApiName.ExternalAppCommands_ProcessActionCommands),
+      ApiName.ExternalAppCommands_ProcessActionCommands,
+      [appId, commandId, extractedParameters],
+    );
+    if (error) {
+      throw error;
+    } else {
+      return response;
+    }
+  }
+
+  /**
+   * @hidden
+   * Checks if the externalAppCommands capability is supported by the host
+   * @returns boolean to represent whether externalAppCommands capability is supported
+   *
+   * @throws Error if {@linkcode app.initialize} has not successfully completed
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   *
+   * @beta
+   */
+  export function isSupported(): boolean {
+    return ensureInitialized(runtime) && runtime.supports.externalAppCommands ? true : false;
+  }
+}

--- a/packages/teams-js/src/private/index.ts
+++ b/packages/teams-js/src/private/index.ts
@@ -21,6 +21,7 @@ export {
 export { conversations } from './conversations';
 export { externalAppAuthentication } from './externalAppAuthentication';
 export { externalAppCardActions } from './externalAppCardActions';
+export { externalAppCommands } from './externalAppCommands';
 export { files } from './files';
 export { meetingRoom } from './meetingRoom';
 export { messageChannels } from './messageChannels';

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -701,6 +701,14 @@ export namespace app {
      * Will be `undefined` when not running in Teams.
      */
     team?: TeamInfo;
+
+    /**
+     * When `processActionCommand` activates a dialog, this dialog should automatically fill in some fields with information. This information comes from M365 and is given to `processActionCommand` as `extractedParameters`.
+     * App developers need to use these `extractedParameters` in their dialog.
+     * They help pre-fill the dialog with necessary information (`dialogParameters`) along with other details.
+     * If there's no key/value pairs passed, the object will be empty in the case
+     */
+    dialogParameters: Record<string, string>;
   }
 
   /**
@@ -1038,6 +1046,7 @@ function transformLegacyContextToAppContext(legacyContext: LegacyContext): app.C
             mySiteDomain: legacyContext.mySiteDomain,
           }
         : undefined,
+    dialogParameters: legacyContext.dialogParameters || {},
   };
 
   return context;

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -739,6 +739,16 @@ export interface Context {
    * The SharePoint relative path to the current users mysite
    */
   mySitePath?: string;
+
+  /**
+   * @deprecated
+   * As of 2.0.0, please use {@link app.Context.dialogParameters} instead
+   *
+   * When `processActionCommand` activates a dialog, this dialog should automatically fill in some fields with information. This information comes from M365 and is given to `processActionCommand` as `extractedParameters`.
+   * App developers need to use these `extractedParameters` in their dialog.
+   * They help pre-fill the dialog with necessary information (`dialogParameters`) along with other details.
+   */
+  dialogParameters?: Record<string, string>;
 }
 
 /** Represents the parameters used to share a deep link. */

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -241,6 +241,7 @@ interface IRuntimeV4 extends IBaseRuntime {
     };
     readonly externalAppAuthentication?: {};
     readonly externalAppCardActions?: {};
+    readonly externalAppCommands?: {};
     readonly geoLocation?: {
       readonly map?: {};
     };

--- a/packages/teams-js/test/private/externalAppCardActions.spec.ts
+++ b/packages/teams-js/test/private/externalAppCardActions.spec.ts
@@ -1,5 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
+import { ExternalAppErrorCode } from '../../src/private/constants';
 import { externalAppCardActions } from '../../src/private/externalAppCardActions';
 import { FrameContexts } from '../../src/public';
 import { app } from '../../src/public/app';
@@ -31,7 +32,7 @@ describe('externalAppCardActions', () => {
       data: {},
     };
     const testError = {
-      errorCode: externalAppCardActions.ActionSubmitErrorCode.INTERNAL_ERROR,
+      errorCode: ExternalAppErrorCode.INTERNAL_ERROR,
       message: 'testMessage',
     };
     it('should not allow calls before initialization', async () => {

--- a/packages/teams-js/test/private/externalAppCommands.spec.ts
+++ b/packages/teams-js/test/private/externalAppCommands.spec.ts
@@ -1,0 +1,131 @@
+import { errorLibraryNotInitialized } from '../../src/internal/constants';
+import { GlobalVars } from '../../src/internal/globalVars';
+import { ExternalAppErrorCode } from '../../src/private/constants';
+import { externalAppCommands } from '../../src/private/externalAppCommands';
+import { FrameContexts } from '../../src/public';
+import { app } from '../../src/public/app';
+import { errorNotSupportedOnPlatform } from '../../src/public/constants';
+import { Utils } from '../utils';
+
+describe('externalAppCommands', () => {
+  let utils = new Utils();
+
+  // This ID was randomly generated for the purpose of these tests
+  const mockAppId = '01b92759-b43a-4085-ac22-7772d94bb7a9';
+  const mockCommandId = 'mock-command-id';
+  const mockExtractedParam: Record<string, string> = { mock_key: 'mock_value' };
+
+  beforeEach(() => {
+    utils = new Utils();
+    utils.mockWindow.parent = undefined;
+    utils.messages = [];
+    GlobalVars.isFramelessWindow = false;
+  });
+
+  afterEach(() => {
+    app._uninitialize();
+    jest.clearAllMocks();
+  });
+
+  describe('Testing ExternalAppCommands.processActionCommand API', () => {
+    it('should not allow calls before initialization', () => {
+      return expect(() =>
+        externalAppCommands.processActionCommand(mockAppId, mockCommandId, mockExtractedParam),
+      ).rejects.toThrowError(new Error(errorLibraryNotInitialized));
+    });
+    const allowedFrameContexts = [FrameContexts.content];
+    const testError = {
+      errorCode: ExternalAppErrorCode.INTERNAL_ERROR,
+      message: 'mockErrorMessage',
+    };
+    const mockResponse: externalAppCommands.ITextActionCommandResponse = {
+      taskModuleClosedReason: 'Done',
+      resultType: 'text',
+      text: 'mock-text',
+    };
+
+    it('should throw error when externalAppCommands capability is not supported', async () => {
+      expect.assertions(1);
+      await utils.initializeWithContext(FrameContexts.content);
+      utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+      try {
+        await externalAppCommands.processActionCommand(mockAppId, mockCommandId, mockExtractedParam);
+      } catch (e) {
+        expect(e).toEqual(errorNotSupportedOnPlatform);
+      }
+    });
+    Object.values(FrameContexts).forEach((frameContext) => {
+      if (allowedFrameContexts.includes(frameContext)) {
+        it(`should resolve when called from context - ${frameContext}`, async () => {
+          expect.assertions(3);
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCommands: {} } });
+          const promise = externalAppCommands.processActionCommand(mockAppId, mockCommandId, mockExtractedParam);
+          const message = utils.findMessageByFunc('externalAppCommands.processActionCommand');
+          if (message && message.args) {
+            expect(message).not.toBeNull();
+            expect(message.args).toEqual([mockAppId, mockCommandId, mockExtractedParam]);
+            // eslint-disable-next-line strict-null-checks/all
+            utils.respondToMessage(message, null, mockResponse);
+          }
+          try {
+            const response = await promise;
+            return expect(response).toEqual(mockResponse);
+          } catch (e) {
+            return expect(e).toBeNull();
+          }
+        });
+        it(`should throw error from host when called from context - ${frameContext}`, async () => {
+          expect.assertions(3);
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCommands: {} } });
+          const promise = externalAppCommands.processActionCommand(mockAppId, mockCommandId, mockExtractedParam);
+          const message = utils.findMessageByFunc('externalAppCommands.processActionCommand');
+          if (message && message.args) {
+            expect(message).not.toBeNull();
+            expect(message.args).toEqual([mockAppId, mockCommandId, mockExtractedParam]);
+            utils.respondToMessage(message, testError, null);
+          }
+          try {
+            const response = await promise;
+            return expect(response).toEqual(testError);
+          } catch (e) {
+            return expect(e).toEqual(testError);
+          }
+        });
+      } else {
+        it(`should not allow calls from ${frameContext} context`, async () => {
+          expect.assertions(1);
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCommands: {} } });
+          return expect(() =>
+            externalAppCommands.processActionCommand(mockAppId, mockCommandId, mockExtractedParam),
+          ).rejects.toThrowError(
+            new Error(
+              `This call is only allowed in following contexts: ${JSON.stringify(allowedFrameContexts)}. ` +
+                `Current context: "${frameContext}".`,
+            ),
+          );
+        });
+      }
+    });
+  });
+
+  describe('isSupported', () => {
+    it('should throw when library is not initialized', () => {
+      return expect(() => externalAppCommands.isSupported()).toThrowError(new Error(errorLibraryNotInitialized));
+    });
+    it('should return true when externalAppCommands capability is supported', async () => {
+      expect.assertions(1);
+      await utils.initializeWithContext(FrameContexts.content);
+      utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCommands: {} } });
+      return expect(externalAppCommands.isSupported()).toEqual(true);
+    });
+    it('should return false when externalAppCommands capability is not supported', async () => {
+      expect.assertions(1);
+      await utils.initializeWithContext(FrameContexts.content);
+      utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
+      return expect(externalAppCommands.isSupported()).toEqual(false);
+    });
+  });
+});

--- a/packages/teams-js/test/private/privateAPIs.spec.ts
+++ b/packages/teams-js/test/private/privateAPIs.spec.ts
@@ -255,6 +255,7 @@ describe('AppSDK-privateAPIs', () => {
       channel: {
         id: 'someChannelId1',
       },
+      dialogParameters: {},
     };
 
     const contextBridge2: Context = {
@@ -284,6 +285,7 @@ describe('AppSDK-privateAPIs', () => {
       channel: {
         id: 'someChannelId2',
       },
+      dialogParameters: {},
     };
 
     const contextBridge3: Context = {
@@ -313,6 +315,7 @@ describe('AppSDK-privateAPIs', () => {
       channel: {
         id: 'someChannelId3',
       },
+      dialogParameters: {},
     };
 
     // respond in the wrong order

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -631,6 +631,7 @@ describe('Testing app capability', () => {
               mySitePath: 'mySitePath',
               mySiteDomain: 'myDomain',
             },
+            dialogParameters: {},
           };
 
           //insert expected time comparison here?
@@ -1490,6 +1491,7 @@ describe('Testing app capability', () => {
               mySitePath: 'mySitePath',
               mySiteDomain: 'myDomain',
             },
+            dialogParameters: {},
           };
 
           await utils.respondToFramelessMessage({


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Adds the 1P internal-only externalAppCommands API for delegating certain actions to the host.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Add externalAppCommands capability
2. Add externalAppCommands.processActionCommand API

## Validation

### Validation performed:

1. Unit tests
2. Capabilities added to the teams test app

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes>

### End-to-end tests added:

<No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes>

