### PR TITLE
Removed all of GUID checks

### DIFF
--- a/change/@microsoft-teams-js-66c6dadf-b3af-4de0-b855-89376c0f873a.json
+++ b/change/@microsoft-teams-js-66c6dadf-b3af-4de0-b855-89376c0f873a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed all of GUID checks on app Id",
+  "packageName": "@microsoft/teams-js",
+  "email": "kangxuanye@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-66c6dadf-b3af-4de0-b855-89376c0f873a.json
+++ b/change/@microsoft-teams-js-66c6dadf-b3af-4de0-b855-89376c0f873a.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Removed all of GUID checks on app Id",
+  "comment": "Removed validation that appIds are UUIDs since some very old published apps have IDs that are not UUIDs (they were published before the manifest schema specified they had to be UUIDs)",
   "packageName": "@microsoft/teams-js",
   "email": "kangxuanye@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -402,16 +402,3 @@ export function inServerSideRenderingEnvironment(): boolean {
 }
 
 const appIdRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-/**
- * @param appID The app ID to validate against the GUID format
- * @throws Error if appID is not a valid GUID
- *
- * @internal
- * Limited to Microsoft-internal use
- */
-export function validateAppIdIsGuid(appId: string): void {
-  if (!appIdRegex.test(appId)) {
-    throw new Error('App ID is not valid. Must be GUID format. App ID: ' + appId);
-  }
-}

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -400,5 +400,3 @@ export function ssrSafeWindow(): Window {
 export function inServerSideRenderingEnvironment(): boolean {
   return typeof window === 'undefined';
 }
-
-const appIdRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/packages/teams-js/src/private/externalAppAuthentication.ts
+++ b/packages/teams-js/src/private/externalAppAuthentication.ts
@@ -1,7 +1,6 @@
 import { sendMessageToParentAsync } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { validateAppIdIsGuid } from '../internal/utils';
 import { FrameContexts } from '../public';
 import { errorNotSupportedOnPlatform } from '../public/constants';
 import { runtime } from '../public/runtime';
@@ -327,8 +326,6 @@ export namespace externalAppAuthentication {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-
-    validateAppIdIsGuid(appId);
     validateOriginalRequestInfo(originalRequestInfo);
 
     // Ask the parent window to open an authentication window with the parameters provided by the caller.
@@ -372,9 +369,6 @@ export namespace externalAppAuthentication {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-
-    validateAppIdIsGuid(appId);
-
     return sendMessageToParentAsync(
       getApiVersionTag(
         externalAppAuthenticationTelemetryVersionNumber,
@@ -410,8 +404,6 @@ export namespace externalAppAuthentication {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-
-    validateAppIdIsGuid(appId);
     validateOriginalRequestInfo(originalRequestInfo);
 
     return sendMessageToParentAsync<[boolean, IInvokeResponse | InvokeErrorWrapper]>(

--- a/packages/teams-js/src/private/externalAppCardActions.ts
+++ b/packages/teams-js/src/private/externalAppCardActions.ts
@@ -1,7 +1,6 @@
 import { sendMessageToParentAsync } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { validateAppIdIsGuid } from '../internal/utils';
 import { FrameContexts } from '../public';
 import { errorNotSupportedOnPlatform } from '../public/constants';
 import { runtime } from '../public/runtime';
@@ -106,9 +105,6 @@ export namespace externalAppCardActions {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-
-    validateAppIdIsGuid(appId);
-
     return sendMessageToParentAsync<[boolean, ActionSubmitError]>(
       getApiVersionTag(
         externalAppCardActionsTelemetryVersionNumber,
@@ -139,8 +135,6 @@ export namespace externalAppCardActions {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-
-    validateAppIdIsGuid(appId);
 
     return sendMessageToParentAsync<[ActionOpenUrlError, ActionOpenUrlType]>(
       getApiVersionTag(

--- a/packages/teams-js/test/internal/utils.spec.ts
+++ b/packages/teams-js/test/internal/utils.spec.ts
@@ -3,7 +3,6 @@ import {
   compareSDKVersions,
   createTeamsAppLink,
   getBase64StringFromBlob,
-  validateAppIdIsGuid,
 } from '../../src/internal/utils';
 import { pages } from '../../src/public';
 import { ClipboardSupportedMimeType } from '../../src/public/interfaces';
@@ -184,29 +183,6 @@ describe('utils', () => {
       } catch (error) {
         expect(error).toEqual(new Error('Blob cannot be empty.'));
       }
-    });
-  });
-
-  describe('validateAppIdIsGuid', () => {
-    it('should throw error when appId is not a valid GUID', async () => {
-      expect.assertions(1);
-      const appId = 'invalid-app-id';
-      try {
-        await validateAppIdIsGuid(appId);
-      } catch (error) {
-        expect(error).toEqual(new Error('App ID is not valid. Must be GUID format. App ID: ' + appId));
-      }
-    });
-    it('should not throw error when appId is a valid GUID', async () => {
-      expect.assertions(1);
-      // App ID randomly generated for this test
-      const appId = 'fe4a8eba-2a31-4737-8e33-e5fae6fee194';
-      return expect(() => validateAppIdIsGuid(appId)).not.toThrow();
-    });
-    it('should not throw error when appId is a valid app ID but not valid v4 UUID', async () => {
-      expect.assertions(1);
-      const appId = '11111111-1111-1111-1111-111111111111';
-      return expect(() => validateAppIdIsGuid(appId)).not.toThrow();
     });
   });
 });

--- a/packages/teams-js/test/private/externalAppAuthentication.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthentication.spec.ts
@@ -143,17 +143,6 @@ describe('externalAppAuthentication', () => {
           }
           return expect(promise).rejects.toEqual(testError);
         });
-        it(`should throw error on invalid app ID with context - ${frameContext}`, async () => {
-          expect.assertions(1);
-          await utils.initializeWithContext(frameContext);
-          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
-          const invalidAppId = 'invalidAppId';
-          try {
-            externalAppAuthentication.authenticateAndResendRequest(invalidAppId, testAuthRequest, testOriginalRequest);
-          } catch (e) {
-            expect(e).toEqual(new Error('App ID is not valid. Must be GUID format. App ID: ' + invalidAppId));
-          }
-        });
         it(`should throw error on original request info command ID exceeds max size with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
@@ -397,21 +386,6 @@ describe('externalAppAuthentication', () => {
             utils.respondToMessage(message, true, testResponse);
           }
           await expect(promise).resolves.toEqual(testResponse);
-        });
-        it(`should throw error on invalid app ID with context - ${frameContext}`, async () => {
-          expect.assertions(1);
-          await utils.initializeWithContext(frameContext);
-          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
-          const invalidAppId = 'invalidAppId';
-          try {
-            externalAppAuthentication.authenticateWithSSOAndResendRequest(
-              invalidAppId,
-              testAuthRequest,
-              testOriginalRequest,
-            );
-          } catch (e) {
-            expect(e).toEqual(new Error('App ID is not valid. Must be GUID format. App ID: ' + invalidAppId));
-          }
         });
         it(`should throw error on original request info command ID exceeds max size with context - ${frameContext}`, async () => {
           expect.assertions(1);

--- a/packages/teams-js/test/private/externalAppCardActions.spec.ts
+++ b/packages/teams-js/test/private/externalAppCardActions.spec.ts
@@ -11,7 +11,6 @@ describe('externalAppCardActions', () => {
 
   // This ID was randomly generated for the purpose of these tests
   const testAppId = '01b92759-b43a-4085-ac22-7772d94bb7a9';
-  const invalidAppId = 'invalid-app-id';
 
   beforeEach(() => {
     utils = new Utils();

--- a/packages/teams-js/test/private/externalAppCardActions.spec.ts
+++ b/packages/teams-js/test/private/externalAppCardActions.spec.ts
@@ -78,16 +78,6 @@ describe('externalAppCardActions', () => {
           }
           return expect(promise).rejects.toEqual(testError);
         });
-        it(`should throw error when appId is invalid with context - ${frameContext}`, async () => {
-          expect.assertions(1);
-          await utils.initializeWithContext(frameContext);
-          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActions: {} } });
-          try {
-            externalAppCardActions.processActionSubmit(invalidAppId, testActionSubmitPayload);
-          } catch (e) {
-            expect(e).toEqual(new Error('App ID is not valid. Must be GUID format. App ID: ' + invalidAppId));
-          }
-        });
       } else {
         it(`should not allow calls from ${frameContext} context`, async () => {
           expect.assertions(1);
@@ -157,16 +147,6 @@ describe('externalAppCardActions', () => {
             utils.respondToMessage(message, testError, null);
           }
           return expect(promise).rejects.toEqual(testError);
-        });
-        it(`should throw error when appId is invalid with context - ${frameContext}`, async () => {
-          expect.assertions(1);
-          await utils.initializeWithContext(frameContext);
-          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActions: {} } });
-          try {
-            externalAppCardActions.processActionOpenUrl(invalidAppId, testUrl);
-          } catch (e) {
-            expect(e).toEqual(new Error('App ID is not valid. Must be GUID format. App ID: ' + invalidAppId));
-          }
         });
       } else {
         it(`should not allow calls from ${frameContext} context`, async () => {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

GUID checks are removed for app Id because apps are not promised to have Id in GUID format.

We had a bug ticket saying that appID works in Teams but failed in Teams-JS library because it is not GUID format. That is to say we are too strict to App Id format so we need to loose it a little bit to be aligned with Teams.
https://github.com/OfficeDev/microsoft-teams-library-js/issues/2223

### Main changes in the PR:

1. Remove everything related to GUID check.

## Validation

### Validation performed:

1. isValidAppId function is removed so it should be compiled successfully and no where is using that function.

### Unit Tests added: No

### End-to-end tests added: No


## Additional Requirements

### Change file added: Yes

