### PR TITLE
Telemetry string size reduction

### DIFF
--- a/change/@microsoft-teams-js-889e1105-9a8b-468a-94d7-ed8253cdf569.json
+++ b/change/@microsoft-teams-js-889e1105-9a8b-468a-94d7-ed8253cdf569.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Made ApiName enum const to reduce package size",
+  "comment": "Made enum const to reduce package size",
   "packageName": "@microsoft/teams-js",
   "email": "noahdarveau@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-889e1105-9a8b-468a-94d7-ed8253cdf569.json
+++ b/change/@microsoft-teams-js-889e1105-9a8b-468a-94d7-ed8253cdf569.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Made ApiName enum const to reduce package size",
+  "packageName": "@microsoft/teams-js",
+  "email": "noahdarveau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -50,7 +50,7 @@ export enum ApiVersionNumber {
   V_3 = 'v3',
 }
 
-export enum ApiName {
+export const enum ApiName {
   App_GetContext = 'app.getContext',
   App_Initialize = 'app.initialize',
   App_NotifyAppLoaded = 'app.notifyAppLoaded',


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Made the telemetry string enum `const` to reduce package size. By making the enum `const` the minified code will symbolize the enum, reducing the package size by ~10%. In typescript, enums by default, have reverse mapping capabilities.

For example (reverse mapping capabilites):
````
enum Enum {
  A,
}
let a = Enum.A;
let nameOfA = Enum[a]; // "A"
````

So given the following enum:
````
enum Enum {
  foo = "bar",
  foo_two = "bar_two"
}
````
When a regular enum is minified, both the left and right sides of the enum are not reduced, resulting in something resembling the following when minified:
````
a.foo="bar",a.foo_two="bar_two"
````
However, a const enum removes the reverse mapping capabilites, which allows for the left side of an enum to be symbolized.

So if the above enum were `const`, it becomes something resembling the following when minified:
````
a.a="bar",a.b="bar_two"
````

Since the ApiName enum has so many values, with many of the values containing a large number of characters on the left side, making it const results in the left size symbolization being a substantial size decrease to the minified file.
## Validation

### Validation performed:

1. Manually went through `ApiName` usages and ensured there were no reverse mapping usages, as well as confirmed with Kangxuan

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
