### PR TITLE
Backed out const enum changes to public api

### DIFF
--- a/change/@microsoft-teams-js-46bb0b2e-b9eb-4242-8a86-665f5cb915ba.json
+++ b/change/@microsoft-teams-js-46bb0b2e-b9eb-4242-8a86-665f5cb915ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Backed out some potential bug causing changes",
+  "packageName": "@microsoft/teams-js",
+  "email": "noahdarveau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-46bb0b2e-b9eb-4242-8a86-665f5cb915ba.json
+++ b/change/@microsoft-teams-js-46bb0b2e-b9eb-4242-8a86-665f5cb915ba.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Backed out some potential bug causing changes",
+  "comment": "Backed out some potential bug-causing changes related to `const` enums.",
   "packageName": "@microsoft/teams-js",
   "email": "noahdarveau@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -767,7 +767,7 @@ export namespace authentication {
    * @internal
    * Limited to Microsoft-internal use
    */
-  export const enum DataResidency {
+  export enum DataResidency {
     /**
      * Public
      */

--- a/packages/teams-js/src/public/call.ts
+++ b/packages/teams-js/src/public/call.ts
@@ -16,7 +16,7 @@ const callTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
  */
 export namespace call {
   /** Modalities that can be associated with a call. */
-  export const enum CallModalities {
+  export enum CallModalities {
     /** Indicates that the modality is unknown or undefined. */
     Unknown = 'unknown',
     /** Indicates that the call includes audio. */

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -30,7 +30,7 @@ export enum HostClientType {
 }
 
 /** HostName indicates the possible hosts for your application. */
-export const enum HostName {
+export enum HostName {
   /**
    * Office.com and Office Windows App
    */
@@ -132,7 +132,7 @@ export enum UserTeamRole {
 /**
  * Dialog module dimension enum
  */
-export const enum DialogDimension {
+export enum DialogDimension {
   /** Represents a large-sized dialog box, which is typically used for displaying large amounts of content or complex workflows that require more space. */
   Large = 'large',
   /** Represents a medium-sized dialog box, which is typically used for displaying moderate amounts of content or workflows that require less space. */
@@ -153,7 +153,7 @@ import { HostVersionsInfo } from './interfaces';
 /**
  * The type of the channel with which the content is associated.
  */
-export const enum ChannelType {
+export enum ChannelType {
   /** The default channel type. Type of channel is used for general collaboration and communication within a team. */
   Regular = 'Regular',
   /** Type of channel is used for sensitive or confidential communication within a team and is only accessible to members of the channel. */

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -186,7 +186,7 @@ export interface LocaleInfo {
 /**
  * Allowed user file open preferences
  */
-export const enum FileOpenPreference {
+export enum FileOpenPreference {
   /** Indicates that the user should be prompted to open the file in inline. */
   Inline = 'inline',
   /** Indicates that the user should be prompted to open the file in the native desktop application associated with the file type. */
@@ -200,7 +200,7 @@ export const enum FileOpenPreference {
  *
  * @beta
  */
-export const enum ActionObjectType {
+export enum ActionObjectType {
   /** Represents content within a Microsoft 365 application. */
   M365Content = 'm365content',
 }
@@ -250,7 +250,7 @@ export interface SecondaryId {
  * See [commonly accessed resources](https://learn.microsoft.com/graph/api/resources/onedrive?view=graph-rest-1.0#commonly-accessed-resources).
  * @beta
  */
-export const enum SecondaryM365ContentIdName {
+export enum SecondaryM365ContentIdName {
   /** OneDrive ID */
   DriveId = 'driveId',
   /** Teams Group ID */
@@ -1054,7 +1054,7 @@ export enum ErrorCode {
 }
 
 /** @hidden */
-export const enum DevicePermission {
+export enum DevicePermission {
   GeoLocation = 'geolocation',
   Media = 'media',
 }

--- a/packages/teams-js/src/public/liveShareHost.ts
+++ b/packages/teams-js/src/public/liveShareHost.ts
@@ -22,7 +22,7 @@ export namespace liveShare {
    * Used in Live Share for its role verification feature.
    * For more information, visit https://learn.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/teams-live-share-capabilities?tabs=javascript#role-verification-for-live-data-structures
    */
-  export const enum UserMeetingRole {
+  export enum UserMeetingRole {
     /**
      * Guest role.
      */
@@ -46,7 +46,7 @@ export namespace liveShare {
    * State of the current Live Share session's Fluid container.
    * This is used internally by the `LiveShareClient` when joining a Live Share session.
    */
-  export const enum ContainerState {
+  export enum ContainerState {
     /**
      * The call to `LiveShareHost.setContainerId()` successfully created the container mapping
      * for the current Live Share session.

--- a/packages/teams-js/src/public/marketplace.ts
+++ b/packages/teams-js/src/public/marketplace.ts
@@ -203,7 +203,7 @@ export namespace marketplace {
    * Represents the persona creating the cart.
    * @beta
    */
-  export const enum Intent {
+  export enum Intent {
     /**
      * @hidden
      * The cart is created by admin of an organization in Teams Admin Center.

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -80,7 +80,7 @@ export namespace media {
   /**
    * Enum for file formats supported
    */
-  export const enum FileFormat {
+  export enum FileFormat {
     /** Base64 encoding */
     Base64 = 'base64',
     /** File id */

--- a/packages/teams-js/src/public/meeting.ts
+++ b/packages/teams-js/src/public/meeting.ts
@@ -409,7 +409,7 @@ export namespace meeting {
    *
    * @beta
    */
-  export const enum MeetingReactionType {
+  export enum MeetingReactionType {
     like = 'like',
     heart = 'heart',
     laugh = 'laugh',
@@ -426,7 +426,7 @@ export namespace meeting {
    * @remarks
    * Teams has several types of meetings to account for different user scenarios and requirements.
    */
-  export const enum MeetingType {
+  export enum MeetingType {
     /**
      * Used when the meeting type is not known.
      *
@@ -481,7 +481,7 @@ export namespace meeting {
    * @hidden
    * Hide from docs.
    */
-  export const enum CallType {
+  export enum CallType {
     /**
      * Represents a call between two people.
      *
@@ -502,7 +502,7 @@ export namespace meeting {
   /**
    * Represents the protocol option for sharing app content to the meeting stage.
    */
-  export const enum SharingProtocol {
+  export enum SharingProtocol {
     /**
      * The default protocol for sharing app content to stage. To learn more, visit https://aka.ms/teamsjs/shareAppContentToStage
      */
@@ -977,7 +977,7 @@ export namespace meeting {
   }
 
   /** The source of the join button click. */
-  export const enum EventActionSource {
+  export enum EventActionSource {
     /**
      * Source is calendar grid context menu.
      */

--- a/packages/teams-js/src/public/menus.ts
+++ b/packages/teams-js/src/public/menus.ts
@@ -144,7 +144,7 @@ export namespace menus {
    * @hidden
    * Represents information about type of list to display in Navigation Bar Menu.
    */
-  export const enum MenuListType {
+  export enum MenuListType {
     dropDown = 'dropDown',
     popOver = 'popOver',
   }

--- a/packages/teams-js/src/public/stageView.ts
+++ b/packages/teams-js/src/public/stageView.ts
@@ -60,7 +60,7 @@ export namespace stageView {
   /**
    * The open mode for stage content.
    */
-  export const enum StageViewOpenMode {
+  export enum StageViewOpenMode {
     /**
      * Open the content in a modal.
      */

--- a/packages/teams-js/src/public/videoEffects.ts
+++ b/packages/teams-js/src/public/videoEffects.ts
@@ -66,7 +66,7 @@ export namespace videoEffects {
    * Video frame format enum, currently only support NV12
    * @beta
    */
-  export const enum VideoFrameFormat {
+  export enum VideoFrameFormat {
     /** Video format used for encoding and decoding YUV color data in video streaming and storage applications. */
     NV12 = 'NV12',
   }
@@ -86,7 +86,7 @@ export namespace videoEffects {
    * Video effect change type enum
    * @beta
    */
-  export const enum EffectChangeType {
+  export enum EffectChangeType {
     /**
      * Current video effect changed
      */


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Initially when making the const enum changes , I made the changes with the understanding that string enums inherently did not get reverse mappings, so it would not be an issue to make all of the public string enums const. However, I have recently learned that by making an enum const, it not only removes the reverse mapping functionality, but completely removes the object at runtime and inlines the values, which could potentially lead to client issues if they are accessing any of the const enums objects at runtime such as through the `Object.values(<enum>)` method. This reintroduces some package size but is necessary as to not potentially cause issue with the next release. 

## Validation

### Validation performed:

1. <Step 1>
3. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
