### PR TITLE
MessageChannels.getTelemetryPort: Add E2E Test JSON

### DIFF
--- a/apps/teams-test-app/e2e-test-data/messageChannels.json
+++ b/apps/teams-test-app/e2e-test-data/messageChannels.json
@@ -1,16 +1,11 @@
 {
   "name": "Message Channels",
-  "checkIsSupported": {
-    "capabilityName": "MessageChannels",
-    "expectedOutput": "MessageChannels is not supported",
-    "testUrlParams": []
-  },
   "platforms": "Web",
   "testCases": [
     {
       "title": "getTelemetryPort API Call - Success",
       "type": "callResponse",
-      "version": ">2.20.0",
+      "version": ">=2.20.0",
       "hostSdkVersion": {
         "web": ">=2.12.0"
       },
@@ -20,7 +15,7 @@
     {
       "title": "getTelemetryPort API Call - Failure (Not MS Owned)",
       "type": "callResponse",
-      "version": ">2.20.0",
+      "version": ">=2.20.0",
       "hostSdkVersion": {
         "web": ">=2.12.0"
       },

--- a/apps/teams-test-app/e2e-test-data/messageChannels.json
+++ b/apps/teams-test-app/e2e-test-data/messageChannels.json
@@ -1,0 +1,26 @@
+{
+  "name": "Message Channels",
+  "checkIsSupported": {
+    "capabilityName": "MessageChannels",
+    "expectedOutput": "MessageChannels is not supported",
+    "testUrlParams": []
+  },
+  "platforms": "Web",
+  "testCases": [
+    {
+      "title": "getTelemetryPort API Call - Success",
+      "type": "callResponse",
+      "version": ">2.10.0",
+      "boxSelector": "#box_checkTelemetryPort",
+      "expectedTestAppValue": "Telemetry port: [object MessagePort]"
+    },
+    {
+      "title": "getTelemetryPort API Call - Failure (Not MS Owned)",
+      "type": "callResponse",
+      "version": ">2.10.0",
+      "boxSelector": "#box_checkTelemetryPort",
+      "testUrlParams": [["appDefOverrides", "{\"isMicrosoftOwned\": false}"]],
+      "expectedTestAppValue": "Error: {\"errorCode\":500,\"message\":\"App does not have the required permissions for this operation\"}"
+    }
+  ]
+}

--- a/apps/teams-test-app/e2e-test-data/messageChannels.json
+++ b/apps/teams-test-app/e2e-test-data/messageChannels.json
@@ -10,14 +10,20 @@
     {
       "title": "getTelemetryPort API Call - Success",
       "type": "callResponse",
-      "version": ">2.10.0",
+      "version": ">2.20.0",
+      "hostSdkVersion": {
+        "web": ">=2.12.0"
+      },
       "boxSelector": "#box_checkTelemetryPort",
       "expectedTestAppValue": "Telemetry port: [object MessagePort]"
     },
     {
       "title": "getTelemetryPort API Call - Failure (Not MS Owned)",
       "type": "callResponse",
-      "version": ">2.10.0",
+      "version": ">2.20.0",
+      "hostSdkVersion": {
+        "web": ">=2.12.0"
+      },
       "boxSelector": "#box_checkTelemetryPort",
       "testUrlParams": [["appDefOverrides", "{\"isMicrosoftOwned\": false}"]],
       "expectedTestAppValue": "Error: {\"errorCode\":500,\"message\":\"App does not have the required permissions for this operation\"}"

--- a/apps/teams-test-app/e2e-test-data/messageChannels.json
+++ b/apps/teams-test-app/e2e-test-data/messageChannels.json
@@ -1,24 +1,20 @@
 {
   "name": "Message Channels",
   "platforms": "Web",
+  "version": ">=2.20.0",
+  "hostSdkVersion": {
+    "web": ">=2.12.0"
+  },
   "testCases": [
     {
       "title": "getTelemetryPort API Call - Success",
       "type": "callResponse",
-      "version": ">=2.20.0",
-      "hostSdkVersion": {
-        "web": ">=2.12.0"
-      },
       "boxSelector": "#box_checkTelemetryPort",
       "expectedTestAppValue": "Telemetry port: [object MessagePort]"
     },
     {
       "title": "getTelemetryPort API Call - Failure (Not MS Owned)",
       "type": "callResponse",
-      "version": ">=2.20.0",
-      "hostSdkVersion": {
-        "web": ">=2.12.0"
-      },
       "boxSelector": "#box_checkTelemetryPort",
       "testUrlParams": [["appDefOverrides", "{\"isMicrosoftOwned\": false}"]],
       "expectedTestAppValue": "Error: {\"errorCode\":500,\"message\":\"App does not have the required permissions for this operation\"}"

--- a/apps/teams-test-app/src/components/privateApis/MessageChannelAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/MessageChannelAPIs.tsx
@@ -4,12 +4,18 @@ import React from 'react';
 import { ApiWithoutInput } from '../utils';
 import { ModuleWrapper } from '../utils/ModuleWrapper';
 
+const CheckMessageChannelsCapability = (): React.ReactElement =>
+  ApiWithoutInput({
+    name: 'checkMessageChannelsCapability',
+    title: 'Check Message Channels Capability',
+    onClick: async () => `MessageChannels ${messageChannels.isSupported() ? 'is' : 'is not'} supported`,
+  });
+
 const GetTelemetryPort = (): React.ReactElement =>
   ApiWithoutInput({
     name: 'checkTelemetryPort',
-    title: 'Check Telemetry Port Capability',
+    title: 'Check Telemetry Port API',
     onClick: async () => {
-      // TODO this is test app, need to look at how this should be tested
       const port = await messageChannels.getTelemetryPort();
       port.postMessage('test message through telemetry port');
       return `Telemetry port: ${port}`;
@@ -19,6 +25,7 @@ const GetTelemetryPort = (): React.ReactElement =>
 const MessageChannelAPIs = (): React.ReactElement => (
   <ModuleWrapper title="Message Channels">
     <GetTelemetryPort />
+    <CheckMessageChannelsCapability />
   </ModuleWrapper>
 );
 


### PR DESCRIPTION
## Description

This change updates the test app and adds JSON for E2E tests for the MessageChannels.getTelemetryPort function.

A follow up PR will add the capability test for MessageChannels once the test app changes are tied to a published version.

### Main changes in the PR:

1. Update test app to have capability check box
2. Create test JSON

## Validation

### Validation performed:

1. Test JSON was validated with an external test runner

### Unit Tests added:
No, this is follow up to the main change [here](https://github.com/OfficeDev/microsoft-teams-library-js/pull/2140), where the unit tests were added.

### End-to-end tests added:

Yes

## Additional Requirements

### Change file added:

Not required for adding an E2E (no changes to published packages)

### Related PRs:

[https://github.com/OfficeDev/microsoft-teams-library-js/pull/2140](https://github.com/OfficeDev/microsoft-teams-library-js/pull/2140)
