### PR TITLE
Defer auth window to Hosts.

### DIFF
--- a/change/@microsoft-teams-js-5f6c016e-96a3-464a-95e1-67d1f38531b0.json
+++ b/change/@microsoft-teams-js-5f6c016e-96a3-464a-95e1-67d1f38531b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Defer auth window to host.",
+  "packageName": "@microsoft/teams-js",
+  "email": "98348000+shrshindeMSFT@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-teams-js-5f6c016e-96a3-464a-95e1-67d1f38531b0.json
+++ b/change/@microsoft-teams-js-5f6c016e-96a3-464a-95e1-67d1f38531b0.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "patch",
   "comment": "Updated `authentication.authenticate` method to defer authentication requests in web hosts to the host, rather than handling internally (requests on all other types of hosts were already being deferred)",
   "packageName": "@microsoft/teams-js",
   "email": "98348000+shrshindeMSFT@users.noreply.github.com",

--- a/change/@microsoft-teams-js-5f6c016e-96a3-464a-95e1-67d1f38531b0.json
+++ b/change/@microsoft-teams-js-5f6c016e-96a3-464a-95e1-67d1f38531b0.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Updated authentication.authenticate method to defer authentication requests in web hosts to the host, rather than handling internally (requests on all other types of hosts were already being deferred)",
+  "comment": "Updated `authentication.authenticate` method to defer authentication requests in web hosts to the host, rather than handling internally (requests on all other types of hosts were already being deferred)",
   "packageName": "@microsoft/teams-js",
   "email": "98348000+shrshindeMSFT@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/change/@microsoft-teams-js-5f6c016e-96a3-464a-95e1-67d1f38531b0.json
+++ b/change/@microsoft-teams-js-5f6c016e-96a3-464a-95e1-67d1f38531b0.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Defer auth window to host.",
+  "comment": "Updated authentication.authenticate method to defer authentication requests in web hosts to the host, rather than handling internally (requests on all other types of hosts were already being deferred)",
   "packageName": "@microsoft/teams-js",
   "email": "98348000+shrshindeMSFT@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -19,7 +19,6 @@ import { getLogger } from '../internal/telemetry';
 import { isNullOrUndefined } from '../internal/typeCheckUtilities';
 import { compareSDKVersions, inServerSideRenderingEnvironment, runWithTimeout } from '../internal/utils';
 import { prefetchOriginsFromCDN } from '../internal/validOrigins';
-// import { authentication } from './authentication';
 import { ChannelType, FrameContexts, HostClientType, HostName, TeamType, UserTeamRole } from './constants';
 import { dialog } from './dialog';
 import { ActionInfo, Context as LegacyContext, FileOpenPreference, LocaleInfo, ResumeContext } from './interfaces';

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -19,7 +19,7 @@ import { getLogger } from '../internal/telemetry';
 import { isNullOrUndefined } from '../internal/typeCheckUtilities';
 import { compareSDKVersions, inServerSideRenderingEnvironment, runWithTimeout } from '../internal/utils';
 import { prefetchOriginsFromCDN } from '../internal/validOrigins';
-import { authentication } from './authentication';
+// import { authentication } from './authentication';
 import { ChannelType, FrameContexts, HostClientType, HostName, TeamType, UserTeamRole } from './constants';
 import { dialog } from './dialog';
 import { ActionInfo, Context as LegacyContext, FileOpenPreference, LocaleInfo, ResumeContext } from './interfaces';
@@ -164,7 +164,6 @@ function initializeHelper(apiVersionTag: string, validMessageOrigins?: string[])
         },
       );
 
-      authentication.initialize();
       menus.initialize();
       pages.config.initialize();
       dialog.initialize();

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -4,7 +4,6 @@ import {
   sendMessageToParentAsync,
   waitForMessageQueue,
 } from '../internal/communication';
-// import { registerHandler, removeHandler } from '../internal/handlers';
 import { ensureInitializeCalled, ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
 import { FrameContexts } from './constants';

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -334,17 +334,6 @@ describe('Testing app capability', () => {
         });
       });
 
-      it('app.initialize should call authentication.initialize', async () => {
-        const spy = jest.spyOn(authentication, 'initialize');
-
-        const initPromise = app.initialize();
-        const initMessage = utils.findMessageByFunc('initialize');
-        await utils.respondToMessage(initMessage, FrameContexts.content);
-        await initPromise;
-
-        expect(spy).toHaveBeenCalled();
-      });
-
       it('app.initialize should call menus.initialize', async () => {
         const spy = jest.spyOn(menus, 'initialize');
 
@@ -1220,22 +1209,6 @@ describe('Testing app capability', () => {
 
           expect(GlobalVars.hostClientType).toBe(hostClientType);
         });
-      });
-
-      it('app.initialize should call authentication.initialize', async () => {
-        const spy = jest.spyOn(authentication, 'initialize');
-
-        const initPromise = app.initialize();
-        const initMessage = utils.findMessageByFunc('initialize');
-        await utils.respondToFramelessMessage({
-          data: {
-            id: initMessage.id,
-            args: [],
-          },
-        } as DOMMessageEvent);
-        await initPromise;
-
-        expect(spy).toHaveBeenCalled();
       });
 
       it('app.initialize should call menus.initialize', async () => {

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
-import { authentication, dialog, menus, pages } from '../../src/public';
+import { dialog, menus, pages } from '../../src/public';
 import { app } from '../../src/public/app';
 import {
   ChannelType,

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -630,55 +630,53 @@ describe('Testing authentication capability', () => {
             );
           });
         } else {
-          allowedHostClientType.forEach((hostClientType) => {
-            it(`authentication.authenticate should successfully ask parent window to open auth window with parameters in the ${hostClientType} client from ${context} context`, async () => {
-              await utils.initializeWithContext(context, hostClientType);
-              const authenticationParams: authentication.AuthenticatePopUpParameters = {
-                url: 'https://someurl',
-                width: 100,
-                height: 200,
-                isExternal: true,
-              };
-              const promise = authentication.authenticate(authenticationParams);
+          it(`authentication.authenticate should successfully ask parent window to open auth window with parameters from ${context} context`, async () => {
+            await utils.initializeWithContext(context);
+            const authenticationParams: authentication.AuthenticatePopUpParameters = {
+              url: 'https://someurl',
+              width: 100,
+              height: 200,
+              isExternal: true,
+            };
+            const promise = authentication.authenticate(authenticationParams);
 
-              const message = utils.findMessageByFunc('authentication.authenticate');
-              expect(message).not.toBeNull();
-              expect(message.args.length).toBe(4);
-              expect(message.args[0]).toBe(authenticationParams.url.toLowerCase() + '/');
-              expect(message.args[1]).toBe(authenticationParams.width);
-              expect(message.args[2]).toBe(authenticationParams.height);
-              expect(message.args[3]).toBe(authenticationParams.isExternal);
+            const message = utils.findMessageByFunc('authentication.authenticate');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(4);
+            expect(message.args[0]).toBe(authenticationParams.url.toLowerCase() + '/');
+            expect(message.args[1]).toBe(authenticationParams.width);
+            expect(message.args[2]).toBe(authenticationParams.height);
+            expect(message.args[3]).toBe(authenticationParams.isExternal);
 
-              await utils.respondToFramelessMessage({
-                data: {
-                  id: message.id,
-                  args: [true, mockResult],
-                },
-              } as DOMMessageEvent);
-              await expect(promise).resolves.toEqual(mockResult);
-            });
+            await utils.respondToFramelessMessage({
+              data: {
+                id: message.id,
+                args: [true, mockResult],
+              },
+            } as DOMMessageEvent);
+            await expect(promise).resolves.toEqual(mockResult);
+          });
 
-            it(`authentication.authenticate should handle auth failure with parameters in the ${hostClientType} client from ${context} context`, async () => {
-              await utils.initializeWithContext(context, hostClientType);
-              const authenticationParams: authentication.AuthenticatePopUpParameters = {
-                url: 'https://someurl',
-                width: 100,
-                height: 200,
-                isExternal: true,
-              };
-              const promise = authentication.authenticate(authenticationParams);
+          it(`authentication.authenticate should handle auth failure with parameters from ${context} context`, async () => {
+            await utils.initializeWithContext(context);
+            const authenticationParams: authentication.AuthenticatePopUpParameters = {
+              url: 'https://someurl',
+              width: 100,
+              height: 200,
+              isExternal: true,
+            };
+            const promise = authentication.authenticate(authenticationParams);
 
-              const message = utils.findMessageByFunc('authentication.authenticate');
-              await utils.respondToFramelessMessage({
-                data: {
-                  id: message.id,
-                  func: 'authentication.authenticate.failure',
-                  args: [false, errorMessage],
-                },
-              } as DOMMessageEvent);
+            const message = utils.findMessageByFunc('authentication.authenticate');
+            await utils.respondToFramelessMessage({
+              data: {
+                id: message.id,
+                func: 'authentication.authenticate.failure',
+                args: [false, errorMessage],
+              },
+            } as DOMMessageEvent);
 
-              await expect(promise).rejects.toThrowError(errorMessage);
-            });
+            await expect(promise).rejects.toThrowError(errorMessage);
           });
         }
       });

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -1,4 +1,3 @@
-// import * as communication from '../../src/internal/communication';
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import * as handlers from '../../src/internal/handlers';
@@ -47,19 +46,7 @@ describe('Testing authentication capability', () => {
     FrameContexts.meetingStage,
   ];
 
-  const allowedHostClientType = [
-    HostClientType.desktop,
-    HostClientType.android,
-    HostClientType.ios,
-    HostClientType.ipados,
-    HostClientType.macos,
-    HostClientType.rigel,
-    HostClientType.teamsRoomsWindows,
-    HostClientType.teamsRoomsAndroid,
-    HostClientType.teamsPhones,
-    HostClientType.teamsDisplays,
-    HostClientType.surfaceHub,
-  ];
+  const allowedHostClientType = Object.values(HostClientType);
   describe('FRAMED - authentication tests', () => {
     let utils: Utils = new Utils();
     beforeEach(() => {
@@ -85,17 +72,6 @@ describe('Testing authentication capability', () => {
         if (allowedContexts.some((allowedContexts) => allowedContexts === context)) {
           it(`authentication.registerAuthenticationHandlers should successfully pop up the auth window when authenticate called with authenticationParams for connectors with ${context} context`, async () => {
             await utils.initializeWithContext(context);
-            let windowOpenCalled = false;
-            jest.spyOn(utils.mockWindow, 'open').mockImplementation((url, name, specsInput): Window => {
-              const specs: string = specsInput as string;
-              expect(url).toEqual('https://someurl/');
-              expect(name).toEqual('_blank');
-              expect(specs.indexOf('width=100')).not.toBe(-1);
-              expect(specs.indexOf('height=200')).not.toBe(-1);
-              windowOpenCalled = true;
-              return utils.childWindow as Window;
-            });
-
             const authenticationParams = {
               url: 'https://someurl/',
               width: 100,
@@ -103,7 +79,12 @@ describe('Testing authentication capability', () => {
             };
             authentication.registerAuthenticationHandlers(authenticationParams);
             authentication.authenticate();
-            expect(windowOpenCalled).toBe(true);
+            const message = utils.findMessageByFunc('authentication.authenticate');
+            expect(message).not.toBeNull();
+            expect(message.args.length).toBe(4);
+            expect(message.args[0]).toBe(authenticationParams.url.toLowerCase());
+            expect(message.args[1]).toBe(authenticationParams.width);
+            expect(message.args[2]).toBe(authenticationParams.height);
           });
         }
       });
@@ -131,310 +112,75 @@ describe('Testing authentication capability', () => {
 
       Object.values(FrameContexts).forEach((context) => {
         if (allowedContexts.some((allowedContext) => allowedContext === context)) {
-          it(`authentication.authenticate should allow calls from ${context} context`, async () => {
-            await utils.initializeWithContext(context);
-
-            const authenticationParams: authentication.AuthenticatePopUpParameters = {
-              url: 'https://someurl/',
-              width: 100,
-              height: 200,
-            };
-            const promise = authentication.authenticate(authenticationParams);
-
-            utils.processMessage({
-              origin: utils.tabOrigin,
-              source: utils.childWindow,
-              data: {
-                id: 0,
-                func: 'authentication.authenticate.success',
-                args: [mockResult],
-              },
-            } as MessageEvent);
-
-            await expect(promise).resolves.toEqual(mockResult);
-          });
-
-          it(`authentication.authenticate should successfully pop up the auth window when initialized with ${context} context`, async () => {
-            expect.assertions(5);
-            await utils.initializeWithContext(context);
-
-            let windowOpenCalled = false;
-            jest.spyOn(utils.mockWindow, 'open').mockImplementation((url, name, specsInput): Window => {
-              const specs: string = specsInput as string;
-              expect(url).toEqual('https://someurl/');
-              expect(name).toEqual('_blank');
-              expect(specs.indexOf('width=100')).not.toBe(-1);
-              expect(specs.indexOf('height=200')).not.toBe(-1);
-              windowOpenCalled = true;
-              return utils.childWindow as Window;
-            });
-
-            const authenticationParams: authentication.AuthenticatePopUpParameters = {
-              url: 'https://someurl/',
-              width: 100,
-              height: 200,
-            };
-            authentication.authenticate(authenticationParams);
-            expect(windowOpenCalled).toBe(true);
-          });
-
-          it(`authentication.authenticate should cancel the flow when the auth window gets closed before notifySuccess/notifyFailure are called in legacy flow from ${context} context`, async () => {
-            expect.assertions(5);
-            await utils.initializeWithContext(context);
-
-            let windowOpenCalled = false;
-            jest.spyOn(utils.mockWindow, 'open').mockImplementation((url, name, specsInput): Window => {
-              const specs: string = specsInput as string;
-              expect(url).toEqual('https://someurl/');
-              expect(name).toEqual('_blank');
-              expect(specs.indexOf('width=100')).not.toBe(-1);
-              expect(specs.indexOf('height=200')).not.toBe(-1);
-              windowOpenCalled = true;
-              return utils.childWindow as Window;
-            });
-            const authenticationParams = {
-              url: 'https://someurl/',
-              width: 100,
-              height: 200,
-              successCallback: () => {
-                expect(true).toBe(false);
-              },
-              failureCallback: (reason: string) => {
-                expect(reason).toEqual('CancelledByUser');
-              },
-            };
-            authentication.authenticate(authenticationParams);
-            expect(windowOpenCalled).toBe(true);
-
-            utils.childWindow.closed = true;
-          });
-
-          it(`authentication.authenticate should successfully handle auth success in legacy flow from ${context} context`, (done) => {
-            utils.initializeWithContext(context).then(() => {
-              const authenticationParams = {
-                url: 'https://someurl/',
-                width: 100,
-                height: 200,
-                successCallback: (result: string) => {
-                  expect(result).toEqual(mockResult);
-                  done();
-                },
-                failureCallback: () => {
-                  done();
-                },
-              };
-              authentication.authenticate(authenticationParams);
-
-              utils.processMessage({
-                origin: utils.tabOrigin,
-                source: utils.childWindow,
-                data: {
-                  id: 0,
-                  func: 'authentication.authenticate.success',
-                  args: [mockResult],
-                },
-              } as MessageEvent);
-            });
-          });
-
-          it(`authentication.authenticate should cancel the flow when the auth window gets closed before notifySuccess/notifyFailure are called from ${context} context`, async () => {
-            // This test actually needs the interval to work so that the window "closes"
-            utils.mockWindow.setInterval = (handler: Function, timeout: number): number => setInterval(handler, 0);
-            expect.assertions(6);
-            await utils.initializeWithContext(context);
-
-            let windowOpenCalled = false;
-            jest.spyOn(utils.mockWindow, 'open').mockImplementation((url, name, specsInput): Window => {
-              const specs: string = specsInput as string;
-              expect(url).toEqual('https://someurl/');
-              expect(name).toEqual('_blank');
-              expect(specs.indexOf('width=100')).not.toBe(-1);
-              expect(specs.indexOf('height=200')).not.toBe(-1);
-              windowOpenCalled = true;
-              return utils.childWindow as Window;
-            });
-
-            const authenticationParams: authentication.AuthenticatePopUpParameters = {
-              url: 'https://someurl/',
-              width: 100,
-              height: 200,
-            };
-            const promise = authentication.authenticate(authenticationParams);
-            expect(windowOpenCalled).toBe(true);
-
-            utils.childWindow.closed = true;
-            await expect(promise).rejects.toThrowError('CancelledByUser');
-          });
-
-          it(`authentication.authenticate should successfully handle auth success from ${context} context`, async () => {
-            await utils.initializeWithContext(context);
-
-            const authenticationParams = {
-              url: 'https://someurl/',
-              width: 100,
-              height: 200,
-            };
-            const promise = authentication.authenticate(authenticationParams);
-
-            utils.processMessage({
-              origin: utils.tabOrigin,
-              source: utils.childWindow,
-              data: {
-                id: 0,
-                func: 'authentication.authenticate.success',
-                args: [mockResult],
-              },
-            } as MessageEvent);
-
-            await expect(promise).resolves.toEqual(mockResult);
-          });
-
-          it(`authentication.authenticate should handle auth failure in legacy flow from ${context} context`, (done) => {
-            utils.initializeWithContext(context).then(() => {
-              const authenticationParams = {
-                url: 'https://someurl/',
-                width: 100,
-                height: 200,
-                successCallback: () => {
-                  done();
-                },
-                failureCallback: (reason: string) => {
-                  expect(reason).toEqual(errorMessage);
-                  done();
-                },
-              };
-              authentication.authenticate(authenticationParams);
-
-              utils.processMessage({
-                origin: utils.tabOrigin,
-                source: utils.childWindow,
-                data: {
-                  id: 0,
-                  func: 'authentication.authenticate.failure',
-                  args: [errorMessage],
-                },
-              } as MessageEvent);
-            });
-          });
-
-          it(`authentication.authenticate should handle auth failure from ${context} context`, async () => {
-            await utils.initializeWithContext(context);
-
-            const authenticationParams = {
-              url: 'https://someurl/',
-              width: 100,
-              height: 200,
-            };
-            const promise = authentication.authenticate(authenticationParams);
-
-            utils.processMessage({
-              origin: utils.tabOrigin,
-              source: utils.childWindow,
-              data: {
-                id: 0,
-                func: 'authentication.authenticate.failure',
-                args: [errorMessage],
-              },
-            } as MessageEvent);
-
-            await expect(promise).rejects.toThrowError(errorMessage);
-          });
-
           Object.values(HostClientType).forEach((hostClientType) => {
-            if (allowedHostClientType.includes(hostClientType)) {
-              it(`authentication.authenticate should successfully send authenticate message to ${hostClientType} client in legacy flow from ${context} context`, () => {
-                return utils.initializeWithContext(context, hostClientType).then(() => {
-                  const authenticationParams = {
-                    url: 'https://someUrl',
-                    width: 100,
-                    height: 200,
-                    isExternal: true,
-                  };
-
-                  authentication.authenticate(authenticationParams);
-                  const message = utils.findMessageByFunc('authentication.authenticate');
-                  expect(message).not.toBeNull();
-                  expect(message.args.length).toBe(4);
-                  expect(message.args[0]).toBe(authenticationParams.url.toLowerCase() + '/');
-                  expect(message.args[1]).toBe(authenticationParams.width);
-                  expect(message.args[2]).toBe(authenticationParams.height);
-                  expect(message.args[3]).toBe(authenticationParams.isExternal);
-                });
-              });
-
-              it(`authentication.authenticate it should successfully handle auth success in the ${hostClientType} client in legacy flow from ${context} context`, (done) => {
-                utils.initializeWithContext(context, hostClientType).then(async () => {
-                  const authenticationParams = {
-                    url: 'https://someUrl',
-                    width: 100,
-                    height: 200,
-                    successCallback: (result: string) => {
-                      expect(result).toEqual(mockResult);
-                      done();
-                    },
-                    failureCallback: () => {
-                      expect(true).toBe(false);
-                      done();
-                    },
-                  };
-                  authentication.authenticate(authenticationParams);
-
-                  expect.assertions(2);
-                  const message = utils.findMessageByFunc('authentication.authenticate');
-                  expect(message).not.toBeNull();
-                  await utils.respondToMessage(message, true, mockResult);
-                });
-              });
-
-              it(`authentication.authenticate should successfully handle auth failure in the ${hostClientType} client in legacy flow from ${context} context`, (done) => {
-                expect.assertions(2);
-                utils.initializeWithContext(context, hostClientType).then(async () => {
-                  const authenticationParams = {
-                    url: 'https://someUrl',
-                    width: 100,
-                    height: 200,
-                    successCallback: () => {
-                      expect(true).toBe(false);
-                      done();
-                    },
-                    failureCallback: (reason: string) => {
-                      expect(reason).toEqual(errorMessage);
-                      done();
-                    },
-                  };
-                  authentication.authenticate(authenticationParams);
-
-                  const message = utils.findMessageByFunc('authentication.authenticate');
-                  expect(message).not.toBeNull();
-
-                  await utils.respondToMessage(message, false, errorMessage);
-                });
-              });
-            } else {
-              it(`authentication.authenticate should open a client window in the ${hostClientType} client in legacy flow from ${context} context`, async () => {
-                expect.assertions(5);
-                await utils.initializeWithContext(context, hostClientType);
-
-                let windowOpenCalled = false;
-                jest.spyOn(utils.mockWindow, 'open').mockImplementation((url, name, specsInput): Window => {
-                  const specs: string = specsInput as string;
-                  expect(url).toEqual('https://someurl/');
-                  expect(name).toEqual('_blank');
-                  expect(specs.indexOf('width=100')).not.toBe(-1);
-                  expect(specs.indexOf('height=200')).not.toBe(-1);
-                  windowOpenCalled = true;
-                  return utils.childWindow as Window;
-                });
-
-                const authenticationParams: authentication.AuthenticatePopUpParameters = {
-                  url: 'https://someurl/',
+            it(`authentication.authenticate should successfully send authenticate message to ${hostClientType} client in legacy flow from ${context} context`, () => {
+              return utils.initializeWithContext(context, hostClientType).then(() => {
+                const authenticationParams = {
+                  url: 'https://someUrl',
                   width: 100,
                   height: 200,
+                  isExternal: true,
+                };
+
+                authentication.authenticate(authenticationParams);
+                const message = utils.findMessageByFunc('authentication.authenticate');
+                expect(message).not.toBeNull();
+                expect(message.args.length).toBe(4);
+                expect(message.args[0]).toBe(authenticationParams.url.toLowerCase() + '/');
+                expect(message.args[1]).toBe(authenticationParams.width);
+                expect(message.args[2]).toBe(authenticationParams.height);
+                expect(message.args[3]).toBe(authenticationParams.isExternal);
+              });
+            });
+
+            it(`authentication.authenticate it should successfully handle auth success in the ${hostClientType} client in legacy flow from ${context} context`, (done) => {
+              utils.initializeWithContext(context, hostClientType).then(async () => {
+                const authenticationParams = {
+                  url: 'https://someUrl',
+                  width: 100,
+                  height: 200,
+                  successCallback: (result: string) => {
+                    expect(result).toEqual(mockResult);
+                    done();
+                  },
+                  failureCallback: () => {
+                    expect(true).toBe(false);
+                    done();
+                  },
                 };
                 authentication.authenticate(authenticationParams);
-                expect(windowOpenCalled).toBe(true);
+
+                expect.assertions(2);
+                const message = utils.findMessageByFunc('authentication.authenticate');
+                expect(message).not.toBeNull();
+                await utils.respondToMessage(message, true, mockResult);
               });
-            }
+            });
+
+            it(`authentication.authenticate should successfully handle auth failure in the ${hostClientType} client in legacy flow from ${context} context`, (done) => {
+              expect.assertions(2);
+              utils.initializeWithContext(context, hostClientType).then(async () => {
+                const authenticationParams = {
+                  url: 'https://someUrl',
+                  width: 100,
+                  height: 200,
+                  successCallback: () => {
+                    expect(true).toBe(false);
+                    done();
+                  },
+                  failureCallback: (reason: string) => {
+                    expect(reason).toEqual(errorMessage);
+                    done();
+                  },
+                };
+                authentication.authenticate(authenticationParams);
+
+                const message = utils.findMessageByFunc('authentication.authenticate');
+                expect(message).not.toBeNull();
+
+                await utils.respondToMessage(message, false, errorMessage);
+              });
+            });
           });
         } else {
           it(`authentication.authenticate should not allow calls from ${context} context`, async () => {

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -1,6 +1,5 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
-import * as handlers from '../../src/internal/handlers';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { FrameContexts, HostClientType } from '../../src/public';
 import { app } from '../../src/public/app';

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -59,14 +59,6 @@ describe('Testing authentication capability', () => {
       app._uninitialize();
     });
 
-    describe('Testing authentication.initialize function', () => {
-      it('authentication.initialize should successfully register authentication.authenticate.success/failure handler', async () => {
-        const spy = jest.spyOn(handlers, 'registerHandler');
-        authentication.initialize();
-        expect(spy).toBeCalledTimes(2);
-      });
-    });
-
     describe('Testing authentication.registerAuthenticationHandlers function', () => {
       Object.values(FrameContexts).forEach((context) => {
         if (allowedContexts.some((allowedContexts) => allowedContexts === context)) {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

There is code in teamsjs to display and communicate with an auth window. It only executes in certain circumstances (when the host environment is web). In all other case, this function defers to the host. In the recent Copilot work, it came to an understanding that unconditionally deferring to the host always seems to work, even in web environments. Based on this, removing the authentication code in teamsjs and just always defer to the host in all situations. Hence this PR addresses this removal of code from `authentication.authenticate` function. 

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Update the `authentication.authenticate` code to defer to host in all host client type. 
2. Update unit test cases accordingly.

## Validation

### Validation performed:

1. Updated unit test cases and verified in E2E test cases.

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes

### End-to-end tests added:

N/A

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes
