### PR TITLE
Split iOS E2E Testing pipeline to two

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -246,7 +246,7 @@ extends:
                   androidAppHostingSdkGitPath: AndroidAppHostingSdk
 
           - job: E2ETestIOS
-            displayName: 'E2E Test - IOS'
+            displayName: 'E2E Test - IOS - Plan A'
             pool:
               name: Azure Pipelines
               image: internal-macos12
@@ -255,3 +255,16 @@ extends:
               - template: tools/yaml-templates/ios-test.yml@self
                 parameters:
                   iOSAppHostingSdkGitPath: IOSAppHostingSdk
+                  testPlan: iosE2ETestPlanA
+
+          - job: E2ETestIOS
+            displayName: 'E2E Test - IOS - Plan B'
+            pool:
+              name: Azure Pipelines
+              image: internal-macos12
+              os: macOS
+            steps:
+              - template: tools/yaml-templates/ios-test.yml@self
+                parameters:
+                  iOSAppHostingSdkGitPath: IOSAppHostingSdk
+                  testPlan: iosE2ETestPlanB

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -257,7 +257,7 @@ extends:
                   iOSAppHostingSdkGitPath: IOSAppHostingSdk
                   testPlan: iosE2ETestPlanA
 
-          - job: E2ETestIOS
+          - job: E2ETestIOS2
             displayName: 'E2E Test - IOS - Plan B'
             pool:
               name: Azure Pipelines

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -67,8 +67,8 @@ steps:
       scheme: 'hubsdkiOS'
       sdk: 'iphoneos'
       configuration: 'Release'
-      workingDirectory: 'metaos-hub-sdk-iOS'
-      xcWorkspacePath: 'metaos-hub-sdk-iOS/$(IOSSdkWorkspace).xcworkspace'
+      workingDirectory: '$(iOSSdk)'
+      xcWorkspacePath: '$(iOSSdk)/$(IOSSdkWorkspace).xcworkspace'
       xcodeVersion: 'default' # Options: 8, 9, 10, 11, 12, default, specifyPath
       xcodeBuildArguments: 'CODE_SIGNING_ALLOWED=NO clean build -derivedDataPath "$(agent.buildDirectory)/iOS/DerivedData"'
 

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -2,6 +2,9 @@ parameters:
   - name: 'iOSAppHostingSdkGitPath'
     default: none
     type: string
+  - name: 'testPlan'
+    default: iosE2ETestPlan
+    type: string
 
 steps:
   - checkout: self

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -60,16 +60,18 @@ steps:
       script: 'nohup pnpm start-test-app &'
       workingDirectory: '$(ClientSdkProjectDirectory)'
 
+  # Ideally, iOS Host SDK will be built as a dependency before running E2E Test, but there is no harm to build it again for a minute.
+  # In practice, building iOS Host SDK before E2E test reduces flaky failure rate comparing to run E2E test directly.
   - task: Xcode@5
     displayName: '[iOS] Build iOS Host SDK'
     inputs:
       actions: 'build'
-      scheme: 'hubsdkiOS'
+      scheme: $(IOSSdkScheme)
       sdk: 'iphoneos'
       configuration: 'Release'
       workingDirectory: '/Users/runner/work/1/iOSHost'
       xcWorkspacePath: '/Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace'
-      xcodeVersion: 'default' # Options: 8, 9, 10, 11, 12, default, specifyPath
+      xcodeVersion: 'default'
       xcodeBuildArguments: 'CODE_SIGNING_ALLOWED=NO clean build -derivedDataPath "$(agent.buildDirectory)/iOS/DerivedData"'
 
   - task: Bash@3
@@ -83,7 +85,7 @@ steps:
     displayName: 'iOS UI/E2E Tests'
     inputs:
       targetType: inline
-      script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' -screenshot-enabled=\"YES\" -quiet -resultBundlePath TestResults test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
+      script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' -screenshot-enabled=\"YES\" -quiet -resultBundlePath TestResults test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   - task: Bash@3

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -71,11 +71,7 @@ steps:
     displayName: 'iOS UI/E2E Tests'
     inputs:
       targetType: inline
-<<<<<<< HEAD
       script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' -screenshot-enabled=\"YES\" -quiet -resultBundlePath TestResults test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
-=======
-      script: '/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkScheme) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination "platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2" -screenshot-enabled="YES" -quiet -resultBundlePath TestResults test'
->>>>>>> a18728d8 (update)
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   - task: Bash@3

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -67,8 +67,8 @@ steps:
       scheme: 'hubsdkiOS'
       sdk: 'iphoneos'
       configuration: 'Release'
-      workingDirectory: '$(iOSSdk)'
-      xcWorkspacePath: '$(iOSSdk)/$(IOSSdkWorkspace).xcworkspace'
+      workingDirectory: '/Users/runner/work/1/iOSHost'
+      xcWorkspacePath: '/Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace'
       xcodeVersion: 'default' # Options: 8, 9, 10, 11, 12, default, specifyPath
       xcodeBuildArguments: 'CODE_SIGNING_ALLOWED=NO clean build -derivedDataPath "$(agent.buildDirectory)/iOS/DerivedData"'
 

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -60,6 +60,18 @@ steps:
       script: 'nohup pnpm start-test-app &'
       workingDirectory: '$(ClientSdkProjectDirectory)'
 
+  - task: Xcode@5
+    displayName: '[iOS] Build iOS Host SDK'
+    inputs:
+      actions: 'build'
+      scheme: 'hubsdkiOS'
+      sdk: 'iphoneos'
+      configuration: 'Release'
+      workingDirectory: 'metaos-hub-sdk-iOS'
+      xcWorkspacePath: 'metaos-hub-sdk-iOS/$(IOSSdkWorkspace).xcworkspace'
+      xcodeVersion: 'default' # Options: 8, 9, 10, 11, 12, default, specifyPath
+      xcodeBuildArguments: 'CODE_SIGNING_ALLOWED=NO clean build -derivedDataPath "$(agent.buildDirectory)/iOS/DerivedData"'
+
   - task: Bash@3
     displayName: 'Disable Slow Animation'
     inputs:

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -71,7 +71,11 @@ steps:
     displayName: 'iOS UI/E2E Tests'
     inputs:
       targetType: inline
+<<<<<<< HEAD
       script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' -screenshot-enabled=\"YES\" -quiet -resultBundlePath TestResults test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
+=======
+      script: '/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkScheme) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination "platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2" -screenshot-enabled="YES" -quiet -resultBundlePath TestResults test'
+>>>>>>> a18728d8 (update)
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   - task: Bash@3


### PR DESCRIPTION
**Summary:**
Separating iOS E2E testing pipeline to be 2 to reduce executing time and avoid hitting time limitation.

**Main Changes:**
Passing test plan name to yaml template to execute E2E test separately in two different pipelines.

**Validation Steps:**
For each of pipeline, you could click 'IOS UI testing' task and at the top of the console, you can read script to figure out which testing plan is executed.

For example, `/usr/bin/xcodebuild -configuration Release -workspace ... -scheme ... -testPlan iosE2ETestPlanA** -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2' -screenshot-enabled="YES" test`