### PR TITLE
Removing beta tag - Vikramtha/update pages current app

### DIFF
--- a/change/@microsoft-teams-js-51421b73-089f-43de-9076-75563e1f064c.json
+++ b/change/@microsoft-teams-js-51421b73-089f-43de-9076-75563e1f064c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Removing beta tag from Pages.CurrentApp Namespace",
+  "packageName": "@microsoft/teams-js",
+  "email": "vikramtha@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-teams-js-51421b73-089f-43de-9076-75563e1f064c.json
+++ b/change/@microsoft-teams-js-51421b73-089f-43de-9076-75563e1f064c.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Removing beta tag from Pages.CurrentApp Namespace",
+  "comment": "Removed beta tag from `pages.currentApp` namespace",
   "packageName": "@microsoft/teams-js",
   "email": "vikramtha@microsoft.com",
   "dependentChangeType": "none"

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -1008,14 +1008,10 @@ export namespace pages {
 
   /**
    * Provides functions for navigating without needing to specify your application ID.
-   *
-   * @beta
    */
   export namespace currentApp {
     /**
      * Parameters for the NavigateWithinApp
-     *
-     * @beta
      */
     export interface NavigateWithinAppParams {
       /**
@@ -1036,8 +1032,6 @@ export namespace pages {
      * specific content within the page).
      * @param params - Parameters for the navigation
      * @returns a promise that will resolve if the navigation was successful
-     *
-     * @beta
      */
     export function navigateTo(params: NavigateWithinAppParams): Promise<void> {
       return new Promise<void>((resolve) => {
@@ -1066,7 +1060,6 @@ export namespace pages {
     /**
      * Navigate to the currently running application's first static page defined in the application
      * manifest.
-     * @beta
      */
     export function navigateToDefaultPage(): Promise<void> {
       return new Promise<void>((resolve) => {
@@ -1096,8 +1089,6 @@ export namespace pages {
      * @returns boolean to represent whether the pages.currentApp capability is supported
      *
      * @throws Error if {@linkcode app.initialize} has not successfully completed
-     *
-     * @beta
      */
     export function isSupported(): boolean {
       return ensureInitialized(runtime) && runtime.supports.pages


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Removed the beta tag as we decided pages.currentApp namespace and the APIs can graduate to stable

### Main changes in the PR:

1. Removed all beta tags under pages.currentApp namespace

