### PR TITLE
Add isBackgroundLoad property on page context

### DIFF
--- a/change/@microsoft-teams-js-2884d1fc-c964-4e5b-858b-3d946100c192.json
+++ b/change/@microsoft-teams-js-2884d1fc-c964-4e5b-858b-3d946100c192.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added a new page property (isBackgroundLoad) for app context. This will be an indicator that the app is being loaded in the background.",
+  "packageName": "@microsoft/teams-js",
+  "email": "helentsang@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -472,6 +472,12 @@ export namespace app {
     isMultiWindow?: boolean;
 
     /**
+     * Indicates whether the page is being loaded in the background as
+     * part of an opt-in performance enhancement.
+     */
+    isBackgroundLoad?: boolean;
+
+    /**
      * Source origin from where the page is opened
      */
     sourceOrigin?: string;
@@ -981,6 +987,7 @@ function transformLegacyContextToAppContext(legacyContext: LegacyContext): app.C
       subPageId: legacyContext.subEntityId,
       isFullScreen: legacyContext.isFullScreen,
       isMultiWindow: legacyContext.isMultiWindow,
+      isBackgroundLoad: legacyContext.isBackgroundLoad,
       sourceOrigin: legacyContext.sourceOrigin,
     },
     user: {

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -670,6 +670,14 @@ export interface Context {
 
   /**
    * @deprecated
+   * As of 2.0.0, please use {@link app.PageInfo.isBackgroundLoad | app.Context.page.isBackgroundLoad} instead
+   *
+   * Indication whether the tab is being loaded in the background
+   */
+  isBackgroundLoad?: boolean;
+
+  /**
+   * @deprecated
    * As of 2.0.0, please use {@link app.AppInfo.iconPositionVertical | app.Context.app.iconPositionVertical} instead
    *
    * Personal app icon y coordinate position

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -553,6 +553,7 @@ describe('Testing app capability', () => {
             userClickTime: 2222,
             userFileOpenPreference: FileOpenPreference.Inline,
             isMultiWindow: true,
+            isBackgroundLoad: true,
             frameContext: context,
             appLaunchId: 'appLaunchId',
             userDisplayName: 'someTestUser',
@@ -585,6 +586,7 @@ describe('Testing app capability', () => {
               sourceOrigin: 'www.origin.com',
               frameContext: context,
               isMultiWindow: true,
+              isBackgroundLoad: true,
             },
             user: {
               id: 'someUserObjectId',


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

A new flag isBackgroundLoad is added to the app context to support an opt-in capability to preload apps in the background for reducing subsequent loading latency. When this flag is on, it indicates that the app is loaded but invisible, and therefore the user will not be able to interact with it.

### Main changes in the PR:

Added isBackgroundLoad to the pageInfo interface.

## Validation

### Validation performed:

Unit test

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes

### Related PRs:

Corresponding PR for metaos-hub-sdk will be linked here.

