### PR TITLE
Update webStorage.json to not be blank, but almost blank

### DIFF
--- a/apps/teams-test-app/e2e-test-data/webStorage.json
+++ b/apps/teams-test-app/e2e-test-data/webStorage.json
@@ -1,4 +1,4 @@
 {
   "name": "webStorage",
-  "testCases": []
+  "testCases":[{}]
 }

--- a/apps/teams-test-app/e2e-test-data/webStorage.json
+++ b/apps/teams-test-app/e2e-test-data/webStorage.json
@@ -1,1 +1,4 @@
-{}
+{
+  "name": "webStorage",
+  "testCases": []
+}


### PR DESCRIPTION
## Description

@KangxuanYe originally said this should be blank, so that's what I did. It turns out that blank actually breaks the tests so I have now updated it to be "almost blank," per @KangxuanYe's recommendation. When testing locally, this does not exhibit the same failure.
