### PR TITLE
Fixed incorrect API telemetry label for Pages_NavigateToApp API

### DIFF
--- a/change/@microsoft-teams-js-d2040181-a9a1-42d2-9080-35acb3a380cd.json
+++ b/change/@microsoft-teams-js-d2040181-a9a1-42d2-9080-35acb3a380cd.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fixed API telemetry tag for Pages.NavigateToApp API",
+  "comment": "Fixed API telemetry tag for `pages.navigateToApp` function",
   "packageName": "@microsoft/teams-js",
   "email": "kangxuanye@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-d2040181-a9a1-42d2-9080-35acb3a380cd.json
+++ b/change/@microsoft-teams-js-d2040181-a9a1-42d2-9080-35acb3a380cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed API telemetry tag for Pages.NavigateToApp API",
+  "packageName": "@microsoft/teams-js",
+  "email": "kangxuanye@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -314,7 +314,7 @@ export namespace pages {
       if (!isSupported()) {
         throw errorNotSupportedOnPlatform;
       }
-      const apiVersionTag: string = getApiVersionTag(pagesTelemetryVersionNumber, ApiName.Pages_NavigateCrossDomain);
+      const apiVersionTag: string = getApiVersionTag(pagesTelemetryVersionNumber, ApiName.Pages_NavigateToApp);
       if (runtime.isLegacyTeams) {
         resolve(sendAndHandleStatusAndReason(apiVersionTag, 'executeDeepLink', createTeamsAppLink(params)));
       } else {


### PR DESCRIPTION
API version tag for Pages.NavigateToApp should use ApiName.Pages_NavigateToApp.