### PR TITLE
Update .npmrc location in release helper scripts

### DIFF
--- a/packages/teams-js/scripts/add-npmrc-npmtoken.ps1
+++ b/packages/teams-js/scripts/add-npmrc-npmtoken.ps1
@@ -1,1 +1,1 @@
-Set-Content -Path $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/_OfficeDev.microsoft-teams-library-js/NPMFeed/.npmrc -Value "//registry.npmjs.org/:_authToken=$Env:NPM_TOKEN"
+Set-Content -Path $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/microsoft-teams-library-js-pipeline/NPMFeed/.npmrc -Value "//registry.npmjs.org/:_authToken=$Env:NPM_TOKEN"

--- a/packages/teams-js/scripts/view-published-packages-urls.ps1
+++ b/packages/teams-js/scripts/view-published-packages-urls.ps1
@@ -1,4 +1,4 @@
-$version = Get-ChildItem -Path $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/_OfficeDev.microsoft-teams-library-js/CDNFeed -Directory -Name
+$version = Get-ChildItem -Path $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/microsoft-teams-library-js-pipeline/CDNFeed -Directory -Name
 Write-Host "Releasing version $version"
 Write-Host "CDN: https://res-sdf.cdn.office.net/teams-js/$version/js/MicrosoftTeams.min.js "
 Write-Host "NPM: https://www.npmjs.com/package/@microsoft/teams-js/v/$version"


### PR DESCRIPTION
I had to rename the pipeline reference name we were using in our release pipeline to be compliant with the OneBranch template. This PR updates that name in our release helper scripts as well.
