### PR TITLE
Publish xctest result for screenshots and diagnostic logs

### DIFF
--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -99,7 +99,7 @@ steps:
     condition: always()
 
   - bash: |
-      cp ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*/Logs/Test/*.junit /Users/runner/work/1/s/iOSHost
+      cp ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.junit /Users/runner/work/1/s/iOSHost
     displayName: Copy Junit File
     condition: succeededOrFailed()
 
@@ -109,7 +109,7 @@ steps:
       testResultsFiles: '**/*.junit'
       failTaskOnFailedTests: false
       testRunTitle: 'E2E Tests - $(agent.JobName)'
-      searchFolder: iOSHost
+      searchFolder: /Users/runner/work/1/s/iOSHost
       mergeTestResults: true
     condition: succeededOrFailed()
 
@@ -119,8 +119,8 @@ steps:
 
       mkdir -p "${output}"
 
-      cp ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*/Logs/Test/index.html "${output}/index.html"
-      cp -r ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*/Logs/Test/*.xcresult "${output}/output.xcresult"
+      cp ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/index.html "${output}/index.html"
+      cp -r ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.xcresult "${output}/output.xcresult"
 
       echo "ls -lR ${output}"
       ls -lR "${output}"
@@ -130,5 +130,5 @@ steps:
   - task: 1ES.PublishPipelineArtifact@1
     inputs:
       path: '$(agent.buildDirectory)/Logs'
-      artifact: iOSDebugLogs - ${{ parameters.testPlan }} -$(System.JobAttempt)
+      artifact: iOSDebugLogs - ${{ parameters.testPlan }} - Attempt $(System.JobAttempt)
     condition: always()

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -115,7 +115,7 @@ steps:
 
   - bash: |
       ls -a ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*
-      ls -a ~/Library/Developer/Xcode/DerivedData/$(parameters.iOSAppHostingSdkProjectDirectory)
+      ls -a ~/Library/Developer/Xcode/DerivedData/$(iOSAppHostingSdkProjectDirectory)
       xchtmlreport -r ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*/Logs/Test/*.xcresult -j
     displayName: Generate E2E test report
     condition: succeededOrFailed()

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -94,7 +94,7 @@ steps:
     inputs:
       targetType: inline
       script: "ls -a"
-      workdingDirectory: '$(Agent.BuildDirectory)/iOSHost'
+    workdingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   - task: Bash@3
     displayName: 'Generate E2E test report'
@@ -104,11 +104,6 @@ steps:
         xchtmlreport -r TestResults -j; if [[ $? == 0 ]]; then echo "Test report has been generated successfully."; exit 0; else echo "Test report generating process failed for some reasons."; exit 1; fi;
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
     condition: always()
-
-  - bash: |
-      cp ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.junit /Users/runner/work/1/s/iOSHost
-    displayName: Copy Junit File
-    condition: succeededOrFailed()
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'
@@ -126,8 +121,7 @@ steps:
 
       mkdir -p "${output}"
 
-      cp ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/index.html "${output}/index.html"
-      cp -r ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.xcresult "${output}/output.xcresult"
+      cp -r $(Agent.BuildDirectory)/iOSHost/TestResults "${output}/output.xcresult"
 
       echo "ls -lR ${output}"
       ls -lR "${output}"

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -98,18 +98,13 @@ steps:
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
     condition: always()
 
-  - bash: |
-      cp ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.junit /Users/runner/work/1/s/iOSHost
-    displayName: Copy Junit File
-    condition: succeededOrFailed()
-
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'
     inputs:
       testResultsFiles: '**/*.junit'
       failTaskOnFailedTests: false
       testRunTitle: 'E2E Tests - $(agent.JobName)'
-      searchFolder: /Users/runner/work/1/s/iOSHost
+      searchFolder: ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test
       mergeTestResults: true
     condition: succeededOrFailed()
 

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -88,24 +88,24 @@ steps:
       script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' -screenshot-enabled=\"YES\" -quiet test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
-  - task: Bash@3
-    displayName: 'Generate E2E test report'
-    condition: succeededOrFailed()
-    inputs:
-      targetType: inline
-      script: |
-        xchtmlreport -r TestResults -j; if [[ $? == 0 ]]; then echo "Test report has been generated successfully."; exit 0; else echo "Test report generating process failed for some reasons."; exit 1; fi;
-      workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
+  # - task: Bash@3
+  #   displayName: 'Generate E2E test report'
+  #   condition: succeededOrFailed()
+  #   inputs:
+  #     targetType: inline
+  #     script: |
+  #       xchtmlreport -r TestResults -j; if [[ $? == 0 ]]; then echo "Test report has been generated successfully."; exit 0; else echo "Test report generating process failed for some reasons."; exit 1; fi;
+  #     workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
-  - task: PublishTestResults@2
-    displayName: 'Publish Test Results'
-    inputs:
-      testResultsFiles: '**/*.junit'
-      failTaskOnFailedTests: false
-      testRunTitle: 'E2E Tests - iOS'
-      searchFolder: '$(Agent.BuildDirectory)/iOSHost'
-      mergeTestResults: true
-    condition: always()
+  # - task: PublishTestResults@2
+  #   displayName: 'Publish Test Results'
+  #   inputs:
+  #     testResultsFiles: '**/*.junit'
+  #     failTaskOnFailedTests: false
+  #     testRunTitle: 'E2E Tests - iOS'
+  #     searchFolder: '$(Agent.BuildDirectory)/iOSHost'
+  #     mergeTestResults: true
+  #   condition: always()
 
   - bash: |
       brew install xctesthtmlreport

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -18,7 +18,8 @@ steps:
       targetType: inline
       script: |
         brew install xctesthtmlreport
-      workingDirectory: '$(System.DefaultWorkingDirectory)'
+      workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
+      condition: succeededOrFailed()
 
   - task: NodeTool@0
     inputs:
@@ -88,14 +89,14 @@ steps:
       script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' -screenshot-enabled=\"YES\" -quiet test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
-  # - task: Bash@3
-  #   displayName: 'Generate E2E test report'
-  #   condition: succeededOrFailed()
-  #   inputs:
-  #     targetType: inline
-  #     script: |
-  #       xchtmlreport -r TestResults -j; if [[ $? == 0 ]]; then echo "Test report has been generated successfully."; exit 0; else echo "Test report generating process failed for some reasons."; exit 1; fi;
-  #     workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
+  - task: Bash@3
+    displayName: 'Generate E2E test report'
+    condition: succeededOrFailed()
+    inputs:
+      targetType: inline
+      script: |
+        xchtmlreport -r ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.xcresult -j; if [[ $? == 0 ]]; then echo "Test report has been generated successfully."; exit 0; else echo "Test report generating process failed for some reasons."; exit 1; fi;
+      workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   # - task: PublishTestResults@2
   #   displayName: 'Publish Test Results'
@@ -107,19 +108,13 @@ steps:
   #     mergeTestResults: true
   #   condition: always()
 
-  - bash: |
-      brew install xctesthtmlreport
-    displayName: 'Install XCTestHtmlReport for publishing result'
-    workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
-    condition: succeededOrFailed()
+  # - bash: |
+  #     xchtmlreport -r ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.xcresult -j
+  #   displayName: Generate E2E test report
+  #   condition: succeededOrFailed()
 
   - bash: |
-      xchtmlreport -r ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.xcresult -j
-    displayName: Generate E2E test report
-    condition: succeededOrFailed()
-
-  - bash: |
-      cp ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*/Logs/Test/*.junit /Users/runner/work/1/s/metaos-hub-sdk-iOS
+      cp ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*/Logs/Test/*.junit /Users/runner/work/1/s/iOSHost
     displayName: Copy Junit File
     condition: succeededOrFailed()
 
@@ -129,7 +124,7 @@ steps:
       testResultsFiles: '**/*.junit'
       failTaskOnFailedTests: false
       testRunTitle: 'E2E Tests - $(agent.JobName)'
-      searchFolder: 'metaos-hub-sdk-iOS'
+      searchFolder: iOSHost
       mergeTestResults: true
     condition: succeededOrFailed()
 
@@ -145,4 +140,4 @@ steps:
       echo "ls -lR ${output}"
       ls -lR "${output}"
     displayName: Preparations for publishing results
-    condition: failed()
+    condition: always() #failed()

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -142,7 +142,7 @@ steps:
     displayName: Preparations for publishing results
     condition: always() #failed()
 
-  - task: PublishBuildArtifacts@1
+  - task: 1ES.PublishPipelineArtifact@1
     inputs:
       pathToPublish: '$(agent.buildDirectory)/Logs'
       artifactName: iOSDebugLogs

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -144,6 +144,6 @@ steps:
 
   - task: 1ES.PublishPipelineArtifact@1
     inputs:
-      pathToPublish: '$(agent.buildDirectory)/Logs'
-      artifactName: iOSDebugLogs
+      path: '$(agent.buildDirectory)/Logs'
+      artifact: iOSDebugLogs
     condition: always()

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -90,13 +90,6 @@ steps:
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   - task: Bash@3
-    displayName: 'List all of files under iOSHost'
-    inputs:
-      targetType: inline
-      script: "ls -a"
-      workdingDirectory: '$(Agent.BuildDirectory)/iOSHost'
-
-  - task: Bash@3
     displayName: 'Generate E2E test report'
     inputs:
       targetType: inline

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -130,5 +130,5 @@ steps:
   - task: 1ES.PublishPipelineArtifact@1
     inputs:
       path: '$(agent.buildDirectory)/Logs'
-      artifact: iOSDebugLogs - ${{ parameters.testPlan }}
+      artifact: iOSDebugLogs - ${{ parameters.testPlan }} -$(System.JobAttempt)
     condition: always()

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -106,3 +106,45 @@ steps:
       searchFolder: '$(Agent.BuildDirectory)/iOSHost'
       mergeTestResults: true
     condition: always()
+
+  - bash: |
+      brew install xctesthtmlreport
+    displayName: 'Install XCTestHtmlReport for publishing result'
+    workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
+    condition: succeededOrFailed()
+
+  - bash: |
+      ls -a ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*
+      ls -a ~/Library/Developer/Xcode/DerivedData/$(parameters.iOSAppHostingSdkProjectDirectory)
+      xchtmlreport -r ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*/Logs/Test/*.xcresult -j
+    displayName: Generate E2E test report
+    condition: succeededOrFailed()
+
+  - bash: |
+      cp ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*/Logs/Test/*.junit /Users/runner/work/1/s/metaos-hub-sdk-iOS
+    displayName: Copy Junit File
+    condition: succeededOrFailed()
+
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results'
+    inputs:
+      testResultsFiles: '**/*.junit'
+      failTaskOnFailedTests: false
+      testRunTitle: 'E2E Tests - $(agent.JobName)'
+      searchFolder: 'metaos-hub-sdk-iOS'
+      mergeTestResults: true
+    condition: succeededOrFailed()
+
+  - bash: |
+      output="$(agent.buildDirectory)/Logs/$(agent.JobName)"
+      rm -rf "${output}" > /dev/null
+
+      mkdir -p "${output}"
+
+      cp ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*/Logs/Test/index.html "${output}/index.html"
+      cp -r ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*/Logs/Test/*.xcresult "${output}/output.xcresult"
+
+      echo "ls -lR ${output}"
+      ls -lR "${output}"
+    displayName: Preparations for publishing results
+    condition: failed()

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -19,7 +19,7 @@ steps:
       script: |
         brew install xctesthtmlreport
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
-      condition: succeededOrFailed()
+      condition: always()
 
   - task: NodeTool@0
     inputs:

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -94,7 +94,7 @@ steps:
     inputs:
       targetType: inline
       script: "ls -a"
-    workdingDirectory: '$(Agent.BuildDirectory)/iOSHost'
+      workdingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   - task: Bash@3
     displayName: 'Generate E2E test report'

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -86,15 +86,22 @@ steps:
     displayName: 'iOS UI/E2E Tests'
     inputs:
       targetType: inline
-      script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' -screenshot-enabled=\"YES\" -quiet test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
+      script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' -screenshot-enabled=\"YES\" -quiet -resultBundlePath TestResults test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
+
+  - task: Bash@3
+    displayName: 'List all of files under iOSHost'
+    inputs:
+      targetType: inline
+      script: "ls -a"
+      workdingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   - task: Bash@3
     displayName: 'Generate E2E test report'
     inputs:
       targetType: inline
       script: |
-        xchtmlreport -r ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.xcresult -j; if [[ $? == 0 ]]; then echo "Test report has been generated successfully."; exit 0; else echo "Test report generating process failed for some reasons."; exit 1; fi;
+        xchtmlreport -r TestResults -j; if [[ $? == 0 ]]; then echo "Test report has been generated successfully."; exit 0; else echo "Test report generating process failed for some reasons."; exit 1; fi;
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
     condition: always()
 

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -122,6 +122,8 @@ steps:
       mkdir -p "${output}"
 
       cp -r $(Agent.BuildDirectory)/iOSHost/TestResults "${output}/output.xcresult"
+      xchtmlreport -r ${output}/output.xcresult -j
+
 
       echo "ls -lR ${output}"
       ls -lR "${output}"

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -141,3 +141,9 @@ steps:
       ls -lR "${output}"
     displayName: Preparations for publishing results
     condition: always() #failed()
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: '$(agent.buildDirectory)/Logs'
+      artifactName: DebugLogs-${{parameters.version}}
+    condition: always()

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -85,7 +85,7 @@ steps:
     displayName: 'iOS UI/E2E Tests'
     inputs:
       targetType: inline
-      script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' -screenshot-enabled=\"YES\" -quiet -resultBundlePath TestResults test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
+      script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' -screenshot-enabled=\"YES\" -quiet test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   - task: Bash@3
@@ -114,9 +114,7 @@ steps:
     condition: succeededOrFailed()
 
   - bash: |
-      ls -a ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*
-      ls -a ~/Library/Developer/Xcode/DerivedData/$(iOSAppHostingSdkProjectDirectory)
-      xchtmlreport -r ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*/Logs/Test/*.xcresult -j
+      xchtmlreport -r ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.xcresult -j
     displayName: Generate E2E test report
     condition: succeededOrFailed()
 

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -145,5 +145,5 @@ steps:
   - task: PublishBuildArtifacts@1
     inputs:
       pathToPublish: '$(agent.buildDirectory)/Logs'
-      artifactName: DebugLogs-${{parameters.version}}
+      artifactName: iOSDebugLogs
     condition: always()

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -91,27 +91,12 @@ steps:
 
   - task: Bash@3
     displayName: 'Generate E2E test report'
-    condition: succeededOrFailed()
     inputs:
       targetType: inline
       script: |
         xchtmlreport -r ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.xcresult -j; if [[ $? == 0 ]]; then echo "Test report has been generated successfully."; exit 0; else echo "Test report generating process failed for some reasons."; exit 1; fi;
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
-
-  # - task: PublishTestResults@2
-  #   displayName: 'Publish Test Results'
-  #   inputs:
-  #     testResultsFiles: '**/*.junit'
-  #     failTaskOnFailedTests: false
-  #     testRunTitle: 'E2E Tests - iOS'
-  #     searchFolder: '$(Agent.BuildDirectory)/iOSHost'
-  #     mergeTestResults: true
-  #   condition: always()
-
-  # - bash: |
-  #     xchtmlreport -r ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.xcresult -j
-  #   displayName: Generate E2E test report
-  #   condition: succeededOrFailed()
+    condition: always()
 
   - bash: |
       cp ~/Library/Developer/Xcode/DerivedData/metaos-hub-sdk*/Logs/Test/*.junit /Users/runner/work/1/s/iOSHost
@@ -140,7 +125,7 @@ steps:
       echo "ls -lR ${output}"
       ls -lR "${output}"
     displayName: Preparations for publishing results
-    condition: always() #failed()
+    condition: always()
 
   - task: 1ES.PublishPipelineArtifact@1
     inputs:

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -145,5 +145,5 @@ steps:
   - task: 1ES.PublishPipelineArtifact@1
     inputs:
       path: '$(agent.buildDirectory)/Logs'
-      artifact: iOSDebugLogs
+      artifact: iOSDebugLogs - ${{ parameters.testPlan }}
     condition: always()

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -98,13 +98,18 @@ steps:
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
     condition: always()
 
+  - bash: |
+      cp ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test/*.junit /Users/runner/work/1/s/iOSHost
+    displayName: Copy Junit File
+    condition: succeededOrFailed()
+
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'
     inputs:
       testResultsFiles: '**/*.junit'
       failTaskOnFailedTests: false
       testRunTitle: 'E2E Tests - $(agent.JobName)'
-      searchFolder: ~/Library/Developer/Xcode/DerivedData/$(AppHostingSdkProjectDirectory)*/Logs/Test
+      searchFolder: '$(Agent.BuildDirectory)/iOSHost'
       mergeTestResults: true
     condition: succeededOrFailed()
 


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This PR is to ALWAYS publish the artifacts on iOS E2E testing pipeline for the convenience of investigating some flaky failures if those happen. You could go to pipeline and click "published artifacts". Then you will find two folders which are called iOSDebugLogs - iosE2ETestPlanA and iOSDebugLogs - iosE2ETestPlanB.

Those folders will always be there for each run but it only worth to take a look into those folders if something fails on iOS E2E pipelines. If all tests are passed successfully, publishing process should only take seconds and I think it is okay. to put always condition on those tasks since sometimes, pipeline will timeout and we also would like to know why and need some diagnostic info.

### Unit Tests added: No

### End-to-end tests added: No
