### PR TITLE
Update the SDF release yaml

### DIFF
--- a/change/@microsoft-teams-js-3df1e388-302e-45ea-b24a-b46d2150dd9b.json
+++ b/change/@microsoft-teams-js-3df1e388-302e-45ea-b24a-b46d2150dd9b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Removing unused scripts and updating the release yaml",
+  "packageName": "@microsoft/teams-js",
+  "email": "jeklouda@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/scripts/add-npmrc-npmtoken-onebranch.ps1
+++ b/packages/teams-js/scripts/add-npmrc-npmtoken-onebranch.ps1
@@ -1,1 +1,0 @@
-Set-Content -Path $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/microsoft-teams-library-js-pipeline/NPMFeed/.npmrc -Value "//registry.npmjs.org/:_authToken=$Env:NPM_TOKEN"

--- a/packages/teams-js/scripts/view-published-packages-urls-onebranch.ps1
+++ b/packages/teams-js/scripts/view-published-packages-urls-onebranch.ps1
@@ -1,4 +1,0 @@
-$version = Get-ChildItem -Path $Env:SYSTEM_DEFAULTWORKINGDIRECTORY/microsoft-teams-library-js-pipeline/CDNFeed -Directory -Name
-Write-Host "Releasing version $version"
-Write-Host "CDN: https://res-sdf.cdn.office.net/teams-js/$version/js/MicrosoftTeams.min.js "
-Write-Host "NPM: https://www.npmjs.com/package/@microsoft/teams-js/v/$version"

--- a/tools/releases/sdf-release.yml
+++ b/tools/releases/sdf-release.yml
@@ -79,7 +79,7 @@ extends:
                 inputs:
                   targetType: 'inline'
                   script: |
-                    $version = Get-ChildItem -Path $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/CDNFeed -Directory -Name
+                    $version = Get-ChildItem -Path $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/CDNFeed -Directory -Name -Exclude _*
                     Write-Host "Releasing version $version"
                     Write-Host "CDN: https://res-sdf.cdn.office.net/teams-js/$version/js/MicrosoftTeams.min.js "
                     Write-Host "NPM: https://www.npmjs.com/package/@microsoft/teams-js/v/$version"

--- a/tools/releases/sdf-release.yml
+++ b/tools/releases/sdf-release.yml
@@ -81,5 +81,5 @@ extends:
                   script: |
                     $version = Get-ChildItem -Path $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/CDNFeed -Directory -Name -Exclude _*
                     Write-Host "Releasing version $version"
-                    Write-Host "CDN: https://res-sdf.cdn.office.net/teams-js/$version/js/MicrosoftTeams.min.js "
+                    Write-Host "CDN: https://res-sdf.cdn.office.net/teams-js/$version/js/MicrosoftTeams.min.js"
                     Write-Host "NPM: https://www.npmjs.com/package/@microsoft/teams-js/v/$version"

--- a/tools/releases/sdf-release.yml
+++ b/tools/releases/sdf-release.yml
@@ -57,18 +57,19 @@ extends:
               - task: PowerShell@2
                 displayName: Update npmrc with NPM-TOKEN
                 inputs:
-                  filePath: $(PIPELINE.WORKSPACE)\microsoft-teams-library-js-pipeline\scripts\add-npmrc-npmtoken-onebranch.ps1
+                  targetType: 'inline'
+                  script: Set-Content -Path $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed/.npmrc -Value "//registry.npmjs.org/:_authToken=$(NPM-TOKEN)"
               - task: Npm@1
                 displayName: Publish to npm (tag beta) KV
                 inputs:
                   command: custom
-                  workingDir: $(System.DefaultWorkingDirectory)/microsoft-teams-library-js-pipeline/NPMFeed
+                  workingDir: $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed
                   verbose: false
                   customCommand: publish  --tag beta
               - task: M365CdnAssetsUpload@1
                 displayName: Push teams-js to M365 1CDN (SDF)
                 inputs:
-                  SourcePath: $(System.DefaultWorkingDirectory)/microsoft-teams-library-js-pipeline/CDNFeed/*
+                  SourcePath: $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/CDNFeed/*
                   ConnectedServiceNameARM: $(serviceConnectionId)
                   Environment: PublicCloudSDF
                   ContainerName: teams-js
@@ -76,5 +77,9 @@ extends:
               - task: PowerShell@2
                 displayName: View Published Package URLs
                 inputs:
-                  filePath: $(PIPELINE.WORKSPACE)\microsoft-teams-library-js-pipeline\scripts\view-published-packages-urls-onebranch.ps1
-                  arguments: $(System.DefaultWorkingDirectory)
+                  targetType: 'inline'
+                  script: |
+                    $version = Get-ChildItem -Path $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/CDNFeed -Directory -Name
+                    Write-Host "Releasing version $version"
+                    Write-Host "CDN: https://res-sdf.cdn.office.net/teams-js/$version/js/MicrosoftTeams.min.js "
+                    Write-Host "NPM: https://www.npmjs.com/package/@microsoft/teams-js/v/$version"


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Update the release yaml to use inline scripts for adding npm token to the .npmrc and listing the npm and cdn release information

## Validation

### Validation performed:

1. Successful NPM and CDN releases performed with the updated YAML

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes
