### PR TITLE
Updated `search` and `otherAppStateChange` e2e tests data in teams-js

### DIFF
--- a/apps/teams-test-app/e2e-test-data/otherAppStateChange.json
+++ b/apps/teams-test-app/e2e-test-data/otherAppStateChange.json
@@ -23,11 +23,10 @@
       "type": "registerAndRaiseEvent",
       "boxSelector": "#box_otherAppStateChange_registerInstallHandler",
       "eventName": "otherApp.install",
-      "eventData": [
+      "eventData":
         {
           "appIds": ["123", "456"]
-        }
-      ],
+        },
       "expectedTestAppValue": "received"
     },
     {

--- a/apps/teams-test-app/e2e-test-data/search.json
+++ b/apps/teams-test-app/e2e-test-data/search.json
@@ -15,11 +15,10 @@
       "type": "registerAndRaiseEvent",
       "boxSelector": "#box_search_registerHandlers",
       "eventName": "queryChange",
-      "eventData": [
+      "eventData":
         {
           "searchTerm": "Hello, world"
-        }
-      ],
+        },
       "expectedTestAppValue": "Update your application with the changed search query: Hello, world"
     },
     {
@@ -28,11 +27,10 @@
       "type": "registerAndRaiseEvent",
       "boxSelector": "#box_search_registerHandlers",
       "eventName": "queryExecute",
-      "eventData": [
+      "eventData":
         {
           "searchTerm": "Hello, world"
-        }
-      ],
+        },
       "expectedTestAppValue": "Update your application to handle an executed search result: Hello, world"
     },
     {
@@ -41,11 +39,10 @@
       "type": "registerAndRaiseEvent",
       "boxSelector": "#box_search_registerHandlers",
       "eventName": "queryClose",
-      "eventData": [
+      "eventData":
         {
           "searchTerm": "Hello, world"
-        }
-      ],
+        },
       "expectedTestAppValue": "Update your application to handle the search experience being closed. Last query: Hello, world"
     },
     {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

The event input data should be sent in the required format. This PR removed unnecessary array wrapping for the event data in e2e tests.

### Main changes in the PR:

1. Updated `search` and `otherAppStateChange` e2e tests data in teams-js.

## Validation

### Validation performed:

1. e2e tests passed.

### Unit Tests added:

No: test data changes.

### End-to-end tests added:

No: test data changes.

## Additional Requirements

### Change file added:

No: test data changes.

