### PR TITLE
Update pipeline source for DDL release

### DIFF
--- a/tools/releases/ddl-release.yml
+++ b/tools/releases/ddl-release.yml
@@ -7,7 +7,7 @@ resources:
     ref: refs/heads/main
   pipelines:
   - pipeline: microsoft-teams-library-js-pipeline
-    source: OfficeDev.microsoft-teams-library-js
+    source: 'M365 Platform/App SDK/OfficeDev.microsoft-teams-library-js'
     project: ISS
 extends:
   template: v2/Microsoft.Official.yml@GovernedTemplates


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

The source variable on the teams-js pipeline was incorrectly listed in the DDL release pipeline, updated with the correct path.

### Main changes in the PR:

1. Update teams-js pipeline source with full path

