### PR TITLE
Trharris/uninitialize fix

### DIFF
--- a/change/@microsoft-teams-js-ace1fe2b-0c05-48f6-b3b4-bdecfe1fb665.json
+++ b/change/@microsoft-teams-js-ace1fe2b-0c05-48f6-b3b4-bdecfe1fb665.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Made fix to function only used for testing",
+  "packageName": "@microsoft/teams-js",
+  "email": "trharris@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -19,6 +19,7 @@ import { getLogger } from '../internal/telemetry';
 import { isNullOrUndefined } from '../internal/typeCheckUtilities';
 import { compareSDKVersions, inServerSideRenderingEnvironment, runWithTimeout } from '../internal/utils';
 import { prefetchOriginsFromCDN } from '../internal/validOrigins';
+import { messageChannels } from '../private';
 import { authentication } from './authentication';
 import { ChannelType, FrameContexts, HostClientType, HostName, TeamType, UserTeamRole } from './constants';
 import { dialog } from './dialog';
@@ -802,6 +803,9 @@ export namespace app {
     GlobalVars.frameContext = undefined;
     GlobalVars.hostClientType = undefined;
     GlobalVars.isFramelessWindow = false;
+
+    messageChannels.telemetry._clearTelemetryPort();
+    messageChannels.dataLayer._clearDataLayerPort();
 
     uninitializeCommunication();
   }

--- a/packages/teams-js/test/private/messageChannels.spec.ts
+++ b/packages/teams-js/test/private/messageChannels.spec.ts
@@ -29,10 +29,6 @@ describe('messageChannels', () => {
 
       app._uninitialize();
     }
-    // Clear the cached telemetry/datalayer ports
-    // Adding to _uninitialize breaks the global state initialization so leaving it here
-    messageChannels.telemetry._clearTelemetryPort();
-    messageChannels.dataLayer._clearDataLayerPort();
   });
 
   describe('Testing messageChannels APIs before initialization', () => {


### PR DESCRIPTION
## Description

A while ago (months ago) I tried to make this change (clear out some test state between every test) and it was causing very weird test failures. I went to investigate why that was happening today and it magically was no longer happening. I'd rather have been able to investigate and figure out what was going on, but since that isn't an option here is the original fix to clear the telemetry port and data layer port every time `app._uninitialize` is called (which is a function only used by unit tests)

### Main changes in the PR:

1. Update `app._uninitialize` to call `messageChannels.telemetry._clearTelemetryPort` and `messageChannels.telemetry._clearDataLayerPort`. Removed calls to those functions from specific unit test files that were using them.

## Validation

### Validation performed:

1. Ran all unit tests

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes. Really I'd like to say this was a `none` change, but since app._uninitialize is technically part of the package we ship there is a theoretical chance this could cause a difference in behavior for someone, which is why it is marked as `patch`
