### PR TITLE
Added url search parameters for insecure e2e testing

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -68,8 +68,8 @@ import WebStorageAPIs from './components/WebStorageAPIs';
 
 const urlParams = new URLSearchParams(window.location.search);
 
-const getOriginParam = urlParams.has('origins') && urlParams.get('origins') ? urlParams.get('origins') : '';
-const validMessageOrigins: string[] = getOriginParam ? [getOriginParam] : [];
+const getOriginsParam = urlParams.has('origins') && urlParams.get('origins') ? urlParams.get('origins') : '';
+const validMessageOrigins: string[] = getOriginsParam ? [getOriginsParam] : [];
 
 // This is added for custom initialization when app can be initialized based upon a trigger/click.
 if (!urlParams.has('customInit') || !urlParams.get('customInit')) {

--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -68,25 +68,18 @@ import WebStorageAPIs from './components/WebStorageAPIs';
 
 const urlParams = new URLSearchParams(window.location.search);
 
-// For InsecureOrigins tests we need to pass insecure origins to app.initialize function.
-if (urlParams.has('doesInsecureUrlHasAppIdException') && urlParams.get('doesInsecureUrlHasAppIdException') === 'true') {
-  isTestBackCompat() ? initialize(undefined, ['https://*.example.com']) : app.initialize(['https://*.example.com']);
-} else if (
-  urlParams.has('doesInsecureUrlHasAppIdException') &&
-  urlParams.get('doesInsecureUrlHasAppIdException') === 'false'
-) {
-  // should block the app from loading and throw InValid_Domain error
-  isTestBackCompat()
-    ? initialize(undefined, ['https://https://*.example.com'])
-    : app.initialize(['https://*.example.com']);
-}
+const getOriginParam =
+  urlParams.has('doesInsecureUrlHasAppIdException') && urlParams.get('doesInsecureUrlHasAppIdException')
+    ? urlParams.get('doesInsecureUrlHasAppIdException')
+    : '';
+const validMessageOrigins: string[] = getOriginParam ? [getOriginParam] : [];
 
 // This is added for custom initialization when app can be initialized based upon a trigger/click.
 if (!urlParams.has('customInit') || !urlParams.get('customInit')) {
   if (isTestBackCompat()) {
     initialize();
   } else {
-    app.initialize();
+    app.initialize(validMessageOrigins);
   }
 }
 

--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -68,10 +68,7 @@ import WebStorageAPIs from './components/WebStorageAPIs';
 
 const urlParams = new URLSearchParams(window.location.search);
 
-const getOriginParam =
-  urlParams.has('doesInsecureUrlHasAppIdException') && urlParams.get('doesInsecureUrlHasAppIdException')
-    ? urlParams.get('doesInsecureUrlHasAppIdException')
-    : '';
+const getOriginParam = urlParams.has('origins') && urlParams.get('origins') ? urlParams.get('origins') : '';
 const validMessageOrigins: string[] = getOriginParam ? [getOriginParam] : [];
 
 // This is added for custom initialization when app can be initialized based upon a trigger/click.
@@ -79,7 +76,7 @@ if (!urlParams.has('customInit') || !urlParams.get('customInit')) {
   if (isTestBackCompat()) {
     initialize(undefined, validMessageOrigins);
   } else {
-    app.initialize(validMessageOrigins);
+    app.initialize(['https://*.example.com']);
   }
 }
 

--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -77,7 +77,7 @@ const validMessageOrigins: string[] = getOriginParam ? [getOriginParam] : [];
 // This is added for custom initialization when app can be initialized based upon a trigger/click.
 if (!urlParams.has('customInit') || !urlParams.get('customInit')) {
   if (isTestBackCompat()) {
-    initialize();
+    initialize(undefined, validMessageOrigins);
   } else {
     app.initialize(validMessageOrigins);
   }

--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -68,6 +68,19 @@ import WebStorageAPIs from './components/WebStorageAPIs';
 
 const urlParams = new URLSearchParams(window.location.search);
 
+// For InsecureOrigins tests we need to pass insecure origins to app.initialize function.
+if (urlParams.has('doesInsecureUrlHasAppIdException') && urlParams.get('doesInsecureUrlHasAppIdException') === 'true') {
+  isTestBackCompat() ? initialize(undefined, ['https://*.example.com']) : app.initialize(['https://*.example.com']);
+} else if (
+  urlParams.has('doesInsecureUrlHasAppIdException') &&
+  urlParams.get('doesInsecureUrlHasAppIdException') === 'false'
+) {
+  // should block the app from loading and throw InValid_Domain error
+  isTestBackCompat()
+    ? initialize(undefined, ['https://https://*.example.com'])
+    : app.initialize(['https://*.example.com']);
+}
+
 // This is added for custom initialization when app can be initialized based upon a trigger/click.
 if (!urlParams.has('customInit') || !urlParams.get('customInit')) {
   if (isTestBackCompat()) {

--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -68,8 +68,11 @@ import WebStorageAPIs from './components/WebStorageAPIs';
 
 const urlParams = new URLSearchParams(window.location.search);
 
+// The search url parameter 'origins' is used to get the valid message origins which will be passed to
+// the initialize function and based on the hosts it will allow the origins or not.
+// The valid message origins are separated by comma. For example: https://relecloud.com/?origins=https://relecoud.com,https://*.relecloud.com
 const getOriginsParam = urlParams.has('origins') && urlParams.get('origins') ? urlParams.get('origins') : '';
-const validMessageOrigins: string[] = getOriginsParam ? [getOriginsParam] : [];
+const validMessageOrigins: string[] | undefined = getOriginsParam ? getOriginsParam.split(',') : undefined;
 
 // This is added for custom initialization when app can be initialized based upon a trigger/click.
 if (!urlParams.has('customInit') || !urlParams.get('customInit')) {

--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -76,7 +76,7 @@ if (!urlParams.has('customInit') || !urlParams.get('customInit')) {
   if (isTestBackCompat()) {
     initialize(undefined, validMessageOrigins);
   } else {
-    app.initialize(['https://*.example.com']);
+    app.initialize(validMessageOrigins);
   }
 }
 


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Added search URL parameter `origins` to send origins to `app.initialize()`.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Added a URL search parameter `origins`.

## Validation

### Validation performed:

N/A

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

No
### End-to-end tests added:

No
