### PR TITLE
Added intAppId parameter to getContext

### DIFF
--- a/change/@microsoft-teams-js-07a56fbc-6d3e-474d-b3d9-6c6fe3a3be50.json
+++ b/change/@microsoft-teams-js-07a56fbc-6d3e-474d-b3d9-6c6fe3a3be50.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added a new parameter to getContext() API called intAppId for Internal App ID",
+  "packageName": "@microsoft/teams-js",
+  "email": "vikramtha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -354,6 +354,11 @@ export namespace app {
      * ID for the current visible app which is different for across cached sessions. Used for correlating telemetry data.
      */
     appLaunchId?: string;
+
+    /**
+     * Internal app id that is used by Hubs to distinguish between different apps sideloaded or in store
+     */
+    intAppId?: string;
   }
 
   /**
@@ -1007,6 +1012,7 @@ function transformLegacyContextToAppContext(legacyContext: LegacyContext): app.C
         ringId: legacyContext.ringId,
       },
       appLaunchId: legacyContext.appLaunchId,
+      intAppId: legacyContext.intAppId,
     },
     page: {
       id: legacyContext.entityId,

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -757,6 +757,14 @@ export interface Context {
    * They help pre-fill the dialog with necessary information (`dialogParameters`) along with other details.
    */
   dialogParameters?: Record<string, string>;
+
+  /**
+   * @deprecated
+   * As of 2.0.0, please use {link app.Context.intAppId} instead
+   *
+   * Internal app id that is used by Hubs to distinguish between different apps sideloaded or in store
+   */
+  intAppId?: string;
 }
 
 /** Represents the parameters used to share a deep link. */

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -558,6 +558,7 @@ describe('Testing app capability', () => {
             appLaunchId: 'appLaunchId',
             userDisplayName: 'someTestUser',
             teamSiteId: 'someSiteId',
+            intAppId: 'someIntAppId',
           };
 
           const expectedContext: app.Context = {
@@ -571,6 +572,7 @@ describe('Testing app capability', () => {
               userClickTime: 2222,
               userFileOpenPreference: FileOpenPreference.Inline,
               appLaunchId: 'appLaunchId',
+              intAppId: 'someintAppId',
               host: {
                 name: HostName.orange,
                 clientType: HostClientType.web,
@@ -1426,6 +1428,7 @@ describe('Testing app capability', () => {
             appLaunchId: 'appLaunchId',
             userDisplayName: 'someTestUser',
             teamSiteId: 'someSiteId',
+            intAppId: 'someintAppId',
           };
 
           const expectedContext: app.Context = {
@@ -1445,6 +1448,7 @@ describe('Testing app capability', () => {
                 ringId: 'someRingId',
               },
               appLaunchId: 'appLaunchId',
+              intAppId: 'someintAppId',
             },
             page: {
               id: 'someEntityId',

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -348,6 +348,7 @@ describe('MicrosoftTeams-publicAPIs', () => {
         appSessionId: 'appSessionId',
         appLaunchId: 'appLaunchId',
         meetingId: 'dummyMeetingId',
+        intAppId: 'dummyIntAppId',
       };
       getContext((context) => {
         Object.keys(expectedContext).forEach((e) => {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This is adding the internal appID to getContext. This is what hubs use to differentiate the app internally as well as what ends up being used in deeplinking

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Added intAppId to getContext() and the AppInfo interface
2. Added dummy values for testing validation

## Validation

### Validation performed:

1. Validated on Orange Web

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

???

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes