### PR TITLE
Always pull Android test artifacts

### DIFF
--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -79,6 +79,14 @@ steps:
       script: 'chmod u+x ./gradlew && chmod u+x e2eTest.sh && ./e2eTest.sh'
       workingDirectory: '$(Agent.BuildDirectory)/androidHost/apps/orangeandroid'
 
+  - task: Bash@3
+    displayName: 'Pull Test Artifacts'
+    inputs:
+      targetType: inline
+      script: 'chmod u+x e2eTestCopyArtifacts.sh && ./e2eTestCopyArtifacts.sh'
+      workingDirectory: '$(Agent.BuildDirectory)/androidHost/apps/orangeandroid'
+    condition: always()
+
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'
     inputs:
@@ -87,7 +95,7 @@ steps:
       testRunTitle: 'E2E Tests - Android'
       searchFolder: '$(Agent.BuildDirectory)/androidHost'
       mergeTestResults: true
-    condition: or(succeededOrFailed(), eq(variables['Agent.JobStatus'], 'Canceled'))
+    condition: always()
 
   - task: 1ES.PublishPipelineArtifact@1
     displayName: 'Publish logs artifact'


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Adds a new step to the Android pipeline for pulling test result data from the device even when the tests time out.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Add new step in android test yaml for pulling test data

## Validation

### Validation performed:

1. Tested against corresponding changes in Android repo

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

No

