### PR TITLE
Do not check navigator in frameless scenario

### DIFF
--- a/packages/teams-js/src/public/clipboard.ts
+++ b/packages/teams-js/src/public/clipboard.ts
@@ -1,4 +1,5 @@
 import { sendAndHandleSdkError } from '../internal/communication';
+import { GlobalVars } from '../internal/globalVars';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
 import * as utils from '../internal/utils';
@@ -99,6 +100,10 @@ export namespace clipboard {
    * @beta
    */
   export function isSupported(): boolean {
-    return ensureInitialized(runtime) && navigator && navigator.clipboard && runtime.supports.clipboard ? true : false;
+    if (GlobalVars.isFramelessWindow) {
+      return ensureInitialized(runtime) && runtime.supports.clipboard ? true : false;
+    } else {
+      return ensureInitialized(runtime) && navigator && navigator.clipboard && runtime.supports.clipboard ? true : false;
+    }
   }
 }


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This fixes a bug where the clipboard capability was reported as not supported in Android hosts when the Android WebView does not support navigator.clipboard despite the fact that the Android clipboard capability does not use navigator.clipboard. clipboard.isSupported should now only check for the navigator dependency in iframe (web) contexts.

### Main changes in the PR:

1. Only check for navigator.clipboard in clipboard.isSupported if teams-js is in a iframe context.

## Validation

### Validation performed:

1. Validated that clipboard functions work when navigator is not supported locally and against Android E2E pipeline

### Unit Tests added:

No.

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
