### PR TITLE
Trharris/messageproxy

### DIFF
--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -770,7 +770,7 @@ function handleChildMessage(evt: DOMMessageEvent): void {
       // @ts-ignore
       sendMessageResponseToChild(message.id, message.uuid, Array.isArray(result) ? result : [result]);
     } else {
-      if (GlobalVars.allowMessageProxy) {
+      if (GlobalVars.allowMessageProxy || GlobalVars.webAuthWindowOpen) {
         // No handler, proxy to parent
         sendMessageToParent(
           getApiVersionTag(ApiVersionNumber.V_2, ApiName.Tasks_StartTask),

--- a/packages/teams-js/src/internal/globalVars.ts
+++ b/packages/teams-js/src/internal/globalVars.ts
@@ -9,4 +9,5 @@ export class GlobalVars {
   public static hostClientType: string | undefined = undefined;
   public static clientSupportedSDKVersion: string;
   public static printCapabilityEnabled = false;
+  public static allowMessageProxy = false;
 }

--- a/packages/teams-js/src/internal/globalVars.ts
+++ b/packages/teams-js/src/internal/globalVars.ts
@@ -10,4 +10,5 @@ export class GlobalVars {
   public static clientSupportedSDKVersion: string;
   public static printCapabilityEnabled = false;
   public static allowMessageProxy = false;
+  public static webAuthWindowOpen = false;
 }

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -6,6 +6,7 @@ import { LoadContext, ResumeContext } from '../public/interfaces';
 import { pages } from '../public/pages';
 import { runtime } from '../public/runtime';
 import { Communication, sendMessageEventToChild, sendMessageToParent } from './communication';
+import { GlobalVars } from './globalVars';
 import { ensureInitialized } from './internalAPIs';
 import { getLogger } from './telemetry';
 import { isNullOrUndefined } from './typeCheckUtilities';
@@ -174,7 +175,7 @@ export function handleThemeChange(theme: string): void {
     HandlersPrivate.themeChangeHandler(theme);
   }
 
-  if (Communication.childWindow) {
+  if (Communication.childWindow && GlobalVars.allowMessageProxy) {
     sendMessageEventToChild('themeChange', [theme]);
   }
 }
@@ -198,12 +199,12 @@ function handleLoad(loadContext: LoadContext): void {
   const resumeContext = convertToResumeContext(loadContext);
   if (HandlersPrivate.resumeHandler) {
     HandlersPrivate.resumeHandler(resumeContext);
-    if (Communication.childWindow) {
+    if (Communication.childWindow && GlobalVars.allowMessageProxy) {
       sendMessageEventToChild('load', [resumeContext]);
     }
   } else if (HandlersPrivate.loadHandler) {
     HandlersPrivate.loadHandler(loadContext);
-    if (Communication.childWindow) {
+    if (Communication.childWindow && GlobalVars.allowMessageProxy) {
       sendMessageEventToChild('load', [loadContext]);
     }
   }

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -245,17 +245,9 @@ async function handleBeforeUnload(): Promise<void> {
 
   if (HandlersPrivate.beforeSuspendOrTerminateHandler) {
     await HandlersPrivate.beforeSuspendOrTerminateHandler();
-    if (Communication.childWindow) {
-      sendMessageEventToChild('beforeUnload');
-    } else {
-      readyToUnload();
-    }
+    readyToUnload();
   } else if (!HandlersPrivate.beforeUnloadHandler || !HandlersPrivate.beforeUnloadHandler(readyToUnload)) {
-    if (Communication.childWindow) {
-      sendMessageEventToChild('beforeUnload');
-    } else {
-      readyToUnload();
-    }
+    readyToUnload();
   }
 }
 

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -6,6 +6,7 @@ import { LoadContext, ResumeContext } from '../public/interfaces';
 import { pages } from '../public/pages';
 import { runtime } from '../public/runtime';
 import { Communication, sendMessageEventToChild, sendMessageToParent } from './communication';
+import { GlobalVars } from './globalVars';
 import { ensureInitialized } from './internalAPIs';
 import { getLogger } from './telemetry';
 import { isNullOrUndefined } from './typeCheckUtilities';
@@ -86,11 +87,11 @@ export function callHandler(name: string, args?: unknown[]): [true, unknown] | [
     callHandlerLogger('Invoking the registered handler for message %s with arguments %o', name, args);
     const result = handler.apply(this, args);
     return [true, result];
-  } else if (Communication.childWindow) {
+  } else if (Communication.childWindow && GlobalVars.allowMessageProxy) {
     sendMessageEventToChild(name, args);
     return [false, undefined];
   } else {
-    callHandlerLogger('Handler for action message %s not found.', name);
+    callHandlerLogger('Handler for action message %s not found or message proxy-ing disabled.', name);
     return [false, undefined];
   }
 }

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -175,7 +175,7 @@ export function handleThemeChange(theme: string): void {
     HandlersPrivate.themeChangeHandler(theme);
   }
 
-  if (Communication.childWindow && GlobalVars.allowMessageProxy) {
+  if (Communication.childWindow && (GlobalVars.allowMessageProxy || GlobalVars.webAuthWindowOpen)) {
     sendMessageEventToChild('themeChange', [theme]);
   }
 }
@@ -199,12 +199,12 @@ function handleLoad(loadContext: LoadContext): void {
   const resumeContext = convertToResumeContext(loadContext);
   if (HandlersPrivate.resumeHandler) {
     HandlersPrivate.resumeHandler(resumeContext);
-    if (Communication.childWindow && GlobalVars.allowMessageProxy) {
+    if (Communication.childWindow && (GlobalVars.allowMessageProxy || GlobalVars.webAuthWindowOpen)) {
       sendMessageEventToChild('load', [resumeContext]);
     }
   } else if (HandlersPrivate.loadHandler) {
     HandlersPrivate.loadHandler(loadContext);
-    if (Communication.childWindow && GlobalVars.allowMessageProxy) {
+    if (Communication.childWindow && (GlobalVars.allowMessageProxy || GlobalVars.webAuthWindowOpen)) {
       sendMessageEventToChild('load', [loadContext]);
     }
   }

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -6,7 +6,6 @@ import { LoadContext, ResumeContext } from '../public/interfaces';
 import { pages } from '../public/pages';
 import { runtime } from '../public/runtime';
 import { Communication, sendMessageEventToChild, sendMessageToParent } from './communication';
-import { GlobalVars } from './globalVars';
 import { ensureInitialized } from './internalAPIs';
 import { getLogger } from './telemetry';
 import { isNullOrUndefined } from './typeCheckUtilities';
@@ -87,11 +86,8 @@ export function callHandler(name: string, args?: unknown[]): [true, unknown] | [
     callHandlerLogger('Invoking the registered handler for message %s with arguments %o', name, args);
     const result = handler.apply(this, args);
     return [true, result];
-  } else if (Communication.childWindow && GlobalVars.allowMessageProxy) {
-    sendMessageEventToChild(name, args);
-    return [false, undefined];
   } else {
-    callHandlerLogger('Handler for action message %s not found or message proxy-ing disabled.', name);
+    callHandlerLogger('Handler for action message %s not found.', name);
     return [false, undefined];
   }
 }

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -922,6 +922,16 @@ export namespace app {
   }
 
   /**
+   * @hidden
+   * Undocumented function used to re-enable message proxy-ing for applications that request one.
+   *
+   * By default, message proxy-ing is disabled for all applications.
+   */
+  export function setAllowMessageProxy(value: boolean = false): void {
+    GlobalVars.allowMessageProxy = value;
+  }
+
+  /**
    * A namespace for enabling the suspension or delayed termination of an app when the user navigates away.
    * When an app registers for the registerBeforeSuspendOrTerminateHandler, it chooses to delay termination.
    * When an app registers for both registerBeforeSuspendOrTerminateHandler and registerOnResumeHandler, it chooses the suspension of the app .

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -328,6 +328,7 @@ export namespace authentication {
     } finally {
       Communication.childWindow = null;
       Communication.childOrigin = null;
+      GlobalVars.webAuthWindowOpen = false;
     }
   }
 
@@ -342,6 +343,7 @@ export namespace authentication {
   function openAuthenticationWindow(authenticateParameters: AuthenticateParameters): void {
     // Close the previously opened window if we have one
     closeAuthenticationWindow();
+
     // Start with a sensible default size
     let width = authenticateParameters.width || 600;
     let height = authenticateParameters.height || 400;
@@ -364,6 +366,8 @@ export namespace authentication {
         : Communication.currentWindow.screenY;
     left += Communication.currentWindow.outerWidth / 2 - width / 2;
     top += Communication.currentWindow.outerHeight / 2 - height / 2;
+
+    GlobalVars.webAuthWindowOpen = true;
     // Open a child window with a desired set of standard browser features
     Communication.childWindow = Communication.currentWindow.open(
       fullyQualifiedURL.href,

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -1,10 +1,8 @@
 import {
-  Communication,
   sendAndHandleSdkError,
   sendAndHandleStatusAndReason,
   sendAndHandleStatusAndReasonWithDefaultError,
   sendAndUnwrap,
-  sendMessageEventToChild,
   sendMessageToParent,
 } from '../internal/communication';
 import { registerHandler, registerHandlerHelper } from '../internal/handlers';
@@ -600,8 +598,6 @@ export namespace pages {
       const saveEventType = new SaveEventImpl(result);
       if (saveHandler) {
         saveHandler(saveEventType);
-      } else if (Communication.childWindow) {
-        sendMessageEventToChild('settings.save', [result]);
       } else {
         // If no handler is registered, we assume success.
         saveEventType.notifySuccess();
@@ -710,8 +706,6 @@ export namespace pages {
       const removeEventType = new RemoveEventImpl();
       if (removeHandler) {
         removeHandler(removeEventType);
-      } else if (Communication.childWindow) {
-        sendMessageEventToChild('settings.remove', []);
       } else {
         // If no handler is registered, we assume success.
         removeEventType.notifySuccess();
@@ -843,12 +837,7 @@ export namespace pages {
 
     function handleBackButtonPress(): void {
       if (!backButtonPressHandler || !backButtonPressHandler()) {
-        if (Communication.childWindow) {
-          // If the current window did not handle it let the child window
-          sendMessageEventToChild('backButtonPress', []);
-        } else {
-          navigateBack();
-        }
+        navigateBack();
       }
     }
 

--- a/packages/teams-js/test/private/privateAPIs.spec.ts
+++ b/packages/teams-js/test/private/privateAPIs.spec.ts
@@ -474,7 +474,6 @@ describe('AppSDK-privateAPIs', () => {
     app.setAllowMessageProxy(false);
   });
 
-  // look into graham change: should I / can I just pull this out and not test it?
   // Also look at other uses of handleChildMessage in the codebase to make sure no other proxying going on
   // verify authentication of messages in handleChildMessage
 

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -1,7 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
-import { MessageResponse } from '../../src/internal/messageObjects';
 import { getGenericOnCompleteHandler } from '../../src/internal/utils';
 import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
@@ -1262,44 +1261,6 @@ describe('Testing pages module', () => {
               const message = utils.findMessageByFunc('settings.save.success');
               validateRequestWithoutArguments(message, 'settings.save.success');
             });
-
-            it('pages.config.registerOnSaveHandler should proxy to childWindow if no handler in top window', async () => {
-              await utils.initializeWithContext(context, null, ['https://teams.microsoft.com']);
-              pages.config.registerOnSaveHandler(undefined);
-              await utils.processMessage({
-                origin: 'https://outlook.office365.com',
-                source: utils.childWindow,
-                data: {
-                  id: 100,
-                  func: 'settings.save',
-                  args: [],
-                } as MessageResponse,
-              } as MessageEvent);
-              expect(utils.childMessages.length).toBe(1);
-              const childMessage = utils.findMessageInChildByFunc('settings.save');
-              expect(childMessage).not.toBeNull();
-            });
-
-            it('pages.config.registerOnSaveHandler should not proxy to childWindow if handler in top window', async () => {
-              await utils.initializeWithContext(context, null, ['https://teams.microsoft.com']);
-              let handlerCalled = false;
-              pages.config.registerOnSaveHandler((saveEvent) => {
-                saveEvent.notifySuccess();
-                handlerCalled = true;
-              });
-              expect(handlerCalled).toBe(false);
-              await utils.processMessage({
-                origin: 'https://outlook.office365.com',
-                source: utils.childWindow,
-                data: {
-                  id: 100,
-                  func: 'settings.save',
-                  args: [],
-                } as MessageResponse,
-              } as MessageEvent);
-              expect(handlerCalled).toBe(true);
-              expect(utils.childMessages.length).toBe(0);
-            });
           } else {
             it(`pages.config.registerOnSaveHandler does not allow calls from ${context} context`, async () => {
               await utils.initializeWithContext(context);
@@ -1361,43 +1322,6 @@ describe('Testing pages module', () => {
               await utils.sendMessage('settings.remove');
 
               expect(handlerCalled).toBeTruthy();
-            });
-
-            it('pages.config.registerOnRemoveHandler should proxy to childWindow if no handler in top window', async () => {
-              await utils.initializeWithContext(context, null, ['https://teams.microsoft.com']);
-              pages.config.registerOnRemoveHandler(undefined);
-              await utils.processMessage({
-                origin: 'https://outlook.office365.com',
-                source: utils.childWindow,
-                data: {
-                  id: 100,
-                  func: 'settings.remove',
-                  args: [],
-                } as MessageResponse,
-              } as MessageEvent);
-              expect(utils.childMessages.length).toBe(1);
-              const childMessage = utils.findMessageInChildByFunc('settings.remove');
-              expect(childMessage).not.toBeNull();
-            });
-
-            it('pages.config.registerOnRemoveHandler should not proxy to childWindow if handler in top window', async () => {
-              await utils.initializeWithContext(context, null, ['https://teams.microsoft.com']);
-              let handlerCalled = false;
-              pages.config.registerOnRemoveHandler(() => {
-                handlerCalled = true;
-              });
-              expect(handlerCalled).toBe(false);
-              await utils.processMessage({
-                origin: 'https://outlook.office365.com',
-                source: utils.childWindow,
-                data: {
-                  id: 100,
-                  func: 'settings.remove',
-                  args: [],
-                } as MessageResponse,
-              } as MessageEvent);
-              expect(handlerCalled).toBe(true);
-              expect(utils.childMessages.length).toBe(0);
             });
 
             it(`pages.config.registerOnRemoveHandler should successfully notify success from the registered remove handler when initialized with ${context} context`, async () => {


### PR DESCRIPTION
## Description

Work In Progress: Feel free to read and ask questions, but there is still more work (and tests) needed before this is ready for checkin.

We'd like to disable message proxying from child windows in as many situations as we can. Message proxying is when an application that is using teamsJS receives a post message from a child window (embedded iframe or new window that the app opened) and "repeats" that message up to the host.

Based on research from PM, we *believe* that the only legitimate use of this functionality if when the `authenticate.authentication` function is called from an app running in a web browser. In those cases, TeamsJS opens a new window for the auth to happen in to avoid the browser popup blocker. In that case, we still want TeamsJS to allow messages from the auth window to be repeated up to the host. In all other cases, we want to prevent message proxy-ing by default, only allowing it for apps that truly need that functionality. I'll go through the PR and leave some comments highlighting interesting bits for reviewers to pay attention to.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
