### PR TITLE
[Draft] Video frame capabilities and attributes

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/VideoEffectsExAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/VideoEffectsExAPIs.tsx
@@ -107,6 +107,7 @@ const MediaStreamRegisterForVideoFrame = (): React.ReactElement =>
     onClick: async (setResult) => {
       try {
         const audioInferenceModel = new ArrayBuffer(8);
+        const requiredCapabilities = [];
         const view = new Uint8Array(audioInferenceModel);
         for (let i = 0; i < view.length; i++) {
           view[i] = i;
@@ -121,6 +122,7 @@ const MediaStreamRegisterForVideoFrame = (): React.ReactElement =>
             format: videoEffects.VideoFrameFormat.NV12,
             requireCameraStream: false,
             audioInferenceModel,
+            requiredCapabilities,
           },
         });
       } catch (error) {
@@ -138,6 +140,7 @@ const SharedFrameRegisterForVideoFrameToBeRemoved = (): React.ReactElement =>
     onClick: async (setResult) => {
       try {
         const audioInferenceModel = new ArrayBuffer(8);
+        const requiredCapabilities = [];
         const view = new Uint8Array(audioInferenceModel);
         for (let i = 0; i < view.length; i++) {
           view[i] = i;
@@ -153,6 +156,7 @@ const SharedFrameRegisterForVideoFrameToBeRemoved = (): React.ReactElement =>
             format: videoEffects.VideoFrameFormat.NV12,
             requireCameraStream: false,
             audioInferenceModel,
+            requiredCapabilities,
           },
         });
       } catch (error) {
@@ -169,6 +173,7 @@ const SharedFrameRegisterForVideoFrame = (): React.ReactElement =>
     onClick: async (setResult) => {
       try {
         const audioInferenceModel = new ArrayBuffer(8);
+        const requiredCapabilities = [];
         const view = new Uint8Array(audioInferenceModel);
         for (let i = 0; i < view.length; i++) {
           view[i] = i;
@@ -184,6 +189,7 @@ const SharedFrameRegisterForVideoFrame = (): React.ReactElement =>
             format: videoEffects.VideoFrameFormat.NV12,
             requireCameraStream: false,
             audioInferenceModel,
+            requiredCapabilities,
           },
         });
       } catch (error) {

--- a/change/@microsoft-teams-js-a8f9bbfe-abed-45eb-89dd-475510d7eb5a.json
+++ b/change/@microsoft-teams-js-a8f9bbfe-abed-45eb-89dd-475510d7eb5a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added new fields to `VideoFrameConfig` and `VideoFrameData` to allow specifying additional capabilities to be applied to a video frame and reading arbitrary attributes on a video frame respectively. The capability is still awaiting support in one or most host applications. To track availability of this capability across different hosts see https://aka.ms/capmatrix",
+  "packageName": "@microsoft/teams-js",
+  "email": "olsolari@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/videoEffectsUtils.ts
+++ b/packages/teams-js/src/internal/videoEffectsUtils.ts
@@ -283,6 +283,7 @@ class OneTextureMetadata {
   // Stream id for audio inference metadata, which is the 4-byte ASCII string "1dia" hardcoded by the host
   // (1dia stands for "audio inference data version 1")
   private readonly AUDIO_INFERENCE_RESULT_STREAM_ID = 0x31646961;
+  private readonly ATTRIBUTE_ID_MAP_STREAM_ID = 0x4d444941;
   public constructor(metadataBuffer: ArrayBuffer, streamCount: number) {
     const metadataDataView = new Uint32Array(metadataBuffer);
     for (let i = 0, index = 0; i < streamCount; i++) {
@@ -296,6 +297,58 @@ class OneTextureMetadata {
 
   public get audioInferenceResult(): Uint8Array | undefined {
     return this.metadataMap.get(this.AUDIO_INFERENCE_RESULT_STREAM_ID);
+  }
+
+  /**
+   * @hidden
+   * Additional attributes on the video frame are string-indexed, with their stream Id dynamically generated.
+   * The mapping of attribute Ids to their stream Ids is itself stored as frame metadata with layout:
+   *
+   * | attribute count  | attribute stream Id  | attribute id                                              | ...   |
+   * | :---:            | :---:                | :---:                                                     | :---: |
+   * | 4 bytes          | 4 bytes              | variable length string (null terminated, 4 byte aligned)  | ...   |
+   *
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  public get attributes(): ReadonlyMap<string, Uint8Array> | undefined {
+    const data = this.metadataMap.get(this.ATTRIBUTE_ID_MAP_STREAM_ID);
+    if (data === undefined) {
+      return undefined;
+    }
+
+    const map: Map<string, Uint8Array> = new Map();
+
+    let offset = 0;
+    const count = data[offset] + (data[++offset] << 8) + (data[++offset] << 16) + (data[++offset] << 24);
+
+    for (let i = 0; i < count && offset < data.length - 1; i++) {
+      const streamId = data[++offset] + (data[++offset] << 8) + (data[++offset] << 16) + (data[++offset] << 24);
+
+      // Find start of null-terminator for the subsequent variable-length string entry
+      const nullTerminatorStartIndex = data.findIndex((value, index, _) => {
+        return value == 0 && index > offset;
+      });
+
+      const decoder = new TextDecoder('utf-8');
+      const attributeId = decoder.decode(data.slice(++offset, nullTerminatorStartIndex));
+
+      // Read attribute value from metadata map
+      const metadata = this.metadataMap.get(streamId);
+      if (metadata !== undefined) {
+        map.set(attributeId, metadata);
+      }
+
+      // Variable length attribute Id strings are null-terminated to a 4-byte alignment
+      const stringByteLength = nullTerminatorStartIndex - offset;
+      const paddingSize = 4 - (stringByteLength % 4);
+
+      // Set offset to index of last trailing zero
+      offset = nullTerminatorStartIndex + (paddingSize - 1);
+    }
+
+    return map;
   }
 }
 
@@ -322,10 +375,9 @@ class TransformerWithMetadata {
     const timestamp = originalFrame.timestamp;
     if (timestamp !== null) {
       try {
-        const { videoFrame, metadata: { audioInferenceResult } = {} } = await this.extractVideoFrameAndMetadata(
-          originalFrame,
-        );
-        const frameProcessedByApp = await this.videoFrameHandler({ videoFrame, audioInferenceResult });
+        const { videoFrame, metadata: { audioInferenceResult, attributes } = {} } =
+          await this.extractVideoFrameAndMetadata(originalFrame);
+        const frameProcessedByApp = await this.videoFrameHandler({ videoFrame, audioInferenceResult, attributes });
         // the current typescript version(4.6.4) dosn't support webcodecs API fully, we have to do type conversion here.
         const processedFrame = new VideoFrame(frameProcessedByApp as unknown as CanvasImageSource, {
           // we need the timestamp to be unchanged from the oirginal frame, so we explicitly set it here.
@@ -371,7 +423,10 @@ class TransformerWithMetadata {
    */
   private extractVideoFrameAndMetadata = async (
     texture: VideoFrame,
-  ): Promise<{ videoFrame: VideoFrame; metadata: { audioInferenceResult?: Uint8Array } }> => {
+  ): Promise<{
+    videoFrame: VideoFrame;
+    metadata: { audioInferenceResult?: Uint8Array; attributes?: ReadonlyMap<string, Uint8Array> };
+  }> => {
     if (inServerSideRenderingEnvironment()) {
       throw errorNotSupportedOnPlatform;
     }
@@ -425,6 +480,7 @@ class TransformerWithMetadata {
       }) as VideoFrame,
       metadata: {
         audioInferenceResult: this.shouldDiscardAudioInferenceResult ? undefined : metadata.audioInferenceResult,
+        attributes: metadata.attributes,
       },
     };
   };

--- a/packages/teams-js/src/private/videoEffectsEx.ts
+++ b/packages/teams-js/src/private/videoEffectsEx.ts
@@ -71,6 +71,15 @@ export namespace videoEffectsEx {
      * Limited to Microsoft-internal use
      */
     audioInferenceModel?: ArrayBuffer;
+    /**
+     * @hidden
+     * Specifies additional capabilities that needs to be applied to the video frame.
+     * @beta
+     *
+     * @internal
+     * Limited to Microsoft-internal use
+     */
+    requiredCapabilities?: string[];
   }
 
   /**
@@ -139,6 +148,15 @@ export namespace videoEffectsEx {
      * Limited to Microsoft-internal use
      */
     audioInferenceResult?: Uint8Array;
+    /**
+     * @hidden
+     * Additional metadata determined by capabilities specified in {@linkcode VideoFrameConfig.requiredCapabilities}
+     * @beta
+     *
+     * @internal
+     * Limited to Microsoft-internal use
+     */
+    attributes?: ReadonlyMap<string, Uint8Array>;
   };
 
   /**

--- a/packages/teams-js/test/private/videoEffectsEx.spec.ts
+++ b/packages/teams-js/test/private/videoEffectsEx.spec.ts
@@ -40,6 +40,7 @@ describe('videoEffectsEx', () => {
         format: videoEffects.VideoFrameFormat.NV12,
         requireCameraStream: false,
         audioInferenceModel: new ArrayBuffer(100),
+        requiredCapabilities: [],
       };
 
       const registerForVideoFrameParameters: videoEffectsEx.RegisterForVideoFrameParameters = {
@@ -698,6 +699,7 @@ describe('videoEffectsEx', () => {
         format: videoEffects.VideoFrameFormat.NV12,
         requireCameraStream: false,
         audioInferenceModel: new ArrayBuffer(100),
+        requiredCapabilities: [],
       };
       const registerForVideoFrameParameters: videoEffectsEx.RegisterForVideoFrameParameters = {
         videoBufferHandler: (_bufferData, _onSuccess, _onError) => {},


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This updates the internal video frame API to allow a video app to specify required capabilities to be applied to the video frame and also read arbitrary attributes on the video frame added by any of the specified capabilities.

### Main changes in the PR:

1. Added `requiredCapabilities` field to `VideoFrameConfig`.
2. Added `attributes` field to `VideoFrameData`.
3. Updated `extractVideoFrameAndMetadata` to read and populate the `attributes` field.

## Validation

### Validation performed:

1. Internal testing

### Unit Tests added:

Updated existing videoEffectsEx unit tests.

### End-to-end tests added:

Updated existing VideoEffectsExAPI e2e tests.

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

- [ ] Update Teams client to use `requiredCapabilities` field
- [ ] Update Avatars app to use `attributes` field
