### PR TITLE
Enable errors to be used be callers of getUser

### DIFF
--- a/apps/teams-test-app/e2e-test-data/authentication.json
+++ b/apps/teams-test-app/e2e-test-data/authentication.json
@@ -17,6 +17,15 @@
       "platformsExcluded": ["iOS"],
       "boxSelector": "#box_getUser",
       "expectedTestAppValue": "Success: {\"oid\":\"mockoid\",\"tid\":\"mocktid\",\"upn\":\"mockupn\",\"loginHint\":\"mockLoginHint\",\"displayName\":\"mockName\",\"dataResidency\":\"public\"}"
+    },
+    {
+      "title": "getUser API Call - Failure (Not full trust)",
+      "version": ">2.25.0",
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_getUser",
+      "testUrlParams": [["appDefOverrides", "{\"isFullTrustApp\": false}"]],
+      "expectedTestAppValue": "Error: Error: Error returned, code = 500, message = App does not have the required permissions for this operation"
     }
   ]
 }

--- a/change/@microsoft-teams-js-fcf61832-de53-4b49-824d-233e1c99caab.json
+++ b/change/@microsoft-teams-js-fcf61832-de53-4b49-824d-233e1c99caab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated `authentication.getUser` to properly unwrap `SdkError` returned from host into a message",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/videoEffectsUtils.ts
+++ b/packages/teams-js/src/internal/videoEffectsUtils.ts
@@ -219,7 +219,10 @@ class OneTextureHeader {
   private readonly ONE_TEXTURE_INPUT_ID = 0x6f746931;
   private readonly INVALID_HEADER_ERROR = 'Invalid video frame header';
   private readonly UNSUPPORTED_LAYOUT_ERROR = 'Unsupported texture layout';
-  public constructor(private readonly headerBuffer: ArrayBuffer, private readonly notifyError: (string) => void) {
+  public constructor(
+    private readonly headerBuffer: ArrayBuffer,
+    private readonly notifyError: (string) => void,
+  ) {
     this.headerDataView = new Uint32Array(headerBuffer);
     // headerDataView will contain the following data:
     // 0: oneTextureLayoutId
@@ -322,9 +325,8 @@ class TransformerWithMetadata {
     const timestamp = originalFrame.timestamp;
     if (timestamp !== null) {
       try {
-        const { videoFrame, metadata: { audioInferenceResult } = {} } = await this.extractVideoFrameAndMetadata(
-          originalFrame,
-        );
+        const { videoFrame, metadata: { audioInferenceResult } = {} } =
+          await this.extractVideoFrameAndMetadata(originalFrame);
         const frameProcessedByApp = await this.videoFrameHandler({ videoFrame, audioInferenceResult });
         // the current typescript version(4.6.4) dosn't support webcodecs API fully, we have to do type conversion here.
         const processedFrame = new VideoFrame(frameProcessedByApp as unknown as CanvasImageSource, {

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -1,6 +1,6 @@
 import * as communication from '../../src/internal/communication';
-import * as handlers from '../../src/internal/handlers';
 import { GlobalVars } from '../../src/internal/globalVars';
+import * as handlers from '../../src/internal/handlers';
 import { MessageRequest } from '../../src/internal/messageObjects';
 import { NestedAppAuthMessageEventNames, NestedAppAuthRequest } from '../../src/internal/nestedAppAuthUtils';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../src/internal/telemetry';

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -1,4 +1,3 @@
-// import * as communication from '../../src/internal/communication';
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import * as handlers from '../../src/internal/handlers';

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -14,8 +14,12 @@ import { Utils } from '../utils';
    large numbers of errors. Then, over time, we can fix the errors and reenable eslint on a per file basis. */
 
 describe('Testing authentication capability', () => {
-  const errorMessage = 'mockError';
+  const errorMessage = 'Sample Error Message';
   const mockResult = 'someResult';
+  const sdkError: SdkError = {
+    errorCode: ErrorCode.INTERNAL_ERROR,
+    message: errorMessage,
+  };
   const mockResource = 'https://someresource/';
   const mockClaim = 'some_claim';
   const mockUser: authentication.UserProfile = {
@@ -837,7 +841,7 @@ describe('Testing authentication capability', () => {
               done();
             };
             const failureCallback = (reason: string): void => {
-              expect(reason).toBe(mockResult);
+              expect(reason).toMatch(new RegExp(sdkError.message!));
               done();
             };
             const userRequest: authentication.UserRequest = {
@@ -849,7 +853,7 @@ describe('Testing authentication capability', () => {
             expect(message).not.toBeNull();
             expect(message.id).toBe(1);
             expect(message.args[0]).toBe(undefined);
-            await utils.respondToMessage(message, false, mockResult);
+            await utils.respondToMessage(message, false, sdkError);
           });
         });
 
@@ -861,8 +865,8 @@ describe('Testing authentication capability', () => {
           expect(message).not.toBeNull();
           expect(message.id).toBe(1);
           expect(message.args[0]).toBe(undefined);
-          await utils.respondToMessage(message, false, mockResult);
-          await expect(promise).rejects.toThrowError(mockResult);
+          await utils.respondToMessage(message, false, sdkError);
+          await expect(promise).rejects.toThrowError(new RegExp(sdkError.message!));
         });
 
         it(`authentication.getUser should successfully get user profile with ${context} context`, async () => {
@@ -888,22 +892,6 @@ describe('Testing authentication capability', () => {
           await utils.respondToMessage(message, true, mockUserWithDataResidency);
           await expect(promise).resolves.toEqual(mockUserWithDataResidency);
         });
-      });
-
-      it('should throw an error message containing the SdkError message when an SdkError is returned from the host', async () => {
-        await utils.initializeWithContext('content');
-
-        const sdkError: SdkError = {
-          errorCode: ErrorCode.INTERNAL_ERROR,
-          message: 'Error Message',
-        };
-
-        const getUserPromise = authentication.getUser();
-
-        const message = utils.findMessageByFunc('authentication.getUser');
-        expect(message).not.toBeNull();
-        await utils.respondToMessage(message!, false, sdkError);
-        await expect(getUserPromise).rejects.toThrowError(new RegExp(sdkError.message!));
       });
     });
 
@@ -1454,7 +1442,7 @@ describe('Testing authentication capability', () => {
               done();
             };
             const failureCallback = (reason: string): void => {
-              expect(reason).toBe(mockResult);
+              expect(reason).toMatch(new RegExp(sdkError.message!));
               done();
             };
             const userRequest: authentication.UserRequest = {
@@ -1469,7 +1457,7 @@ describe('Testing authentication capability', () => {
             await utils.respondToFramelessMessage({
               data: {
                 id: message.id,
-                args: [false, mockResult],
+                args: [false, sdkError],
               },
             } as DOMMessageEvent);
           });
@@ -1486,10 +1474,10 @@ describe('Testing authentication capability', () => {
           await utils.respondToFramelessMessage({
             data: {
               id: message.id,
-              args: [false, mockResult],
+              args: [false, sdkError],
             },
           } as DOMMessageEvent);
-          await expect(promise).rejects.toThrowError(mockResult);
+          await expect(promise).rejects.toThrowError(new RegExp(errorMessage));
         });
 
         it(`authentication.getUser should successfully get user profile with ${context} context`, async () => {

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -4,7 +4,7 @@ import { GlobalVars } from '../../src/internal/globalVars';
 import * as handlers from '../../src/internal/handlers';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import * as internalUtils from '../../src/internal/utils';
-import { FrameContexts, HostClientType } from '../../src/public';
+import { ErrorCode, FrameContexts, HostClientType, SdkError } from '../../src/public';
 import { app } from '../../src/public/app';
 import { authentication } from '../../src/public/authentication';
 import { Utils } from '../utils';
@@ -888,6 +888,22 @@ describe('Testing authentication capability', () => {
           await utils.respondToMessage(message, true, mockUserWithDataResidency);
           await expect(promise).resolves.toEqual(mockUserWithDataResidency);
         });
+      });
+
+      it('should throw an error message containing the SdkError message when an SdkError is returned from the host', async () => {
+        await utils.initializeWithContext('content');
+
+        const sdkError: SdkError = {
+          errorCode: ErrorCode.INTERNAL_ERROR,
+          message: 'Error Message',
+        };
+
+        const getUserPromise = authentication.getUser();
+
+        const message = utils.findMessageByFunc('authentication.getUser');
+        expect(message).not.toBeNull();
+        await utils.respondToMessage(message!, false, sdkError);
+        await expect(getUserPromise).rejects.toThrowError(new RegExp(sdkError.message!));
       });
     });
 


### PR DESCRIPTION
## Description

In the case of an error returned from `authentication.getUser`, the error message was not being properly unwrapped and so callers couldn't really make heads or tails of it. This change ensures the `SdkError` returned by the host is properly transformed into an `Error` so it can be interpreted by the caller. This was in response to a user report.

Prior to this change, you'd have to know how to dig into multiply nested objects to get the result. Now it's just a standard `Error` with `message`.

I added an E2E test for this (and validated that it ran and passed in these pipelines):
```
      ✓ - Target Web Host SDK v-latest - getUser API Call - Failure (Not full trust)  - iOS Excluded  - >2.25.0
```

I updated the unit tests to validate this behavior. There were already unit tests, but they were validating behavior that never happened in reality because they depended on message responses not having `SdkError` objects, which is not how the host SDK operated.
