### PR TITLE
Switch iOS E2E trigger to PR builds only

### DIFF
--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -84,6 +84,7 @@ steps:
 
   - task: Bash@3
     displayName: 'iOS UI/E2E Tests'
+    condition: eq(variables['Build.Reason'], 'PullRequest') # Run E2E only for PR builds temporarily until the iOS E2E issue is resolved. 
     inputs:
       targetType: inline
       script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' -screenshot-enabled=\"YES\" -quiet -resultBundlePath TestResults test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
@@ -91,12 +92,12 @@ steps:
 
   - task: Bash@3
     displayName: 'Generate E2E test report'
+    condition: eq(variables['Build.Reason'], 'PullRequest') # Generate E2E test report only for PR builds temporarily until the iOS E2E issue is resolved. 
     inputs:
       targetType: inline
       script: |
         xchtmlreport -r TestResults -j; if [[ $? == 0 ]]; then echo "Test report has been generated successfully."; exit 0; else echo "Test report generating process failed for some reasons."; exit 1; fi;
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
-    condition: always()
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'


### PR DESCRIPTION
## Description

Temporarily enabling iOS E2E tests exclusively for `PR Automated` triggers and disabling them for all other triggers until the iOS E2E issue is resolved.

### Main changes in the PR:

1. Added a condition in the ios-test.yml file to restrict the run to PR builds only.

## Validation

### Validation performed:

1. Tested on a manual build.

### Unit Tests added:

N/A

### End-to-end tests added:

N/A
