### PR TITLE
Update e2e tests with targetted versions for getUser update

### DIFF
--- a/apps/teams-test-app/e2e-test-data/authentication.json
+++ b/apps/teams-test-app/e2e-test-data/authentication.json
@@ -21,11 +21,62 @@
     {
       "title": "getUser API Call - Failure (Not full trust)",
       "version": ">2.25.0",
+      "hostSdkVersion": {
+        "web": "<3.1.0"
+      },
       "type": "callResponse",
       "platformsExcluded": ["iOS"],
       "boxSelector": "#box_getUser",
       "testUrlParams": [["appDefOverrides", "{\"isFullTrustApp\": false}"]],
       "expectedTestAppValue": "Error: Error: Error returned, code = 500, message = App does not have the required permissions for this operation"
+    },
+    {
+      "title": "getUser API Call - Failure (Not full trust and not Microsoft owned)",
+      "version": ">2.25.0",
+      "hostSdkVersion": {
+        "web": ">3.1.0"
+      },
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_getUser",
+      "testUrlParams": [["appDefOverrides", "{\"isFullTrustApp\": false, \"isMicrosoftOwned\": false}"]],
+      "expectedTestAppValue": "Error: Error: Error returned, code = 500, message = App does not have the required permissions for this operation"
+    },
+    {
+      "title": "getUser API Call - Success (Full trust app)",
+      "version": ">2.25.0",
+      "hostSdkVersion": {
+        "web": ">3.1.0"
+      },
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_getUser",
+      "testUrlParams": [["appDefOverrides", "{\"isFullTrustApp\": true, \"isMicrosoftOwned\": false}"]],
+      "expectedTestAppValue": "{\"oid\":\"mockoid\",\"tid\":\"mocktid\",\"upn\":\"mockupn\",\"loginHint\":\"mockLoginHint\",\"displayName\":\"mockName\",\"dataResidency\":\"public\"}"
+    },
+    {
+      "title": "getUser API Call - Success (Microsoft owned app)",
+      "version": ">2.25.0",
+      "hostSdkVersion": {
+        "web": ">3.1.0"
+      },
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_getUser",
+      "testUrlParams": [["appDefOverrides", "{\"isFullTrustApp\": false, \"isMicrosoftOwned\": true}"]],
+      "expectedTestAppValue": "{\"oid\":\"mockoid\",\"tid\":\"mocktid\",\"upn\":\"mockupn\",\"loginHint\":\"mockLoginHint\",\"displayName\":\"mockName\",\"dataResidency\":\"public\"}"
+    },
+    {
+      "title": "getUser API Call - Success (Full trust and Microsoft owned app)",
+      "version": ">2.25.0",
+      "hostSdkVersion": {
+        "web": ">3.1.0"
+      },
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_getUser",
+      "testUrlParams": [["appDefOverrides", "{\"isFullTrustApp\": true, \"isMicrosoftOwned\": true}"]],
+      "expectedTestAppValue": "{\"oid\":\"mockoid\",\"tid\":\"mocktid\",\"upn\":\"mockupn\",\"loginHint\":\"mockLoginHint\",\"displayName\":\"mockName\",\"dataResidency\":\"public\"}"
     }
   ]
 }

--- a/apps/teams-test-app/e2e-test-data/authentication.json
+++ b/apps/teams-test-app/e2e-test-data/authentication.json
@@ -34,7 +34,7 @@
       "title": "getUser API Call - Failure (Not full trust and not Microsoft owned)",
       "version": ">2.25.0",
       "hostSdkVersion": {
-        "web": ">3.1.0"
+        "web": ">=3.1.0"
       },
       "type": "callResponse",
       "platformsExcluded": ["iOS"],
@@ -46,7 +46,7 @@
       "title": "getUser API Call - Success (Full trust app)",
       "version": ">2.25.0",
       "hostSdkVersion": {
-        "web": ">3.1.0"
+        "web": ">=3.1.0"
       },
       "type": "callResponse",
       "platformsExcluded": ["iOS"],
@@ -58,7 +58,7 @@
       "title": "getUser API Call - Success (Microsoft owned app)",
       "version": ">2.25.0",
       "hostSdkVersion": {
-        "web": ">3.1.0"
+        "web": ">=3.1.0"
       },
       "type": "callResponse",
       "platformsExcluded": ["iOS"],
@@ -70,7 +70,7 @@
       "title": "getUser API Call - Success (Full trust and Microsoft owned app)",
       "version": ">2.25.0",
       "hostSdkVersion": {
-        "web": ">3.1.0"
+        "web": ">=3.1.0"
       },
       "type": "callResponse",
       "platformsExcluded": ["iOS"],

--- a/apps/teams-test-app/e2e-test-data/authentication.json
+++ b/apps/teams-test-app/e2e-test-data/authentication.json
@@ -55,18 +55,6 @@
       "expectedTestAppValue": "{\"oid\":\"mockoid\",\"tid\":\"mocktid\",\"upn\":\"mockupn\",\"loginHint\":\"mockLoginHint\",\"displayName\":\"mockName\",\"dataResidency\":\"public\"}"
     },
     {
-      "title": "getUser API Call - Success (Microsoft owned app)",
-      "version": ">2.25.0",
-      "hostSdkVersion": {
-        "web": ">=3.1.0"
-      },
-      "type": "callResponse",
-      "platformsExcluded": ["iOS"],
-      "boxSelector": "#box_getUser",
-      "testUrlParams": [["appDefOverrides", "{\"isFullTrustApp\": false, \"isMicrosoftOwned\": true}"]],
-      "expectedTestAppValue": "{\"oid\":\"mockoid\",\"tid\":\"mocktid\",\"upn\":\"mockupn\",\"loginHint\":\"mockLoginHint\",\"displayName\":\"mockName\",\"dataResidency\":\"public\"}"
-    },
-    {
       "title": "getUser API Call - Success (Full trust and Microsoft owned app)",
       "version": ">2.25.0",
       "hostSdkVersion": {

--- a/apps/teams-test-app/e2e-test-data/authentication.json
+++ b/apps/teams-test-app/e2e-test-data/authentication.json
@@ -22,7 +22,7 @@
       "title": "getUser API Call - Failure (Not full trust)",
       "version": ">2.25.0",
       "hostSdkVersion": {
-        "web": "<3.1.0"
+        "web": "<=3.1.0"
       },
       "type": "callResponse",
       "platformsExcluded": ["iOS"],
@@ -34,7 +34,7 @@
       "title": "getUser API Call - Failure (Not full trust and not Microsoft owned)",
       "version": ">2.25.0",
       "hostSdkVersion": {
-        "web": ">=3.1.0"
+        "web": ">3.1.0"
       },
       "type": "callResponse",
       "platformsExcluded": ["iOS"],
@@ -46,7 +46,7 @@
       "title": "getUser API Call - Success (Full trust app)",
       "version": ">2.25.0",
       "hostSdkVersion": {
-        "web": ">=3.1.0"
+        "web": ">3.1.0"
       },
       "type": "callResponse",
       "platformsExcluded": ["iOS"],
@@ -58,7 +58,7 @@
       "title": "getUser API Call - Success (Full trust and Microsoft owned app)",
       "version": ">2.25.0",
       "hostSdkVersion": {
-        "web": ">=3.1.0"
+        "web": ">3.1.0"
       },
       "type": "callResponse",
       "platformsExcluded": ["iOS"],


### PR DESCRIPTION
## Description
Updated the getUser test to be in line with the expected changes from the updated getUser function which will enable Micrsoft owned apps the same permissions of full-trust apps. 

### Main changes in the PR:

1. Add hostSdkVersion boundaries
2. Add tests that cover the new cases with a second boolean variable

## Validation

### Validation performed:

1. tests pass locally in the host SDK

### End-to-end tests added:

Yes