### PR TITLE
Update authentication test to include isMicrosoftOwned case in getUser

### DIFF
--- a/apps/teams-test-app/e2e-test-data/authentication.json
+++ b/apps/teams-test-app/e2e-test-data/authentication.json
@@ -55,6 +55,18 @@
       "expectedTestAppValue": "{\"oid\":\"mockoid\",\"tid\":\"mocktid\",\"upn\":\"mockupn\",\"loginHint\":\"mockLoginHint\",\"displayName\":\"mockName\",\"dataResidency\":\"public\"}"
     },
     {
+      "title": "getUser API Call - Success (Microsoft owned app)",
+      "version": ">2.25.0",
+      "hostSdkVersion": {
+        "web": ">3.1.0"
+      },
+      "type": "callResponse",
+      "platformsExcluded": ["iOS"],
+      "boxSelector": "#box_getUser",
+      "testUrlParams": [["appDefOverrides", "{\"isFullTrustApp\": false, \"isMicrosoftOwned\": true}"]],
+      "expectedTestAppValue": "{\"oid\":\"mockoid\",\"tid\":\"mocktid\",\"upn\":\"mockupn\",\"loginHint\":\"mockLoginHint\",\"displayName\":\"mockName\",\"dataResidency\":\"public\"}"
+    },
+    {
       "title": "getUser API Call - Success (Full trust and Microsoft owned app)",
       "version": ">2.25.0",
       "hostSdkVersion": {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This PR adds a new test case for the getUser API Call specifically for Microsoft-owned apps with host SDK version >3.1.0. This ensures that the getUser functionality works correctly for Microsoft-owned apps in newer host SDK versions.

### Main changes in the PR:

1. Added a new test case in the authentication.json file for getUser API Call with hostSdkVersion > 3.1.0 for Microsoft-owned apps
2. Maintained existing test parameters and expected results for consistency

## Validation

### Validation performed:

1. Ran e2e tests locally

### Unit Tests added:

No

### End-to-end tests added:

Yes

## Additional Requirements

### Change file added:

Yes

### Related PRs:

N/A

### Next/remaining steps:

The feature is complete after this PR.

### Screenshots:

N/A