### PR TITLE
Switch all calls of runAppsWithE2ETest.js to the TS version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,7 +122,7 @@ extends:
                 condition: succeeded()
                 inputs:
                   targetType: inline
-                  script: 'node tools/cli/runAppsWithE2ETests.js --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
+                  script: 'pnpm exec ts-node tools/cli/runAppsWithE2ETests.ts --appUrl=https://localhost:4002 --reportFileName=e2e-tests-report-perf --envType=perf'
                   workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
               - task: PublishTestResults@2
@@ -178,7 +178,7 @@ extends:
                     pnpm build-test-app-CDN
                   workingDirectory: '$(ClientSdkProjectDirectory)'
 
-              - bash: 'node tools/cli/runAppsWithE2ETests.js --useDataFromLocal=true --reportFileName=e2e-tests-report-cdn-script-tag --envType=cdnScriptTag'
+              - bash: 'pnpm exec ts-node tools/cli/runAppsWithE2ETests.ts --useDataFromLocal=true --reportFileName=e2e-tests-report-cdn-script-tag --envType=cdnScriptTag'
                 displayName: 'Run E2E integration tests with local script tag on latest cdn bundles'
                 condition: succeeded()
                 workingDirectory: '$(AppHostingSdkProjectDirectory)'

--- a/tools/yaml-templates/web-e2e-tests-job.yml
+++ b/tools/yaml-templates/web-e2e-tests-job.yml
@@ -47,7 +47,7 @@ jobs:
               workingDirectory: '$(ClientSdkProjectDirectory)'
 
           - bash: >
-              node tools/cli/runAppsWithE2ETests.js
+              pnpm exec ts-node tools/cli/runAppsWithE2ETests.ts
               --useDataFromLocal=true
               --testPrefixPattern "${{testPrefixPattern}}"
               --envType=${{ variables.envType }}
@@ -57,7 +57,7 @@ jobs:
 
           - bash: |
               # This sets up the server but runs no tests
-              node tools/cli/runAppsWithE2ETests.js --useDataFromLocal=true --testPrefixPattern "{[]}"
+              pnpm exec ts-node tools/cli/runAppsWithE2ETests.ts --useDataFromLocal=true --testPrefixPattern "{[]}"
               # This runs the Electron tests, which currently cannot be filtered
               pnpm exec xvfb-maybe playwright test
             displayName: 'Run Electron E2E tests'


### PR DESCRIPTION
## Description

The JS file used to run E2E tests is getting replaced with a TS file. Functionality is currently identical between them, so this change just updates the tests to target the new TS file.

## Validation

### Validation performed:

Ensured that all E2E tests ran and passed (see the associated pipeline runs)