### PR TITLE
Use server manager script for electron tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "cSpell.words": ["adal", "teamspace", "uninitialize"],
+  "cSpell.words": ["adal", "teamspace", "uninitialize", "xvfb"],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.insertSpaces": true,

--- a/tools/yaml-templates/web-e2e-tests-job.yml
+++ b/tools/yaml-templates/web-e2e-tests-job.yml
@@ -58,10 +58,10 @@ jobs:
             workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
           - bash: |
-              pnpm exec ts-node tools/cli/testAppManagerCli.ts --envType=test
-              # This runs the Electron integration-layer tests, which currently cannot be filtered
+              pnpm exec ts-node tools/cli/serverManagerCli.ts --envType=orange --serverUrl=https://local.teams.office.com:8080
+              # This runs the Electron-integration layer tests, which currently cannot be filtered
               pnpm exec xvfb-maybe playwright test
-            displayName: 'Run Electron Integration-Layer tests'
+            displayName: 'Run Electron-Integration Layer tests'
             condition: and(succeeded(), eq('${{ parameters.hostingEnvironmentType }}', 'electron'))
             workingDirectory: '$(AppHostingSdkProjectDirectory)'
 

--- a/tools/yaml-templates/web-e2e-tests-job.yml
+++ b/tools/yaml-templates/web-e2e-tests-job.yml
@@ -58,7 +58,7 @@ jobs:
             workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
           - bash: |
-              pnpm exec ts-node tools/cli/testAppManagerCli.ts --envType=electron
+              pnpm exec ts-node tools/cli/testAppManagerCli.ts --envType=test
               # This runs the Electron integration-layer tests, which currently cannot be filtered
               pnpm exec xvfb-maybe playwright test
             displayName: 'Run Electron Integration-Layer tests'

--- a/tools/yaml-templates/web-e2e-tests-job.yml
+++ b/tools/yaml-templates/web-e2e-tests-job.yml
@@ -21,6 +21,8 @@ parameters:
 
 jobs:
   - ${{each testPrefixPattern in parameters.testPrefixPatternGroups}}:
+      # This replaces all characters expected to be see in the test prefix pattern that are not valid in a job name with underscores.
+      # Sadly ADO does not support regex matching here at this time.
       - job: E2ETestsWeb_${{parameters.teamsJsReferenceType}}_${{ replace(replace(replace(replace(replace(replace(testPrefixPattern, '[', '_'), ']', '_' ), '{', '_'), '}', '_'), ',', '_'), '-', '_') }}
         displayName: 'E2E Tests - Web - Via ${{parameters.teamsJsReferenceType}} - ${{parameters.hostingEnvironmentType}} Hosted - ${{testPrefixPattern}}'
         pool:
@@ -56,11 +58,10 @@ jobs:
             workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
           - bash: |
-              # This sets up the server but runs no tests
-              pnpm exec ts-node tools/cli/runAppsWithE2ETests.ts --useDataFromLocal=true --testPrefixPattern "{[]}"
-              # This runs the Electron tests, which currently cannot be filtered
+              pnpm exec ts-node tools/cli/testAppManagerCli.ts --envType=electron
+              # This runs the Electron integration-layer tests, which currently cannot be filtered
               pnpm exec xvfb-maybe playwright test
-            displayName: 'Run Electron E2E tests'
+            displayName: 'Run Electron Integration-Layer tests'
             condition: and(succeeded(), eq('${{ parameters.hostingEnvironmentType }}', 'electron'))
             workingDirectory: '$(AppHostingSdkProjectDirectory)'
 

--- a/tools/yaml-templates/web-e2e-tests-job.yml
+++ b/tools/yaml-templates/web-e2e-tests-job.yml
@@ -58,7 +58,7 @@ jobs:
             workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
           - bash: |
-              pnpm exec ts-node tools/cli/serverManagerCli.ts --envType=orange --serverUrl=https://localhost:4000/
+              pnpm exec ts-node tools/cli/serverManagerCli.ts --envType=test --serverUrl=https://localhost:4000/
               pnpm exec ts-node tools/cli/serverManagerCli.ts --envType=orange --serverUrl=https://local.teams.office.com:8080
               # This runs the Electron-integration layer tests, which currently cannot be filtered
               pnpm exec xvfb-maybe playwright test

--- a/tools/yaml-templates/web-e2e-tests-job.yml
+++ b/tools/yaml-templates/web-e2e-tests-job.yml
@@ -58,6 +58,7 @@ jobs:
             workingDirectory: '$(AppHostingSdkProjectDirectory)'
 
           - bash: |
+              pnpm exec ts-node tools/cli/serverManagerCli.ts --envType=orange --serverUrl=https://localhost:4000/
               pnpm exec ts-node tools/cli/serverManagerCli.ts --envType=orange --serverUrl=https://local.teams.office.com:8080
               # This runs the Electron-integration layer tests, which currently cannot be filtered
               pnpm exec xvfb-maybe playwright test


### PR DESCRIPTION
## Description

The Electron integration tests need the test app and test host to be running in order to function. There was not previously a way to get these running without using the E2E test script and supplying no tests to run and relying on the side effect of it starting these.

I recently introduced the server manager script in the other repo to directly expose this functionality and these changes leverage it.

I also added a comment requested from a previous PR.

## Validation

### Validation performed:

1. Ensured that electron tests pass
2. Ensured that failed electron tests fail the pipeline (they actually don't show up in the tests tab but that's a problem that appears to have existed for a long time; I can look into that in the future).