### PR TITLE
Update WebStorage to test proper result responses from the host sdk

### DIFF
--- a/apps/teams-test-app/e2e-test-data/webStorage.json
+++ b/apps/teams-test-app/e2e-test-data/webStorage.json
@@ -7,7 +7,7 @@
   },
   "checkIsSupported": {
     "domElementName": "checkWebStorageCapability",
-    "expectedOutput": "webStorage is not supported"
+    "expectedOutput": "webStorage is supported"
   },
   "testCases": [
     {
@@ -15,7 +15,31 @@
       "type": "callResponse",
       "boxSelector": "#box_isWebStorageClearedOnUserLogOut",
       "expectedAlertValue": "isWebStorageClearedOnUserLogOut called",
-      "expectedTestAppValue": "webStorage is cleared on user log out"
+      "expectedTestAppValue": "webStorage is cleared on user log out",
+      "hostSdkVersion": {
+        "web": "<4.0.2"
+      }
+    },
+    {
+      "title": "isWebStorageClearedOnUserLogOut function Call - Success (True case)",
+      "type": "callResponse",
+      "boxSelector": "#box_isWebStorageClearedOnUserLogOut",
+      "expectedAlertValue": "isWebStorageClearedOnUserLogOut called",
+      "expectedTestAppValue": "webStorage is cleared on user log out. Result from sdk: true",
+      "hostSdkVersion": {
+        "web": ">=4.0.2"
+      }
+    },
+    {
+      "title": "isWebStorageClearedOnUserLogOut function Call - Success (False case)",
+      "type": "callResponse",
+      "boxSelector": "#box_isWebStorageClearedOnUserLogOut",
+      "modulesToDisable": ["shouldWebStorageResolveToTrueToggle"],
+      "expectedAlertValue": "isWebStorageClearedOnUserLogOut called",
+      "expectedTestAppValue": "webStorage is not cleared on user log out. Result from sdk: false",
+      "hostSdkVersion": {
+        "web": ">=4.0.2"
+      }
     }
   ]
 }

--- a/apps/teams-test-app/src/components/WebStorageAPIs.tsx
+++ b/apps/teams-test-app/src/components/WebStorageAPIs.tsx
@@ -15,8 +15,20 @@ const IsWebStorageClearedOnLogOut = (): React.ReactElement =>
   ApiWithoutInput({
     name: 'isWebStorageClearedOnUserLogOut',
     title: 'Is Web Storage Cleared on Log Out',
-    onClick: async () =>
-      `webStorage ${(await webStorage.isWebStorageClearedOnUserLogOut()) ? 'is' : 'is not'} cleared on user log out`,
+    onClick: async () => {
+      const result = await webStorage.isWebStorageClearedOnUserLogOut();
+      try {
+        if (result === true) {
+          return `webStorage is cleared on user log out. Result from sdk: ${result}`;
+        } else if (result === false) {
+          return `webStorage is not cleared on user log out. Result from sdk: ${result}`;
+        } else {
+          throw new Error('Invalid result: must be true or false');
+        }
+      } catch (error) {
+        return `Error: ${error}. Result from sdk: ${result}`;
+      }
+    },
   });
 
 const WebStorageAPIs = (): ReactElement => (


### PR DESCRIPTION
## Description

This PR updates the WebStorage E2E tests to better handle different host SDK versions. We're adding new test cases for webstorage because we have a new flag to test webstorage behavior.

### Main changes in the PR:

1. Updated the WebStorage E2E test configuration in `apps/teams-test-app/e2e-test-data/webStorage.json`.
2. Modified the `isWebStorageClearedOnUserLogOut` function implementation in `apps/teams-test-app/src/components/WebStorageAPIs.tsx`.

## Validation

### Validation performed:

1. Ran the updated E2E tests locally to verify that they pass for different host SDK versions.
2. Checked that the tests correctly handle the behavior differences between SDK versions before and after 4.0.2.

### Unit Tests added:

No new unit tests were added as this change primarily affects E2E tests.

### End-to-end tests added:

Yes, the existing E2E tests for WebStorage have been updated and expanded.

## Additional Requirements

### Change file added:

No

### Related PRs:

N/A

### Next/remaining steps:

- [ ] Consider adding similar version-specific tests for other modules if needed.
- [ ] Update documentation to reflect these changes in testing strategy, if applicable.

### Screenshots:

N/A