### PR TITLE
Removing validations not valid for content fields

### DIFF
--- a/change/@microsoft-teams-js-a1bf0d67-6f27-4b52-bcbb-30f734313db1.json
+++ b/change/@microsoft-teams-js-a1bf0d67-6f27-4b52-bcbb-30f734313db1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Removing validations not valid for content fields",
+  "packageName": "@microsoft/teams-js",
+  "email": "shmayura@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-a1bf0d67-6f27-4b52-bcbb-30f734313db1.json
+++ b/change/@microsoft-teams-js-a1bf0d67-6f27-4b52-bcbb-30f734313db1.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Removed validations not valid for content fields on `IContentResponse` interfaced",
+  "comment": "Removed invalid validations for content fields on `IContentResponse` interface",
   "packageName": "@microsoft/teams-js",
   "email": "shmayura@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-a1bf0d67-6f27-4b52-bcbb-30f734313db1.json
+++ b/change/@microsoft-teams-js-a1bf0d67-6f27-4b52-bcbb-30f734313db1.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Removing validations not valid for content fields",
+  "comment": "Removed validations not valid for content fields on `IContentResponse` interfaced",
   "packageName": "@microsoft/teams-js",
   "email": "shmayura@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/public/sharing.ts
+++ b/packages/teams-js/src/public/sharing.ts
@@ -213,9 +213,9 @@ export namespace sharing {
       title: string;
       /** Reference of the shared content */
       contentReference: string;
-      /** Id of the thread where the content was shared. This is a UUID */
+      /** Id of the thread where the content was shared. */
       threadId: string;
-      /** Id of the user who shared the content. This is a UUID */
+      /** Id of the user who shared the content. */
       author: string;
       /** Type of the shared content.
        * For sharing to Teams stage scenarios, this value would be `ShareToStage`

--- a/packages/teams-js/src/public/sharing.ts
+++ b/packages/teams-js/src/public/sharing.ts
@@ -1,7 +1,7 @@
 import { sendAndHandleSdkError } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { callCallbackWithSdkErrorFromPromiseAndReturnPromise, InputFunction, validateUuid } from '../internal/utils';
+import { callCallbackWithSdkErrorFromPromiseAndReturnPromise, InputFunction } from '../internal/utils';
 import { errorNotSupportedOnPlatform, FrameContexts } from './constants';
 import { ErrorCode, SdkError } from './interfaces';
 import { runtime } from './runtime';
@@ -243,10 +243,6 @@ export namespace sharing {
         getApiVersionTag(sharingTelemetryVersionNumber_v2, ApiName.Sharing_History_GetContent),
         'sharing.history.getContent',
       );
-      contentDetails.map((contentDetails) => {
-        validateUuid(contentDetails.author);
-        validateUuid(contentDetails.threadId);
-      });
 
       return contentDetails;
     }

--- a/packages/teams-js/test/public/sharing.spec.ts
+++ b/packages/teams-js/test/public/sharing.spec.ts
@@ -758,50 +758,6 @@ describe('sharing_v2', () => {
           } as DOMMessageEvent);
           expect(promise).rejects.toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
         });
-
-        it(`sharing.history.getContent should throw if author id is invalid uuid. context: ${context}`, async () => {
-          await utils.initializeWithContext(context);
-          utils.setRuntimeConfig({ apiVersion: 1, supports: { sharing: { history: {} } } });
-          const promise = sharing.history.getContent();
-          const contentDetails = [
-            {
-              appId: 'appId',
-              title: 'title',
-              contentReference: 'contentReference',
-              threadId: 'fe4a8eba-2a31-4737-8e33-e5fae6fee194',
-              author: 'authorId',
-              contentType: 'contentType',
-            },
-          ];
-          await utils.respondToFramelessMessage({
-            data: {
-              args: [null, contentDetails],
-            },
-          } as DOMMessageEvent);
-          expect(promise).rejects.toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
-        });
-
-        it(`sharing.history.getContent should throw if threadId is invalid uuid. context: ${context}`, async () => {
-          await utils.initializeWithContext(context);
-          utils.setRuntimeConfig({ apiVersion: 1, supports: { sharing: { history: {} } } });
-          const promise = sharing.history.getContent();
-          const contentDetails = [
-            {
-              appId: 'appId',
-              title: 'title',
-              contentReference: 'contentReference',
-              threadId: 'threadId',
-              author: 'da5b7aeb-2a31-6151-5e51-d4eab4abe577',
-              contentType: 'contentType',
-            },
-          ];
-          await utils.respondToFramelessMessage({
-            data: {
-              args: [null, contentDetails],
-            },
-          } as DOMMessageEvent);
-          expect(promise).rejects.toEqual({ errorCode: ErrorCode.INTERNAL_ERROR });
-        });
       } else {
         it(`should not allow sharing.history.getContent calls from ${context} context`, async () => {
           await utils.initializeWithContext(context);


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Removing validations not valid for content fields. AuthorId and ThreadIds are not valid uuids.

### Main changes in the PR:

Removing validations for authorId and threadId not valid for content fields.


### Unit Tests added:

Yes

## Additional Requirements

### Change file added:

Yes