### PR TITLE
Fix a bug where null values in RuntimeConfig cause initialize to fail

### DIFF
--- a/change/@microsoft-teams-js-1257aa2f-91cd-490f-94ba-d9fd85728ddf.json
+++ b/change/@microsoft-teams-js-1257aa2f-91cd-490f-94ba-d9fd85728ddf.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fixed a bug where `null` values in `RuntimeConfig` would cause `app.initialize` to fail and updated `AppEligibilityInformation` interface to be consistent with interface defined in host SDK library.",
+  "comment": "Fixed a bug with `AppEligibilityInformation` that could cause `app.initialize` to fail.",
   "packageName": "@microsoft/teams-js",
   "email": "erinha@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-1257aa2f-91cd-490f-94ba-d9fd85728ddf.json
+++ b/change/@microsoft-teams-js-1257aa2f-91cd-490f-94ba-d9fd85728ddf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed a bug where `null` values in `RuntimeConfig` would cause `app.initialize` to fail and updated `AppEligibilityInformation` interface to be consistent with interface defined in host SDK library.",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -94,6 +94,9 @@ export function generateGUID(): string {
  */
 export function deepFreeze<T extends object>(obj: T): T {
   Object.keys(obj).forEach((prop) => {
+    if (obj[prop] === null || obj[prop] === undefined) {
+      return;
+    }
     if (typeof obj[prop] === 'object') {
       deepFreeze(obj[prop]);
     }

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -1135,7 +1135,7 @@ export interface AppEligibilityInformation {
   /**
    * Education Eligibility Information for the app user
    */
-  userClassification: UserClassification;
+  userClassification: UserClassification | null;
 }
 
 /**

--- a/packages/teams-js/test/private/copilot.spec.ts
+++ b/packages/teams-js/test/private/copilot.spec.ts
@@ -18,6 +18,15 @@ const mockedAppEligibilityInformation = {
   },
 };
 
+const mockedAppEligibilityInformationUserClassificationNull = {
+  cohort: Cohort.BCAIS,
+  ageGroup: LegalAgeGroupClassification.Adult,
+  isCopilotEnabledRegion: true,
+  isCopilotEligible: true,
+  isOptedOutByAdmin: false,
+  userClassification: null,
+};
+
 const copilotRuntimeConfig: Runtime = {
   apiVersion: 4,
   hostVersionsInfo: {
@@ -35,6 +44,25 @@ const copilotRuntimeConfig: Runtime = {
     logs: {},
   },
 };
+
+const copilotRuntimeConfigWithUserClassificationNull: Runtime = {
+  apiVersion: 4,
+  hostVersionsInfo: {
+    appEligibilityInformation: mockedAppEligibilityInformationUserClassificationNull,
+  },
+  supports: {
+    pages: {
+      appButton: {},
+      tabs: {},
+      config: {},
+      backStack: {},
+      fullTrust: {},
+    },
+    teamsCore: {},
+    logs: {},
+  },
+};
+
 describe('copilot', () => {
   let utils: Utils;
   beforeEach(() => {
@@ -72,6 +100,12 @@ describe('copilot', () => {
       expect(() => copilot.eligibility.getEligibilityInfo()).toThrowError(
         expect.objectContaining(errorNotSupportedOnPlatform),
       );
+    });
+    it('should return null userClassification if the host provided eligibility information with userClassification as null', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      utils.setRuntimeConfig(copilotRuntimeConfigWithUserClassificationNull);
+      expect(copilot.eligibility.isSupported()).toBeTruthy();
+      expect(copilot.eligibility.getEligibilityInfo()).toBe(mockedAppEligibilityInformationUserClassificationNull);
     });
   });
 });


### PR DESCRIPTION
## Description
The `AppEligibilityInformation` interface has properties that can be `null` on it. If the `RuntimeConfig` object sent from host SDK to teams-js contains `null` values for those properties, the `applyRuntimeConfig` function in teams-js will throw an error ("TypeError: Cannot convert undefined or null to object") and cause `app.initialize` to fail.

Additionally, this PR ensures that the `AppEligibilityInformation` interface is consistent with the definition in the host SDK library.

### Main changes in the PR:

1. Handle the case where `null` values in the `RuntimeConfig` from the host SDK will cause an error, ultimately causing `app.initialize` to fail.
2. Update the `AppEligibilityInformation` interface to match the definition in the host SDK library and add a unit test to validate handling `null` values.

## Validation

### Validation performed:

1. Added a unit test that failed before updating the `deepFreeze` function. Validated that it passes after changing the function.
2. Ran all unit tests and validated they all pass.

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes
