### PR TITLE
Fix bug where eslint configuration could not resolve tsconfig in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,11 +2,11 @@
   "cSpell.words": ["adal", "ipados", "teamspace", "uninitialize", "xvfb"],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "eslint.workingDirectories": [
-    "./packages/teams-js/",
-    "./apps/teams-perf-test-app",
     "./apps/ssr-test-app/",
+    "./apps/teams-perf-test-app",
     "./apps/teams-test-app/",
-    "./apps/typed-dependency-tester/"
+    "./apps/typed-dependency-tester/",
+    "./packages/teams-js/"
   ],
   "editor.formatOnSave": true,
   "editor.insertSpaces": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,13 @@
 {
   "cSpell.words": ["adal", "ipados", "teamspace", "uninitialize", "xvfb"],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "eslint.workingDirectories": [
+    "./packages/teams-js/",
+    "./apps/teams-perf-test-app",
+    "./apps/ssr-test-app/",
+    "./apps/teams-test-app/",
+    "./apps/typed-dependency-tester/"
+  ],
   "editor.formatOnSave": true,
   "editor.insertSpaces": true,
   "editor.tabSize": 2,


### PR DESCRIPTION
This adds a configuration to the workspace vscode settings to make vscode recognize the proper eslint configuration file and the relative working directory for each sub-package in the monorepo.

### Main changes in the PR:

1. Add working directories settings through workspace settings in vscode

## Validation

I opened the files locally and created apparent error lines that eslint should point out and it work flawlessly. As this change is done through the vscode setting, this does not impact any other outside script other than the editor experience.

### Unit Tests added:

Not needed as it related to developer experience instead of a new feature or bug.

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| ![image](https://github.com/user-attachments/assets/fb001f4f-f82d-4781-8996-db3725655a65) |  ![image](https://github.com/user-attachments/assets/92dc624a-ea09-44b3-8f64-cf8f30bb518e) |

Notice the error in the editor disappeared.
