### PR TITLE
Release 2.28.0

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.27.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-QGb/h0ACuraFEnqrpkMcMBTU+baTLZy1Mh61IGbM206IPGRWiWCIL5dkLzG1RKZH"
+      src="https://res.cdn.office.net/teams-js/2.28.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-gT2igbByugSUPXBgDA+rtfKk4JMSCfG+3DKSivyLqF2Riv4vTLqaC/tFpySw0eIM"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm lint && webpack",

--- a/change/@microsoft-teams-js-1257aa2f-91cd-490f-94ba-d9fd85728ddf.json
+++ b/change/@microsoft-teams-js-1257aa2f-91cd-490f-94ba-d9fd85728ddf.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fixed a bug with `AppEligibilityInformation` that could cause `app.initialize` to fail.",
-  "packageName": "@microsoft/teams-js",
-  "email": "erinha@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-a1bf0d67-6f27-4b52-bcbb-30f734313db1.json
+++ b/change/@microsoft-teams-js-a1bf0d67-6f27-4b52-bcbb-30f734313db1.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Removed invalid validations for content fields on `IContentResponse` interface",
-  "packageName": "@microsoft/teams-js",
-  "email": "shmayura@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-ae62d2ab-6f4d-48ba-a644-fc76e1bc23c0.json
+++ b/change/@microsoft-teams-js-ae62d2ab-6f4d-48ba-a644-fc76e1bc23c0.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Released 2.27.0",
-  "packageName": "@microsoft/teams-js",
-  "email": "jadahiya@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Wed, 28 Aug 2024 19:31:44 GMT and should not be manually modified.
+This log was last generated on Tue, 03 Sep 2024 22:19:52 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.28.0
+
+Tue, 03 Sep 2024 22:19:52 GMT
+
+### Minor changes
+
+- Removed invalid validations for content fields on `IContentResponse` interface
+
+### Patches
+
+- Fixed a bug with `AppEligibilityInformation` that could cause `app.initialize` to fail.
 
 ## 2.27.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.27.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.28.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.27.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-QGb/h0ACuraFEnqrpkMcMBTU+baTLZy1Mh61IGbM206IPGRWiWCIL5dkLzG1RKZH"
+  src="https://res.cdn.office.net/teams-js/2.28.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-gT2igbByugSUPXBgDA+rtfKk4JMSCfG+3DKSivyLqF2Riv4vTLqaC/tFpySw0eIM"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.27.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.28.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",


### PR DESCRIPTION
## 2.28.0

Tue, 03 Sep 2024 22:19:52 GMT

### Minor changes

- Removed invalid validations for content fields on `IContentResponse` interface

### Patches

- Fixed a bug with `AppEligibilityInformation` that could cause `app.initialize` to fail.