### PR TITLE
Add TJS version in default log

### DIFF
--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -747,8 +747,7 @@ export namespace app {
     // This will always be the current script because browsers load and execute scripts in order.
     // Whenever a script is executing for the first time it will be the last script in this array.
     const currentScriptSrc = scripts && scripts[scripts.length - 1] && scripts[scripts.length - 1].src;
-    const scriptUsageWarning =
-      'Today, teamsjs can only be used from a single script or you may see undefined behavior. This log line is used to help detect cases where teamsjs is loaded multiple times -- it is always written. The presence of the log itself does not indicate a multi-load situation, but multiples of these log lines will. If you would like to use teamjs from more than one script at the same time, please open an issue at https://github.com/OfficeDev/microsoft-teams-library-js/issues';
+    const scriptUsageWarning = `Today, teamsjs version: ${version} can only be used from a single script or you may see undefined behavior. This log line is used to help detect cases where teamsjs is loaded multiple times -- it is always written. The presence of the log itself does not indicate a multi-load situation, but multiples of these log lines will. If you would like to use teamjs from more than one script at the same time, please open an issue at https://github.com/OfficeDev/microsoft-teams-library-js/issues`;
     if (!currentScriptSrc || currentScriptSrc.length === 0) {
       appLogger('teamsjs is being used from a script tag embedded directly in your html. %s', scriptUsageWarning);
     } else {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Adding TJS version into default log so that developers will know what version of TJS is using clearly from console.