### PR TITLE
Add button to test app to reload itself

### DIFF
--- a/apps/teams-test-app/src/pages/TestApp.tsx
+++ b/apps/teams-test-app/src/pages/TestApp.tsx
@@ -71,6 +71,7 @@ export const TestApp: React.FC = () => {
 
   return (
     <>
+      <button onClick={() => window.location.reload()}>Reload This App</button>
       <div className="App-container">
         <AppAPIs />
         <AppInitializationAPIs />

--- a/apps/teams-test-app/src/pages/TestApp.tsx
+++ b/apps/teams-test-app/src/pages/TestApp.tsx
@@ -71,7 +71,9 @@ export const TestApp: React.FC = () => {
 
   return (
     <>
-      <button onClick={() => window.location.reload()}>Reload This App</button>
+      <button id="button_reload" onClick={() => window.location.reload()}>
+        Reload This App
+      </button>
       <div className="App-container">
         <AppAPIs />
         <AppInitializationAPIs />


### PR DESCRIPTION
## Description

There have recently been some bugs exposed when apps reload themselves internally (as opposed to the host reloading the whole app container). This change adds a button to the test app which will trigger an internal reload so that tests can be written which trigger this behavior.

## Validation

### Validation performed:

- Manually verified that when I click the button it reloads
- Verified that reloading in this fashion on older host SDKs exposes some of the recently fixed bugs 
