### PR TITLE
Improve message logging from communications module

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "cSpell.words": ["adal", "ipados", "teamspace", "uninitialize", "xvfb"],
+  "cSpell.words": ["adal", "frameless", "ipados", "teamspace", "uninitialize", "xvfb"],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "eslint.workingDirectories": [
     "./apps/ssr-test-app/",

--- a/change/@microsoft-teams-js-b61435ce-c9da-47bc-9b65-2710406ac8d7.json
+++ b/change/@microsoft-teams-js-b61435ce-c9da-47bc-9b65-2710406ac8d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated logging for messages to be clearer",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -767,7 +767,7 @@ function handleIncomingMessageFromParent(evt: DOMMessageEvent): void {
   } else if ('func' in evt.data && typeof evt.data.func === 'string') {
     // Delegate the request to the proper handler
     const message = evt.data as MessageRequest;
-    logger('Received a message from parent, id: %s, action: "%s"', getMessageIdsAsLogString(message), message.func);
+    logger('Received a message from parent %s, action: "%s"', getMessageIdsAsLogString(message), message.func);
     callHandler(message.func, message.args);
   } else {
     logger('Received an unknown message: %O', evt);

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -87,8 +87,7 @@ export function initializeCommunication(
   apiVersionTag: string,
 ): Promise<InitializeResponse> {
   // Listen for messages post to our window
-  CommunicationPrivate.messageListener = async (evt: DOMMessageEvent): Promise<void> =>
-    await processIncomingMessage(evt);
+  CommunicationPrivate.messageListener = (evt: DOMMessageEvent): Promise<void> => processIncomingMessage(evt);
 
   // If we are in an iframe, our parent window is the one hosting us (i.e., window.parent); otherwise,
   // it's the window that opened us (i.e., window.opener)
@@ -1066,6 +1065,7 @@ function createMessageEvent(func: string, args?: any[]): MessageRequest {
 function getMessageIdsAsLogString(
   message:
     | SerializedMessageRequest
+    | SerializedMessageResponse
     | MessageRequestWithRequiredProperties
     | MessageRequest
     | MessageResponse


### PR DESCRIPTION
## Description

From having read a lot of logs recently, the messages emitted from the communications module were often confusing or hard to follow. This change fixes the issues seen:
- Message ids logged were originally confusing and inconsistent. This was because the code was only logging some of the ids some of the time (e.g. only the uuids and not the legacy ids). Moreover, when it was logging the UUIDs, it was using the `%i` format specifier, which I _think_ tells it to format it as an integer (although [the official debug docs](https://www.npmjs.com/package/debug) don't list `%i` as an officially supported formatter). This change logs both IDs all the time and it now correctly logs the UUIDs as strings.
- This change now explicitly logs information about when the library is relaying messages to and from child frames
- I renamed some of the functions to be clearer about their purpose (e.g. whether they were handling incoming messages from a place or outgoing message to a place)

There is no functionality change in this, it's all renames and logging (which I guess is a sort of functionality change, but you know what I mean).

## Validation

### Validation performed:

Read a lot of logs as I was implementing and testing this, including nested app scenarios, to ensure that they all looked right and could be followed.

## Additional Requirements

### Change file added:

Yes