### PR TITLE
Unify some of the appid code, improve script tag detection and add validation

### DIFF
--- a/change/@microsoft-teams-js-81b620f2-8af1-4450-89b0-20600bac843e.json
+++ b/change/@microsoft-teams-js-81b620f2-8af1-4450-89b0-20600bac843e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Unified app id validation, removed incomplete HTML element transformation, and refreshed how script tags are identified in strings",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-81b620f2-8af1-4450-89b0-20600bac843e.json
+++ b/change/@microsoft-teams-js-81b620f2-8af1-4450-89b0-20600bac843e.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Unified app id validation, removed incomplete HTML element transformation, and refreshed how script tags are identified in strings",
+  "comment": "Updated internal app id validation",
   "packageName": "@microsoft/teams-js",
   "email": "36546967+AE-MS@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/internal/appIdValidation.ts
+++ b/packages/teams-js/src/internal/appIdValidation.ts
@@ -1,3 +1,5 @@
+import { hasScriptTags } from './utils';
+
 /**
  * This function can be used to validate if a string is a "valid" app id.
  * Valid is a relative term, in this case. Truly valid app ids are UUIDs as documented in the schema:
@@ -10,7 +12,7 @@
  * @throws Error with a message describing the exact validation violation
  */
 export function validateStringAsAppId(potentialAppId: string): void {
-  if (doesStringContainScriptTags(potentialAppId)) {
+  if (hasScriptTags(potentialAppId)) {
     throw new Error(`Potential app id (${potentialAppId}) is invalid; it contains script tags.`);
   }
 
@@ -23,11 +25,6 @@ export function validateStringAsAppId(potentialAppId: string): void {
   if (doesStringContainNonPrintableCharacters(potentialAppId)) {
     throw new Error(`Potential app id (${potentialAppId}) is invalid; it contains non-printable characters.`);
   }
-}
-
-export function doesStringContainScriptTags(str: string): boolean {
-  const scriptRegex = /<script[^>]*>[\s\S]*?<\/script[^>]*>/gi;
-  return scriptRegex.test(str);
 }
 
 export const minimumValidAppIdLength = 4;

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -407,6 +407,21 @@ export function inServerSideRenderingEnvironment(): boolean {
   return typeof window === 'undefined';
 }
 
+/**
+ * @param id The id to validate
+ * @param errorToThrow Customized error to throw if the id is not valid
+ *
+ * @throws Error if id is not valid
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function validateId(id: string, errorToThrow?: Error): void {
+  if (hasScriptTags(id) || !isIdLengthValid(id) || !isOpaque(id)) {
+    throw errorToThrow || new Error('id is not valid.');
+  }
+}
+
 export function validateUrl(url: URL, errorToThrow?: Error): void {
   const urlString = url.toString().toLocaleLowerCase();
   if (hasScriptTags(urlString)) {
@@ -458,6 +473,20 @@ export function hasScriptTags(input: string): boolean {
     'gi',
   );
   return openingOrClosingScriptTagRegex.test(input);
+}
+
+function isIdLengthValid(id: string): boolean {
+  return id.length < 256 && id.length > 4;
+}
+
+function isOpaque(id: string): boolean {
+  for (let i = 0; i < id.length; i++) {
+    const charCode = id.charCodeAt(i);
+    if (charCode < 32 || charCode > 126) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -407,21 +407,6 @@ export function inServerSideRenderingEnvironment(): boolean {
   return typeof window === 'undefined';
 }
 
-/**
- * @param id The id to validate
- * @param errorToThrow Customized error to throw if the id is not valid
- *
- * @throws Error if id is not valid
- *
- * @internal
- * Limited to Microsoft-internal use
- */
-export function validateId(id: string, errorToThrow?: Error): void {
-  if (hasScriptTags(id) || !isIdLengthValid(id) || !isOpaque(id)) {
-    throw errorToThrow || new Error('id is not valid.');
-  }
-}
-
 export function validateUrl(url: URL, errorToThrow?: Error): void {
   const urlString = url.toString().toLocaleLowerCase();
   if (hasScriptTags(urlString)) {
@@ -460,57 +445,19 @@ export function fullyQualifyUrlString(fullOrRelativePath: string): URL {
 }
 
 /**
- * The hasScriptTags function first decodes any HTML entities in the input string using the decodeHTMLEntities function.
- * It then tries to decode the result as a URI component. If the URI decoding fails (which would throw an error), it assumes that the input was not encoded and uses the original input.
- * Next, it defines a regular expression scriptRegex that matches any string that starts with <script (followed by any characters), then has any characters (including newlines),
- * and ends with </script> (preceded by any characters).
- * Finally, it uses the test method to check if the decoded input matches this regular expression. The function returns true if a match is found and false otherwise.
- * @param input URL converted to string to pattern match
+ * Detects if there are any script tags in a given string, even if they are Uri encoded or encoded as HTML entities.
+ * @param input string to test for script tags
  * @returns true if the input string contains a script tag, false otherwise
  */
-function hasScriptTags(input: string): boolean {
-  let decodedInput;
-  try {
-    const decodedHTMLInput = decodeHTMLEntities(input);
-    decodedInput = decodeURIComponent(decodedHTMLInput);
-  } catch (e) {
-    // input was not encoded, use it as is
-    decodedInput = input;
-  }
-  const scriptRegex = /<script[^>]*>[\s\S]*?<\/script[^>]*>/gi;
-  return scriptRegex.test(decodedInput);
-}
+export function hasScriptTags(input: string): boolean {
+  const openingScriptTagRegex = /<script[^>]*>|&lt;script[^&]*&gt;|%3Cscript[^%]*%3E/gi;
+  const closingScriptTagRegex = /<\/script[^>]*>|&lt;\/script[^&]*&gt;|%3C\/script[^%]*%3E/gi;
 
-/**
- * The decodeHTMLEntities function replaces HTML entities in the input string with their corresponding characters.
- */
-function decodeHTMLEntities(input: string): string {
-  const entityMap = new Map<string, string>([
-    ['&lt;', '<'],
-    ['&gt;', '>'],
-    ['&amp;', '&'],
-    ['&quot;', '"'],
-    ['&#39;', "'"],
-    ['&#x2F;', '/'],
-  ]);
-  entityMap.forEach((value, key) => {
-    input = input.replace(new RegExp(key, 'gi'), value);
-  });
-  return input;
-}
-
-function isIdLengthValid(id: string): boolean {
-  return id.length < 256 && id.length > 4;
-}
-
-function isOpaque(id: string): boolean {
-  for (let i = 0; i < id.length; i++) {
-    const charCode = id.charCodeAt(i);
-    if (charCode < 32 || charCode > 126) {
-      return false;
-    }
-  }
-  return true;
+  const openingOrClosingScriptTagRegex = new RegExp(
+    `${openingScriptTagRegex.source}|${closingScriptTagRegex.source}`,
+    'gi',
+  );
+  return openingOrClosingScriptTagRegex.test(input);
 }
 
 /**

--- a/packages/teams-js/src/private/externalAppAuthentication.ts
+++ b/packages/teams-js/src/private/externalAppAuthentication.ts
@@ -1,7 +1,7 @@
 import { sendMessageToParentAsync } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { validateUrl } from '../internal/utils';
+import { validateId, validateUrl } from '../internal/utils';
 import { AppId } from '../public';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
 import { runtime } from '../public/runtime';

--- a/packages/teams-js/src/private/externalAppAuthentication.ts
+++ b/packages/teams-js/src/private/externalAppAuthentication.ts
@@ -1,7 +1,8 @@
 import { sendMessageToParentAsync } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { validateId, validateUrl } from '../internal/utils';
+import { validateUrl } from '../internal/utils';
+import { AppId } from '../public';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
 import { runtime } from '../public/runtime';
 
@@ -351,7 +352,7 @@ export namespace externalAppAuthentication {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-    validateId(appId, new Error('App id is not valid.'));
+    const typeSafeAppId: AppId = new AppId(appId);
     validateOriginalRequestInfo(originalRequestInfo);
 
     // Ask the parent window to open an authentication window with the parameters provided by the caller.
@@ -362,7 +363,7 @@ export namespace externalAppAuthentication {
       ),
       'externalAppAuthentication.authenticateAndResendRequest',
       [
-        appId,
+        typeSafeAppId.toString(),
         originalRequestInfo,
         authenticateParameters.url.href,
         authenticateParameters.width,
@@ -395,14 +396,15 @@ export namespace externalAppAuthentication {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-    validateId(appId, new Error('App id is not valid.'));
+    const typeSafeAppId: AppId = new AppId(appId);
+
     return sendMessageToParentAsync(
       getApiVersionTag(
         externalAppAuthenticationTelemetryVersionNumber,
         ApiName.ExternalAppAuthentication_AuthenticateWithSSO,
       ),
       'externalAppAuthentication.authenticateWithSSO',
-      [appId, authTokenRequest.claims, authTokenRequest.silent],
+      [typeSafeAppId.toString(), authTokenRequest.claims, authTokenRequest.silent],
     ).then(([wasSuccessful, error]: [boolean, InvokeError]) => {
       if (!wasSuccessful) {
         throw error;
@@ -431,7 +433,7 @@ export namespace externalAppAuthentication {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-    validateId(appId, new Error('App id is not valid.'));
+    const typeSafeAppId: AppId = new AppId(appId);
 
     validateOriginalRequestInfo(originalRequestInfo);
 
@@ -441,7 +443,7 @@ export namespace externalAppAuthentication {
         ApiName.ExternalAppAuthentication_AuthenticateWithSSOAndResendRequest,
       ),
       'externalAppAuthentication.authenticateWithSSOAndResendRequest',
-      [appId, originalRequestInfo, authTokenRequest.claims, authTokenRequest.silent],
+      [typeSafeAppId.toString(), originalRequestInfo, authTokenRequest.claims, authTokenRequest.silent],
     ).then(([wasSuccessful, response]: [boolean, IInvokeResponse | InvokeErrorWrapper]) => {
       if (wasSuccessful && response.responseType != null) {
         return response as IInvokeResponse;

--- a/packages/teams-js/src/private/externalAppCardActions.ts
+++ b/packages/teams-js/src/private/externalAppCardActions.ts
@@ -1,7 +1,7 @@
 import { sendMessageToParentAsync } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { validateId } from '../internal/utils';
+import { AppId } from '../public';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
 import { runtime } from '../public/runtime';
 import { ExternalAppErrorCode } from './constants';
@@ -96,7 +96,7 @@ export namespace externalAppCardActions {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-    validateId(appId, new Error('App id is not valid.'));
+    const typeSafeAppId: AppId = new AppId(appId);
 
     return sendMessageToParentAsync<[boolean, ActionSubmitError]>(
       getApiVersionTag(
@@ -104,7 +104,7 @@ export namespace externalAppCardActions {
         ApiName.ExternalAppCardActions_ProcessActionSubmit,
       ),
       'externalAppCardActions.processActionSubmit',
-      [appId, actionSubmitPayload],
+      [typeSafeAppId, actionSubmitPayload],
     ).then(([wasSuccessful, error]: [boolean, ActionSubmitError]) => {
       if (!wasSuccessful) {
         throw error;
@@ -135,14 +135,14 @@ export namespace externalAppCardActions {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-    validateId(appId, new Error('App id is not valid.'));
+    const typeSafeAppId: AppId = new AppId(appId);
     return sendMessageToParentAsync<[ActionOpenUrlError, ActionOpenUrlType]>(
       getApiVersionTag(
         externalAppCardActionsTelemetryVersionNumber,
         ApiName.ExternalAppCardActions_ProcessActionOpenUrl,
       ),
       'externalAppCardActions.processActionOpenUrl',
-      [appId, url.href, fromElement],
+      [typeSafeAppId.toString(), url.href, fromElement],
     ).then(([error, response]: [ActionOpenUrlError, ActionOpenUrlType]) => {
       if (error) {
         throw error;

--- a/packages/teams-js/src/private/externalAppCardActions.ts
+++ b/packages/teams-js/src/private/externalAppCardActions.ts
@@ -104,7 +104,7 @@ export namespace externalAppCardActions {
         ApiName.ExternalAppCardActions_ProcessActionSubmit,
       ),
       'externalAppCardActions.processActionSubmit',
-      [typeSafeAppId, actionSubmitPayload],
+      [typeSafeAppId.toString(), actionSubmitPayload],
     ).then(([wasSuccessful, error]: [boolean, ActionSubmitError]) => {
       if (!wasSuccessful) {
         throw error;

--- a/packages/teams-js/src/private/externalAppCommands.ts
+++ b/packages/teams-js/src/private/externalAppCommands.ts
@@ -1,7 +1,7 @@
 import { sendMessageToParentAsync } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { validateId } from '../internal/utils';
+import { AppId } from '../public';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
 import { runtime } from '../public/runtime';
 import { ExternalAppErrorCode } from './constants';
@@ -135,12 +135,12 @@ export namespace externalAppCommands {
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-    validateId(appId, new Error('App id is not valid.'));
+    const typeSafeAppId: AppId = new AppId(appId);
 
     const [error, response] = await sendMessageToParentAsync<[ActionCommandError, IActionCommandResponse]>(
       getApiVersionTag(externalAppCommandsTelemetryVersionNumber, ApiName.ExternalAppCommands_ProcessActionCommands),
       ApiName.ExternalAppCommands_ProcessActionCommands,
-      [appId, commandId, extractedParameters],
+      [typeSafeAppId.toString(), commandId, extractedParameters],
     );
     if (error) {
       throw error;

--- a/packages/teams-js/test/internal/appIdValidation.spec.ts
+++ b/packages/teams-js/test/internal/appIdValidation.spec.ts
@@ -1,6 +1,5 @@
 import {
   doesStringContainNonPrintableCharacters,
-  doesStringContainScriptTags,
   isStringWithinAppIdLengthLimits,
   maximumValidAppIdLength,
   minimumValidAppIdLength,

--- a/packages/teams-js/test/internal/appIdValidation.spec.ts
+++ b/packages/teams-js/test/internal/appIdValidation.spec.ts
@@ -58,37 +58,6 @@ describe('isStringWithinAppIdLengthLimits', () => {
   });
 });
 
-describe('doesStringContainScriptTags', () => {
-  test('should return true for strings containing script tags', () => {
-    expect(doesStringContainScriptTags('<script>alert("Hello")</script>')).toBe(true);
-    expect(doesStringContainScriptTags('<script src="example.js"></script>')).toBe(true);
-    expect(doesStringContainScriptTags('<script type="text/javascript">console.log("test")</script>')).toBe(true);
-  });
-
-  test('should return false for strings without script tags', () => {
-    expect(doesStringContainScriptTags('This is a test string')).toBe(false);
-    expect(doesStringContainScriptTags('8e6523aa-97f9-49ad-8614-75cae22f6597')).toBe(false);
-    expect(doesStringContainScriptTags('com.microsoft.teamspace.tab.youtube')).toBe(false);
-    expect(doesStringContainScriptTags('<div>This is a div</div>')).toBe(false);
-    expect(doesStringContainScriptTags('<a href="example.com">Link</a>')).toBe(false);
-  });
-
-  test('should return true for strings with script tags containing newlines and spaces', () => {
-    expect(doesStringContainScriptTags('<script>\nalert("Hello")\n</script>')).toBe(true);
-    expect(doesStringContainScriptTags('<script> \n console.log("test") \n </script>')).toBe(true);
-  });
-
-  test('should return false for empty string', () => {
-    expect(doesStringContainScriptTags('')).toBe(false);
-  });
-
-  test('should return true for strings with multiple script tags', () => {
-    expect(doesStringContainScriptTags('<script>alert("Hello")</script><script>console.log("test")</script>')).toBe(
-      true,
-    );
-  });
-});
-
 // Since there are plenty of tests validating the individual validation functions, these tests are intentionally not as
 // comprehensive as those. It executes a few basic tests and also validates that the error messages thrown are as expected.
 describe('validateStringAsAppId', () => {

--- a/packages/teams-js/test/internal/appIdValidation.spec.ts
+++ b/packages/teams-js/test/internal/appIdValidation.spec.ts
@@ -66,15 +66,15 @@ describe('validateStringAsAppId', () => {
   });
 
   test('should throw error with "script" in message for app id containing script tag', () => {
-    expect(() => validateStringAsAppId('<script>alert("Hello")</script>')).toThrowError(/script/);
+    expect(() => validateStringAsAppId('<script>alert("Hello")</script>')).toThrowError(/script/i);
   });
 
   test('should throw error with "length" in message for app id too long or too short', () => {
-    expect(() => validateStringAsAppId('a')).toThrowError(/length/);
-    expect(() => validateStringAsAppId('a'.repeat(maximumValidAppIdLength))).toThrowError(/length/);
+    expect(() => validateStringAsAppId('a')).toThrowError(/length/i);
+    expect(() => validateStringAsAppId('a'.repeat(maximumValidAppIdLength))).toThrowError(/length/i);
   });
 
   test('should throw error with "printable" in message for app id containing non-printable characters', () => {
-    expect(() => validateStringAsAppId('hello\u0080world')).toThrowError(/printable/);
+    expect(() => validateStringAsAppId('hello\u0080world')).toThrowError(/printable/i);
   });
 });

--- a/packages/teams-js/test/private/externalAppAuthentication.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthentication.spec.ts
@@ -147,46 +147,43 @@ describe('externalAppAuthentication', () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
-          const invalidAppId = 'invalidAppIdwith<script>alert(1)</script>';
-          try {
-            await externalAppAuthentication.authenticateAndResendRequest(
-              invalidAppId,
-              testAuthRequest,
-              testOriginalRequest,
-            );
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          const invalidAppId = 'invalidAppIdWith<script>alert(1)</script>';
+          expect(
+            async () =>
+              await externalAppAuthentication.authenticateAndResendRequest(
+                invalidAppId,
+                testAuthRequest,
+                testOriginalRequest,
+              ),
+          ).toThrowError(/script/);
         });
-        it(`should throw error on invalid app ID if it contains non printabe ASCII characters with context - ${frameContext}`, async () => {
+        it(`should throw error on invalid app ID if it contains non printable ASCII characters with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
           const invalidAppId = 'appId\u0000';
-          try {
-            await externalAppAuthentication.authenticateAndResendRequest(
-              invalidAppId,
-              testAuthRequest,
-              testOriginalRequest,
-            );
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          expect(
+            async () =>
+              await externalAppAuthentication.authenticateAndResendRequest(
+                invalidAppId,
+                testAuthRequest,
+                testOriginalRequest,
+              ),
+          ).toThrowError(/characters/);
         });
         it(`should throw error on invalid app ID if its size exceeds 256 characters with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
           const invalidAppId = 'a'.repeat(257);
-          try {
-            await externalAppAuthentication.authenticateAndResendRequest(
-              invalidAppId,
-              testAuthRequest,
-              testOriginalRequest,
-            );
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          expect(
+            async () =>
+              await externalAppAuthentication.authenticateAndResendRequest(
+                invalidAppId,
+                testAuthRequest,
+                testOriginalRequest,
+              ),
+          ).toThrowError(/length/);
         });
         it(`should throw error on original request info command ID exceeds max size with context - ${frameContext}`, async () => {
           expect.assertions(1);
@@ -870,27 +867,26 @@ describe('externalAppAuthentication', () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
-          const invalidsingInUrl = new URL('https://example.com?param=<script>alert("Hello, world!");</script>');
-          try {
-            await externalAppAuthentication.authenticateWithPowerPlatformConnectorPlugins(
-              titleId,
-              invalidsingInUrl,
-              testPPCWindowParameters,
-            );
-          } catch (e) {
-            expect(e).toEqual(new Error('Invalid Url'));
-          }
+          const invalidStingInUrl = new URL('https://example.com?param=<script>alert("Hello, world!");</script>');
+          expect(
+            async () =>
+              await externalAppAuthentication.authenticateWithPowerPlatformConnectorPlugins(
+                titleId,
+                invalidStingInUrl,
+                testPPCWindowParameters,
+              ),
+          ).toThrowError(/script/);
         });
         it(`should throw error on a non-http signInUrl - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
           // eslint-disable-next-line @microsoft/sdl/no-insecure-url
-          const invalidsingInUrl = new URL('http://pishingsite.com');
+          const invalidStingInUrl = new URL('http://pishingsite.com');
           try {
             await externalAppAuthentication.authenticateWithPowerPlatformConnectorPlugins(
               titleId,
-              invalidsingInUrl,
+              invalidStingInUrl,
               testPPCWindowParameters,
             );
           } catch (e) {

--- a/packages/teams-js/test/private/externalAppAuthentication.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthentication.spec.ts
@@ -864,15 +864,16 @@ describe('externalAppAuthentication', () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
-          const invalidStingInUrl = new URL('https://example.com?param=<script>alert("Hello, world!");</script>');
-          await expect(
-            async () =>
-              await externalAppAuthentication.authenticateWithPowerPlatformConnectorPlugins(
-                titleId,
-                invalidStingInUrl,
-                testPPCWindowParameters,
-              ),
-          ).rejects.toThrowError(/script/i);
+          const invalidStringInUrl = new URL('https://example.com?param=<script>alert("Hello, world!");</script>');
+          try {
+            await externalAppAuthentication.authenticateWithPowerPlatformConnectorPlugins(
+              titleId,
+              invalidStringInUrl,
+              testPPCWindowParameters,
+            );
+          } catch (e) {
+            expect(e).toEqual(new Error('Invalid Url'));
+          }
         });
         it(`should throw error on a non-http signInUrl - ${frameContext}`, async () => {
           expect.assertions(1);

--- a/packages/teams-js/test/private/externalAppAuthentication.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthentication.spec.ts
@@ -880,11 +880,11 @@ describe('externalAppAuthentication', () => {
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
           // eslint-disable-next-line @microsoft/sdl/no-insecure-url
-          const invalidStingInUrl = new URL('http://adatum.com');
+          const invalidStringInUrl = new URL('http://adatum.com');
           try {
             await externalAppAuthentication.authenticateWithPowerPlatformConnectorPlugins(
               titleId,
-              invalidStingInUrl,
+              invalidStringInUrl,
               testPPCWindowParameters,
             );
           } catch (e) {

--- a/packages/teams-js/test/private/externalAppAuthentication.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthentication.spec.ts
@@ -880,7 +880,7 @@ describe('externalAppAuthentication', () => {
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
           // eslint-disable-next-line @microsoft/sdl/no-insecure-url
-          const invalidStingInUrl = new URL('http://pishingsite.com');
+          const invalidStingInUrl = new URL('http://adatum.com');
           try {
             await externalAppAuthentication.authenticateWithPowerPlatformConnectorPlugins(
               titleId,
@@ -895,7 +895,7 @@ describe('externalAppAuthentication', () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
-          let dummyUrl = 'https://dummy.com?param=';
+          let dummyUrl = 'https://contoso.com?param=';
           while (dummyUrl.length < 2050) {
             dummyUrl += 'a';
           }

--- a/packages/teams-js/test/private/externalAppAuthentication.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthentication.spec.ts
@@ -148,42 +148,42 @@ describe('externalAppAuthentication', () => {
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
           const invalidAppId = 'invalidAppIdWith<script>alert(1)</script>';
-          expect(
+          await expect(
             async () =>
               await externalAppAuthentication.authenticateAndResendRequest(
                 invalidAppId,
                 testAuthRequest,
                 testOriginalRequest,
               ),
-          ).toThrowError(/script/);
+          ).rejects.toThrowError(/script/i);
         });
         it(`should throw error on invalid app ID if it contains non printable ASCII characters with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
           const invalidAppId = 'appId\u0000';
-          expect(
+          await expect(
             async () =>
               await externalAppAuthentication.authenticateAndResendRequest(
                 invalidAppId,
                 testAuthRequest,
                 testOriginalRequest,
               ),
-          ).toThrowError(/characters/);
+          ).rejects.toThrowError(/characters/i);
         });
         it(`should throw error on invalid app ID if its size exceeds 256 characters with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
           const invalidAppId = 'a'.repeat(257);
-          expect(
+          await expect(
             async () =>
               await externalAppAuthentication.authenticateAndResendRequest(
                 invalidAppId,
                 testAuthRequest,
                 testOriginalRequest,
               ),
-          ).toThrowError(/length/);
+          ).rejects.toThrowError(/length/i);
         });
         it(`should throw error on original request info command ID exceeds max size with context - ${frameContext}`, async () => {
           expect.assertions(1);
@@ -438,45 +438,42 @@ describe('externalAppAuthentication', () => {
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
           const invalidAppId = 'invalidAppIdwith<script>alert(1)</script>';
-          try {
-            await externalAppAuthentication.authenticateWithSSOAndResendRequest(
-              invalidAppId,
-              testAuthRequest,
-              testOriginalRequest,
-            );
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          await expect(
+            async () =>
+              await externalAppAuthentication.authenticateWithSSOAndResendRequest(
+                invalidAppId,
+                testAuthRequest,
+                testOriginalRequest,
+              ),
+          ).rejects.toThrowError(/script/i);
         });
-        it(`should throw error on invalid app ID if it contains non printabe ASCII characters with context - ${frameContext}`, async () => {
+        it(`should throw error on invalid app ID if it contains non printable ASCII characters with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
           const invalidAppId = 'appId\u0000';
-          try {
-            await externalAppAuthentication.authenticateWithSSOAndResendRequest(
-              invalidAppId,
-              testAuthRequest,
-              testOriginalRequest,
-            );
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          await expect(
+            async () =>
+              await externalAppAuthentication.authenticateWithSSOAndResendRequest(
+                invalidAppId,
+                testAuthRequest,
+                testOriginalRequest,
+              ),
+          ).rejects.toThrowError(/characters/i);
         });
         it(`should throw error on invalid app ID if if its size exceeds 256 characters with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
           const invalidAppId = 'a'.repeat(257);
-          try {
-            await externalAppAuthentication.authenticateWithSSOAndResendRequest(
-              invalidAppId,
-              testAuthRequest,
-              testOriginalRequest,
-            );
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          await expect(
+            async () =>
+              await externalAppAuthentication.authenticateWithSSOAndResendRequest(
+                invalidAppId,
+                testAuthRequest,
+                testOriginalRequest,
+              ),
+          ).rejects.toThrowError(/length/i);
         });
 
         it(`should throw error on original request info command ID exceeds max size with context - ${frameContext}`, async () => {
@@ -868,14 +865,14 @@ describe('externalAppAuthentication', () => {
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthentication: {} } });
           const invalidStingInUrl = new URL('https://example.com?param=<script>alert("Hello, world!");</script>');
-          expect(
+          await expect(
             async () =>
               await externalAppAuthentication.authenticateWithPowerPlatformConnectorPlugins(
                 titleId,
                 invalidStingInUrl,
                 testPPCWindowParameters,
               ),
-          ).toThrowError(/script/);
+          ).rejects.toThrowError(/script/i);
         });
         it(`should throw error on a non-http signInUrl - ${frameContext}`, async () => {
           expect.assertions(1);

--- a/packages/teams-js/test/private/externalAppCardActions.spec.ts
+++ b/packages/teams-js/test/private/externalAppCardActions.spec.ts
@@ -82,34 +82,28 @@ describe('externalAppCardActions', () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActions: {} } });
-          const invalidAppId = 'invalidAppIdwith<script>alert(1)</script>';
-          try {
-            await externalAppCardActions.processActionSubmit(invalidAppId, testActionSubmitPayload);
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          const invalidAppId = 'invalidAppIdWith<script>alert(1)</script>';
+          expect(
+            async () => await externalAppCardActions.processActionSubmit(invalidAppId, testActionSubmitPayload),
+          ).toThrowError(/script/);
         });
-        it(`should throw error on invalid app ID if it contains non printabe ASCII characters. context - ${frameContext}`, async () => {
+        it(`should throw error on invalid app ID if it contains non printable ASCII characters. context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActions: {} } });
           const invalidAppId = 'appId\u0000';
-          try {
-            await externalAppCardActions.processActionSubmit(invalidAppId, testActionSubmitPayload);
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          expect(
+            async () => await externalAppCardActions.processActionSubmit(invalidAppId, testActionSubmitPayload),
+          ).toThrowError(/characters/);
         });
         it(`should throw error on invalid app ID if it its size exceeds 256 characters. context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActions: {} } });
           const invalidAppId = 'a'.repeat(257);
-          try {
-            await externalAppCardActions.processActionSubmit(invalidAppId, testActionSubmitPayload);
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          expect(
+            async () => await externalAppCardActions.processActionSubmit(invalidAppId, testActionSubmitPayload),
+          ).toThrowError(/length/);
         });
       } else {
         it(`should not allow calls from ${frameContext} context`, async () => {

--- a/packages/teams-js/test/private/externalAppCardActions.spec.ts
+++ b/packages/teams-js/test/private/externalAppCardActions.spec.ts
@@ -83,27 +83,27 @@ describe('externalAppCardActions', () => {
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActions: {} } });
           const invalidAppId = 'invalidAppIdWith<script>alert(1)</script>';
-          expect(
+          await expect(
             async () => await externalAppCardActions.processActionSubmit(invalidAppId, testActionSubmitPayload),
-          ).toThrowError(/script/);
+          ).rejects.toThrowError(/script/i);
         });
         it(`should throw error on invalid app ID if it contains non printable ASCII characters. context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActions: {} } });
           const invalidAppId = 'appId\u0000';
-          expect(
+          await expect(
             async () => await externalAppCardActions.processActionSubmit(invalidAppId, testActionSubmitPayload),
-          ).toThrowError(/characters/);
+          ).rejects.toThrowError(/characters/i);
         });
         it(`should throw error on invalid app ID if it its size exceeds 256 characters. context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActions: {} } });
           const invalidAppId = 'a'.repeat(257);
-          expect(
+          await expect(
             async () => await externalAppCardActions.processActionSubmit(invalidAppId, testActionSubmitPayload),
-          ).toThrowError(/length/);
+          ).rejects.toThrowError(/length/i);
         });
       } else {
         it(`should not allow calls from ${frameContext} context`, async () => {
@@ -182,33 +182,27 @@ describe('externalAppCardActions', () => {
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActions: {} } });
           const invalidAppId = 'invalidAppIdwith<script>alert(1)</script>';
-          try {
-            await externalAppCardActions.processActionOpenUrl(invalidAppId, testUrl);
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          await expect(
+            async () => await externalAppCardActions.processActionOpenUrl(invalidAppId, testUrl),
+          ).rejects.toThrowError(/script/i);
         });
-        it(`should throw error on invalid app ID if it contains non printabe ASCII characters with context - ${frameContext}`, async () => {
+        it(`should throw error on invalid app ID if it contains non printable ASCII characters with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActions: {} } });
           const invalidAppId = 'appId\u0000';
-          try {
-            await externalAppCardActions.processActionOpenUrl(invalidAppId, testUrl);
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          await expect(
+            async () => await externalAppCardActions.processActionOpenUrl(invalidAppId, testUrl),
+          ).rejects.toThrowError(/characters/i);
         });
         it(`should throw error on invalid app ID if its size exceeds 256 characters with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActions: {} } });
           const invalidAppId = 'a'.repeat(257);
-          try {
-            await externalAppCardActions.processActionOpenUrl(invalidAppId, testUrl);
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          await expect(
+            async () => await externalAppCardActions.processActionOpenUrl(invalidAppId, testUrl),
+          ).rejects.toThrowError(/length/i);
         });
       } else {
         it(`should not allow calls from ${frameContext} context`, async () => {

--- a/packages/teams-js/test/private/externalAppCommands.spec.ts
+++ b/packages/teams-js/test/private/externalAppCommands.spec.ts
@@ -98,27 +98,27 @@ describe('externalAppCommands', () => {
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCommands: {} } });
           const invalidAppId = 'invalidAppIdWith<script>alert(1)</script>';
-          expect(
+          await expect(
             async () => await externalAppCommands.processActionCommand(invalidAppId, mockCommandId, mockExtractedParam),
-          ).toThrowError(/script/);
+          ).rejects.toThrowError(/script/i);
         });
         it(`should throw error on invalid app ID if it contains non printable ASCII characters with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCommands: {} } });
           const invalidAppId = 'appId\u0000';
-          expect(
+          await expect(
             async () => await externalAppCommands.processActionCommand(invalidAppId, mockCommandId, mockExtractedParam),
-          ).toThrowError(/characters/);
+          ).rejects.toThrowError(/characters/i);
         });
         it(`should throw error on invalid app ID if its size exceeds 256 characters with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCommands: {} } });
           const invalidAppId = 'a'.repeat(257);
-          expect(
+          await expect(
             async () => await externalAppCommands.processActionCommand(invalidAppId, mockCommandId, mockExtractedParam),
-          ).toThrowError(/length/);
+          ).rejects.toThrowError(/length/i);
         });
       } else {
         it(`should not allow calls from ${frameContext} context`, async () => {

--- a/packages/teams-js/test/private/externalAppCommands.spec.ts
+++ b/packages/teams-js/test/private/externalAppCommands.spec.ts
@@ -97,34 +97,28 @@ describe('externalAppCommands', () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCommands: {} } });
-          const invalidAppId = 'invalidAppIdwith<script>alert(1)</script>';
-          try {
-            await externalAppCommands.processActionCommand(invalidAppId, mockCommandId, mockExtractedParam);
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          const invalidAppId = 'invalidAppIdWith<script>alert(1)</script>';
+          expect(
+            async () => await externalAppCommands.processActionCommand(invalidAppId, mockCommandId, mockExtractedParam),
+          ).toThrowError(/script/);
         });
-        it(`should throw error on invalid app ID if it contains non printabe ASCII characters with context - ${frameContext}`, async () => {
+        it(`should throw error on invalid app ID if it contains non printable ASCII characters with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCommands: {} } });
           const invalidAppId = 'appId\u0000';
-          try {
-            await externalAppCommands.processActionCommand(invalidAppId, mockCommandId, mockExtractedParam);
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          expect(
+            async () => await externalAppCommands.processActionCommand(invalidAppId, mockCommandId, mockExtractedParam),
+          ).toThrowError(/characters/);
         });
         it(`should throw error on invalid app ID if its size exceeds 256 characters with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCommands: {} } });
           const invalidAppId = 'a'.repeat(257);
-          try {
-            await externalAppCommands.processActionCommand(invalidAppId, mockCommandId, mockExtractedParam);
-          } catch (e) {
-            expect(e).toEqual(new Error('App id is not valid.'));
-          }
+          expect(
+            async () => await externalAppCommands.processActionCommand(invalidAppId, mockCommandId, mockExtractedParam),
+          ).toThrowError(/length/);
         });
       } else {
         it(`should not allow calls from ${frameContext} context`, async () => {

--- a/packages/teams-js/test/public/appId.spec.ts
+++ b/packages/teams-js/test/public/appId.spec.ts
@@ -10,15 +10,15 @@ describe('doesStringContainNonPrintableCharacters', () => {
   });
 
   test('should throw error with "script" in message for app id containing script tag', () => {
-    expect(() => new AppId('<script>alert("Hello")</script>')).toThrowError(/script/);
+    expect(() => new AppId('<script>alert("Hello")</script>')).toThrowError(/script/i);
   });
 
   test('should throw error with "length" in message for app id too long or too short', () => {
-    expect(() => new AppId('a')).toThrowError(/length/);
-    expect(() => new AppId('a'.repeat(maximumValidAppIdLength))).toThrowError(/length/);
+    expect(() => new AppId('a')).toThrowError(/length/i);
+    expect(() => new AppId('a'.repeat(maximumValidAppIdLength))).toThrowError(/length/i);
   });
 
   test('should throw error with "printable" in message for app id containing non-printable characters', () => {
-    expect(() => new AppId('hello\u0080world')).toThrowError(/printable/);
+    expect(() => new AppId('hello\u0080world')).toThrowError(/printable/i);
   });
 });


### PR DESCRIPTION
## Description

The codebase currently has some duplication in a few areas:
- Multiple different ways of accepting, storing, and validation of app ids
- Multiple (different) ways of identifying the presence of script tags

### Main changes in the PR:

1. Unify all App Id logic around the `AppId` type -- note: the input parameters for appids unfortunately cannot be changed from `string` to `AppId` at this time since that would be a API-breaking change. 
2. Remove incomplete implementation of HTML entity decoding (since it was missing a lot of other entities) and remove need for such functionality by just looking specifically for encoded script tags (script tag searching was the only function using the entity decoding helper)
3. All related tests that were using a regex to test for a specific substring were updated to be case-insensitive, since they are intentionally not looking to exact match the error message (the exact error message is not part of the API contract)
4. Explicitly added unit tests for validate the `hasScriptTags` function
5. Updated unit tests for functions that were doing app id validation to no longer test on the exact error message (it's not part of the API contract) and only test for the presence of a descriptive word (in a case-insensitive way). Relatedly: updated these tests to more directly use Jest-provided affordances for testing async functions that throw errors.
6. Updated unit test usage of domains not controlled by Microsoft to use Microsoft-owned domains

## Validation

### Validation performed:

1. All existing and new unit tests were run and passed
2. Private helper functions that previously didn't have specific unit tests now do

### Unit Tests added:

Yes

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes

### Next/remaining steps:
There are still a few places that use the old `validateId` function but that I did not change to use `AppId`. This is because the data being validated were not actually an app ids -- they are fields like "title id" and "oauthConfigId". It's not clear why these other ID types were using the app id validation code so I can't tell whether to unify them now. I have questions out to the owners about this and will follow up in a subsequent change.
