### PR TITLE
Add userClickTimeV2 context value.

### DIFF
--- a/change/@microsoft-teams-js-a4e76c3e-7ab3-4dd4-9a24-c0c909040b64.json
+++ b/change/@microsoft-teams-js-a4e76c3e-7ab3-4dd4-9a24-c0c909040b64.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add userClickTimeV2 new context field.",
+  "packageName": "@microsoft/teams-js",
+  "email": "jcardenasr123@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -340,6 +340,11 @@ export namespace app {
     userClickTime?: number;
 
     /**
+     * Monotonic timer when the user clicked on the tab
+     */
+    userClickTimeV2?: number;
+
+    /**
      * The ID of the parent message from which this task module was launched.
      * This is only available in task modules launched from bot cards.
      */
@@ -999,6 +1004,7 @@ function transformLegacyContextToAppContext(legacyContext: LegacyContext): app.C
       osLocaleInfo: legacyContext.osLocaleInfo,
       parentMessageId: legacyContext.parentMessageId,
       userClickTime: legacyContext.userClickTime,
+      userClickTimeV2: legacyContext.userClickTimeV2,
       userFileOpenPreference: legacyContext.userFileOpenPreference,
       host: {
         name: legacyContext.hostName ? legacyContext.hostName : HostName.teams,

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -713,6 +713,14 @@ export interface Context {
 
   /**
    * @deprecated
+   * As of TeamsJS v2.0.0, please use {@link app.AppInfo.userClickTimeV2 | app.Context.app.userClickTimeV2} instead
+   *
+   * Monotonic timer when the user clicked on the tab
+   */
+  userClickTimeV2?: number;
+
+  /**
+   * @deprecated
    * As of TeamsJS v2.0.0, please use {@link app.TeamInfo.templateId | app.Context.team.templateId} instead
    *
    * Team Template ID if there was a Team Template associated with the creation of the team.
@@ -1008,7 +1016,7 @@ export interface SdkError {
   errorCode: ErrorCode;
   /**
   Optional description for the error. This may contain useful information for web-app developers.
-  This string will not be localized and is not for end-user consumption. 
+  This string will not be localized and is not for end-user consumption.
   App should not depend on the string content. The exact value may change. This is only for debugging purposes.
   */
   message?: string;

--- a/packages/teams-js/test/private/privateAPIs.spec.ts
+++ b/packages/teams-js/test/private/privateAPIs.spec.ts
@@ -358,6 +358,7 @@ describe('AppSDK-privateAPIs', () => {
       appLaunchId: 'appLaunchId',
       sourceOrigin: 'someOrigin',
       userClickTime: 1000,
+      userClickTimeV2: 1001,
       teamTemplateId: 'com.microsoft.teams.ManageAProject',
       userFileOpenPreference: FileOpenPreference.Web,
     };

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -556,6 +556,7 @@ describe('Testing app capability', () => {
             sourceOrigin: 'www.origin.com',
             teamTemplateId: 'someTeamTemplateId',
             userClickTime: 2222,
+            userClickTimeV2: 3333,
             userFileOpenPreference: FileOpenPreference.Inline,
             isMultiWindow: true,
             isBackgroundLoad: true,
@@ -574,6 +575,7 @@ describe('Testing app capability', () => {
               sessionId: 'appSessionId',
               theme: 'someTheme',
               userClickTime: 2222,
+              userClickTimeV2: 3333,
               userFileOpenPreference: FileOpenPreference.Inline,
               appLaunchId: 'appLaunchId',
               host: {
@@ -1424,6 +1426,7 @@ describe('Testing app capability', () => {
             sourceOrigin: 'www.origin.com',
             teamTemplateId: 'someTeamTemplateId',
             userClickTime: 2222,
+            userClickTimeV2: 3333,
             userFileOpenPreference: FileOpenPreference.Inline,
             isMultiWindow: true,
             frameContext: context,
@@ -1441,6 +1444,7 @@ describe('Testing app capability', () => {
               osLocaleInfo: undefined,
               parentMessageId: 'someParentMessageId',
               userClickTime: 2222,
+              userClickTimeV2: 3333,
               userFileOpenPreference: FileOpenPreference.Inline,
               host: {
                 name: HostName.orange,


### PR DESCRIPTION
## Description

This pull request exposes the new field `userClickTimeV2` which can be used to properly measured app initialization time since the user clicked on the app. This field must be set by using the monotonic timers API exposed by the `performance` feature of JavaScript as `performance.now() + performance.timeOrigin` and can be used to measure any necessary elapsed time between click and any other point.

### Main changes in the PR:

1. Add `userClickTimeV2` in context type objects.

## Validation

### Validation performed:

Ran tests and build everything to validate everything keep working as usual.

### Unit Tests added:

No, didn't seem needed as this field is not set by this codebase.

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes

