### PR TITLE
Log version on startup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "cSpell.words": ["adal", "frameless", "ipados", "teamspace", "uninitialize", "xvfb"],
+  "cSpell.words": ["adal", "frameless", "ipados", "teamsjs", "teamspace", "uninitialize", "xvfb"],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "eslint.workingDirectories": [
     "./apps/ssr-test-app/",

--- a/change/@microsoft-teams-js-120060c9-a050-4da3-a0a5-2323e3a78d10.json
+++ b/change/@microsoft-teams-js-120060c9-a050-4da3-a0a5-2323e3a78d10.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added logging for version on startup",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -750,11 +750,13 @@ export namespace app {
     const scriptUsageWarning =
       'Today, teamsjs can only be used from a single script or you may see undefined behavior. This log line is used to help detect cases where teamsjs is loaded multiple times -- it is always written. The presence of the log itself does not indicate a multi-load situation, but multiples of these log lines will. If you would like to use teamjs from more than one script at the same time, please open an issue at https://github.com/OfficeDev/microsoft-teams-library-js/issues';
     if (!currentScriptSrc || currentScriptSrc.length === 0) {
-      appLogger('teamsjs is being used from a script tag embedded directly in your html. %s', scriptUsageWarning);
-      appLogger('teamsjs is version: %s', version);
+      appLogger(
+        'teamsjs version %s is being used from a script tag embedded directly in your html. %s',
+        version,
+        scriptUsageWarning,
+      );
     } else {
-      appLogger('teamsjs is being used from %s. %s', currentScriptSrc, scriptUsageWarning);
-      appLogger('teamsjs %s is version: %s', currentScriptSrc, version);
+      appLogger('teamsjs version %s is being used from %s. %s', version, currentScriptSrc, scriptUsageWarning);
     }
   }
 

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -751,8 +751,10 @@ export namespace app {
       'Today, teamsjs can only be used from a single script or you may see undefined behavior. This log line is used to help detect cases where teamsjs is loaded multiple times -- it is always written. The presence of the log itself does not indicate a multi-load situation, but multiples of these log lines will. If you would like to use teamjs from more than one script at the same time, please open an issue at https://github.com/OfficeDev/microsoft-teams-library-js/issues';
     if (!currentScriptSrc || currentScriptSrc.length === 0) {
       appLogger('teamsjs is being used from a script tag embedded directly in your html. %s', scriptUsageWarning);
+      appLogger('teamsjs is version: %s', version);
     } else {
       appLogger('teamsjs is being used from %s. %s', currentScriptSrc, scriptUsageWarning);
+      appLogger('teamsjs %s is version: %s', currentScriptSrc, version);
     }
   }
 


### PR DESCRIPTION
## Description

When reviewing client logs, it would be helpful to see what version of teamsjs is in use.

### Main changes in the PR:

Log the version of teamsjs in use when starting

## Validation

### Validation performed:

![image](https://github.com/user-attachments/assets/1f02830b-db29-4bed-9abd-ccd34b6b700c)

## Additional Requirements

### Change file added:

Yes