### PR TITLE
Added the teamsjs instance identifier and timestamp to every log line

### DIFF
--- a/change/@microsoft-teams-js-b1e62451-f7ad-44d0-b700-d5fe996761f9.json
+++ b/change/@microsoft-teams-js-b1e62451-f7ad-44d0-b700-d5fe996761f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added logging for current teamsjs instance and timestamps",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -8,7 +8,7 @@ export const teamsJsInstanceIdentifier = new UUID();
 // Every log statement will get prepended with the teamsJsInstanceIdentifier and a timestamp
 const origFormatArgs = registerLogger.formatArgs;
 registerLogger.formatArgs = function (args) {
-  args[0] = `${teamsJsInstanceIdentifier.toString()} (${new Date().toISOString()}): ${args[0]}`;
+  args[0] = `(${new Date().toISOString()}): ${args[0]} [${teamsJsInstanceIdentifier.toString()}]`;
   origFormatArgs.call(this, args);
 };
 

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -1,5 +1,14 @@
 import { debug as registerLogger, Debugger } from 'debug';
 
+import { UUID } from './uuidObject';
+
+export const teamsJsInstanceIdentifier = new UUID();
+const origFormatArgs = registerLogger.formatArgs;
+registerLogger.formatArgs = function (args) {
+  args[0] = `${teamsJsInstanceIdentifier.toString()} (${new Date().toISOString()}): ${args[0]}`;
+  origFormatArgs.call(this, args);
+};
+
 const topLevelLogger = registerLogger('teamsJs');
 
 /**

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -6,10 +6,10 @@ import { UUID } from './uuidObject';
 export const teamsJsInstanceIdentifier = new UUID();
 
 // Every log statement will get prepended with the teamsJsInstanceIdentifier and a timestamp
-const origFormatArgs = registerLogger.formatArgs;
+const originalFormatArgsFunction = registerLogger.formatArgs;
 registerLogger.formatArgs = function (args) {
   args[0] = `(${new Date().toISOString()}): ${args[0]} [${teamsJsInstanceIdentifier.toString()}]`;
-  origFormatArgs.call(this, args);
+  originalFormatArgsFunction.call(this, args);
 };
 
 const topLevelLogger = registerLogger('teamsJs');

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -2,7 +2,10 @@ import { debug as registerLogger, Debugger } from 'debug';
 
 import { UUID } from './uuidObject';
 
+// Each teamsjs instance gets a unique identifier that will be prepended to every log statement
 export const teamsJsInstanceIdentifier = new UUID();
+
+// Every log statement will get prepended with the teamsJsInstanceIdentifier and a timestamp
 const origFormatArgs = registerLogger.formatArgs;
 registerLogger.formatArgs = function (args) {
   args[0] = `${teamsJsInstanceIdentifier.toString()} (${new Date().toISOString()}): ${args[0]}`;

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -750,17 +750,19 @@ export namespace app {
     const scriptUsageWarning =
       'Today, teamsjs can only be used from a single script or you may see undefined behavior. This log line is used to help detect cases where teamsjs is loaded multiple times -- it is always written. The presence of the log itself does not indicate a multi-load situation, but multiples of these log lines will. If you would like to use teamjs from more than one script at the same time, please open an issue at https://github.com/OfficeDev/microsoft-teams-library-js/issues';
     if (!currentScriptSrc || currentScriptSrc.length === 0) {
-      appLogger(
-        'teamsjs version %s is being used from a script tag embedded directly in your html. %s',
-        version,
-        scriptUsageWarning,
-      );
+      appLogger('teamsjs is being used from a script tag embedded directly in your html. %s', scriptUsageWarning);
     } else {
-      appLogger('teamsjs version %s is being used from %s. %s', version, currentScriptSrc, scriptUsageWarning);
+      appLogger('teamsjs is being used from %s. %s', currentScriptSrc, scriptUsageWarning);
     }
   }
 
   // This is called right away to make sure that we capture which script is being executed correctly
+  appLogger(
+    'teamsjs instance is version %s, starting at %s UTC (%s local)',
+    version,
+    new Date().toISOString(),
+    new Date().toLocaleString(),
+  );
   logWhereTeamsJsIsBeingUsed();
 
   /**

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -756,7 +756,7 @@ export namespace app {
     }
   }
 
-  // This is called right away to make sure that we capture which script is being executed correctly
+  // This is called right away to make sure that we capture which script is being executed and important stats about the current teamsjs instance
   appLogger(
     'teamsjs instance is version %s, starting at %s UTC (%s local)',
     version,


### PR DESCRIPTION
## Description

Added the teamsjs instance identifier and timestamp to every log line. This will help us debug issues where multiple teamsjs instances are being used (which is an unsupported scenario).

## Validation

### Validation performed:

Ensured everything looked right in the logs:
![image](https://github.com/user-attachments/assets/a4182e65-a4d1-4005-a15a-c8c6efce58f8)
...even in the multi-instance scenario:
![image](https://github.com/user-attachments/assets/99a10fff-8645-4875-9c47-e89fa4266481)

### Change file added:

Yes