### PR TITLE
[getMeetingDetailsVerbose] Disable E2E test for newer version of hostSDK

### DIFF
--- a/apps/teams-test-app/e2e-test-data/meeting.json
+++ b/apps/teams-test-app/e2e-test-data/meeting.json
@@ -34,6 +34,17 @@
       "expectedTestAppValue": "{\"details\":{\"id\":\"testDetailsId\",\"scheduledStartTime\":\"testStartTime\",\"scheduledEndTime\":\"testEndTime\",\"joinUrl\":\"testJoinUrl\",\"title\":\"testTitle\",\"type\":\"Unknown\"},\"conversation\":{\"id\":\"testConversationId\"},\"organizer\":{\"id\":\"testOrganizerId\",\"tenantId\":\"testTenantId\"}}"
     },
     {
+      "title": "getMeetingDetailsVerbose API Call - Success",
+      "version": ">2.22.0 && <=2.28.0",
+      "hostSdkVersion": {
+        "web": "<= 4.2.2"
+      },
+      "type": "callResponse",
+      "boxSelector": "#box_getMeetingDetailsVerbose",
+      "expectedAlertValue": "getMeetingDetails called with shouldGetVerboseDetails: true",
+      "expectedTestAppValue": "{\"details\":{\"scheduledStartTime\":\"testStartTime\",\"joinUrl\":\"testJoinUrl\",\"type\":\"oneOnOneCall\",\"originalCaller\":\"testCallerId\",\"dialedEntity\":\"testDnis\",\"trackingId\":\"testTrackingId\"},\"conversation\":{\"id\":\"testConversationId\"},\"organizer\":{\"id\":\"testOrganizerId\",\"tenantId\":\"testTenantId\"}}"
+    },
+    {
       "title": "getAuthenticationTokenForAnonymousUser API Call - Success",
       "type": "callResponse",
       "boxSelector": "#box_getAuthTokenForAnonymousUser",

--- a/apps/teams-test-app/e2e-test-data/meeting.json
+++ b/apps/teams-test-app/e2e-test-data/meeting.json
@@ -34,14 +34,6 @@
       "expectedTestAppValue": "{\"details\":{\"id\":\"testDetailsId\",\"scheduledStartTime\":\"testStartTime\",\"scheduledEndTime\":\"testEndTime\",\"joinUrl\":\"testJoinUrl\",\"title\":\"testTitle\",\"type\":\"Unknown\"},\"conversation\":{\"id\":\"testConversationId\"},\"organizer\":{\"id\":\"testOrganizerId\",\"tenantId\":\"testTenantId\"}}"
     },
     {
-      "title": "getMeetingDetailsVerbose API Call - Success",
-      "version": ">2.22.0",
-      "type": "callResponse",
-      "boxSelector": "#box_getMeetingDetailsVerbose",
-      "expectedAlertValue": "getMeetingDetails called with shouldGetVerboseDetails: true",
-      "expectedTestAppValue": "{\"details\":{\"scheduledStartTime\":\"testStartTime\",\"joinUrl\":\"testJoinUrl\",\"type\":\"oneOnOneCall\",\"originalCaller\":\"testCallerId\",\"dialedEntity\":\"testDnis\",\"trackingId\":\"testTrackingId\"},\"conversation\":{\"id\":\"testConversationId\"},\"organizer\":{\"id\":\"testOrganizerId\",\"tenantId\":\"testTenantId\"}}"
-    },
-    {
       "title": "getAuthenticationTokenForAnonymousUser API Call - Success",
       "type": "callResponse",
       "boxSelector": "#box_getAuthTokenForAnonymousUser",


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description
This PR disables the E2E test for newer versions of the hostSDK.