### PR TITLE
Revert the changes of moving common data models to interface file for externalAppCardAction(ForCEA) files

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/ExternalAppCardActionsAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/ExternalAppCardActionsAPIs.tsx
@@ -1,4 +1,4 @@
-import { externalAppCardActions, IAdaptiveCardActionSubmit } from '@microsoft/teams-js';
+import { externalAppCardActions } from '@microsoft/teams-js';
 import React from 'react';
 
 import { ApiWithoutInput, ApiWithTextInput } from '../utils';
@@ -15,7 +15,7 @@ const CheckExternalAppCardActionsCapability = (): React.ReactElement =>
 const ProcessActionSubmit = (): React.ReactElement =>
   ApiWithTextInput<{
     appId: string;
-    actionSubmitPayload: IAdaptiveCardActionSubmit;
+    actionSubmitPayload: externalAppCardActions.IAdaptiveCardActionSubmit;
   }>({
     name: 'processActionSubmit',
     title: 'Process Action Submit',

--- a/apps/teams-test-app/src/components/privateApis/ExternalAppCardActionsForCEAAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/ExternalAppCardActionsForCEAAPIs.tsx
@@ -1,4 +1,4 @@
-import { AppId, externalAppCardActionsForCEA, IAdaptiveCardActionSubmit } from '@microsoft/teams-js';
+import { AppId, externalAppCardActions, externalAppCardActionsForCEA } from '@microsoft/teams-js';
 import React from 'react';
 
 import { ApiWithoutInput, ApiWithTextInput } from '../utils';
@@ -18,7 +18,7 @@ const ProcessActionSubmitForCEA = (): React.ReactElement =>
   ApiWithTextInput<{
     appId: string;
     conversationId: string;
-    actionSubmitPayload: IAdaptiveCardActionSubmit;
+    actionSubmitPayload: externalAppCardActions.IAdaptiveCardActionSubmit;
   }>({
     name: 'processActionSubmitForCEA',
     title: 'Process Action Submit For CEA',

--- a/change/@microsoft-teams-js-4fe5ca49-b46c-4a6b-b580-bd6035df67e6.json
+++ b/change/@microsoft-teams-js-4fe5ca49-b46c-4a6b-b580-bd6035df67e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Keep the common data models in the `externalAppCardAction` API file to share with the `externalAppCardActionForCEA` API.",
+  "packageName": "@microsoft/teams-js",
+  "email": "maggiegong@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-4fe5ca49-b46c-4a6b-b580-bd6035df67e6.json
+++ b/change/@microsoft-teams-js-4fe5ca49-b46c-4a6b-b580-bd6035df67e6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Keep the common data models in the `externalAppCardAction` API file to share with the `externalAppCardActionForCEA` API.",
+  "comment": "Unified common data models for external card actions into externalAppCardActions namespace.",
   "packageName": "@microsoft/teams-js",
   "email": "maggiegong@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-4fe5ca49-b46c-4a6b-b580-bd6035df67e6.json
+++ b/change/@microsoft-teams-js-4fe5ca49-b46c-4a6b-b580-bd6035df67e6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Unified common data models for external card actions into externalAppCardActions namespace.",
+  "comment": "Unified common data models for external card actions into `externalAppCardActions` namespace.",
   "packageName": "@microsoft/teams-js",
   "email": "maggiegong@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/private/externalAppCardActions.ts
+++ b/packages/teams-js/src/private/externalAppCardActions.ts
@@ -4,7 +4,7 @@ import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemet
 import { AppId } from '../public';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
 import { runtime } from '../public/runtime';
-import { ActionOpenUrlError, ActionSubmitError, IAdaptiveCardActionSubmit } from './interfaces';
+import { ExternalAppErrorCode } from './constants';
 
 /**
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
@@ -29,6 +29,62 @@ export namespace externalAppCardActions {
     DeepLinkOther = 'DeepLinkOther',
     DeepLinkStageView = 'DeepLinkStageView',
     GenericUrl = 'GenericUrl',
+  }
+
+  /**
+   * @beta
+   * @hidden
+   * Error that can be thrown from IExternalAppCardActionService.handleActionOpenUrl
+   * and IExternalAppCardActionForCEAService.handleActionOpenUrl
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  export interface ActionOpenUrlError {
+    errorCode: ActionOpenUrlErrorCode;
+    message?: string;
+  }
+
+  /**
+   * @beta
+   * @hidden
+   * Error codes that can be thrown from IExternalAppCardActionService.handleActionOpenUrl
+   * and IExternalAppCardActionForCEAService.handleActionOpenUrl
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  export enum ActionOpenUrlErrorCode {
+    INTERNAL_ERROR = 'INTERNAL_ERROR', // Generic error
+    INVALID_LINK = 'INVALID_LINK', // Deep link is invalid
+    NOT_SUPPORTED = 'NOT_SUPPORTED', // Deep link is not supported
+  }
+
+  /**
+   * @beta
+   * @hidden
+   * The payload that is used when executing an Adaptive Card Action.Submit
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  export interface IAdaptiveCardActionSubmit {
+    id: string;
+    data: string | Record<string, unknown>;
+  }
+
+  /**
+   * @beta
+   * @hidden
+   * Error that can be thrown from IExternalAppCardActionService.handleActionSubmit
+   * and IExternalAppCardActionForCEAService.handleActionSubmit
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  export interface ActionSubmitError {
+    errorCode: ExternalAppErrorCode;
+    message?: string;
   }
 
   /**

--- a/packages/teams-js/src/private/externalAppCardActionsForCEA.ts
+++ b/packages/teams-js/src/private/externalAppCardActionsForCEA.ts
@@ -5,7 +5,7 @@ import { validateId } from '../internal/utils';
 import { AppId } from '../public';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
 import { runtime } from '../public/runtime';
-import { ActionOpenUrlError, ActionOpenUrlType, ActionSubmitError, IAdaptiveCardActionSubmit } from './interfaces';
+import { externalAppCardActions } from './externalAppCardActions';
 
 /**
  * All of APIs in this capability file should send out API version v2 ONLY
@@ -35,13 +35,15 @@ export namespace externalAppCardActionsForCEA {
     appId: AppId,
     conversationId: string,
     url: URL,
-  ): Promise<ActionOpenUrlType> {
+  ): Promise<externalAppCardActions.ActionOpenUrlType> {
     ensureInitialized(runtime, FrameContexts.content);
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
     validateId(conversationId, new Error('conversation id is not valid.'));
-    const [error, response] = await sendMessageToParentAsync<[ActionOpenUrlError, ActionOpenUrlType]>(
+    const [error, response] = await sendMessageToParentAsync<
+      [externalAppCardActions.ActionOpenUrlError, externalAppCardActions.ActionOpenUrlType]
+    >(
       getApiVersionTag(
         externalAppCardActionsTelemetryVersionNumber,
         ApiName.ExternalAppCardActionsForCEA_ProcessActionOpenUrl,
@@ -71,14 +73,14 @@ export namespace externalAppCardActionsForCEA {
   export async function processActionSubmit(
     appId: AppId,
     conversationId: string,
-    actionSubmitPayload: IAdaptiveCardActionSubmit,
+    actionSubmitPayload: externalAppCardActions.IAdaptiveCardActionSubmit,
   ): Promise<void> {
     ensureInitialized(runtime, FrameContexts.content);
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
     validateId(conversationId, new Error('conversation id is not valid.'));
-    const error = await sendAndUnwrap<ActionSubmitError | undefined>(
+    const error = await sendAndUnwrap<externalAppCardActions.ActionSubmitError | undefined>(
       getApiVersionTag(
         externalAppCardActionsTelemetryVersionNumber,
         ApiName.ExternalAppCardActionsForCEA_ProcessActionSubmit,

--- a/packages/teams-js/src/private/interfaces.ts
+++ b/packages/teams-js/src/private/interfaces.ts
@@ -1,5 +1,4 @@
 import { FileOpenPreference, TeamInformation } from '../public/interfaces';
-import { ExternalAppErrorCode } from './constants';
 
 /**
  * @hidden
@@ -271,75 +270,4 @@ export interface UserJoinedTeamsInformation {
    * Limited to Microsoft-internal use
    */
   userJoinedTeams: TeamInformation[];
-}
-
-/**
- * @beta
- * @hidden
- * The types for ActionOpenUrl
- *
- * @internal
- * Limited to Microsoft-internal use
- */
-export enum ActionOpenUrlType {
-  DeepLinkDialog = 'DeepLinkDialog',
-  DeepLinkOther = 'DeepLinkOther',
-  DeepLinkStageView = 'DeepLinkStageView',
-  GenericUrl = 'GenericUrl',
-}
-
-/**
- * @beta
- * @hidden
- * Error that can be thrown from IExternalAppCardActionService.handleActionOpenUrl
- * and IExternalAppCardActionForCEAService.handleActionOpenUrl
- *
- * @internal
- * Limited to Microsoft-internal use
- */
-export interface ActionOpenUrlError {
-  errorCode: ActionOpenUrlErrorCode;
-  message?: string;
-}
-
-/**
- * @beta
- * @hidden
- * Error codes that can be thrown from IExternalAppCardActionService.handleActionOpenUrl
- * and IExternalAppCardActionForCEAService.handleActionOpenUrl
- *
- * @internal
- * Limited to Microsoft-internal use
- */
-export enum ActionOpenUrlErrorCode {
-  INTERNAL_ERROR = 'INTERNAL_ERROR', // Generic error
-  INVALID_LINK = 'INVALID_LINK', // Deep link is invalid
-  NOT_SUPPORTED = 'NOT_SUPPORTED', // Deep link is not supported
-}
-
-/**
- * @beta
- * @hidden
- * The payload that is used when executing an Adaptive Card Action.Submit
- *
- * @internal
- * Limited to Microsoft-internal use
- */
-export interface IAdaptiveCardActionSubmit {
-  id: string;
-  data: string | Record<string, unknown>;
-}
-
-/**
- * @beta
- * @hidden
- * Error that can be thrown from IExternalAppCardActionService.handleActionSubmit
- * and IExternalAppCardActionForCEAService.handleActionSubmit
- *
- * @internal
- * Limited to Microsoft-internal use
- */
-export interface ActionSubmitError {
-  errorCode: ExternalAppErrorCode;
-  message?: string;
 }

--- a/packages/teams-js/test/private/externalAppCardActions.spec.ts
+++ b/packages/teams-js/test/private/externalAppCardActions.spec.ts
@@ -2,7 +2,6 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { ExternalAppErrorCode } from '../../src/private/constants';
 import { externalAppCardActions } from '../../src/private/externalAppCardActions';
-import { ActionOpenUrlErrorCode } from '../../src/private/interfaces';
 import { FrameContexts } from '../../src/public';
 import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform } from '../../src/public/constants';
@@ -128,7 +127,7 @@ describe('externalAppCardActions', () => {
     const allowedFrameContexts = [FrameContexts.content];
     const testUrl = new URL('https://example.com');
     const testError = {
-      errorCode: ActionOpenUrlErrorCode.INTERNAL_ERROR,
+      errorCode: externalAppCardActions.ActionOpenUrlErrorCode.INTERNAL_ERROR,
       message: 'testMessage',
     };
     const testResponse = externalAppCardActions.ActionOpenUrlType.DeepLinkDialog;

--- a/packages/teams-js/test/private/externalAppCardActionsForCEA.spec.ts
+++ b/packages/teams-js/test/private/externalAppCardActionsForCEA.spec.ts
@@ -2,8 +2,8 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { ApiName } from '../../src/internal/telemetry';
 import { ExternalAppErrorCode } from '../../src/private/constants';
+import { externalAppCardActions } from '../../src/private/externalAppCardActions';
 import { externalAppCardActionsForCEA } from '../../src/private/externalAppCardActionsForCEA';
-import { ActionOpenUrlErrorCode, ActionOpenUrlType } from '../../src/private/interfaces';
 import { AppId, FrameContexts } from '../../src/public';
 import { app } from '../../src/public/app';
 import { errorNotSupportedOnPlatform } from '../../src/public/constants';
@@ -123,10 +123,10 @@ describe('externalAppCardActionsForCEA', () => {
     const allowedFrameContexts = [FrameContexts.content];
     const testUrl = new URL('https://example.com');
     const testError = {
-      errorCode: ActionOpenUrlErrorCode.INTERNAL_ERROR,
+      errorCode: externalAppCardActions.ActionOpenUrlErrorCode.INTERNAL_ERROR,
       message: 'testMessage',
     };
-    const testResponse = ActionOpenUrlType.DeepLinkDialog;
+    const testResponse = externalAppCardActions.ActionOpenUrlType.DeepLinkDialog;
 
     it('should not allow calls before initialization', async () => {
       expect.assertions(1);


### PR DESCRIPTION

For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Revert the changes of moving common data models to interface file for externalAppCardAction(ForCEA) APIs to avoid the breaking changes.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.


