### PR TITLE
Prep for Release 2.29.0

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.28.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-gT2igbByugSUPXBgDA+rtfKk4JMSCfG+3DKSivyLqF2Riv4vTLqaC/tFpySw0eIM"
+      src="https://res.cdn.office.net/teams-js/2.29.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-HCj4C0CvWvv0xKWpolDpLs3Q2f8+k4AUwYACBrszhvquzHsIUz1ZB6z1KLIQTnSW"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm lint && webpack",

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.29.0",
+  "version": "2.28.0",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm lint && webpack",

--- a/change/@microsoft-teams-js-04213847-0138-4547-976c-ae02297702f0.json
+++ b/change/@microsoft-teams-js-04213847-0138-4547-976c-ae02297702f0.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Updated types for `externalAppCardActionsForCEA` capability.",
-  "packageName": "@microsoft/teams-js",
-  "email": "maggiegong@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-04213847-0138-4547-976c-ae02297702f0.json
+++ b/change/@microsoft-teams-js-04213847-0138-4547-976c-ae02297702f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated types for `externalAppCardActionsForCEA` capability.",
+  "packageName": "@microsoft/teams-js",
+  "email": "maggiegong@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-120060c9-a050-4da3-a0a5-2323e3a78d10.json
+++ b/change/@microsoft-teams-js-120060c9-a050-4da3-a0a5-2323e3a78d10.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added logging for version on startup",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-120060c9-a050-4da3-a0a5-2323e3a78d10.json
+++ b/change/@microsoft-teams-js-120060c9-a050-4da3-a0a5-2323e3a78d10.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added logging for version on startup",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-3c6d20f0-0715-499f-8835-457526329b67.json
+++ b/change/@microsoft-teams-js-3c6d20f0-0715-499f-8835-457526329b67.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Updated `pages.navigateToApp` to now optionally accept a more type-safe input object",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-3c6d20f0-0715-499f-8835-457526329b67.json
+++ b/change/@microsoft-teams-js-3c6d20f0-0715-499f-8835-457526329b67.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated `pages.navigateToApp` to now optionally accept a more type-safe input object",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-4c2cf5b3-6661-4e5f-925b-7a8a49ad9d91.json
+++ b/change/@microsoft-teams-js-4c2cf5b3-6661-4e5f-925b-7a8a49ad9d91.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added three properties to `ICallDetails`, `originalCallerInfo`, `dialedEntityInfo`, and `callId`, created a new type `ICallParticipantIdentifiers`, and  deprecated the `originalCaller` and `dialedEntity` properties",
-  "packageName": "@microsoft/teams-js",
-  "email": "johnsle@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-4c2cf5b3-6661-4e5f-925b-7a8a49ad9d91.json
+++ b/change/@microsoft-teams-js-4c2cf5b3-6661-4e5f-925b-7a8a49ad9d91.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added three properties to `ICallDetails`, `originalCallerInfo`, `dialedEntityInfo`, and `callId`, created a new type `ICallParticipantIdentifiers`, and  deprecated the `originalCaller` and `dialedEntity` properties",
+  "packageName": "@microsoft/teams-js",
+  "email": "johnsle@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-4fe5ca49-b46c-4a6b-b580-bd6035df67e6.json
+++ b/change/@microsoft-teams-js-4fe5ca49-b46c-4a6b-b580-bd6035df67e6.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Unified common data models for external card actions into `externalAppCardActions` namespace.",
-  "packageName": "@microsoft/teams-js",
-  "email": "maggiegong@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-4fe5ca49-b46c-4a6b-b580-bd6035df67e6.json
+++ b/change/@microsoft-teams-js-4fe5ca49-b46c-4a6b-b580-bd6035df67e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Unified common data models for external card actions into `externalAppCardActions` namespace.",
+  "packageName": "@microsoft/teams-js",
+  "email": "maggiegong@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-75e3c524-ba26-4b6a-b01b-9a1f0e315d91.json
+++ b/change/@microsoft-teams-js-75e3c524-ba26-4b6a-b01b-9a1f0e315d91.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added APIs for `externalAppCardActionsForCEA` capability.",
+  "packageName": "@microsoft/teams-js",
+  "email": "maggiegong@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-75e3c524-ba26-4b6a-b01b-9a1f0e315d91.json
+++ b/change/@microsoft-teams-js-75e3c524-ba26-4b6a-b01b-9a1f0e315d91.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added APIs for `externalAppCardActionsForCEA` capability.",
-  "packageName": "@microsoft/teams-js",
-  "email": "maggiegong@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-81b620f2-8af1-4450-89b0-20600bac843e.json
+++ b/change/@microsoft-teams-js-81b620f2-8af1-4450-89b0-20600bac843e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated internal app id validation",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-81b620f2-8af1-4450-89b0-20600bac843e.json
+++ b/change/@microsoft-teams-js-81b620f2-8af1-4450-89b0-20600bac843e.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Updated internal app id validation",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-87505803-bfad-44bd-a44d-f2ba244c46ad.json
+++ b/change/@microsoft-teams-js-87505803-bfad-44bd-a44d-f2ba244c46ad.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added a Rollup built bundle of Teams-JS",
-  "packageName": "@microsoft/teams-js",
-  "email": "noahdarveau@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-87505803-bfad-44bd-a44d-f2ba244c46ad.json
+++ b/change/@microsoft-teams-js-87505803-bfad-44bd-a44d-f2ba244c46ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added a Rollup built bundle of Teams-JS",
+  "packageName": "@microsoft/teams-js",
+  "email": "noahdarveau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-8b361cdc-41c8-48a8-9e4c-cb57a8b80411.json
+++ b/change/@microsoft-teams-js-8b361cdc-41c8-48a8-9e4c-cb57a8b80411.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Added `edgeapi.svc.cloud.microsoft` to valid domains list",
-  "packageName": "@microsoft/teams-js",
-  "email": "jadahiya@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-8b361cdc-41c8-48a8-9e4c-cb57a8b80411.json
+++ b/change/@microsoft-teams-js-8b361cdc-41c8-48a8-9e4c-cb57a8b80411.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added `edgeapi.svc.cloud.microsoft` to valid domains list",
+  "packageName": "@microsoft/teams-js",
+  "email": "jadahiya@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-9226f943-a345-4cef-95fe-607b0df82934.json
+++ b/change/@microsoft-teams-js-9226f943-a345-4cef-95fe-607b0df82934.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Renamed prepBetaRelease.js to use .cjs file extension",
-  "packageName": "@microsoft/teams-js",
-  "email": "noahdarveau@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-9226f943-a345-4cef-95fe-607b0df82934.json
+++ b/change/@microsoft-teams-js-9226f943-a345-4cef-95fe-607b0df82934.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Renamed prepBetaRelease.js to use .cjs file extension",
+  "packageName": "@microsoft/teams-js",
+  "email": "noahdarveau@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-teams-js-ad734c6e-e931-4790-8795-e2a577ffb281.json
+++ b/change/@microsoft-teams-js-ad734c6e-e931-4790-8795-e2a577ffb281.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Released 2.28.0, <<this can be removed from the changelog>>",
-  "packageName": "@microsoft/teams-js",
-  "email": "noahdarveau@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-ad734c6e-e931-4790-8795-e2a577ffb281.json
+++ b/change/@microsoft-teams-js-ad734c6e-e931-4790-8795-e2a577ffb281.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Released 2.28.0, <<this can be removed from the changelog>>",
+  "packageName": "@microsoft/teams-js",
+  "email": "noahdarveau@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-teams-js-b1e62451-f7ad-44d0-b700-d5fe996761f9.json
+++ b/change/@microsoft-teams-js-b1e62451-f7ad-44d0-b700-d5fe996761f9.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added logging for current teamsjs instance and timestamps",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-b1e62451-f7ad-44d0-b700-d5fe996761f9.json
+++ b/change/@microsoft-teams-js-b1e62451-f7ad-44d0-b700-d5fe996761f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added logging for current teamsjs instance and timestamps",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-b61435ce-c9da-47bc-9b65-2710406ac8d7.json
+++ b/change/@microsoft-teams-js-b61435ce-c9da-47bc-9b65-2710406ac8d7.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Updated logging for messages to be clearer",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-b61435ce-c9da-47bc-9b65-2710406ac8d7.json
+++ b/change/@microsoft-teams-js-b61435ce-c9da-47bc-9b65-2710406ac8d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated logging for messages to be clearer",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-cee144c2-e3b9-40a5-bb3e-05608280d179.json
+++ b/change/@microsoft-teams-js-cee144c2-e3b9-40a5-bb3e-05608280d179.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added support for `ExternalAppAuthenticationForCEA` capability",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-cee144c2-e3b9-40a5-bb3e-05608280d179.json
+++ b/change/@microsoft-teams-js-cee144c2-e3b9-40a5-bb3e-05608280d179.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added support for `ExternalAppAuthenticationForCEA` capability",
-  "packageName": "@microsoft/teams-js",
-  "email": "lakhveerkaur@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,30 +1,8 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Thu, 03 Oct 2024 20:49:08 GMT and should not be manually modified.
+This log was last generated on Tue, 03 Sep 2024 22:19:52 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 2.29.0
-
-Thu, 03 Oct 2024 20:49:08 GMT
-
-### Minor changes
-
-- Added support for `externalAppAuthenticationForCEA` capability
-- Added support for `externalAppCardActionsForCEA` capability.
-- Added logging for current teamsjs instance and timestamps
-- Added a Rollup built bundle of Teams-JS
-- Added three properties to `ICallDetails`, `originalCallerInfo`, `dialedEntityInfo`, and `callId`, created a new type `ICallParticipantIdentifiers`, and deprecated the `originalCaller` and `dialedEntity` properties
-- Updated `pages.navigateToApp` to now optionally accept a more type-safe input object
-- Added logging for version on startup
-
-### Patches
-
-- Updated logging for messages to be clearer
-- Added `edgeapi.svc.cloud.microsoft` to valid domains list
-- Updated internal app id validation
-- Unified common data models for external card actions into `externalAppCardActions` namespace.
-- Updated types for `externalAppCardActionsForCEA` capability.
 
 ## 2.28.0
 
@@ -368,7 +346,7 @@ Fri, 03 Mar 2023 19:57:31 GMT
 
 - Updated documentation for `dialog` and `tasks` capabilities
 - Elaborated on various areas of `authentication` documentation
-- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
+- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
 
 ## 2.8.0
 
@@ -383,7 +361,7 @@ Wed, 01 Feb 2023 23:22:55 GMT
 
 ### Patches
 
-- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
+- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
 - Updated typedoc version and fixed doc issues raised by it
 - Added documentation for `dialog.submit`
 - Changed user facing documentation associated with `meeting.ts`

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,30 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Tue, 03 Sep 2024 22:19:52 GMT and should not be manually modified.
+This log was last generated on Thu, 03 Oct 2024 20:49:08 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.29.0
+
+Thu, 03 Oct 2024 20:49:08 GMT
+
+### Minor changes
+
+- Added support for `ExternalAppAuthenticationForCEA` capability
+- Added logging for current teamsjs instance and timestamps
+- Added a Rollup built bundle of Teams-JS
+- Added APIs for `externalAppCardActionsForCEA` capability.
+- Added three properties to `ICallDetails`, `originalCallerInfo`, `dialedEntityInfo`, and `callId`, created a new type `ICallParticipantIdentifiers`, and  deprecated the `originalCaller` and `dialedEntity` properties
+- Updated `pages.navigateToApp` to now optionally accept a more type-safe input object
+- Added logging for version on startup
+
+### Patches
+
+- Updated logging for messages to be clearer
+- Added `edgeapi.svc.cloud.microsoft` to valid domains list
+- Updated internal app id validation
+- Unified common data models for external card actions into `externalAppCardActions` namespace.
+- Updated types for `externalAppCardActionsForCEA` capability.
 
 ## 2.28.0
 

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -10,11 +10,11 @@ Thu, 03 Oct 2024 22:51:48 GMT
 
 ### Minor changes
 
-- Added support for `ExternalAppAuthenticationForCEA` capability
+- Added support for `externalAppAuthenticationForCEA` capability
+- Added support for `externalAppCardActionsForCEA` capability.
 - Added logging for current teamsjs instance and timestamps
 - Added a Rollup built bundle of Teams-JS
-- Added APIs for `externalAppCardActionsForCEA` capability.
-- Added three properties to `ICallDetails`, `originalCallerInfo`, `dialedEntityInfo`, and `callId`, created a new type `ICallParticipantIdentifiers`, and  deprecated the `originalCaller` and `dialedEntity` properties
+- Added three properties to `ICallDetails`, `originalCallerInfo`, `dialedEntityInfo`, and `callId`, created a new type `ICallParticipantIdentifiers`, and deprecated the `originalCaller` and `dialedEntity` properties
 - Updated `pages.navigateToApp` to now optionally accept a more type-safe input object
 - Added logging for version on startup
 
@@ -368,7 +368,7 @@ Fri, 03 Mar 2023 19:57:31 GMT
 
 - Updated documentation for `dialog` and `tasks` capabilities
 - Elaborated on various areas of `authentication` documentation
-- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
+- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
 
 ## 2.8.0
 
@@ -383,7 +383,7 @@ Wed, 01 Feb 2023 23:22:55 GMT
 
 ### Patches
 
-- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
+- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
 - Updated typedoc version and fixed doc issues raised by it
 - Added documentation for `dialog.submit`
 - Changed user facing documentation associated with `meeting.ts`

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -10,11 +10,11 @@ Thu, 03 Oct 2024 20:49:08 GMT
 
 ### Minor changes
 
-- Added support for `ExternalAppAuthenticationForCEA` capability
+- Added support for `externalAppAuthenticationForCEA` capability
+- Added support for `externalAppCardActionsForCEA` capability.
 - Added logging for current teamsjs instance and timestamps
 - Added a Rollup built bundle of Teams-JS
-- Added APIs for `externalAppCardActionsForCEA` capability.
-- Added three properties to `ICallDetails`, `originalCallerInfo`, `dialedEntityInfo`, and `callId`, created a new type `ICallParticipantIdentifiers`, and  deprecated the `originalCaller` and `dialedEntity` properties
+- Added three properties to `ICallDetails`, `originalCallerInfo`, `dialedEntityInfo`, and `callId`, created a new type `ICallParticipantIdentifiers`, and deprecated the `originalCaller` and `dialedEntity` properties
 - Updated `pages.navigateToApp` to now optionally accept a more type-safe input object
 - Added logging for version on startup
 
@@ -368,7 +368,7 @@ Fri, 03 Mar 2023 19:57:31 GMT
 
 - Updated documentation for `dialog` and `tasks` capabilities
 - Elaborated on various areas of `authentication` documentation
-- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
+- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
 
 ## 2.8.0
 
@@ -383,7 +383,7 @@ Wed, 01 Feb 2023 23:22:55 GMT
 
 ### Patches
 
-- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
+- Added @beta tags to `registerBeforeUnloadHandler` and `registerOnLoadHandler` APIs.
 - Updated typedoc version and fixed doc issues raised by it
 - Added documentation for `dialog.submit`
 - Changed user facing documentation associated with `meeting.ts`

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,30 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Tue, 03 Sep 2024 22:19:52 GMT and should not be manually modified.
+This log was last generated on Thu, 03 Oct 2024 22:51:48 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.29.0
+
+Thu, 03 Oct 2024 22:51:48 GMT
+
+### Minor changes
+
+- Added support for `ExternalAppAuthenticationForCEA` capability
+- Added logging for current teamsjs instance and timestamps
+- Added a Rollup built bundle of Teams-JS
+- Added APIs for `externalAppCardActionsForCEA` capability.
+- Added three properties to `ICallDetails`, `originalCallerInfo`, `dialedEntityInfo`, and `callId`, created a new type `ICallParticipantIdentifiers`, and  deprecated the `originalCaller` and `dialedEntity` properties
+- Updated `pages.navigateToApp` to now optionally accept a more type-safe input object
+- Added logging for version on startup
+
+### Patches
+
+- Updated logging for messages to be clearer
+- Added `edgeapi.svc.cloud.microsoft` to valid domains list
+- Updated internal app id validation
+- Unified common data models for external card actions into `externalAppCardActions` namespace.
+- Updated types for `externalAppCardActionsForCEA` capability.
 
 ## 2.28.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.28.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.29.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.28.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-gT2igbByugSUPXBgDA+rtfKk4JMSCfG+3DKSivyLqF2Riv4vTLqaC/tFpySw0eIM"
+  src="https://res.cdn.office.net/teams-js/2.29.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-HCj4C0CvWvv0xKWpolDpLs3Q2f8+k4AUwYACBrszhvquzHsIUz1ZB6z1KLIQTnSW"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.28.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.29.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.29.0",
+  "version": "2.28.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,7 +554,7 @@ packages:
   '@azure/core-http@3.0.4':
     resolution: {integrity: sha512-Fok9VVhMdxAFOtqiiAtg74fL0UJkt0z3D+ouUUxcRLzZNBioPRAMJFVxiWoJljYpXsRi4GDQHzQHDc9AiYaIUQ==}
     engines: {node: '>=14.0.0'}
-    deprecated: deprecating as we migrated to core v2
+    deprecated: This package is no longer supported. Please migrate to use @azure/core-rest-pipeline
 
   '@azure/core-lro@2.7.2':
     resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,7 +554,7 @@ packages:
   '@azure/core-http@3.0.4':
     resolution: {integrity: sha512-Fok9VVhMdxAFOtqiiAtg74fL0UJkt0z3D+ouUUxcRLzZNBioPRAMJFVxiWoJljYpXsRi4GDQHzQHDc9AiYaIUQ==}
     engines: {node: '>=14.0.0'}
-    deprecated: This package is no longer supported. Please migrate to use @azure/core-rest-pipeline
+    deprecated: deprecating as we migrated to core v2
 
   '@azure/core-lro@2.7.2':
     resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}

--- a/tools/cli/preRelease.js
+++ b/tools/cli/preRelease.js
@@ -22,7 +22,7 @@ const execShellCommand = async (cmd) => {
 };
 
 const buildAndGetIntegrityHash = async () => {
-  const relativePathToManifestJson = '../../packages/teams-js/dist/MicrosoftTeams-manifest.json';
+  const relativePathToManifestJson = '../../packages/teams-js/dist/umd/MicrosoftTeams-manifest.json';
   const absolutePathToManifestJson = path.resolve(__dirname, relativePathToManifestJson);
 
   console.log('Building @microsoft/teams-js');


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description
## 2.29.0

Thu, 03 Oct 2024 20:49:08 GMT

### Minor changes

- Added support for `externalAppAuthenticationForCEA` capability
- Added support for `externalAppCardActionsForCEA` capability.
- Added logging for current teamsjs instance and timestamps
- Added a Rollup built bundle of Teams-JS
- Added three properties to `ICallDetails`, `originalCallerInfo`, `dialedEntityInfo`, and `callId`, created a new type `ICallParticipantIdentifiers`, and deprecated the `originalCaller` and `dialedEntity` properties
- Updated `pages.navigateToApp` to now optionally accept a more type-safe input object
- Added logging for version on startup

### Patches

- Updated logging for messages to be clearer
- Added `edgeapi.svc.cloud.microsoft` to valid domains list
- Updated internal app id validation
- Unified common data models for external card actions into `externalAppCardActions` namespace.
- Updated types for `externalAppCardActionsForCEA` capability.


> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
