### PR TITLE
Fixed CDN hash bug in path of preRelease script

### DIFF
--- a/tools/cli/preRelease.js
+++ b/tools/cli/preRelease.js
@@ -22,7 +22,7 @@ const execShellCommand = async (cmd) => {
 };
 
 const buildAndGetIntegrityHash = async () => {
-  const relativePathToManifestJson = '../../packages/teams-js/dist/MicrosoftTeams-manifest.json';
+  const relativePathToManifestJson = '../../packages/teams-js/dist/umd/MicrosoftTeams-manifest.json';
   const absolutePathToManifestJson = path.resolve(__dirname, relativePathToManifestJson);
 
   console.log('Building @microsoft/teams-js');


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Currently the preRelease script is looking for the CDN hash manifest in a folder that no longer contains it. Moving the pathing to resolve to the new one that we added for the rollup release.