### PR TITLE
Update docs to clarify usage of validOrigins parameter on initialize call

### DIFF
--- a/change/@microsoft-teams-js-0ee21e72-d019-4626-8510-28cc59a46290.json
+++ b/change/@microsoft-teams-js-0ee21e72-d019-4626-8510-28cc59a46290.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Clarified usage for `validMessageOrigins` parameter on `app.initialize` in documentation",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -771,8 +771,10 @@ export namespace app {
    * @remarks
    * Initialize must have completed successfully (as determined by the resolved Promise) before any other library calls are made
    *
-   * @param validMessageOrigins - Optionally specify a list of cross frame message origins. They must have
-   * https: protocol otherwise they will be ignored. Example: https://www.example.com
+   * @param validMessageOrigins - Optionally specify a list of cross-frame message origins. This parameter is used if you know that your app
+   * will be hosted on a custom domain (i.e., not a standard Microsoft 365 host like Teams, Outlook, etc.) Most apps will never need
+   * to pass a value for this parameter.
+   * Any domains passed in the array must have the https: protocol on the string otherwise they will be ignored. Example: https://www.example.com
    * @returns Promise that will be fulfilled when initialization has completed, or rejected if the initialization fails or times out
    */
   export function initialize(validMessageOrigins?: string[]): Promise<void> {

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -45,8 +45,10 @@ export type registerOnThemeChangeHandlerFunctionType = (theme: string) => void;
  * Initializes the library. This must be called before any other SDK calls
  * but after the frame is loaded successfully.
  * @param callback - Optionally specify a callback to invoke when Teams SDK has successfully initialized
- * @param validMessageOrigins - Optionally specify a list of cross frame message origins. There must have
- * https: protocol otherwise they will be ignored. Example: https://www.example.com
+ * @param validMessageOrigins - Optionally specify a list of cross-frame message origins. This parameter is used if you know that your app
+ * will be hosted on a custom domain (i.e., not a standard Microsoft 365 host like Teams, Outlook, etc.) Most apps will never need
+ * to pass a value for this parameter.
+ * Any domains passed in the array must have the https: protocol on the string otherwise they will be ignored. Example: https://www.example.com
  */
 export function initialize(callback?: callbackFunctionType, validMessageOrigins?: string[]): void {
   appInitializeHelper(


### PR DESCRIPTION
## Description

The documentation didn't really explain how or why one would use the `validOrigins` parameter to `initialize` so I updated it to clarify usage.