### PR TITLE
Added a url param to skip initialization when running test app

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -17,7 +17,12 @@ const getOriginsParam = urlParams.has('origins') && urlParams.get('origins') ? u
 const validMessageOrigins: string[] | undefined = getOriginsParam ? getOriginsParam.split(',') : undefined;
 
 // This is added for custom initialization when app can be initialized based upon a trigger/click.
-if (!urlParams.has('customInit') || !urlParams.get('customInit')) {
+if (
+  !urlParams.has('customInit') ||
+  !urlParams.get('customInit') ||
+  !urlParams.has('skipInit') ||
+  !urlParams.get('skipInit')
+) {
   if (isTestBackCompat()) {
     initialize(undefined, validMessageOrigins);
   } else {
@@ -29,7 +34,8 @@ if (!urlParams.has('customInit') || !urlParams.get('customInit')) {
 // we do it by adding appInitializationTest=true to query string
 if (
   (urlParams.has('customInit') && urlParams.get('customInit')) ||
-  (urlParams.has(appInitializationTestQueryParameter) && urlParams.get(appInitializationTestQueryParameter))
+  (urlParams.has(appInitializationTestQueryParameter) && urlParams.get(appInitializationTestQueryParameter)) ||
+  (urlParams.has('skipInit') && urlParams.get('skipInit'))
 ) {
   console.info('Not calling appInitialization because part of App Initialization Test run');
 } else {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Added a `skipInit` URL parameter in test app to make it (will happen later) as the only URL parameter to skip initialization for test app. `customInit` and `appInitializationTest` URL parameters will be removed.

### Unit Tests added: No

### End-to-end tests added: No

## Additional Requirements

### Change file added: No