### PR TITLE
Updating edgeapi endpoint to chatuxmanager

### DIFF
--- a/change/@microsoft-teams-js-c869bc74-fed2-4af2-9795-312fd14d1218.json
+++ b/change/@microsoft-teams-js-c869bc74-fed2-4af2-9795-312fd14d1218.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated edgeapi.freya.svc.cloud.microsoft to chatuxmanager.svc.cloud.microsoft",
+  "packageName": "@microsoft/teams-js",
+  "email": "jadahiya@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/artifactsForCDN/validDomains.json
+++ b/packages/teams-js/src/artifactsForCDN/validDomains.json
@@ -32,7 +32,7 @@
     "www.staging-bing-int.com",
     "*.cloud.microsoft",
     "*.m365.cloud.microsoft",
-    "edgeapi.freya.svc.cloud.microsoft",
+    "chatuxmanager.svc.cloud.microsoft",
     "copilot.microsoft.com",
     "windows.msn.com",
     "fa000000125.resources.office.net",


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Updated `edgeapi.freya.svc.cloud.microsoft` endpoint to `chatuxmanager.svc.cloud.microsoft`