### PR TITLE
noahdarveau/app helpers refactor

### DIFF
--- a/change/@microsoft-teams-js-0dfea369-ca36-49f5-87e9-4f2825d7c380.json
+++ b/change/@microsoft-teams-js-0dfea369-ca36-49f5-87e9-4f2825d7c380.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Refactored helper functions from app file to their own file",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/internal/appHelpers.ts
+++ b/packages/teams-js/src/internal/appHelpers.ts
@@ -1,0 +1,191 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { initializeCommunication, sendAndHandleStatusAndReason, sendMessageToParent } from '../internal/communication';
+import { defaultSDKVersionForCompatCheck } from '../internal/constants';
+import { GlobalVars } from '../internal/globalVars';
+import * as Handlers from '../internal/handlers'; // Conflict with some names
+import { ensureInitializeCalled, ensureInitialized, processAdditionalValidOrigins } from '../internal/internalAPIs';
+import { getLogger } from '../internal/telemetry';
+import { isNullOrUndefined } from '../internal/typeCheckUtilities';
+import { compareSDKVersions, inServerSideRenderingEnvironment, runWithTimeout } from '../internal/utils';
+import * as app from '../public/app';
+import { authentication } from '../public/authentication';
+import { FrameContexts } from '../public/constants';
+import { dialog } from '../public/dialog';
+import { menus } from '../public/menus';
+import { pages } from '../public/pages';
+import {
+  applyRuntimeConfig,
+  generateVersionBasedTeamsRuntimeConfig,
+  IBaseRuntime,
+  mapTeamsVersionToSupportedCapabilities,
+  runtime,
+  versionAndPlatformAgnosticTeamsRuntimeConfig,
+} from '../public/runtime';
+import { version } from '../public/version';
+
+/**
+ * Number of milliseconds we'll give the initialization call to return before timing it out
+ */
+const initializationTimeoutInMs = 5000;
+
+const appLogger = getLogger('app');
+
+export function appInitializeHelper(apiVersionTag: string, validMessageOrigins?: string[]): Promise<void> {
+  if (!inServerSideRenderingEnvironment()) {
+    return runWithTimeout(
+      () => initializeHelper(apiVersionTag, validMessageOrigins),
+      initializationTimeoutInMs,
+      new Error('SDK initialization timed out.'),
+    );
+  } else {
+    const initializeLogger = appLogger.extend('initialize');
+    // This log statement should NEVER actually be written. This code path exists only to enable compilation in server-side rendering environments.
+    // If you EVER see this statement in ANY log file, something has gone horribly wrong and a bug needs to be filed.
+    initializeLogger('window object undefined at initialization');
+    return Promise.resolve();
+  }
+}
+
+export function notifyAppLoadedHelper(apiVersionTag: string): void {
+  sendMessageToParent(apiVersionTag, app.Messages.AppLoaded, [version]);
+}
+
+export function notifyExpectedFailureHelper(
+  apiVersionTag: string,
+  expectedFailureRequest: app.IExpectedFailureRequest,
+): void {
+  sendMessageToParent(apiVersionTag, app.Messages.ExpectedFailure, [
+    expectedFailureRequest.reason,
+    expectedFailureRequest.message,
+  ]);
+}
+
+export function notifyFailureHelper(apiVersiontag: string, appInitializationFailedRequest: app.IFailedRequest): void {
+  sendMessageToParent(apiVersiontag, app.Messages.Failure, [
+    appInitializationFailedRequest.reason,
+    appInitializationFailedRequest.message,
+  ]);
+}
+
+export function notifySuccessHelper(apiVersionTag: string): void {
+  sendMessageToParent(apiVersionTag, app.Messages.Success, [version]);
+}
+
+const initializeHelperLogger = appLogger.extend('initializeHelper');
+function initializeHelper(apiVersionTag: string, validMessageOrigins?: string[]): Promise<void> {
+  return new Promise<void>((resolve) => {
+    // Independent components might not know whether the SDK is initialized so might call it to be safe.
+    // Just no-op if that happens to make it easier to use.
+    if (!GlobalVars.initializeCalled) {
+      GlobalVars.initializeCalled = true;
+      Handlers.initializeHandlers();
+      GlobalVars.initializePromise = initializeCommunication(validMessageOrigins, apiVersionTag).then(
+        ({ context, clientType, runtimeConfig, clientSupportedSDKVersion = defaultSDKVersionForCompatCheck }) => {
+          GlobalVars.frameContext = context;
+          GlobalVars.hostClientType = clientType;
+          GlobalVars.clientSupportedSDKVersion = clientSupportedSDKVersion;
+          // Temporary workaround while the Host is updated with the new argument order.
+          // For now, we might receive any of these possibilities:
+          // - `runtimeConfig` in `runtimeConfig` and `clientSupportedSDKVersion` in `clientSupportedSDKVersion`.
+          // - `runtimeConfig` in `clientSupportedSDKVersion` and `clientSupportedSDKVersion` in `runtimeConfig`.
+          // - `clientSupportedSDKVersion` in `runtimeConfig` and no `clientSupportedSDKVersion`.
+          // This code supports any of these possibilities
+
+          // Teams AppHost won't provide this runtime config
+          // so we assume that if we don't have it, we must be running in Teams.
+          // After Teams updates its client code, we can remove this default code.
+          try {
+            initializeHelperLogger('Parsing %s', runtimeConfig);
+            const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(runtimeConfig);
+            initializeHelperLogger('Checking if %o is a valid runtime object', givenRuntimeConfig ?? 'null');
+            // Check that givenRuntimeConfig is a valid instance of IBaseRuntime
+            if (!givenRuntimeConfig || !givenRuntimeConfig.apiVersion) {
+              throw new Error('Received runtime config is invalid');
+            }
+            runtimeConfig && applyRuntimeConfig(givenRuntimeConfig);
+          } catch (e) {
+            if (e instanceof SyntaxError) {
+              try {
+                initializeHelperLogger('Attempting to parse %s as an SDK version', runtimeConfig);
+                // if the given runtime config was actually meant to be a SDK version, store it as such.
+                // TODO: This is a temporary workaround to allow Teams to store clientSupportedSDKVersion even when
+                // it doesn't provide the runtimeConfig. After Teams updates its client code, we should
+                // remove this feature.
+                if (!isNaN(compareSDKVersions(runtimeConfig, defaultSDKVersionForCompatCheck))) {
+                  GlobalVars.clientSupportedSDKVersion = runtimeConfig;
+                }
+                const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(clientSupportedSDKVersion);
+                initializeHelperLogger('givenRuntimeConfig parsed to %o', givenRuntimeConfig ?? 'null');
+
+                if (!givenRuntimeConfig) {
+                  throw new Error(
+                    'givenRuntimeConfig string was successfully parsed. However, it parsed to value of null',
+                  );
+                } else {
+                  applyRuntimeConfig(givenRuntimeConfig);
+                }
+              } catch (e) {
+                if (e instanceof SyntaxError) {
+                  applyRuntimeConfig(
+                    generateVersionBasedTeamsRuntimeConfig(
+                      GlobalVars.clientSupportedSDKVersion,
+                      versionAndPlatformAgnosticTeamsRuntimeConfig,
+                      mapTeamsVersionToSupportedCapabilities,
+                    ),
+                  );
+                } else {
+                  throw e;
+                }
+              }
+            } else {
+              // If it's any error that's not a JSON parsing error, we want the program to fail.
+              throw e;
+            }
+          }
+
+          GlobalVars.initializeCompleted = true;
+        },
+      );
+
+      authentication.initialize();
+      menus.initialize();
+      pages.config.initialize();
+      dialog.initialize();
+    }
+
+    // Handle additional valid message origins if specified
+    if (Array.isArray(validMessageOrigins)) {
+      processAdditionalValidOrigins(validMessageOrigins);
+    }
+
+    if (GlobalVars.initializePromise !== undefined) {
+      resolve(GlobalVars.initializePromise);
+    } else {
+      initializeHelperLogger('GlobalVars.initializePromise is unexpectedly undefined');
+    }
+  });
+}
+
+export function registerOnThemeChangeHandlerHelper(apiVersionTag: string, handler: app.themeHandler): void {
+  // allow for registration cleanup even when not called initialize
+  !isNullOrUndefined(handler) && ensureInitializeCalled();
+  Handlers.registerOnThemeChangeHandler(apiVersionTag, handler);
+}
+
+export function openLinkHelper(apiVersionTag: string, deepLink: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    ensureInitialized(
+      runtime,
+      FrameContexts.content,
+      FrameContexts.sidePanel,
+      FrameContexts.settings,
+      FrameContexts.task,
+      FrameContexts.stage,
+      FrameContexts.meetingStage,
+    );
+    resolve(sendAndHandleStatusAndReason(apiVersionTag, 'executeDeepLink', deepLink));
+  });
+}

--- a/packages/teams-js/src/internal/appHelpers.ts
+++ b/packages/teams-js/src/internal/appHelpers.ts
@@ -10,7 +10,7 @@ import { ensureInitializeCalled, ensureInitialized, processAdditionalValidOrigin
 import { getLogger } from '../internal/telemetry';
 import { isNullOrUndefined } from '../internal/typeCheckUtilities';
 import { compareSDKVersions, inServerSideRenderingEnvironment, runWithTimeout } from '../internal/utils';
-import * as app from '../public/app';
+import { app } from '../public/app';
 import { authentication } from '../public/authentication';
 import { FrameContexts } from '../public/constants';
 import { dialog } from '../public/dialog';

--- a/packages/teams-js/src/private/index.ts
+++ b/packages/teams-js/src/private/index.ts
@@ -18,7 +18,7 @@ export {
   registerUserSettingsChangeHandler,
   openFilePreview,
 } from './privateAPIs';
-export { conversations } from './conversations';
+export { conversations, OpenConversationRequest } from './conversations';
 export { copilot } from './copilot';
 export { externalAppAuthentication } from './externalAppAuthentication';
 export { externalAppAuthenticationForCEA } from './externalAppAuthenticationForCEA';

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -2,208 +2,24 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import {
-  Communication,
-  initializeCommunication,
-  sendAndHandleStatusAndReason,
-  sendAndUnwrap,
-  sendMessageToParent,
-  uninitializeCommunication,
-} from '../internal/communication';
-import { defaultSDKVersionForCompatCheck } from '../internal/constants';
+import * as appHelpers from '../internal/appHelpers';
+import { Communication, sendAndUnwrap, uninitializeCommunication } from '../internal/communication';
 import { GlobalVars } from '../internal/globalVars';
 import * as Handlers from '../internal/handlers'; // Conflict with some names
-import { ensureInitializeCalled, ensureInitialized, processAdditionalValidOrigins } from '../internal/internalAPIs';
-import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { getLogger } from '../internal/telemetry';
-import { isNullOrUndefined } from '../internal/typeCheckUtilities';
-import { compareSDKVersions, inServerSideRenderingEnvironment, runWithTimeout } from '../internal/utils';
+import { ensureInitializeCalled, ensureInitialized } from '../internal/internalAPIs';
+import { ApiName, ApiVersionNumber, getApiVersionTag, getLogger } from '../internal/telemetry';
+import { inServerSideRenderingEnvironment } from '../internal/utils';
 import { prefetchOriginsFromCDN } from '../internal/validOrigins';
 import { messageChannels } from '../private/messageChannels';
-import { authentication } from './authentication';
 import { ChannelType, FrameContexts, HostClientType, HostName, TeamType, UserTeamRole } from './constants';
-import { dialog } from './dialog';
 import { ActionInfo, Context as LegacyContext, FileOpenPreference, LocaleInfo, ResumeContext } from './interfaces';
-import { menus } from './menus';
-import { pages } from './pages';
-import {
-  applyRuntimeConfig,
-  generateVersionBasedTeamsRuntimeConfig,
-  IBaseRuntime,
-  mapTeamsVersionToSupportedCapabilities,
-  runtime,
-  versionAndPlatformAgnosticTeamsRuntimeConfig,
-} from './runtime';
+import { runtime } from './runtime';
 import { version } from './version';
 
 /**
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const appTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Number of milliseconds we'll give the initialization call to return before timing it out
- */
-const initializationTimeoutInMs = 5000;
-
-const appLogger = getLogger('app');
-
-export function appInitializeHelper(apiVersionTag: string, validMessageOrigins?: string[]): Promise<void> {
-  if (!inServerSideRenderingEnvironment()) {
-    return runWithTimeout(
-      () => initializeHelper(apiVersionTag, validMessageOrigins),
-      initializationTimeoutInMs,
-      new Error('SDK initialization timed out.'),
-    );
-  } else {
-    const initializeLogger = appLogger.extend('initialize');
-    // This log statement should NEVER actually be written. This code path exists only to enable compilation in server-side rendering environments.
-    // If you EVER see this statement in ANY log file, something has gone horribly wrong and a bug needs to be filed.
-    initializeLogger('window object undefined at initialization');
-    return Promise.resolve();
-  }
-}
-
-export function notifyAppLoadedHelper(apiVersionTag: string): void {
-  sendMessageToParent(apiVersionTag, app.Messages.AppLoaded, [version]);
-}
-
-export function notifyExpectedFailureHelper(
-  apiVersionTag: string,
-  expectedFailureRequest: app.IExpectedFailureRequest,
-): void {
-  sendMessageToParent(apiVersionTag, app.Messages.ExpectedFailure, [
-    expectedFailureRequest.reason,
-    expectedFailureRequest.message,
-  ]);
-}
-
-export function notifyFailureHelper(apiVersiontag: string, appInitializationFailedRequest: app.IFailedRequest): void {
-  sendMessageToParent(apiVersiontag, app.Messages.Failure, [
-    appInitializationFailedRequest.reason,
-    appInitializationFailedRequest.message,
-  ]);
-}
-
-export function notifySuccessHelper(apiVersionTag: string): void {
-  sendMessageToParent(apiVersionTag, app.Messages.Success, [version]);
-}
-
-const initializeHelperLogger = appLogger.extend('initializeHelper');
-function initializeHelper(apiVersionTag: string, validMessageOrigins?: string[]): Promise<void> {
-  return new Promise<void>((resolve) => {
-    // Independent components might not know whether the SDK is initialized so might call it to be safe.
-    // Just no-op if that happens to make it easier to use.
-    if (!GlobalVars.initializeCalled) {
-      GlobalVars.initializeCalled = true;
-      Handlers.initializeHandlers();
-      GlobalVars.initializePromise = initializeCommunication(validMessageOrigins, apiVersionTag).then(
-        ({ context, clientType, runtimeConfig, clientSupportedSDKVersion = defaultSDKVersionForCompatCheck }) => {
-          GlobalVars.frameContext = context;
-          GlobalVars.hostClientType = clientType;
-          GlobalVars.clientSupportedSDKVersion = clientSupportedSDKVersion;
-          // Temporary workaround while the Host is updated with the new argument order.
-          // For now, we might receive any of these possibilities:
-          // - `runtimeConfig` in `runtimeConfig` and `clientSupportedSDKVersion` in `clientSupportedSDKVersion`.
-          // - `runtimeConfig` in `clientSupportedSDKVersion` and `clientSupportedSDKVersion` in `runtimeConfig`.
-          // - `clientSupportedSDKVersion` in `runtimeConfig` and no `clientSupportedSDKVersion`.
-          // This code supports any of these possibilities
-
-          // Teams AppHost won't provide this runtime config
-          // so we assume that if we don't have it, we must be running in Teams.
-          // After Teams updates its client code, we can remove this default code.
-          try {
-            initializeHelperLogger('Parsing %s', runtimeConfig);
-            const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(runtimeConfig);
-            initializeHelperLogger('Checking if %o is a valid runtime object', givenRuntimeConfig ?? 'null');
-            // Check that givenRuntimeConfig is a valid instance of IBaseRuntime
-            if (!givenRuntimeConfig || !givenRuntimeConfig.apiVersion) {
-              throw new Error('Received runtime config is invalid');
-            }
-            runtimeConfig && applyRuntimeConfig(givenRuntimeConfig);
-          } catch (e) {
-            if (e instanceof SyntaxError) {
-              try {
-                initializeHelperLogger('Attempting to parse %s as an SDK version', runtimeConfig);
-                // if the given runtime config was actually meant to be a SDK version, store it as such.
-                // TODO: This is a temporary workaround to allow Teams to store clientSupportedSDKVersion even when
-                // it doesn't provide the runtimeConfig. After Teams updates its client code, we should
-                // remove this feature.
-                if (!isNaN(compareSDKVersions(runtimeConfig, defaultSDKVersionForCompatCheck))) {
-                  GlobalVars.clientSupportedSDKVersion = runtimeConfig;
-                }
-                const givenRuntimeConfig: IBaseRuntime | null = JSON.parse(clientSupportedSDKVersion);
-                initializeHelperLogger('givenRuntimeConfig parsed to %o', givenRuntimeConfig ?? 'null');
-
-                if (!givenRuntimeConfig) {
-                  throw new Error(
-                    'givenRuntimeConfig string was successfully parsed. However, it parsed to value of null',
-                  );
-                } else {
-                  applyRuntimeConfig(givenRuntimeConfig);
-                }
-              } catch (e) {
-                if (e instanceof SyntaxError) {
-                  applyRuntimeConfig(
-                    generateVersionBasedTeamsRuntimeConfig(
-                      GlobalVars.clientSupportedSDKVersion,
-                      versionAndPlatformAgnosticTeamsRuntimeConfig,
-                      mapTeamsVersionToSupportedCapabilities,
-                    ),
-                  );
-                } else {
-                  throw e;
-                }
-              }
-            } else {
-              // If it's any error that's not a JSON parsing error, we want the program to fail.
-              throw e;
-            }
-          }
-
-          GlobalVars.initializeCompleted = true;
-        },
-      );
-
-      authentication.initialize();
-      menus.initialize();
-      pages.config.initialize();
-      dialog.initialize();
-    }
-
-    // Handle additional valid message origins if specified
-    if (Array.isArray(validMessageOrigins)) {
-      processAdditionalValidOrigins(validMessageOrigins);
-    }
-
-    if (GlobalVars.initializePromise !== undefined) {
-      resolve(GlobalVars.initializePromise);
-    } else {
-      initializeHelperLogger('GlobalVars.initializePromise is unexpectedly undefined');
-    }
-  });
-}
-
-export function registerOnThemeChangeHandlerHelper(apiVersionTag: string, handler: app.themeHandler): void {
-  // allow for registration cleanup even when not called initialize
-  !isNullOrUndefined(handler) && ensureInitializeCalled();
-  Handlers.registerOnThemeChangeHandler(apiVersionTag, handler);
-}
-
-export function openLinkHelper(apiVersionTag: string, deepLink: string): Promise<void> {
-  return new Promise<void>((resolve) => {
-    ensureInitialized(
-      runtime,
-      FrameContexts.content,
-      FrameContexts.sidePanel,
-      FrameContexts.settings,
-      FrameContexts.task,
-      FrameContexts.stage,
-      FrameContexts.meetingStage,
-    );
-    resolve(sendAndHandleStatusAndReason(apiVersionTag, 'executeDeepLink', deepLink));
-  });
-}
 
 /**
  * Namespace to interact with app initialization and lifecycle.
@@ -779,7 +595,7 @@ export namespace app {
    */
   export function initialize(validMessageOrigins?: string[]): Promise<void> {
     prefetchOriginsFromCDN();
-    return appInitializeHelper(
+    return appHelpers.appInitializeHelper(
       getApiVersionTag(appTelemetryVersionNumber, ApiName.App_Initialize),
       validMessageOrigins,
     );
@@ -841,7 +657,7 @@ export namespace app {
    */
   export function notifyAppLoaded(): void {
     ensureInitializeCalled();
-    notifyAppLoadedHelper(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifyAppLoaded));
+    appHelpers.notifyAppLoadedHelper(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifyAppLoaded));
   }
 
   /**
@@ -849,7 +665,7 @@ export namespace app {
    */
   export function notifySuccess(): void {
     ensureInitializeCalled();
-    notifySuccessHelper(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifySuccess));
+    appHelpers.notifySuccessHelper(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifySuccess));
   }
 
   /**
@@ -860,7 +676,7 @@ export namespace app {
    */
   export function notifyFailure(appInitializationFailedRequest: IFailedRequest): void {
     ensureInitializeCalled();
-    notifyFailureHelper(
+    appHelpers.notifyFailureHelper(
       getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifyFailure),
       appInitializationFailedRequest,
     );
@@ -873,7 +689,7 @@ export namespace app {
    */
   export function notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void {
     ensureInitializeCalled();
-    notifyExpectedFailureHelper(
+    appHelpers.notifyExpectedFailureHelper(
       getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifyExpectedFailure),
       expectedFailureRequest,
     );
@@ -888,7 +704,7 @@ export namespace app {
    * @param handler - The handler to invoke when the user changes their theme.
    */
   export function registerOnThemeChangeHandler(handler: themeHandler): void {
-    registerOnThemeChangeHandlerHelper(
+    appHelpers.registerOnThemeChangeHandlerHelper(
       getApiVersionTag(appTelemetryVersionNumber, ApiName.App_RegisterOnThemeChangeHandler),
       handler,
     );
@@ -926,7 +742,7 @@ export namespace app {
    * does not necessarily indicate whether the target loaded successfully.
    */
   export function openLink(deepLink: string): Promise<void> {
-    return openLinkHelper(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_OpenLink), deepLink);
+    return appHelpers.openLinkHelper(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_OpenLink), deepLink);
   }
 
   /**

--- a/packages/teams-js/src/public/appInitialization.ts
+++ b/packages/teams-js/src/public/appInitialization.ts
@@ -1,11 +1,11 @@
-import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
 import {
-  app,
   notifyAppLoadedHelper,
   notifyExpectedFailureHelper,
   notifyFailureHelper,
   notifySuccessHelper,
-} from './app';
+} from '../internal/appHelpers';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
+import { app } from './app';
 
 /**
  * @deprecated

--- a/packages/teams-js/src/public/pages.ts
+++ b/packages/teams-js/src/public/pages.ts
@@ -1,3 +1,4 @@
+import { appInitializeHelper } from '../internal/appHelpers';
 import {
   Communication,
   sendAndHandleSdkError,
@@ -14,7 +15,6 @@ import { isNullOrUndefined } from '../internal/typeCheckUtilities';
 import { createTeamsAppLink } from '../internal/utils';
 import { prefetchOriginsFromCDN } from '../internal/validOrigins';
 import { AppId } from '../public/appId';
-import { appInitializeHelper } from './app';
 import { errorNotSupportedOnPlatform, FrameContexts } from './constants';
 import { FrameInfo, ShareDeepLinkParameters, TabInformation, TabInstance, TabInstanceParameters } from './interfaces';
 import { runtime } from './runtime';

--- a/packages/teams-js/src/public/publicAPIs.ts
+++ b/packages/teams-js/src/public/publicAPIs.ts
@@ -1,10 +1,10 @@
+import { appInitializeHelper, openLinkHelper, registerOnThemeChangeHandlerHelper } from '../internal/appHelpers';
 import { sendMessageToParent } from '../internal/communication';
 import { GlobalVars } from '../internal/globalVars';
 import { registerHandlerHelper } from '../internal/handlers';
 import { ensureInitializeCalled, ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
 import { getGenericOnCompleteHandler } from '../internal/utils';
-import { appInitializeHelper, openLinkHelper, registerOnThemeChangeHandlerHelper } from './app';
 import { FrameContexts } from './constants';
 import {
   Context,

--- a/packages/teams-js/test/public/appInitialization.spec.ts
+++ b/packages/teams-js/test/public/appInitialization.spec.ts
@@ -1,3 +1,4 @@
+import * as AppHelpersFile from '../../src/internal/appHelpers';
 import * as AppFile from '../../src/public/app';
 import { appInitialization } from '../../src/public/appInitialization';
 import { version } from '../../src/public/version';
@@ -30,7 +31,7 @@ describe('appInitialization', () => {
   describe('testing notifyAppLoaded', () => {
     it('should call notifyAppLoadedHelper from the legacy code', async () => {
       await utils.initializeWithContext('content');
-      const notifyAppLoadedHelperFunc = jest.spyOn(AppFile, 'notifyAppLoadedHelper');
+      const notifyAppLoadedHelperFunc = jest.spyOn(AppHelpersFile, 'notifyAppLoadedHelper');
       appInitialization.notifyAppLoaded();
       expect(notifyAppLoadedHelperFunc).toHaveBeenCalled();
       expect(notifyAppLoadedHelperFunc).toHaveReturned();
@@ -59,7 +60,7 @@ describe('appInitialization', () => {
   describe('testing notifySuccess', () => {
     it('should call app.notifySuccess from the legacy code', async () => {
       await utils.initializeWithContext('content');
-      const notifySuccessHelperFile = jest.spyOn(AppFile, 'notifySuccessHelper');
+      const notifySuccessHelperFile = jest.spyOn(AppHelpersFile, 'notifySuccessHelper');
       appInitialization.notifySuccess();
       expect(notifySuccessHelperFile).toHaveBeenCalled();
       expect(notifySuccessHelperFile).toHaveReturned();
@@ -88,7 +89,7 @@ describe('appInitialization', () => {
   describe('testing notifyExpectedFailure', () => {
     it('should call app.notifyExpectedFailure from the legacy code', async () => {
       await utils.initializeWithContext('content');
-      const notifyExpectedFailureHelperFunc = jest.spyOn(AppFile, 'notifyExpectedFailureHelper');
+      const notifyExpectedFailureHelperFunc = jest.spyOn(AppHelpersFile, 'notifyExpectedFailureHelper');
       appInitialization.notifyExpectedFailure({
         reason: appInitialization.ExpectedFailureReason.PermissionError,
         message: 'Permission denied',
@@ -128,7 +129,7 @@ describe('appInitialization', () => {
   describe('testing notifyFailure', () => {
     it('should call app.notifyFailure from the legacy code', async () => {
       await utils.initializeWithContext('content');
-      const notifyFailureHelperFunc = jest.spyOn(AppFile, 'notifyFailureHelper');
+      const notifyFailureHelperFunc = jest.spyOn(AppHelpersFile, 'notifyFailureHelper');
       appInitialization.notifyFailure({
         reason: appInitialization.FailedReason.AuthFailed,
         message: 'Failed message',


### PR DESCRIPTION
**This PR is part of the larger Treeshaking effort with more PR's to come**

The app.ts file has a large number of helper functions that are not a part of the app namespace and are also not exported through the index file to be used by the package consumer, they are only exported to be used by other parts of teams-js. As such I have moved all of the helper functions that are not a part of the app namespace to their own file, appHelpers.ts, located in the internal folder. This helps keep teams-js's structure more consistent. Also, in a future PR as part of the treeshaking work, I will need to remove the app namespace and update the index file with `export  * as app`. Since the helper functions are marked as exports so they can be used by the rest of the library, that change would cause them to be exported through the index file to the library consumer. As such they need to be moved to their own separate file anyways. 

I also updated a reference in the private index folder to export an interface that was missing and should be exported. This was a bug not caught by our docs generation as it was covered up by the bundler. Since we've moved to a new bundler that will not cover for the bug, this change will need to be added.
