### PR TITLE
Prep release 2.30.0

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.29.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-HCj4C0CvWvv0xKWpolDpLs3Q2f8+k4AUwYACBrszhvquzHsIUz1ZB6z1KLIQTnSW"
+      src="https://res.cdn.office.net/teams-js/2.30.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-8I0Bv4bWDPSX5ZYhJcChnvrBNoieX3zASTxmZ9URwnjEVx70hsrN0ZUy/C46u8dw"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm lint && webpack",

--- a/change/@microsoft-teams-js-0ee21e72-d019-4626-8510-28cc59a46290.json
+++ b/change/@microsoft-teams-js-0ee21e72-d019-4626-8510-28cc59a46290.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Clarified usage for `validMessageOrigins` parameter on `app.initialize` in documentation",
-  "packageName": "@microsoft/teams-js",
-  "email": "36546967+AE-MS@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-1aa01dc3-75e3-43e1-8fa9-36340595f99d.json
+++ b/change/@microsoft-teams-js-1aa01dc3-75e3-43e1-8fa9-36340595f99d.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Updated edgeapi endpoint from `edgeapi.svc.cloud.microsoft` to `edgeapi.freya.svc.cloud.microsoft` in valid domains list. Added `work.bing.com` to valid domains list.",
-  "packageName": "@microsoft/teams-js",
-  "email": "jadahiya@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-286cc515-1cef-4d54-9af6-d869e00d96c9.json
+++ b/change/@microsoft-teams-js-286cc515-1cef-4d54-9af6-d869e00d96c9.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Updated `copilot.eligibility.getEligibilityInfo` to be async and get the eligibility info from the host if it is not already available.",
-  "packageName": "@microsoft/teams-js",
-  "email": "erinha@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-c84a8a6a-9440-4ec4-a930-b9e6921a4932.json
+++ b/change/@microsoft-teams-js-c84a8a6a-9440-4ec4-a930-b9e6921a4932.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Released v2.29.0",
-  "packageName": "@microsoft/teams-js",
-  "email": "lakhveerkaur@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-c869bc74-fed2-4af2-9795-312fd14d1218.json
+++ b/change/@microsoft-teams-js-c869bc74-fed2-4af2-9795-312fd14d1218.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Updated edgeapi.freya.svc.cloud.microsoft to chatuxmanager.svc.cloud.microsoft",
-  "packageName": "@microsoft/teams-js",
-  "email": "jadahiya@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,22 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Thu, 03 Oct 2024 22:51:48 GMT and should not be manually modified.
+This log was last generated on Mon, 21 Oct 2024 18:11:30 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.30.0
+
+Mon, 21 Oct 2024 18:11:30 GMT
+
+### Minor changes
+
+- Updated `copilot.eligibility.getEligibilityInfo` to be async and get the eligibility info from the host if it is not already available.
+
+### Patches
+
+- Updated edgeapi.freya.svc.cloud.microsoft to chatuxmanager.svc.cloud.microsoft
+- Updated edgeapi endpoint from `edgeapi.svc.cloud.microsoft` to `edgeapi.freya.svc.cloud.microsoft` in valid domains list. Added `work.bing.com` to valid domains list.
+- Clarified usage for `validMessageOrigins` parameter on `app.initialize` in documentation
 
 ## 2.29.0
 

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -14,9 +14,9 @@ Mon, 21 Oct 2024 18:11:30 GMT
 
 ### Patches
 
-- Updated edgeapi.freya.svc.cloud.microsoft to chatuxmanager.svc.cloud.microsoft
+- Updated edgeapi.freya.svc.cloud.microsoft to chatuxmanager.svc.cloud.microsoft.
 - Updated edgeapi endpoint from `edgeapi.svc.cloud.microsoft` to `edgeapi.freya.svc.cloud.microsoft` in valid domains list. Added `work.bing.com` to valid domains list.
-- Clarified usage for `validMessageOrigins` parameter on `app.initialize` in documentation
+- Clarified usage for `validMessageOrigins` parameter on `app.initialize` in documentation.
 
 ## 2.29.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.29.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.30.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.29.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-HCj4C0CvWvv0xKWpolDpLs3Q2f8+k4AUwYACBrszhvquzHsIUz1ZB6z1KLIQTnSW"
+  src="https://res.cdn.office.net/teams-js/2.30.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-8I0Bv4bWDPSX5ZYhJcChnvrBNoieX3zASTxmZ9URwnjEVx70hsrN0ZUy/C46u8dw"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.29.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.30.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

From the changelog:

## 2.30.0

Mon, 21 Oct 2024 18:11:30 GMT

### Minor changes

- Updated `copilot.eligibility.getEligibilityInfo` to be async and get the eligibility info from the host if it is not already available.

### Patches

- Updated edgeapi.freya.svc.cloud.microsoft to chatuxmanager.svc.cloud.microsoft
- Updated edgeapi endpoint from `edgeapi.svc.cloud.microsoft` to `edgeapi.freya.svc.cloud.microsoft` in valid domains list. Added `work.bing.com` to valid domains list.
- Clarified usage for `validMessageOrigins` parameter on `app.initialize` in documentation
