### PR TITLE
noahdarveau/dts plugin and some treeshaking changes

### DIFF
--- a/change/@microsoft-teams-js-b23ef57f-9184-4659-93c8-48d862788dd3.json
+++ b/change/@microsoft-teams-js-b23ef57f-9184-4659-93c8-48d862788dd3.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Made `app`, `appInitialization`, and `settings` treeshakable as well as added dts rollup plugin",
+  "comment": "Made the `app`, `appInitialization`, and `settings` files treeshakable",
   "packageName": "@microsoft/teams-js",
   "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-b23ef57f-9184-4659-93c8-48d862788dd3.json
+++ b/change/@microsoft-teams-js-b23ef57f-9184-4659-93c8-48d862788dd3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Made `app`, `appInitialization`, and `settings` treeshakable as well as added dts rollup plugin",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "prettier": "^3.3.2",
     "rimraf": "^5.0.7",
     "rollup": "^4.24.0",
+    "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-polyfill-node": "^0.13.0",
     "shx": "^0.3.4",
     "style-loader": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "copy-webpack-plugin": "9.1.0",
     "cross-env": "^7.0.3",
     "css-loader": "^6.11.0",
-    "dts-bundle-webpack": "^1.0.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-node": "^11.1.0",

--- a/packages/teams-js/rollup.config.mjs
+++ b/packages/teams-js/rollup.config.mjs
@@ -6,53 +6,65 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
+import dts from 'rollup-plugin-polyfill-node';
 import nodePolyfills from 'rollup-plugin-polyfill-node';
 
 import version from './package.json' assert { type: 'json' };
 
-export default {
-  input: './src/index.ts',
-  output: {
-    dir: 'dist/esm',
-    name: '@microsoft/teams-js',
-    format: 'es',
-    preserveModules: true,
-    entryFileNames: '[name].js',
-    sourcemap: false,
-    plugins: [terser()],
-    globals: {
-      buffer: 'Buffer',
-      tty: 'tty',
-      util: 'util',
-      os: 'os',
+export default [
+  {
+    input: './src/index.ts',
+    output: {
+      dir: 'dist/esm',
+      name: '@microsoft/teams-js',
+      format: 'es',
+      preserveModules: true,
+      entryFileNames: '[name].js',
+      sourcemap: false,
+      plugins: [terser()],
+      globals: {
+        buffer: 'Buffer',
+        tty: 'tty',
+        util: 'util',
+        os: 'os',
+      },
+    },
+    preserveEntrySignatures: 'strict',
+    plugins: [
+      nodeResolve({
+        extensions: ['.js', '.ts', '.d.ts', '.json'],
+      }),
+      replace({
+        preventAssignment: true,
+        'process.env.NODE_ENV': JSON.stringify('production'),
+        PACKAGE_VERSION: JSON.stringify(version.version),
+      }),
+      typescript(),
+      json(),
+      commonjs(),
+      nodePolyfills(),
+    ],
+    treeshake: {
+      moduleSideEffects: [
+        'src/internal/communication.ts',
+        'src/internal/nestedAppAuthUtils.ts',
+        'src/internal/utils.ts',
+        'src/internal/videoEffectsUtils.ts',
+        'src/private/constants.ts',
+        'src/private/interfaces.ts',
+        'src/public/constants.ts',
+        'src/public/handlers.ts',
+        'src/public/interfaces.ts',
+      ],
     },
   },
-  preserveEntrySignatures: 'strict',
-  plugins: [
-    nodeResolve({
-      extensions: ['.js', '.ts', '.d.ts', '.json'],
-    }),
-    replace({
-      preventAssignment: true,
-      'process.env.NODE_ENV': JSON.stringify('production'),
-      PACKAGE_VERSION: JSON.stringify(version.version),
-    }),
-    typescript(),
-    json(),
-    commonjs(),
-    nodePolyfills(),
-  ],
-  treeshake: {
-    moduleSideEffects: [
-      'src/internal/communication.ts',
-      'src/internal/nestedAppAuthUtils.ts',
-      'src/internal/utils.ts',
-      'src/internal/videoEffectsUtils.ts',
-      'src/private/constants.ts',
-      'src/private/interfaces.ts',
-      'src/public/constants.ts',
-      'src/public/handlers.ts',
-      'src/public/interfaces.ts',
-    ],
+  {
+    input: './dist/esm/packages/teams-js/dts/index.d.ts',
+    output: {
+      file: 'dist/umd/MicrosoftTeams.d.ts',
+      format: 'es',
+      sourcemap: false,
+    },
+    plugins: [dts()],
   },
-};
+];

--- a/packages/teams-js/rollup.config.mjs
+++ b/packages/teams-js/rollup.config.mjs
@@ -6,7 +6,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
-import dts from 'rollup-plugin-polyfill-node';
+import dts from 'rollup-plugin-dts';
 import nodePolyfills from 'rollup-plugin-polyfill-node';
 
 import version from './package.json' assert { type: 'json' };

--- a/packages/teams-js/src/internal/appHelpers.ts
+++ b/packages/teams-js/src/internal/appHelpers.ts
@@ -10,7 +10,7 @@ import { ensureInitializeCalled, ensureInitialized, processAdditionalValidOrigin
 import { getLogger } from '../internal/telemetry';
 import { isNullOrUndefined } from '../internal/typeCheckUtilities';
 import { compareSDKVersions, inServerSideRenderingEnvironment, runWithTimeout } from '../internal/utils';
-import { app } from '../public/app';
+import * as app from '../public/app';
 import { authentication } from '../public/authentication';
 import { FrameContexts } from '../public/constants';
 import { dialog } from '../public/dialog';

--- a/packages/teams-js/src/public/app.ts
+++ b/packages/teams-js/src/public/app.ts
@@ -24,379 +24,379 @@ const appTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 /**
  * Namespace to interact with app initialization and lifecycle.
  */
-export namespace app {
-  const appLogger = getLogger('app');
 
-  // ::::::::::::::::::::::: MicrosoftTeams client SDK public API ::::::::::::::::::::
+const appLogger = getLogger('app');
 
-  /** App Initialization Messages */
-  export const Messages = {
-    /** App loaded. */
-    AppLoaded: 'appInitialization.appLoaded',
-    /** App initialized successfully. */
-    Success: 'appInitialization.success',
-    /** App initialization failed. */
-    Failure: 'appInitialization.failure',
-    /** App initialization expected failure. */
-    ExpectedFailure: 'appInitialization.expectedFailure',
-  };
+// ::::::::::::::::::::::: MicrosoftTeams client SDK public API ::::::::::::::::::::
+
+/** App Initialization Messages */
+export const Messages = {
+  /** App loaded. */
+  AppLoaded: 'appInitialization.appLoaded',
+  /** App initialized successfully. */
+  Success: 'appInitialization.success',
+  /** App initialization failed. */
+  Failure: 'appInitialization.failure',
+  /** App initialization expected failure. */
+  ExpectedFailure: 'appInitialization.expectedFailure',
+};
+
+/**
+ * Describes errors that caused app initialization to fail
+ */
+export enum FailedReason {
+  /**
+   * Authentication failed
+   */
+  AuthFailed = 'AuthFailed',
+  /**
+   * The application timed out
+   */
+  Timeout = 'Timeout',
+  /**
+   * The app failed for a different reason
+   */
+  Other = 'Other',
+}
+
+/**
+ * Describes expected errors that occurred during an otherwise successful
+ * app initialization
+ */
+export enum ExpectedFailureReason {
+  /**
+   * There was a permission error
+   */
+  PermissionError = 'PermissionError',
+  /**
+   * The item was not found
+   */
+  NotFound = 'NotFound',
+  /**
+   * The network is currently throttled
+   */
+  Throttling = 'Throttling',
+  /**
+   * The application is currently offline
+   */
+  Offline = 'Offline',
+  /**
+   * The app failed for a different reason
+   */
+  Other = 'Other',
+}
+
+/**
+ * Represents the failed request sent during a failed app initialization.
+ */
+export interface IFailedRequest {
+  /**
+   * The reason for the failure
+   */
+  reason: FailedReason;
+  /**
+   * This property is currently unused.
+   */
+  message?: string;
+}
+
+/**
+ * Represents the failure request sent during an erroneous app initialization.
+ */
+export interface IExpectedFailureRequest {
+  /**
+   * The reason for the failure
+   */
+  reason: ExpectedFailureReason;
+  /**
+   * A message that describes the failure
+   */
+  message?: string;
+}
+
+/**
+ * Represents application information.
+ */
+export interface AppInfo {
+  /**
+   * The current locale that the user has configured for the app formatted as
+   * languageId-countryId (for example, en-us).
+   */
+  locale: string;
 
   /**
-   * Describes errors that caused app initialization to fail
+   * The current UI theme of the host. Possible values: "default", "dark", "contrast" or "glass".
    */
-  export enum FailedReason {
-    /**
-     * Authentication failed
-     */
-    AuthFailed = 'AuthFailed',
-    /**
-     * The application timed out
-     */
-    Timeout = 'Timeout',
-    /**
-     * The app failed for a different reason
-     */
-    Other = 'Other',
-  }
+  theme: string;
 
   /**
-   * Describes expected errors that occurred during an otherwise successful
-   * app initialization
+   * Unique ID for the current session for use in correlating telemetry data. A session corresponds to the lifecycle of an app. A new session begins upon the creation of a webview (on Teams mobile) or iframe (in Teams desktop) hosting the app, and ends when it is destroyed.
    */
-  export enum ExpectedFailureReason {
-    /**
-     * There was a permission error
-     */
-    PermissionError = 'PermissionError',
-    /**
-     * The item was not found
-     */
-    NotFound = 'NotFound',
-    /**
-     * The network is currently throttled
-     */
-    Throttling = 'Throttling',
-    /**
-     * The application is currently offline
-     */
-    Offline = 'Offline',
-    /**
-     * The app failed for a different reason
-     */
-    Other = 'Other',
-  }
+  sessionId: string;
 
   /**
-   * Represents the failed request sent during a failed app initialization.
+   * Info of the host
    */
-  export interface IFailedRequest {
-    /**
-     * The reason for the failure
-     */
-    reason: FailedReason;
-    /**
-     * This property is currently unused.
-     */
-    message?: string;
-  }
+  host: AppHostInfo;
 
   /**
-   * Represents the failure request sent during an erroneous app initialization.
+   * More detailed locale info from the user's OS if available. Can be used together with
+   * the @microsoft/globe NPM package to ensure your app respects the user's OS date and
+   * time format configuration
    */
-  export interface IExpectedFailureRequest {
-    /**
-     * The reason for the failure
-     */
-    reason: ExpectedFailureReason;
-    /**
-     * A message that describes the failure
-     */
-    message?: string;
-  }
+  osLocaleInfo?: LocaleInfo;
+  /**
+   * Personal app icon y coordinate position
+   */
+  iconPositionVertical?: number;
 
   /**
-   * Represents application information.
+   * Time when the user clicked on the tab
    */
-  export interface AppInfo {
-    /**
-     * The current locale that the user has configured for the app formatted as
-     * languageId-countryId (for example, en-us).
-     */
-    locale: string;
-
-    /**
-     * The current UI theme of the host. Possible values: "default", "dark", "contrast" or "glass".
-     */
-    theme: string;
-
-    /**
-     * Unique ID for the current session for use in correlating telemetry data. A session corresponds to the lifecycle of an app. A new session begins upon the creation of a webview (on Teams mobile) or iframe (in Teams desktop) hosting the app, and ends when it is destroyed.
-     */
-    sessionId: string;
-
-    /**
-     * Info of the host
-     */
-    host: AppHostInfo;
-
-    /**
-     * More detailed locale info from the user's OS if available. Can be used together with
-     * the @microsoft/globe NPM package to ensure your app respects the user's OS date and
-     * time format configuration
-     */
-    osLocaleInfo?: LocaleInfo;
-    /**
-     * Personal app icon y coordinate position
-     */
-    iconPositionVertical?: number;
-
-    /**
-     * Time when the user clicked on the tab
-     */
-    userClickTime?: number;
-
-    /**
-     * The ID of the parent message from which this task module was launched.
-     * This is only available in task modules launched from bot cards.
-     */
-    parentMessageId?: string;
-
-    /**
-     * Where the user prefers the file to be opened from by default during file open
-     */
-    userFileOpenPreference?: FileOpenPreference;
-
-    /**
-     * ID for the current visible app which is different for across cached sessions. Used for correlating telemetry data.
-     */
-    appLaunchId?: string;
-  }
+  userClickTime?: number;
 
   /**
-   * Represents information about the application's host.
+   * The ID of the parent message from which this task module was launched.
+   * This is only available in task modules launched from bot cards.
    */
-  export interface AppHostInfo {
-    /**
-     * Identifies which host is running your app
-     */
-    name: HostName;
-
-    /**
-     * The client type on which the host is running
-     */
-    clientType: HostClientType;
-
-    /**
-     * Unique ID for the current Host session for use in correlating telemetry data.
-     */
-    sessionId: string;
-
-    /**
-     * Current ring ID
-     */
-    ringId?: string;
-  }
+  parentMessageId?: string;
 
   /**
-   * Represents Channel information.
+   * Where the user prefers the file to be opened from by default during file open
    */
-  export interface ChannelInfo {
-    /**
-     * The Microsoft Teams ID for the channel with which the content is associated.
-     */
-    id: string;
-
-    /**
-     * The name for the channel with which the content is associated.
-     */
-    displayName?: string;
-
-    /**
-     * The relative path to the SharePoint folder associated with the channel.
-     */
-    relativeUrl?: string;
-
-    /**
-     * The type of the channel with which the content is associated.
-     */
-    membershipType?: ChannelType;
-
-    /**
-     * The OneNote section ID that is linked to the channel.
-     */
-    defaultOneNoteSectionId?: string;
-
-    /**
-     * The tenant ID of the team which owns the channel.
-     */
-    ownerTenantId?: string;
-
-    /**
-     * The Microsoft Entra group ID of the team which owns the channel.
-     */
-    ownerGroupId?: string;
-  }
+  userFileOpenPreference?: FileOpenPreference;
 
   /**
-   * Represents Chat information.
+   * ID for the current visible app which is different for across cached sessions. Used for correlating telemetry data.
    */
-  export interface ChatInfo {
-    /**
-     * The Microsoft Teams ID for the chat with which the content is associated.
-     */
-    id: string;
-  }
+  appLaunchId?: string;
+}
+
+/**
+ * Represents information about the application's host.
+ */
+export interface AppHostInfo {
+  /**
+   * Identifies which host is running your app
+   */
+  name: HostName;
 
   /**
-   * Represents Meeting information.
+   * The client type on which the host is running
    */
-  export interface MeetingInfo {
-    /**
-     * Meeting Id used by tab when running in meeting context
-     */
-    id: string;
-  }
+  clientType: HostClientType;
 
   /**
-   * Represents Page information.
+   * Unique ID for the current Host session for use in correlating telemetry data.
    */
-  export interface PageInfo {
-    /**
-     * The developer-defined unique ID for the page this content points to.
-     */
-    id: string;
-
-    /**
-     * The context where page url is loaded (content, task, setting, remove, sidePanel)
-     */
-    frameContext: FrameContexts;
-
-    /**
-     * The developer-defined unique ID for the sub-page this content points to.
-     * This field should be used to restore to a specific state within a page,
-     * such as scrolling to or activating a specific piece of content.
-     */
-    subPageId?: string;
-
-    /**
-     * Indication whether the page is in full-screen mode.
-     */
-    isFullScreen?: boolean;
-
-    /**
-     * Indication whether the page is in a pop out window
-     */
-    isMultiWindow?: boolean;
-
-    /**
-     * Indicates whether the page is being loaded in the background as
-     * part of an opt-in performance enhancement.
-     */
-    isBackgroundLoad?: boolean;
-
-    /**
-     * Source origin from where the page is opened
-     */
-    sourceOrigin?: string;
-  }
+  sessionId: string;
 
   /**
-   * Represents Team information.
+   * Current ring ID
    */
-  export interface TeamInfo {
-    /**
-     * The Microsoft Teams ID for the team with which the content is associated.
-     */
-    internalId: string;
+  ringId?: string;
+}
 
-    /**
-     * The name for the team with which the content is associated.
-     */
-    displayName?: string;
+/**
+ * Represents Channel information.
+ */
+export interface ChannelInfo {
+  /**
+   * The Microsoft Teams ID for the channel with which the content is associated.
+   */
+  id: string;
 
-    /**
-     * The type of the team.
-     */
-    type?: TeamType;
+  /**
+   * The name for the channel with which the content is associated.
+   */
+  displayName?: string;
 
-    /**
-     * The Office 365 group ID for the team with which the content is associated.
-     * This field is available only when the identity permission is requested in the manifest.
-     */
-    groupId?: string;
+  /**
+   * The relative path to the SharePoint folder associated with the channel.
+   */
+  relativeUrl?: string;
 
-    /**
-     * Indicates whether team is archived.
-     * Apps should use this as a signal to prevent any changes to content associated with archived teams.
-     */
-    isArchived?: boolean;
+  /**
+   * The type of the channel with which the content is associated.
+   */
+  membershipType?: ChannelType;
 
-    /**
-     * Team Template ID if there was a Team Template associated with the creation of the team.
-     */
-    templateId?: string;
+  /**
+   * The OneNote section ID that is linked to the channel.
+   */
+  defaultOneNoteSectionId?: string;
 
-    /**
+  /**
+   * The tenant ID of the team which owns the channel.
+   */
+  ownerTenantId?: string;
+
+  /**
+   * The Microsoft Entra group ID of the team which owns the channel.
+   */
+  ownerGroupId?: string;
+}
+
+/**
+ * Represents Chat information.
+ */
+export interface ChatInfo {
+  /**
+   * The Microsoft Teams ID for the chat with which the content is associated.
+   */
+  id: string;
+}
+
+/**
+ * Represents Meeting information.
+ */
+export interface MeetingInfo {
+  /**
+   * Meeting Id used by tab when running in meeting context
+   */
+  id: string;
+}
+
+/**
+ * Represents Page information.
+ */
+export interface PageInfo {
+  /**
+   * The developer-defined unique ID for the page this content points to.
+   */
+  id: string;
+
+  /**
+   * The context where page url is loaded (content, task, setting, remove, sidePanel)
+   */
+  frameContext: FrameContexts;
+
+  /**
+   * The developer-defined unique ID for the sub-page this content points to.
+   * This field should be used to restore to a specific state within a page,
+   * such as scrolling to or activating a specific piece of content.
+   */
+  subPageId?: string;
+
+  /**
+   * Indication whether the page is in full-screen mode.
+   */
+  isFullScreen?: boolean;
+
+  /**
+   * Indication whether the page is in a pop out window
+   */
+  isMultiWindow?: boolean;
+
+  /**
+   * Indicates whether the page is being loaded in the background as
+   * part of an opt-in performance enhancement.
+   */
+  isBackgroundLoad?: boolean;
+
+  /**
+   * Source origin from where the page is opened
+   */
+  sourceOrigin?: string;
+}
+
+/**
+ * Represents Team information.
+ */
+export interface TeamInfo {
+  /**
+   * The Microsoft Teams ID for the team with which the content is associated.
+   */
+  internalId: string;
+
+  /**
+   * The name for the team with which the content is associated.
+   */
+  displayName?: string;
+
+  /**
+   * The type of the team.
+   */
+  type?: TeamType;
+
+  /**
+   * The Office 365 group ID for the team with which the content is associated.
+   * This field is available only when the identity permission is requested in the manifest.
+   */
+  groupId?: string;
+
+  /**
+   * Indicates whether team is archived.
+   * Apps should use this as a signal to prevent any changes to content associated with archived teams.
+   */
+  isArchived?: boolean;
+
+  /**
+   * Team Template ID if there was a Team Template associated with the creation of the team.
+   */
+  templateId?: string;
+
+  /**
      * The user's role in the team.
 
      * Because a malicious party can run your content in a browser, this value should
      * be used only as a hint as to the user's role, and never as proof of her role.
      */
-    userRole?: UserTeamRole;
-  }
+  userRole?: UserTeamRole;
+}
+
+/**
+ * Represents User information.
+ */
+export interface UserInfo {
+  /**
+   * The Microsoft Entra object id of the current user.
+   *
+   * Because a malicious party can run your content in a browser, this value should
+   * be used only as a optimization hint as to who the user is and never as proof of identity.
+   * Specifically, this value should never be used to determine if a user is authorized to access
+   * a resource; access tokens should be used for that.
+   * See {@link authentication.getAuthToken} and {@link authentication.authenticate} for more information on access tokens.
+   *
+   * This field is available only when the identity permission is requested in the manifest.
+   */
+  id: string;
 
   /**
-   * Represents User information.
+   * The address book name of the current user.
    */
-  export interface UserInfo {
-    /**
-     * The Microsoft Entra object id of the current user.
-     *
-     * Because a malicious party can run your content in a browser, this value should
-     * be used only as a optimization hint as to who the user is and never as proof of identity.
-     * Specifically, this value should never be used to determine if a user is authorized to access
-     * a resource; access tokens should be used for that.
-     * See {@link authentication.getAuthToken} and {@link authentication.authenticate} for more information on access tokens.
-     *
-     * This field is available only when the identity permission is requested in the manifest.
-     */
-    id: string;
+  displayName?: string;
 
-    /**
-     * The address book name of the current user.
-     */
-    displayName?: string;
+  /**
+   * Represents whether calling is allowed for the current logged in User
+   */
+  isCallingAllowed?: boolean;
 
-    /**
-     * Represents whether calling is allowed for the current logged in User
-     */
-    isCallingAllowed?: boolean;
+  /**
+   * Represents whether PSTN calling is allowed for the current logged in User
+   */
+  isPSTNCallingAllowed?: boolean;
 
-    /**
-     * Represents whether PSTN calling is allowed for the current logged in User
-     */
-    isPSTNCallingAllowed?: boolean;
+  /**
+   * The license type for the current user. Possible values are:
+   * "Unknown", "Teacher", "Student", "Free", "SmbBusinessVoice", "SmbNonVoice", "FrontlineWorker", "Anonymous"
+   */
+  licenseType?: string;
 
-    /**
-     * The license type for the current user. Possible values are:
-     * "Unknown", "Teacher", "Student", "Free", "SmbBusinessVoice", "SmbNonVoice", "FrontlineWorker", "Anonymous"
-     */
-    licenseType?: string;
+  /**
+   * A value suitable for use when providing a login_hint to Microsoft Entra ID for authentication purposes.
+   * See [Provide optional claims to your app](https://learn.microsoft.com/azure/active-directory/develop/active-directory-optional-claims#v10-and-v20-optional-claims-set)
+   * for more information about the use of login_hint
+   *
+   * Because a malicious party can run your content in a browser, this value should
+   * be used only as a optimization hint as to who the user is and never as proof of identity.
+   * Specifically, this value should never be used to determine if a user is authorized to access
+   * a resource; access tokens should be used for that.
+   * See {@link authentication.getAuthToken} and {@link authentication.authenticate} for more information on access tokens.
+   */
+  loginHint?: string;
 
-    /**
-     * A value suitable for use when providing a login_hint to Microsoft Entra ID for authentication purposes.
-     * See [Provide optional claims to your app](https://learn.microsoft.com/azure/active-directory/develop/active-directory-optional-claims#v10-and-v20-optional-claims-set)
-     * for more information about the use of login_hint
-     *
-     * Because a malicious party can run your content in a browser, this value should
-     * be used only as a optimization hint as to who the user is and never as proof of identity.
-     * Specifically, this value should never be used to determine if a user is authorized to access
-     * a resource; access tokens should be used for that.
-     * See {@link authentication.getAuthToken} and {@link authentication.authenticate} for more information on access tokens.
-     */
-    loginHint?: string;
-
-    /**
+  /**
      * The UPN of the current user. This may be an externally-authenticated UPN (e.g., guest users).
 
      * Because a malicious party can run your content in a browser, this value should
@@ -405,19 +405,19 @@ export namespace app {
      * a resource; access tokens should be used for that.
      * See {@link authentication.getAuthToken} and {@link authentication.authenticate} for more information on access tokens.
      */
-    userPrincipalName?: string;
-
-    /**
-     * The tenant related info of the current user.
-     */
-    tenant?: TenantInfo;
-  }
+  userPrincipalName?: string;
 
   /**
-   * Represents Tenant information.
+   * The tenant related info of the current user.
    */
-  export interface TenantInfo {
-    /**
+  tenant?: TenantInfo;
+}
+
+/**
+ * Represents Tenant information.
+ */
+export interface TenantInfo {
+  /**
      * The Microsoft Entra tenant ID of the current user.
 
      * Because a malicious party can run your content in a browser, this value should
@@ -426,382 +426,381 @@ export namespace app {
      * a resource; access tokens should be used for that.
      * See {@link authentication.getAuthToken} and {@link authentication.authenticate} for more information on access tokens.
      */
-    id: string;
-
-    /**
-     * The type of license for the current user's tenant. Possible values are enterprise, free, edu, and unknown.
-     */
-    teamsSku?: string;
-  }
-
-  /** Represents information about a SharePoint site */
-  export interface SharePointSiteInfo {
-    /**
-     * The root SharePoint site associated with the team.
-     */
-    teamSiteUrl?: string;
-
-    /**
-     * The domain of the root SharePoint site associated with the team.
-     */
-    teamSiteDomain?: string;
-
-    /**
-     * The relative path to the SharePoint site associated with the team.
-     */
-    teamSitePath?: string;
-
-    /**
-     * Teamsite ID, aka sharepoint site id.
-     */
-    teamSiteId?: string;
-
-    /**
-     * The SharePoint my site domain associated with the user.
-     */
-    mySiteDomain?: string;
-
-    /**
-     * The SharePoint relative path to the current users mysite
-     */
-    mySitePath?: string;
-  }
+  id: string;
 
   /**
-   * Represents structure of the received context message.
+   * The type of license for the current user's tenant. Possible values are enterprise, free, edu, and unknown.
    */
-  export interface Context {
-    /**
-     * Content Action Info
-     *
-     * @beta
-     */
-    actionInfo?: ActionInfo;
-    /**
-     * Properties about the current session for your app
-     */
-    app: AppInfo;
+  teamsSku?: string;
+}
 
-    /**
-     * Info about the current page context hosting your app
-     */
-    page: PageInfo;
-
-    /**
-     * Info about the currently logged in user running the app.
-     * If the current user is not logged in/authenticated (e.g. a meeting app running for an anonymously-joined partcipant) this will be `undefined`.
-     */
-    user?: UserInfo;
-
-    /**
-     * When running in the context of a Teams channel, provides information about the channel, else `undefined`
-     */
-    channel?: ChannelInfo;
-
-    /**
-     * When running in the context of a Teams chat, provides information about the chat, else `undefined`
-     */
-    chat?: ChatInfo;
-
-    /**
-     * When running in the context of a Teams meeting, provides information about the meeting, else `undefined`
-     */
-    meeting?: MeetingInfo;
-
-    /**
-     * When hosted in SharePoint, this is the [SharePoint PageContext](https://learn.microsoft.com/javascript/api/sp-page-context/pagecontext?view=sp-typescript-latest), else `undefined`
-     */
-    sharepoint?: any;
-
-    /**
-     * When running in Teams for an organization with a tenant, provides information about the SharePoint site associated with the team.
-     * Will be `undefined` when not running in Teams for an organization with a tenant.
-     */
-    sharePointSite?: SharePointSiteInfo;
-
-    /**
-     * When running in Teams, provides information about the Team context in which your app is running.
-     * Will be `undefined` when not running in Teams.
-     */
-    team?: TeamInfo;
-
-    /**
-     * When `processActionCommand` activates a dialog, this dialog should automatically fill in some fields with information. This information comes from M365 and is given to `processActionCommand` as `extractedParameters`.
-     * App developers need to use these `extractedParameters` in their dialog.
-     * They help pre-fill the dialog with necessary information (`dialogParameters`) along with other details.
-     * If there's no key/value pairs passed, the object will be empty in the case
-     */
-    dialogParameters: Record<string, string>;
-  }
-
+/** Represents information about a SharePoint site */
+export interface SharePointSiteInfo {
   /**
-   * This function is passed to registerOnThemeHandler. It is called every time the user changes their theme.
+   * The root SharePoint site associated with the team.
    */
-  export type themeHandler = (theme: string) => void;
+  teamSiteUrl?: string;
 
   /**
-   * Checks whether the Teams client SDK has been initialized.
-   * @returns whether the Teams client SDK has been initialized.
+   * The domain of the root SharePoint site associated with the team.
    */
-  export function isInitialized(): boolean {
-    return GlobalVars.initializeCompleted;
-  }
+  teamSiteDomain?: string;
 
   /**
-   * Gets the Frame Context that the App is running in. See {@link FrameContexts} for the list of possible values.
-   * @returns the Frame Context.
+   * The relative path to the SharePoint site associated with the team.
    */
-  export function getFrameContext(): FrameContexts | undefined {
-    return GlobalVars.frameContext;
-  }
-
-  function logWhereTeamsJsIsBeingUsed(): void {
-    if (inServerSideRenderingEnvironment()) {
-      return;
-    }
-    const scripts = document.getElementsByTagName('script');
-    // This will always be the current script because browsers load and execute scripts in order.
-    // Whenever a script is executing for the first time it will be the last script in this array.
-    const currentScriptSrc = scripts && scripts[scripts.length - 1] && scripts[scripts.length - 1].src;
-    const scriptUsageWarning =
-      'Today, teamsjs can only be used from a single script or you may see undefined behavior. This log line is used to help detect cases where teamsjs is loaded multiple times -- it is always written. The presence of the log itself does not indicate a multi-load situation, but multiples of these log lines will. If you would like to use teamjs from more than one script at the same time, please open an issue at https://github.com/OfficeDev/microsoft-teams-library-js/issues';
-    if (!currentScriptSrc || currentScriptSrc.length === 0) {
-      appLogger('teamsjs is being used from a script tag embedded directly in your html. %s', scriptUsageWarning);
-    } else {
-      appLogger('teamsjs is being used from %s. %s', currentScriptSrc, scriptUsageWarning);
-    }
-  }
-
-  // This is called right away to make sure that we capture which script is being executed and important stats about the current teamsjs instance
-  appLogger(
-    'teamsjs instance is version %s, starting at %s UTC (%s local)',
-    version,
-    new Date().toISOString(),
-    new Date().toLocaleString(),
-  );
-  logWhereTeamsJsIsBeingUsed();
+  teamSitePath?: string;
 
   /**
-   * Initializes the library.
-   *
-   * @remarks
-   * Initialize must have completed successfully (as determined by the resolved Promise) before any other library calls are made
-   *
-   * @param validMessageOrigins - Optionally specify a list of cross-frame message origins. This parameter is used if you know that your app
-   * will be hosted on a custom domain (i.e., not a standard Microsoft 365 host like Teams, Outlook, etc.) Most apps will never need
-   * to pass a value for this parameter.
-   * Any domains passed in the array must have the https: protocol on the string otherwise they will be ignored. Example: https://www.example.com
-   * @returns Promise that will be fulfilled when initialization has completed, or rejected if the initialization fails or times out
+   * Teamsite ID, aka sharepoint site id.
    */
-  export function initialize(validMessageOrigins?: string[]): Promise<void> {
-    prefetchOriginsFromCDN();
-    return appHelpers.appInitializeHelper(
-      getApiVersionTag(appTelemetryVersionNumber, ApiName.App_Initialize),
-      validMessageOrigins,
-    );
-  }
+  teamSiteId?: string;
 
   /**
-   * @hidden
-   * Undocumented function used to set a mock window for unit tests
-   *
-   * @internal
-   * Limited to Microsoft-internal use
+   * The SharePoint my site domain associated with the user.
    */
-  export function _initialize(hostWindow: any): void {
-    Communication.currentWindow = hostWindow;
-  }
+  mySiteDomain?: string;
 
   /**
-   * @hidden
-   * Undocumented function used to clear state between unit tests
-   *
-   * @internal
-   * Limited to Microsoft-internal use
+   * The SharePoint relative path to the current users mysite
    */
-  export function _uninitialize(): void {
-    if (!GlobalVars.initializeCalled) {
-      return;
-    }
+  mySitePath?: string;
+}
 
-    Handlers.uninitializeHandlers();
-
-    GlobalVars.initializeCalled = false;
-    GlobalVars.initializeCompleted = false;
-    GlobalVars.initializePromise = undefined;
-    GlobalVars.additionalValidOrigins = [];
-    GlobalVars.frameContext = undefined;
-    GlobalVars.hostClientType = undefined;
-    GlobalVars.isFramelessWindow = false;
-
-    messageChannels.telemetry._clearTelemetryPort();
-    messageChannels.dataLayer._clearDataLayerPort();
-
-    uninitializeCommunication();
-  }
-
+/**
+ * Represents structure of the received context message.
+ */
+export interface Context {
   /**
-   * Retrieves the current context the frame is running in.
-   *
-   * @returns Promise that will resolve with the {@link app.Context} object.
-   */
-  export function getContext(): Promise<app.Context> {
-    return new Promise<LegacyContext>((resolve) => {
-      ensureInitializeCalled();
-      resolve(sendAndUnwrap(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_GetContext), 'getContext'));
-    }).then((legacyContext) => transformLegacyContextToAppContext(legacyContext)); // converts globalcontext to app.context
-  }
-
-  /**
-   * Notifies the frame that app has loaded and to hide the loading indicator if one is shown.
-   */
-  export function notifyAppLoaded(): void {
-    ensureInitializeCalled();
-    appHelpers.notifyAppLoadedHelper(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifyAppLoaded));
-  }
-
-  /**
-   * Notifies the frame that app initialization is successful and is ready for user interaction.
-   */
-  export function notifySuccess(): void {
-    ensureInitializeCalled();
-    appHelpers.notifySuccessHelper(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifySuccess));
-  }
-
-  /**
-   * Notifies the frame that app initialization has failed and to show an error page in its place.
-   *
-   * @param appInitializationFailedRequest - The failure request containing the reason for why the app failed
-   * during initialization as well as an optional message.
-   */
-  export function notifyFailure(appInitializationFailedRequest: IFailedRequest): void {
-    ensureInitializeCalled();
-    appHelpers.notifyFailureHelper(
-      getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifyFailure),
-      appInitializationFailedRequest,
-    );
-  }
-
-  /**
-   * Notifies the frame that app initialized with some expected errors.
-   *
-   * @param expectedFailureRequest - The expected failure request containing the reason and an optional message
-   */
-  export function notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void {
-    ensureInitializeCalled();
-    appHelpers.notifyExpectedFailureHelper(
-      getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifyExpectedFailure),
-      expectedFailureRequest,
-    );
-  }
-
-  /**
-   * Registers a handler for theme changes.
-   *
-   * @remarks
-   * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
-   *
-   * @param handler - The handler to invoke when the user changes their theme.
-   */
-  export function registerOnThemeChangeHandler(handler: themeHandler): void {
-    appHelpers.registerOnThemeChangeHandlerHelper(
-      getApiVersionTag(appTelemetryVersionNumber, ApiName.App_RegisterOnThemeChangeHandler),
-      handler,
-    );
-  }
-
-  /**
-   * This function opens deep links to other modules in the host such as chats or channels or
-   * general-purpose links (to external websites). It should not be used for navigating to your
-   * own or other apps.
-   *
-   * @remarks
-   * If you need to navigate to your own or other apps, use:
-   *
-   * - {@link pages.currentApp.navigateToDefaultPage} for navigating to the default page of your own app
-   * - {@link pages.currentApp.navigateTo} for navigating to a section of your own app
-   * - {@link pages.navigateToApp} for navigating to other apps besides your own
-   *
-   * Many areas of functionality previously provided by deep links are now handled by strongly-typed functions in capabilities.
-   * If your app is using a deep link to trigger these specific components, use the strongly-typed alternatives.
-   * For example (this list is not exhaustive):
-   * - To open an app installation dialog, use the {@link appInstallDialog} capability
-   * - To start a call, use the {@link call} capability
-   * - To open a chat, use the {@link chat} capability
-   * - To open a dialog, use the {@link dialog} capability
-   * - To create a new meeting, use the {@link calendar.composeMeeting} function
-   * - To open a Stage View, use the {@link stageView} capability
-   *
-   * In each of these capabilities, you can use the `isSupported()` function to determine if the host supports that capability.
-   * When using a deep link to trigger these components, there's no way to determine whether the host supports it.
-   *
-   * For more information on crafting deep links to the host, see [Configure deep links](https://learn.microsoft.com/microsoftteams/platform/concepts/build-and-test/deep-links)
-   *
-   * @param deepLink The host deep link or external web URL to which to navigate
-   * @returns `Promise` that will be fulfilled when the navigation has initiated. A successful `Promise` resolution
-   * does not necessarily indicate whether the target loaded successfully.
-   */
-  export function openLink(deepLink: string): Promise<void> {
-    return appHelpers.openLinkHelper(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_OpenLink), deepLink);
-  }
-
-  /**
-   * A namespace for enabling the suspension or delayed termination of an app when the user navigates away.
-   * When an app registers for the registerBeforeSuspendOrTerminateHandler, it chooses to delay termination.
-   * When an app registers for both registerBeforeSuspendOrTerminateHandler and registerOnResumeHandler, it chooses the suspension of the app .
-   * Please note that selecting suspension doesn't guarantee prevention of background termination.
-   * The outcome is influenced by factors such as available memory and the number of suspended apps.
+   * Content Action Info
    *
    * @beta
    */
-  export namespace lifecycle {
-    /**
-     * Register on resume handler function type
-     *
-     * @param context - Data structure to be used to pass the context to the app.
-     */
-    export type registerOnResumeHandlerFunctionType = (context: ResumeContext) => void;
+  actionInfo?: ActionInfo;
+  /**
+   * Properties about the current session for your app
+   */
+  app: AppInfo;
 
-    /**
-     * Register before suspendOrTerminate handler function type
-     *
-     * @returns void
-     */
-    export type registerBeforeSuspendOrTerminateHandlerFunctionType = () => Promise<void>;
+  /**
+   * Info about the current page context hosting your app
+   */
+  page: PageInfo;
 
-    /**
-     * Registers a handler to be called before the page is suspended or terminated. Once a user navigates away from an app,
-     * the handler will be invoked. App developers can use this handler to save unsaved data, pause sync calls etc.
-     *
-     * @param handler - The handler to invoke before the page is suspended or terminated. When invoked, app can perform tasks like cleanups, logging etc.
-     * Upon returning, the app will be suspended or terminated.
-     *
-     */
-    export function registerBeforeSuspendOrTerminateHandler(
-      handler: registerBeforeSuspendOrTerminateHandlerFunctionType,
-    ): void {
-      if (!handler) {
-        throw new Error('[app.lifecycle.registerBeforeSuspendOrTerminateHandler] Handler cannot be null');
-      }
-      ensureInitialized(runtime);
-      Handlers.registerBeforeSuspendOrTerminateHandler(handler);
+  /**
+   * Info about the currently logged in user running the app.
+   * If the current user is not logged in/authenticated (e.g. a meeting app running for an anonymously-joined partcipant) this will be `undefined`.
+   */
+  user?: UserInfo;
+
+  /**
+   * When running in the context of a Teams channel, provides information about the channel, else `undefined`
+   */
+  channel?: ChannelInfo;
+
+  /**
+   * When running in the context of a Teams chat, provides information about the chat, else `undefined`
+   */
+  chat?: ChatInfo;
+
+  /**
+   * When running in the context of a Teams meeting, provides information about the meeting, else `undefined`
+   */
+  meeting?: MeetingInfo;
+
+  /**
+   * When hosted in SharePoint, this is the [SharePoint PageContext](https://learn.microsoft.com/javascript/api/sp-page-context/pagecontext?view=sp-typescript-latest), else `undefined`
+   */
+  sharepoint?: any;
+
+  /**
+   * When running in Teams for an organization with a tenant, provides information about the SharePoint site associated with the team.
+   * Will be `undefined` when not running in Teams for an organization with a tenant.
+   */
+  sharePointSite?: SharePointSiteInfo;
+
+  /**
+   * When running in Teams, provides information about the Team context in which your app is running.
+   * Will be `undefined` when not running in Teams.
+   */
+  team?: TeamInfo;
+
+  /**
+   * When `processActionCommand` activates a dialog, this dialog should automatically fill in some fields with information. This information comes from M365 and is given to `processActionCommand` as `extractedParameters`.
+   * App developers need to use these `extractedParameters` in their dialog.
+   * They help pre-fill the dialog with necessary information (`dialogParameters`) along with other details.
+   * If there's no key/value pairs passed, the object will be empty in the case
+   */
+  dialogParameters: Record<string, string>;
+}
+
+/**
+ * This function is passed to registerOnThemeHandler. It is called every time the user changes their theme.
+ */
+export type themeHandler = (theme: string) => void;
+
+/**
+ * Checks whether the Teams client SDK has been initialized.
+ * @returns whether the Teams client SDK has been initialized.
+ */
+export function isInitialized(): boolean {
+  return GlobalVars.initializeCompleted;
+}
+
+/**
+ * Gets the Frame Context that the App is running in. See {@link FrameContexts} for the list of possible values.
+ * @returns the Frame Context.
+ */
+export function getFrameContext(): FrameContexts | undefined {
+  return GlobalVars.frameContext;
+}
+
+function logWhereTeamsJsIsBeingUsed(): void {
+  if (inServerSideRenderingEnvironment()) {
+    return;
+  }
+  const scripts = document.getElementsByTagName('script');
+  // This will always be the current script because browsers load and execute scripts in order.
+  // Whenever a script is executing for the first time it will be the last script in this array.
+  const currentScriptSrc = scripts && scripts[scripts.length - 1] && scripts[scripts.length - 1].src;
+  const scriptUsageWarning =
+    'Today, teamsjs can only be used from a single script or you may see undefined behavior. This log line is used to help detect cases where teamsjs is loaded multiple times -- it is always written. The presence of the log itself does not indicate a multi-load situation, but multiples of these log lines will. If you would like to use teamjs from more than one script at the same time, please open an issue at https://github.com/OfficeDev/microsoft-teams-library-js/issues';
+  if (!currentScriptSrc || currentScriptSrc.length === 0) {
+    appLogger('teamsjs is being used from a script tag embedded directly in your html. %s', scriptUsageWarning);
+  } else {
+    appLogger('teamsjs is being used from %s. %s', currentScriptSrc, scriptUsageWarning);
+  }
+}
+
+// This is called right away to make sure that we capture which script is being executed and important stats about the current teamsjs instance
+appLogger(
+  'teamsjs instance is version %s, starting at %s UTC (%s local)',
+  version,
+  new Date().toISOString(),
+  new Date().toLocaleString(),
+);
+logWhereTeamsJsIsBeingUsed();
+
+/**
+ * Initializes the library.
+ *
+ * @remarks
+ * Initialize must have completed successfully (as determined by the resolved Promise) before any other library calls are made
+ *
+ * @param validMessageOrigins - Optionally specify a list of cross-frame message origins. This parameter is used if you know that your app
+ * will be hosted on a custom domain (i.e., not a standard Microsoft 365 host like Teams, Outlook, etc.) Most apps will never need
+ * to pass a value for this parameter.
+ * Any domains passed in the array must have the https: protocol on the string otherwise they will be ignored. Example: https://www.example.com
+ * @returns Promise that will be fulfilled when initialization has completed, or rejected if the initialization fails or times out
+ */
+export function initialize(validMessageOrigins?: string[]): Promise<void> {
+  prefetchOriginsFromCDN();
+  return appHelpers.appInitializeHelper(
+    getApiVersionTag(appTelemetryVersionNumber, ApiName.App_Initialize),
+    validMessageOrigins,
+  );
+}
+
+/**
+ * @hidden
+ * Undocumented function used to set a mock window for unit tests
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function _initialize(hostWindow: any): void {
+  Communication.currentWindow = hostWindow;
+}
+
+/**
+ * @hidden
+ * Undocumented function used to clear state between unit tests
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function _uninitialize(): void {
+  if (!GlobalVars.initializeCalled) {
+    return;
+  }
+
+  Handlers.uninitializeHandlers();
+
+  GlobalVars.initializeCalled = false;
+  GlobalVars.initializeCompleted = false;
+  GlobalVars.initializePromise = undefined;
+  GlobalVars.additionalValidOrigins = [];
+  GlobalVars.frameContext = undefined;
+  GlobalVars.hostClientType = undefined;
+  GlobalVars.isFramelessWindow = false;
+
+  messageChannels.telemetry._clearTelemetryPort();
+  messageChannels.dataLayer._clearDataLayerPort();
+
+  uninitializeCommunication();
+}
+
+/**
+ * Retrieves the current context the frame is running in.
+ *
+ * @returns Promise that will resolve with the {@link app.Context} object.
+ */
+export function getContext(): Promise<Context> {
+  return new Promise<LegacyContext>((resolve) => {
+    ensureInitializeCalled();
+    resolve(sendAndUnwrap(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_GetContext), 'getContext'));
+  }).then((legacyContext) => transformLegacyContextToAppContext(legacyContext)); // converts globalcontext to app.context
+}
+
+/**
+ * Notifies the frame that app has loaded and to hide the loading indicator if one is shown.
+ */
+export function notifyAppLoaded(): void {
+  ensureInitializeCalled();
+  appHelpers.notifyAppLoadedHelper(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifyAppLoaded));
+}
+
+/**
+ * Notifies the frame that app initialization is successful and is ready for user interaction.
+ */
+export function notifySuccess(): void {
+  ensureInitializeCalled();
+  appHelpers.notifySuccessHelper(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifySuccess));
+}
+
+/**
+ * Notifies the frame that app initialization has failed and to show an error page in its place.
+ *
+ * @param appInitializationFailedRequest - The failure request containing the reason for why the app failed
+ * during initialization as well as an optional message.
+ */
+export function notifyFailure(appInitializationFailedRequest: IFailedRequest): void {
+  ensureInitializeCalled();
+  appHelpers.notifyFailureHelper(
+    getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifyFailure),
+    appInitializationFailedRequest,
+  );
+}
+
+/**
+ * Notifies the frame that app initialized with some expected errors.
+ *
+ * @param expectedFailureRequest - The expected failure request containing the reason and an optional message
+ */
+export function notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void {
+  ensureInitializeCalled();
+  appHelpers.notifyExpectedFailureHelper(
+    getApiVersionTag(appTelemetryVersionNumber, ApiName.App_NotifyExpectedFailure),
+    expectedFailureRequest,
+  );
+}
+
+/**
+ * Registers a handler for theme changes.
+ *
+ * @remarks
+ * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
+ *
+ * @param handler - The handler to invoke when the user changes their theme.
+ */
+export function registerOnThemeChangeHandler(handler: themeHandler): void {
+  appHelpers.registerOnThemeChangeHandlerHelper(
+    getApiVersionTag(appTelemetryVersionNumber, ApiName.App_RegisterOnThemeChangeHandler),
+    handler,
+  );
+}
+
+/**
+ * This function opens deep links to other modules in the host such as chats or channels or
+ * general-purpose links (to external websites). It should not be used for navigating to your
+ * own or other apps.
+ *
+ * @remarks
+ * If you need to navigate to your own or other apps, use:
+ *
+ * - {@link pages.currentApp.navigateToDefaultPage} for navigating to the default page of your own app
+ * - {@link pages.currentApp.navigateTo} for navigating to a section of your own app
+ * - {@link pages.navigateToApp} for navigating to other apps besides your own
+ *
+ * Many areas of functionality previously provided by deep links are now handled by strongly-typed functions in capabilities.
+ * If your app is using a deep link to trigger these specific components, use the strongly-typed alternatives.
+ * For example (this list is not exhaustive):
+ * - To open an app installation dialog, use the {@link appInstallDialog} capability
+ * - To start a call, use the {@link call} capability
+ * - To open a chat, use the {@link chat} capability
+ * - To open a dialog, use the {@link dialog} capability
+ * - To create a new meeting, use the {@link calendar.composeMeeting} function
+ * - To open a Stage View, use the {@link stageView} capability
+ *
+ * In each of these capabilities, you can use the `isSupported()` function to determine if the host supports that capability.
+ * When using a deep link to trigger these components, there's no way to determine whether the host supports it.
+ *
+ * For more information on crafting deep links to the host, see [Configure deep links](https://learn.microsoft.com/microsoftteams/platform/concepts/build-and-test/deep-links)
+ *
+ * @param deepLink The host deep link or external web URL to which to navigate
+ * @returns `Promise` that will be fulfilled when the navigation has initiated. A successful `Promise` resolution
+ * does not necessarily indicate whether the target loaded successfully.
+ */
+export function openLink(deepLink: string): Promise<void> {
+  return appHelpers.openLinkHelper(getApiVersionTag(appTelemetryVersionNumber, ApiName.App_OpenLink), deepLink);
+}
+
+/**
+ * A namespace for enabling the suspension or delayed termination of an app when the user navigates away.
+ * When an app registers for the registerBeforeSuspendOrTerminateHandler, it chooses to delay termination.
+ * When an app registers for both registerBeforeSuspendOrTerminateHandler and registerOnResumeHandler, it chooses the suspension of the app .
+ * Please note that selecting suspension doesn't guarantee prevention of background termination.
+ * The outcome is influenced by factors such as available memory and the number of suspended apps.
+ *
+ * @beta
+ */
+export namespace lifecycle {
+  /**
+   * Register on resume handler function type
+   *
+   * @param context - Data structure to be used to pass the context to the app.
+   */
+  export type registerOnResumeHandlerFunctionType = (context: ResumeContext) => void;
+
+  /**
+   * Register before suspendOrTerminate handler function type
+   *
+   * @returns void
+   */
+  export type registerBeforeSuspendOrTerminateHandlerFunctionType = () => Promise<void>;
+
+  /**
+   * Registers a handler to be called before the page is suspended or terminated. Once a user navigates away from an app,
+   * the handler will be invoked. App developers can use this handler to save unsaved data, pause sync calls etc.
+   *
+   * @param handler - The handler to invoke before the page is suspended or terminated. When invoked, app can perform tasks like cleanups, logging etc.
+   * Upon returning, the app will be suspended or terminated.
+   *
+   */
+  export function registerBeforeSuspendOrTerminateHandler(
+    handler: registerBeforeSuspendOrTerminateHandlerFunctionType,
+  ): void {
+    if (!handler) {
+      throw new Error('[app.lifecycle.registerBeforeSuspendOrTerminateHandler] Handler cannot be null');
     }
+    ensureInitialized(runtime);
+    Handlers.registerBeforeSuspendOrTerminateHandler(handler);
+  }
 
-    /**
-     * Registers a handler to be called when the page has been requested to resume from being suspended.
-     *
-     * @param handler - The handler to invoke when the page is requested to be resumed. The app is supposed to navigate to
-     * the appropriate page using the ResumeContext. Once done, the app should then call {@link notifySuccess}.
-     *
-     * @beta
-     */
-    export function registerOnResumeHandler(handler: registerOnResumeHandlerFunctionType): void {
-      if (!handler) {
-        throw new Error('[app.lifecycle.registerOnResumeHandler] Handler cannot be null');
-      }
-      ensureInitialized(runtime);
-      Handlers.registerOnResumeHandler(handler);
+  /**
+   * Registers a handler to be called when the page has been requested to resume from being suspended.
+   *
+   * @param handler - The handler to invoke when the page is requested to be resumed. The app is supposed to navigate to
+   * the appropriate page using the ResumeContext. Once done, the app should then call {@link notifySuccess}.
+   *
+   * @beta
+   */
+  export function registerOnResumeHandler(handler: registerOnResumeHandlerFunctionType): void {
+    if (!handler) {
+      throw new Error('[app.lifecycle.registerOnResumeHandler] Handler cannot be null');
     }
+    ensureInitialized(runtime);
+    Handlers.registerOnResumeHandler(handler);
   }
 }
 
@@ -812,8 +811,8 @@ export namespace app {
  * @internal
  * Limited to Microsoft-internal use
  */
-function transformLegacyContextToAppContext(legacyContext: LegacyContext): app.Context {
-  const context: app.Context = {
+function transformLegacyContextToAppContext(legacyContext: LegacyContext): Context {
+  const context: Context = {
     actionInfo: legacyContext.actionInfo,
     app: {
       locale: legacyContext.locale,

--- a/packages/teams-js/src/public/appInitialization.ts
+++ b/packages/teams-js/src/public/appInitialization.ts
@@ -5,7 +5,7 @@ import {
   notifySuccessHelper,
 } from '../internal/appHelpers';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { app } from './app';
+import { ExpectedFailureReason, FailedReason, IExpectedFailureRequest, IFailedRequest, Messages } from './app';
 
 /**
  * @deprecated
@@ -15,86 +15,84 @@ import { app } from './app';
  */
 const appInitializationTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
 
-export namespace appInitialization {
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link app.Messages} instead.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  export import Messages = app.Messages;
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link app.FailedReason} instead.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  export import FailedReason = app.FailedReason;
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link app.ExpectedFailureReason} instead.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  export import ExpectedFailureReason = app.ExpectedFailureReason;
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link app.IFailedRequest} instead.
-   */
-  export import IFailedRequest = app.IFailedRequest;
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link app.IExpectedFailureRequest} instead.
-   */
-  export import IExpectedFailureRequest = app.IExpectedFailureRequest;
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link app.Messages} instead.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export { Messages };
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link app.FailedReason} instead.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export { FailedReason };
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link app.ExpectedFailureReason} instead.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export { ExpectedFailureReason };
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link app.IFailedRequest} instead.
+ */
+export { IFailedRequest };
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link app.IExpectedFailureRequest} instead.
+ */
+export { IExpectedFailureRequest };
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link app.notifyAppLoaded app.notifyAppLoaded(): void} instead.
-   *
-   * Notifies the frame that app has loaded and to hide the loading indicator if one is shown.
-   */
-  export function notifyAppLoaded(): void {
-    notifyAppLoadedHelper(
-      getApiVersionTag(appInitializationTelemetryVersionNumber, ApiName.AppInitialization_NotifyAppLoaded),
-    );
-  }
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link app.notifyAppLoaded app.notifyAppLoaded(): void} instead.
+ *
+ * Notifies the frame that app has loaded and to hide the loading indicator if one is shown.
+ */
+export function notifyAppLoaded(): void {
+  notifyAppLoadedHelper(
+    getApiVersionTag(appInitializationTelemetryVersionNumber, ApiName.AppInitialization_NotifyAppLoaded),
+  );
+}
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link app.notifySuccess app.notifySuccess(): void} instead.
-   *
-   * Notifies the frame that app initialization is successful and is ready for user interaction.
-   */
-  export function notifySuccess(): void {
-    notifySuccessHelper(
-      getApiVersionTag(appInitializationTelemetryVersionNumber, ApiName.AppInitialization_NotifySuccess),
-    );
-  }
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link app.notifySuccess app.notifySuccess(): void} instead.
+ *
+ * Notifies the frame that app initialization is successful and is ready for user interaction.
+ */
+export function notifySuccess(): void {
+  notifySuccessHelper(
+    getApiVersionTag(appInitializationTelemetryVersionNumber, ApiName.AppInitialization_NotifySuccess),
+  );
+}
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link app.notifyFailure app.notifyFailure(appInitializationFailedRequest: IFailedRequest): void} instead.
-   *
-   * Notifies the frame that app initialization has failed and to show an error page in its place.
-   * @param appInitializationFailedRequest - The failure request containing the reason for why the app failed
-   * during initialization as well as an optional message.
-   */
-  export function notifyFailure(appInitializationFailedRequest: IFailedRequest): void {
-    notifyFailureHelper(
-      getApiVersionTag(appInitializationTelemetryVersionNumber, ApiName.AppInitialization_NotifyFailure),
-      appInitializationFailedRequest,
-    );
-  }
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link app.notifyFailure app.notifyFailure(appInitializationFailedRequest: IFailedRequest): void} instead.
+ *
+ * Notifies the frame that app initialization has failed and to show an error page in its place.
+ * @param appInitializationFailedRequest - The failure request containing the reason for why the app failed
+ * during initialization as well as an optional message.
+ */
+export function notifyFailure(appInitializationFailedRequest: IFailedRequest): void {
+  notifyFailureHelper(
+    getApiVersionTag(appInitializationTelemetryVersionNumber, ApiName.AppInitialization_NotifyFailure),
+    appInitializationFailedRequest,
+  );
+}
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link app.notifyExpectedFailure app.notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void} instead.
-   *
-   * Notifies the frame that app initialized with some expected errors.
-   * @param expectedFailureRequest - The expected failure request containing the reason and an optional message
-   */
-  export function notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void {
-    notifyExpectedFailureHelper(
-      getApiVersionTag(appInitializationTelemetryVersionNumber, ApiName.AppInitialization_NotifyExpectedFailure),
-      expectedFailureRequest,
-    );
-  }
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link app.notifyExpectedFailure app.notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void} instead.
+ *
+ * Notifies the frame that app initialized with some expected errors.
+ * @param expectedFailureRequest - The expected failure request containing the reason and an optional message
+ */
+export function notifyExpectedFailure(expectedFailureRequest: IExpectedFailureRequest): void {
+  notifyExpectedFailureHelper(
+    getApiVersionTag(appInitializationTelemetryVersionNumber, ApiName.AppInitialization_NotifyExpectedFailure),
+    expectedFailureRequest,
+  );
 }

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -147,7 +147,7 @@ import { AdaptiveCardVersion, ErrorCode, SdkError } from './interfaces';
  * As of TeamsJS v2.0.0, please use {@link DialogDimension} instead.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export import TaskModuleDimension = DialogDimension;
+export { DialogDimension as TaskModuleDimension };
 import { HostVersionsInfo } from './interfaces';
 
 /**

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -116,7 +116,7 @@ export {
   onCompleteHandlerFunctionType,
   returnFocus,
 } from './navigation';
-export { settings } from './settings';
+export * as settings from './settings';
 export { tasks } from './tasks';
 export { liveShare, LiveShareHost } from './liveShareHost';
 export { marketplace } from './marketplace';

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -40,7 +40,7 @@ export {
   TeamInformation,
   UrlDialogInfo,
 } from './interfaces';
-export { app } from './app';
+export * as app from './app';
 export { AppId } from './appId';
 export { EmailAddress } from './emailAddress';
 export { appInstallDialog } from './appInstallDialog';
@@ -78,7 +78,7 @@ export { version } from './version';
 export { visualMedia } from './visualMedia';
 export { webStorage } from './webStorage';
 export { call } from './call';
-export { appInitialization } from './appInitialization';
+export * as appInitialization from './appInitialization';
 export { thirdPartyCloudStorage } from './thirdPartyCloudStorage';
 export {
   callbackFunctionType,

--- a/packages/teams-js/src/public/settings.ts
+++ b/packages/teams-js/src/public/settings.ts
@@ -17,145 +17,147 @@ const settingsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
  * Namespace to interact with the settings-specific part of the SDK.
  * This object is usable only on the settings frame.
  */
-export namespace settings {
-  /** Register on remove handler function type */
-  export type registerOnRemoveHandlerFunctionType = (evt: RemoveEvent) => void;
-  /** Register on save handler function type */
-  export type registerOnSaveHandlerFunctionType = (evt: SaveEvent) => void;
-  /** Set settings on complete function type */
-  export type setSettingsOnCompleteFunctionType = (status: boolean, reason?: string) => void;
-  /** Get settings callback function type */
-  export type getSettingsCallbackFunctionType = (instanceSettings: Settings) => void;
+/** Register on remove handler function type */
+export type registerOnRemoveHandlerFunctionType = (evt: RemoveEvent) => void;
+/** Register on save handler function type */
+export type registerOnSaveHandlerFunctionType = (evt: SaveEvent) => void;
+/** Set settings on complete function type */
+export type setSettingsOnCompleteFunctionType = (status: boolean, reason?: string) => void;
+/** Get settings callback function type */
+export type getSettingsCallbackFunctionType = (instanceSettings: Settings) => void;
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link pages.config.Config} instead.
-   * @remarks
-   * Renamed to config in pages.Config
-   */
-  export import Settings = pages.InstanceConfig;
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link pages.config} instead.
+ * @remarks
+ * Renamed to config in pages.Config
+ */
+type Settings = pages.InstanceConfig;
+export { Settings };
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link pages.config.SaveEvent} instead.
-   * @remarks
-   * See pages.SaveEvent
-   */
-  export import SaveEvent = pages.config.SaveEvent;
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link pages.config.SaveEvent} instead.
+ * @remarks
+ * See pages.SaveEvent
+ */
+type SaveEvent = pages.config.SaveEvent;
+export { SaveEvent };
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link pages.config.RemoveEvent} instead.
-   * @remarks
-   * See pages.RemoveEvent
-   */
-  export import RemoveEvent = pages.config.RemoveEvent;
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link pages.config.RemoveEvent} instead.
+ * @remarks
+ * See pages.RemoveEvent
+ */
+type RemoveEvent = pages.config.RemoveEvent;
+export { RemoveEvent };
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link pages.config.SaveParameters} instead.
-   * @remarks
-   * See pages.SaveParameters
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  export import SaveParameters = pages.config.SaveParameters;
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link pages.config.SaveParameters} instead.
+ * @remarks
+ * See pages.SaveParameters
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type SaveParameters = pages.config.SaveParameters;
+export { SaveParameters };
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link pages.config.setValidityState pages.config.setValidityState(validityState: boolean): void} instead.
-   *
-   * Sets the validity state for the settings.
-   * The initial value is false, so the user cannot save the settings until this is called with true.
-   *
-   * @param validityState - Indicates whether the save or remove button is enabled for the user.
-   */
-  export function setValidityState(validityState: boolean): void {
-    configSetValidityStateHelper(
-      getApiVersionTag(settingsTelemetryVersionNumber, ApiName.Settings_SetValidityState),
-      validityState,
-    );
-  }
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link pages.config.setValidityState pages.config.setValidityState(validityState: boolean): void} instead.
+ *
+ * Sets the validity state for the settings.
+ * The initial value is false, so the user cannot save the settings until this is called with true.
+ *
+ * @param validityState - Indicates whether the save or remove button is enabled for the user.
+ */
+export function setValidityState(validityState: boolean): void {
+  configSetValidityStateHelper(
+    getApiVersionTag(settingsTelemetryVersionNumber, ApiName.Settings_SetValidityState),
+    validityState,
+  );
+}
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link pages.getConfig pages.getConfig(): Promise\<InstanceConfig\>} instead.
-   *
-   * Gets the settings for the current instance.
-   *
-   * @param callback - The callback to invoke when the {@link Settings} object is retrieved.
-   */
-  export function getSettings(callback: getSettingsCallbackFunctionType): void {
-    ensureInitialized(
-      runtime,
-      FrameContexts.content,
-      FrameContexts.settings,
-      FrameContexts.remove,
-      FrameContexts.sidePanel,
-    );
-    getConfigHelper(getApiVersionTag(settingsTelemetryVersionNumber, ApiName.Settings_GetSettings)).then(
-      (config: pages.InstanceConfig) => {
-        callback(config);
-      },
-    );
-  }
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link pages.getConfig pages.getConfig(): Promise\<InstanceConfig\>} instead.
+ *
+ * Gets the settings for the current instance.
+ *
+ * @param callback - The callback to invoke when the {@link Settings} object is retrieved.
+ */
+export function getSettings(callback: getSettingsCallbackFunctionType): void {
+  ensureInitialized(
+    runtime,
+    FrameContexts.content,
+    FrameContexts.settings,
+    FrameContexts.remove,
+    FrameContexts.sidePanel,
+  );
+  getConfigHelper(getApiVersionTag(settingsTelemetryVersionNumber, ApiName.Settings_GetSettings)).then(
+    (config: pages.InstanceConfig) => {
+      callback(config);
+    },
+  );
+}
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link pages.config.setConfig pages.config.setConfig(instanceSettings: Config): Promise\<void\>} instead.
-   *
-   * Sets the settings for the current instance.
-   * This is an asynchronous operation; calls to getSettings are not guaranteed to reflect the changed state.
-   *
-   * @param - Set the desired settings for this instance.
-   */
-  export function setSettings(instanceSettings: Settings, onComplete?: setSettingsOnCompleteFunctionType): void {
-    ensureInitialized(runtime, FrameContexts.content, FrameContexts.settings, FrameContexts.sidePanel);
-    const completionHandler: setSettingsOnCompleteFunctionType = onComplete ?? getGenericOnCompleteHandler();
-    configSetConfigHelper(
-      getApiVersionTag(settingsTelemetryVersionNumber, ApiName.Settings_SetSettings),
-      instanceSettings,
-    )
-      .then(() => {
-        completionHandler(true);
-      })
-      .catch((error: Error) => {
-        completionHandler(false, error.message);
-      });
-  }
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link pages.config.setConfig pages.config.setConfig(instanceSettings: Config): Promise\<void\>} instead.
+ *
+ * Sets the settings for the current instance.
+ * This is an asynchronous operation; calls to getSettings are not guaranteed to reflect the changed state.
+ *
+ * @param - Set the desired settings for this instance.
+ */
+export function setSettings(instanceSettings: Settings, onComplete?: setSettingsOnCompleteFunctionType): void {
+  ensureInitialized(runtime, FrameContexts.content, FrameContexts.settings, FrameContexts.sidePanel);
+  const completionHandler: setSettingsOnCompleteFunctionType = onComplete ?? getGenericOnCompleteHandler();
+  configSetConfigHelper(
+    getApiVersionTag(settingsTelemetryVersionNumber, ApiName.Settings_SetSettings),
+    instanceSettings,
+  )
+    .then(() => {
+      completionHandler(true);
+    })
+    .catch((error: Error) => {
+      completionHandler(false, error.message);
+    });
+}
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link pages.config.registerOnSaveHandler pages.config.registerOnSaveHandler(handler: registerOnSaveHandlerFunctionType): void} instead.
-   *
-   * Registers a handler for when the user attempts to save the settings. This handler should be used
-   * to create or update the underlying resource powering the content.
-   * The object passed to the handler must be used to notify whether to proceed with the save.
-   * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
-   *
-   * @param handler - The handler to invoke when the user selects the save button.
-   */
-  export function registerOnSaveHandler(handler: registerOnSaveHandlerFunctionType): void {
-    pages.config.registerOnSaveHandlerHelper(
-      getApiVersionTag(settingsTelemetryVersionNumber, ApiName.Settings_RegisterOnSaveHandler),
-      handler,
-    );
-  }
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link pages.config.registerOnSaveHandler pages.config.registerOnSaveHandler(handler: registerOnSaveHandlerFunctionType): void} instead.
+ *
+ * Registers a handler for when the user attempts to save the settings. This handler should be used
+ * to create or update the underlying resource powering the content.
+ * The object passed to the handler must be used to notify whether to proceed with the save.
+ * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.
+ *
+ * @param handler - The handler to invoke when the user selects the save button.
+ */
+export function registerOnSaveHandler(handler: registerOnSaveHandlerFunctionType): void {
+  pages.config.registerOnSaveHandlerHelper(
+    getApiVersionTag(settingsTelemetryVersionNumber, ApiName.Settings_RegisterOnSaveHandler),
+    handler,
+  );
+}
 
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link pages.config.registerOnRemoveHandler pages.config.registerOnRemoveHandler(handler: registerOnRemoveHandlerFunctionType): void} instead.
-   *
-   * Registers a handler for user attempts to remove content. This handler should be used
-   * to remove the underlying resource powering the content.
-   * The object passed to the handler must be used to indicate whether to proceed with the removal.
-   * Only one handler may be registered at a time. Subsequent registrations will override the first.
-   *
-   * @param handler - The handler to invoke when the user selects the remove button.
-   */
-  export function registerOnRemoveHandler(handler: registerOnRemoveHandlerFunctionType): void {
-    pages.config.registerOnRemoveHandlerHelper(
-      getApiVersionTag(settingsTelemetryVersionNumber, ApiName.Settings_RegisterOnRemoveHandler),
-      handler,
-    );
-  }
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link pages.config.registerOnRemoveHandler pages.config.registerOnRemoveHandler(handler: registerOnRemoveHandlerFunctionType): void} instead.
+ *
+ * Registers a handler for user attempts to remove content. This handler should be used
+ * to remove the underlying resource powering the content.
+ * The object passed to the handler must be used to indicate whether to proceed with the removal.
+ * Only one handler may be registered at a time. Subsequent registrations will override the first.
+ *
+ * @param handler - The handler to invoke when the user selects the remove button.
+ */
+export function registerOnRemoveHandler(handler: registerOnRemoveHandlerFunctionType): void {
+  pages.config.registerOnRemoveHandlerHelper(
+    getApiVersionTag(settingsTelemetryVersionNumber, ApiName.Settings_RegisterOnRemoveHandler),
+    handler,
+  );
 }

--- a/packages/teams-js/src/public/webStorage.ts
+++ b/packages/teams-js/src/public/webStorage.ts
@@ -2,7 +2,7 @@ import { sendAndUnwrap } from '../internal/communication';
 import { GlobalVars } from '../internal/globalVars';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { app } from './app';
+import * as app from './app';
 import { errorNotSupportedOnPlatform, HostClientType, HostName } from './constants';
 import { runtime } from './runtime';
 

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -6,7 +6,7 @@ import { NestedAppAuthMessageEventNames, NestedAppAuthRequest } from '../../src/
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../src/internal/telemetry';
 import { UUID } from '../../src/internal/uuidObject';
 import { FrameContexts } from '../../src/public';
-import * as from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { Utils } from '../utils';
 
 jest.mock('../../src/internal/handlers', () => ({

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -6,7 +6,7 @@ import { NestedAppAuthMessageEventNames, NestedAppAuthRequest } from '../../src/
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../src/internal/telemetry';
 import { UUID } from '../../src/internal/uuidObject';
 import { FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as from '../../src/public/app';
 import { Utils } from '../utils';
 
 jest.mock('../../src/internal/handlers', () => ({

--- a/packages/teams-js/test/internal/validOrigins.spec.ts
+++ b/packages/teams-js/test/internal/validOrigins.spec.ts
@@ -1,6 +1,6 @@
 import { GlobalVars } from '../../src/internal/globalVars';
 import { validateOrigin } from '../../src/internal/validOrigins';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';
 describe('validOrigins', () => {

--- a/packages/teams-js/test/private/appEntity.spec.ts
+++ b/packages/teams-js/test/private/appEntity.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { appEntity } from '../../src/private/appEntity';
 import { FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform } from '../../src/public/constants';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/private/conversations.spec.ts
+++ b/packages/teams-js/test/private/conversations.spec.ts
@@ -1,6 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { conversations, OpenConversationRequest } from '../../src/private/conversations';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/private/copilot.spec.ts
+++ b/packages/teams-js/test/private/copilot.spec.ts
@@ -1,6 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { copilot } from '../../src/private/copilot';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { Cohort, EduType, ErrorCode, LegalAgeGroupClassification, Persona } from '../../src/public/interfaces';
 import { _minRuntimeConfigToUninitialize, Runtime } from '../../src/public/runtime';

--- a/packages/teams-js/test/private/externalAppAuthentication.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthentication.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { externalAppAuthentication } from '../../src/private/externalAppAuthentication';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/private/externalAppAuthenticationForCEA.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthenticationForCEA.spec.ts
@@ -3,7 +3,7 @@ import { GlobalVars } from '../../src/internal/globalVars';
 import { externalAppAuthentication } from '../../src/private/externalAppAuthentication';
 import { externalAppAuthenticationForCEA } from '../../src/private/externalAppAuthenticationForCEA';
 import { AppId } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/private/externalAppCardActions.spec.ts
+++ b/packages/teams-js/test/private/externalAppCardActions.spec.ts
@@ -3,7 +3,7 @@ import { GlobalVars } from '../../src/internal/globalVars';
 import { ExternalAppErrorCode } from '../../src/private/constants';
 import { externalAppCardActions } from '../../src/private/externalAppCardActions';
 import { FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform } from '../../src/public/constants';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/private/externalAppCardActionsForCEA.spec.ts
+++ b/packages/teams-js/test/private/externalAppCardActionsForCEA.spec.ts
@@ -5,7 +5,7 @@ import { ExternalAppErrorCode } from '../../src/private/constants';
 import { externalAppCardActions } from '../../src/private/externalAppCardActions';
 import { externalAppCardActionsForCEA } from '../../src/private/externalAppCardActionsForCEA';
 import { AppId, FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform } from '../../src/public/constants';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/private/externalAppCommands.spec.ts
+++ b/packages/teams-js/test/private/externalAppCommands.spec.ts
@@ -3,7 +3,7 @@ import { GlobalVars } from '../../src/internal/globalVars';
 import { ExternalAppErrorCode } from '../../src/private/constants';
 import { externalAppCommands } from '../../src/private/externalAppCommands';
 import { FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform } from '../../src/public/constants';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/private/hostEntity.spec.ts
+++ b/packages/teams-js/test/private/hostEntity.spec.ts
@@ -2,7 +2,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { hostEntity } from '../../src/private/hostEntity';
 import { ErrorCode, FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/private/logs.spec.ts
+++ b/packages/teams-js/test/private/logs.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { logs } from '../../src/private/logs';
 import { FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform } from '../../src/public/constants';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/private/meetingRoom.spec.ts
+++ b/packages/teams-js/test/private/meetingRoom.spec.ts
@@ -2,7 +2,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { meetingRoom } from '../../src/private/meetingRoom';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/private/messageChannels.spec.ts
+++ b/packages/teams-js/test/private/messageChannels.spec.ts
@@ -2,7 +2,7 @@ import * as communication from '../../src/internal/communication';
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { messageChannels } from '../../src/private/messageChannels';
 import { FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform } from '../../src/public/constants';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/private/notifications.spec.ts
+++ b/packages/teams-js/test/private/notifications.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { NotificationTypes, ShowNotificationParameters } from '../../src/private/interfaces';
 import { notifications } from '../../src/private/notifications';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/private/privateAPIs.spec.ts
+++ b/packages/teams-js/test/private/privateAPIs.spec.ts
@@ -7,7 +7,7 @@ import {
   sendCustomEvent,
   sendCustomMessage,
 } from '../../src/private/privateAPIs';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { FrameContexts, HostClientType, HostName, TeamType } from '../../src/public/constants';
 import { Context, FileOpenPreference } from '../../src/public/interfaces';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/private/remoteCamera.spec.ts
+++ b/packages/teams-js/test/private/remoteCamera.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { remoteCamera } from '../../src/private/remoteCamera';
 import { FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform } from '../../src/public/constants';
 import { SdkError } from '../../src/public/interfaces';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';

--- a/packages/teams-js/test/private/teams.spec.ts
+++ b/packages/teams-js/test/private/teams.spec.ts
@@ -1,6 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { TeamInstanceParameters, teams } from '../../src/private';
-import { app } from '../../src/public';
+import * as app from '../../src/public';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/private/teams.spec.ts
+++ b/packages/teams-js/test/private/teams.spec.ts
@@ -1,6 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { TeamInstanceParameters, teams } from '../../src/private';
-import * as app from '../../src/public';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/private/videoEffectsEx.spec.ts
+++ b/packages/teams-js/test/private/videoEffectsEx.spec.ts
@@ -5,7 +5,7 @@ import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { MessageRequest } from '../../src/internal/messageObjects';
 import { VideoPerformanceMonitor } from '../../src/internal/videoPerformanceMonitor';
 import { videoEffectsEx } from '../../src/private/videoEffectsEx';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { videoEffects } from '../../src/public/videoEffects';
 import { Utils } from '../utils';
@@ -1204,7 +1204,7 @@ describe('videoEffectsEx', () => {
 });
 
 function numToByteArray(num: number): Uint8Array {
-  return new Uint8Array((new Uint32Array([num])).buffer);
+  return new Uint8Array(new Uint32Array([num]).buffer);
 }
 
 function generateOneTextureMetadataMock(attributes: ReadonlyMap<string, Uint8Array>, streamCount: number): Uint8Array {
@@ -1228,7 +1228,7 @@ function generateOneTextureMetadataMock(attributes: ReadonlyMap<string, Uint8Arr
 
     attributesData.push(...numToByteArray(streamId++));
     attributesData.push(...stringBytes);
-    attributesData.push(...(new Uint8Array(paddingSize)));
+    attributesData.push(...new Uint8Array(paddingSize));
 
     dataSegment.push(...attributeData);
   });
@@ -1300,7 +1300,9 @@ function mockMediaStreamAPI() {
     1 + frameAttributesMock.size, // multiStreamCount
   ]);
 
-  const oneTextureMetadataMock = new Uint8Array(generateOneTextureMetadataMock(frameAttributesMock, oneTextureHeaderMock[7]));
+  const oneTextureMetadataMock = new Uint8Array(
+    generateOneTextureMetadataMock(frameAttributesMock, oneTextureHeaderMock[7]),
+  );
 
   const originalReadableStream = window['ReadableStream'];
 
@@ -1316,7 +1318,8 @@ function mockMediaStreamAPI() {
               codedWidth: 100,
               codedHeight: 100,
               format: 'NV12',
-              copyTo: jest.fn()
+              copyTo: jest
+                .fn()
                 .mockImplementationOnce((buffer) => new Uint32Array(buffer).set(oneTextureHeaderMock))
                 .mockImplementationOnce((buffer) => new Uint8Array(buffer).set(oneTextureMetadataMock)),
               // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -2,7 +2,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { authentication, dialog, menus, pages } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import {
   ChannelType,
   FrameContexts,

--- a/packages/teams-js/test/public/appInitialization.spec.ts
+++ b/packages/teams-js/test/public/appInitialization.spec.ts
@@ -1,5 +1,5 @@
 import * as AppHelpersFile from '../../src/internal/appHelpers';
-import * as AppFile from '../../src/public/app';
+import * as app from '../../src/public/app';
 import * as appInitialization from '../../src/public/appInitialization';
 import { version } from '../../src/public/version';
 import { Utils } from '../utils';
@@ -10,7 +10,6 @@ import { Utils } from '../utils';
 
 describe('appInitialization', () => {
   const utils = new Utils();
-  const app = AppFile;
 
   beforeEach(() => {
     utils.processMessage = null;

--- a/packages/teams-js/test/public/appInitialization.spec.ts
+++ b/packages/teams-js/test/public/appInitialization.spec.ts
@@ -1,6 +1,6 @@
 import * as AppHelpersFile from '../../src/internal/appHelpers';
 import * as AppFile from '../../src/public/app';
-import { appInitialization } from '../../src/public/appInitialization';
+import * as appInitialization from '../../src/public/appInitialization';
 import { version } from '../../src/public/version';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/public/appInitialization.spec.ts
+++ b/packages/teams-js/test/public/appInitialization.spec.ts
@@ -10,7 +10,7 @@ import { Utils } from '../utils';
 
 describe('appInitialization', () => {
   const utils = new Utils();
-  const app = AppFile.app;
+  const app = AppFile;
 
   beforeEach(() => {
     utils.processMessage = null;

--- a/packages/teams-js/test/public/appWindow.spec.ts
+++ b/packages/teams-js/test/public/appWindow.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { ChildAppWindow, ParentAppWindow } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { FrameContexts } from '../../src/public/constants';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -4,7 +4,7 @@ import * as handlers from '../../src/internal/handlers';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import * as internalUtils from '../../src/internal/utils';
 import { ErrorCode, FrameContexts, HostClientType, SdkError } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { authentication } from '../../src/public/authentication';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/public/barCode.spec.ts
+++ b/packages/teams-js/test/public/barCode.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { barCode } from '../../src/public/barCode';
 import { errorNotSupportedOnPlatform, FrameContexts, HostClientType } from '../../src/public/constants';
 import { ErrorCode } from '../../src/public/interfaces';

--- a/packages/teams-js/test/public/calendar.spec.ts
+++ b/packages/teams-js/test/public/calendar.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { calendar } from '../../src/public/calendar';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { validateCalendarDeepLinkPrefix } from '../internal/deepLinkUtilities.spec';

--- a/packages/teams-js/test/public/chat.spec.ts
+++ b/packages/teams-js/test/public/chat.spec.ts
@@ -1,5 +1,5 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { chat, OpenGroupChatRequest, OpenSingleChatRequest } from '../../src/public/chat';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';

--- a/packages/teams-js/test/public/clipboard.spec.ts
+++ b/packages/teams-js/test/public/clipboard.spec.ts
@@ -2,7 +2,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { clipboard } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts, HostClientType } from '../../src/public/constants';
 import { ClipboardSupportedMimeType } from '../../src/public/interfaces';
 import { Utils } from '../utils';
@@ -45,13 +45,13 @@ describe('clipboard', () => {
         // Clipboard capabilities should function in frameless context when navigator.clipboard is not available
         Object.assign(navigator, {
           clipboard: null,
-        })
+        });
       });
 
       afterEach(() => {
         Object.assign(navigator, {
           clipboard: {},
-        })
+        });
         app._uninitialize();
         GlobalVars.isFramelessWindow = true;
       });

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -2,7 +2,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { doesHandlerExist } from '../../src/internal/handlers';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import {
   DialogDimension,
   errorNotSupportedOnPlatform,

--- a/packages/teams-js/test/public/geoLocation.spec.ts
+++ b/packages/teams-js/test/public/geoLocation.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized, permissionsAPIsRequiredVersion } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { ErrorCode, geoLocation, location } from '../../src/public/index';
 import { DevicePermission } from '../../src/public/interfaces';

--- a/packages/teams-js/test/public/liveShareHost.spec.ts
+++ b/packages/teams-js/test/public/liveShareHost.spec.ts
@@ -1,5 +1,5 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { liveShare, LiveShareHost } from '../../src/public/liveShareHost';
 import { setUnitializedRuntime } from '../../src/public/runtime';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/public/location.spec.ts
+++ b/packages/teams-js/test/public/location.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized, locationAPIsRequiredVersion } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { ErrorCode, location, SdkError } from '../../src/public/index';
 import { setUnitializedRuntime } from '../../src/public/runtime';

--- a/packages/teams-js/test/public/mail.spec.ts
+++ b/packages/teams-js/test/public/mail.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { mail } from '../../src/public/mail';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/public/marketplace.spec.ts
+++ b/packages/teams-js/test/public/marketplace.spec.ts
@@ -3,7 +3,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { marketplace } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { MatcherType, validateExpectedArgumentsInRequest } from '../resultValidation';

--- a/packages/teams-js/test/public/media.spec.ts
+++ b/packages/teams-js/test/public/media.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized, permissionsAPIsRequiredVersion } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts, HostClientType } from '../../src/public/constants';
 import { DevicePermission, ErrorCode, SdkError } from '../../src/public/interfaces';
 import { media } from '../../src/public/media';

--- a/packages/teams-js/test/public/meeting.spec.ts
+++ b/packages/teams-js/test/public/meeting.spec.ts
@@ -3,7 +3,7 @@ import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { MessageRequest } from '../../src/internal/messageObjects';
 import { EmailAddress, FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { ErrorCode, SdkError } from '../../src/public/interfaces';
 import { meeting } from '../../src/public/meeting';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/public/monetization.spec.ts
+++ b/packages/teams-js/test/public/monetization.spec.ts
@@ -2,7 +2,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { FrameContexts } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform } from '../../src/public/constants';
 import { SdkError } from '../../src/public/interfaces';
 import { monetization } from '../../src/public/monetization';

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -3,7 +3,7 @@ import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { MessageResponse } from '../../src/internal/messageObjects';
 import { getGenericOnCompleteHandler } from '../../src/internal/utils';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { FrameInfo, ShareDeepLinkParameters, TabInstance, TabInstanceParameters } from '../../src/public/interfaces';
 import {

--- a/packages/teams-js/test/public/people.spec.ts
+++ b/packages/teams-js/test/public/people.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { ErrorCode, SdkError } from '../../src/public/interfaces';
 import { people } from '../../src/public/people';

--- a/packages/teams-js/test/public/profile.spec.ts
+++ b/packages/teams-js/test/public/profile.spec.ts
@@ -1,5 +1,5 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { FrameContexts } from '../../src/public/constants';
 import { ErrorCode } from '../../src/public/interfaces';
 import { ShowProfileRequestInternal } from '../../src/public/profile';

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -1,6 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import * as utilFunc from '../../src/internal/utils';
-import { app } from '../../src/public';
+import * as app from '../../src/public';
 import { HostClientType, TeamType, UserTeamRole } from '../../src/public/constants';
 import { FrameContexts } from '../../src/public/constants';
 import { Context, FrameContext, LoadContext, TabInstanceParameters } from '../../src/public/interfaces';

--- a/packages/teams-js/test/public/publicAPIs.spec.ts
+++ b/packages/teams-js/test/public/publicAPIs.spec.ts
@@ -1,6 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import * as utilFunc from '../../src/internal/utils';
-import * as app from '../../src/public';
+import * as app from '../../src/public/app';
 import { HostClientType, TeamType, UserTeamRole } from '../../src/public/constants';
 import { FrameContexts } from '../../src/public/constants';
 import { Context, FrameContext, LoadContext, TabInstanceParameters } from '../../src/public/interfaces';

--- a/packages/teams-js/test/public/search.spec.ts
+++ b/packages/teams-js/test/public/search.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { FrameContexts } from '../../src/public/constants';
 import { search } from '../../src/public/search';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/public/secondaryBrowser.spec.ts
+++ b/packages/teams-js/test/public/secondaryBrowser.spec.ts
@@ -1,5 +1,5 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { ErrorCode, HostClientType, secondaryBrowser } from '../../src/public/index';
 import { setUnitializedRuntime } from '../../src/public/runtime';

--- a/packages/teams-js/test/public/settings.spec.ts
+++ b/packages/teams-js/test/public/settings.spec.ts
@@ -1,7 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { app, FrameContexts } from '../../src/public';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
-import { settings } from '../../src/public/settings';
+import * as settings from '../../src/public/settings';
 import { Utils } from '../utils';
 
 /* eslint-disable */

--- a/packages/teams-js/test/public/sharing.spec.ts
+++ b/packages/teams-js/test/public/sharing.spec.ts
@@ -2,7 +2,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { compareSDKVersions } from '../../src/internal/utils';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts, HostClientType } from '../../src/public/constants';
 import { ErrorCode } from '../../src/public/interfaces';
 import {
@@ -778,7 +778,7 @@ describe('sharing_v2', () => {
       });
       afterEach(() => {
         app._uninitialize();
-      });      
+      });
       it('sharing.history.isSupported should return false if the runtime says sharing.history is not supported', async () => {
         await utils.initializeWithContext(FrameContexts.content);
         utils.setRuntimeConfig({ apiVersion: 1, supports: { sharing: {} } });

--- a/packages/teams-js/test/public/stageView.spec.ts
+++ b/packages/teams-js/test/public/stageView.spec.ts
@@ -1,6 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { ErrorCode } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { stageView } from '../../src/public/stageView';
@@ -14,7 +14,7 @@ describe('stageView', () => {
   const utils = new Utils();
 
   function makeRuntimeSupportStageViewCapability() {
-    utils.setRuntimeConfig({ apiVersion: 1, supports: { stageView: {self: {}} } });
+    utils.setRuntimeConfig({ apiVersion: 1, supports: { stageView: { self: {} } } });
   }
 
   beforeEach(() => {
@@ -43,7 +43,7 @@ describe('stageView', () => {
     websiteUrl: 'websiteUrl',
     entityId: 'entityId',
     openMode: stageView.StageViewOpenMode.modal,
-    messageId: 'messageId'
+    messageId: 'messageId',
   };
 
   describe('isSupported', () => {

--- a/packages/teams-js/test/public/tasks.spec.ts
+++ b/packages/teams-js/test/public/tasks.spec.ts
@@ -1,5 +1,5 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { minAdaptiveCardVersion, TaskModuleDimension } from '../../src/public/constants';
 import { FrameContexts } from '../../src/public/constants';
 import { TaskInfo } from '../../src/public/interfaces';

--- a/packages/teams-js/test/public/teamsAPIs.spec.ts
+++ b/packages/teams-js/test/public/teamsAPIs.spec.ts
@@ -1,6 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { LoadContext } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { teamsCore } from '../../src/public/teamsAPIs';

--- a/packages/teams-js/test/public/videoEffects.spec.ts
+++ b/packages/teams-js/test/public/videoEffects.spec.ts
@@ -2,7 +2,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { VideoPerformanceMonitor } from '../../src/internal/videoPerformanceMonitor';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { videoEffects } from '../../src/public/videoEffects';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/public/visualMedia.spec.ts
+++ b/packages/teams-js/test/public/visualMedia.spec.ts
@@ -2,7 +2,7 @@ import { errorLibraryNotInitialized, permissionsAPIsRequiredVersion } from '../.
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { visualMedia } from '../../src/public';
-import { app } from '../../src/public/app';
+import * as app from '../../src/public/app';
 import { errorInvalidCount, errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { DevicePermission, ErrorCode } from '../../src/public/interfaces';
 import { setUnitializedRuntime } from '../../src/public/runtime';

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -6,7 +6,7 @@ import { MessageRequest, SerializedMessageRequest, SerializedMessageResponse } f
 import { NestedAppAuthRequest } from '../src/internal/nestedAppAuthUtils';
 import { UUID as MessageUUID } from '../src/internal/uuidObject';
 import { HostClientType } from '../src/public';
-import { app } from '../src/public/app';
+import * as app from '../src/public/app';
 import { applyRuntimeConfig, IBaseRuntime, setUnitializedRuntime } from '../src/public/runtime';
 
 function deserializeMessageRequest(serializedMessage: SerializedMessageRequest): MessageRequest {

--- a/packages/teams-js/webpack.config.cjs
+++ b/packages/teams-js/webpack.config.cjs
@@ -73,14 +73,6 @@ module.exports = {
       PACKAGE_VERSION: JSON.stringify(packageVersion),
     }),
 
-    new DtsBundleWebpack({
-      name: '@microsoft/teams-js',
-      main: './dist/esm/packages/teams-js/dts',
-      out: '~/dist/umd/MicrosoftTeams.d.ts',
-      removeSource: true,
-      outputAsModuleFolder: true,
-    }),
-
     // https://www.npmjs.com/package/webpack-subresource-integrity
     new SubresourceIntegrityPlugin({ enabled: true }),
 

--- a/packages/teams-js/webpack.config.cjs
+++ b/packages/teams-js/webpack.config.cjs
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable no-undef */
 const TerserPlugin = require('terser-webpack-plugin');
-const DtsBundleWebpack = require('dts-bundle-webpack');
 const { SubresourceIntegrityPlugin } = require('webpack-subresource-integrity');
 const { readFileSync } = require('fs');
 const { join } = require('path');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       rollup:
         specifier: ^4.24.0
         version: 4.24.0
+      rollup-plugin-dts:
+        specifier: ^6.1.1
+        version: 6.1.1(rollup@4.24.0)(typescript@4.9.5)
       rollup-plugin-polyfill-node:
         specifier: ^0.13.0
         version: 0.13.0(rollup@4.24.0)
@@ -8519,6 +8522,13 @@ packages:
     resolution: {integrity: sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg==}
     engines: {node: '>=14.18'}
     hasBin: true
+
+  rollup-plugin-dts@6.1.1:
+    resolution: {integrity: sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      rollup: ^3.29.4 || ^4
+      typescript: ^4.5 || ^5.0
 
   rollup-plugin-polyfill-node@0.13.0:
     resolution: {integrity: sha512-FYEvpCaD5jGtyBuBFcQImEGmTxDTPbiHjJdrYIp+mFIwgXiXabxvKUK7ZT9P31ozu2Tqm9llYQMRWsfvTMTAOw==}
@@ -20743,6 +20753,14 @@ snapshots:
   rimraf@5.0.7:
     dependencies:
       glob: 10.4.2
+
+  rollup-plugin-dts@6.1.1(rollup@4.24.0)(typescript@4.9.5):
+    dependencies:
+      magic-string: 0.30.11
+      rollup: 4.24.0
+      typescript: 4.9.5
+    optionalDependencies:
+      '@babel/code-frame': 7.24.7
 
   rollup-plugin-polyfill-node@0.13.0(rollup@4.24.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,9 +136,6 @@ importers:
       css-loader:
         specifier: ^6.11.0
         version: 6.11.0(webpack@5.94.0(webpack-cli@5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.1.0)(webpack@5.94.0)))
-      dts-bundle-webpack:
-        specifier: ^1.0.2
-        version: 1.0.2
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -3117,9 +3114,6 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
-  '@types/detect-indent@0.1.30':
-    resolution: {integrity: sha512-AUmj9JHuHTD94slY1WR1VulFxRGC6D1pcNCN0MCulKFyiihvV/28lLS8oRHgfmc2Cxq954J8Vmosa8qzm7PLGQ==}
-
   '@types/es-aggregate-error@1.0.6':
     resolution: {integrity: sha512-qJ7LIFp06h1QE1aVxbVd+zJP2wdaugYXYfd6JxsyRMrYHaxb6itXPogW2tz+ylUJ1n1b+JF1PHyYCfYHm0dvUg==}
 
@@ -3146,9 +3140,6 @@ packages:
 
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
-
-  '@types/glob@5.0.30':
-    resolution: {integrity: sha512-ZM05wDByI+WA153sfirJyEHoYYoIuZ7lA2dB/Gl8ymmpMTR78fNRtDMqa7Z6SdH4fZdLWZNRE6mZpx3XqBOrHw==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -3207,14 +3198,8 @@ packages:
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
-  '@types/minimatch@5.1.2':
-    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
-
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
-
-  '@types/mkdirp@0.3.29':
-    resolution: {integrity: sha512-QRLQpFsIQGO2k8pupga9abfei85GKotAtQ+F6xuQmSGomUt6C52TyMiTFpP8kUwuPKr00gNtu3itLlC6gvI/NA==}
 
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
@@ -3239,9 +3224,6 @@ packages:
 
   '@types/node@18.19.39':
     resolution: {integrity: sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==}
-
-  '@types/node@8.0.0':
-    resolution: {integrity: sha512-j2tekvJCO7j22cs+LO6i0kRPhmQ9MXaPZ55TzOc1lzkN5b6BWqq4AFjl04s1oRRQ1v5rSe+KEvnLUSTonuls/A==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -4772,11 +4754,6 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  detect-indent@0.2.0:
-    resolution: {integrity: sha512-C6jyrDu/eGH4KT0ZxAzijiH+ts5YLy7DqGFoDuHGxZjMOdjzRltp3jByySnpFBVIy4Em0ZkLN8tIV6mcREdw5A==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-
   detect-indent@5.0.0:
     resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
     engines: {node: '>=4'}
@@ -4884,14 +4861,6 @@ packages:
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
-
-  dts-bundle-webpack@1.0.2:
-    resolution: {integrity: sha512-/gBQBu5spW8BsGKyYwZeDb+gzDsipisf4Hg0ERPrrS0661cYajVUHARwvts/vfvG5wuv+p295byoNl2da+Re6w==}
-
-  dts-bundle@0.7.3:
-    resolution: {integrity: sha512-EEAEuPRk8QyKhoN90NHTh+spSQujkkvOnKWUfuzpmC/fgryiWopL1SegSktx0UsoPfNidIGVDN7/AXpBDBv0WQ==}
-    engines: {node: '>= 0.10.0'}
-    hasBin: true
 
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -5568,10 +5537,6 @@ packages:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
     engines: {node: '>=8'}
 
-  get-stdin@0.1.0:
-    resolution: {integrity: sha512-/WBu3IaQZxE3bs3BhBmR10ipDY4pjN+U4EZgXULa1eqKA0B/Lka/MVoAqhTVYBkkRlCrEGDOU9itrzIgm9Ksng==}
-    engines: {node: '>=0.10.0'}
-
   get-stream@6.0.0:
     resolution: {integrity: sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==}
     engines: {node: '>=10'}
@@ -5626,10 +5591,6 @@ packages:
     resolution: {integrity: sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==}
     engines: {node: '>=16 || 14 >=14.18'}
     hasBin: true
-
-  glob@6.0.4:
-    resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -13956,8 +13917,6 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
-  '@types/detect-indent@0.1.30': {}
-
   '@types/es-aggregate-error@1.0.6':
     dependencies:
       '@types/node': 18.19.39
@@ -13995,11 +13954,6 @@ snapshots:
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 16.18.101
-
-  '@types/glob@5.0.30':
-    dependencies:
-      '@types/minimatch': 5.1.2
-      '@types/node': 18.19.39
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -14062,11 +14016,7 @@ snapshots:
 
   '@types/minimatch@3.0.5': {}
 
-  '@types/minimatch@5.1.2': {}
-
   '@types/minimist@1.2.5': {}
-
-  '@types/mkdirp@0.3.29': {}
 
   '@types/ms@0.7.34': {}
 
@@ -14092,8 +14042,6 @@ snapshots:
   '@types/node@18.19.39':
     dependencies:
       undici-types: 5.26.5
-
-  '@types/node@8.0.0': {}
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -15983,11 +15931,6 @@ snapshots:
 
   destroy@1.2.0: {}
 
-  detect-indent@0.2.0:
-    dependencies:
-      get-stdin: 0.1.0
-      minimist: 0.2.4
-
   detect-indent@5.0.0: {}
 
   detect-newline@3.1.0: {}
@@ -16095,21 +16038,6 @@ snapshots:
   dotenv@10.0.0: {}
 
   dotenv@16.4.5: {}
-
-  dts-bundle-webpack@1.0.2:
-    dependencies:
-      dts-bundle: 0.7.3
-
-  dts-bundle@0.7.3:
-    dependencies:
-      '@types/detect-indent': 0.1.30
-      '@types/glob': 5.0.30
-      '@types/mkdirp': 0.3.29
-      '@types/node': 8.0.0
-      commander: 2.20.3
-      detect-indent: 0.2.0
-      glob: 6.0.4
-      mkdirp: 0.5.6
 
   duplexer@0.1.2: {}
 
@@ -16997,8 +16925,6 @@ snapshots:
 
   get-port@5.1.1: {}
 
-  get-stdin@0.1.0: {}
-
   get-stream@6.0.0: {}
 
   get-stream@6.0.1: {}
@@ -17064,14 +16990,6 @@ snapshots:
       minipass: 7.1.2
       package-json-from-dist: 1.0.0
       path-scurry: 1.11.1
-
-  glob@6.0.4:
-    dependencies:
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
 
   glob@7.2.3:
     dependencies:


### PR DESCRIPTION
**This PR is part of the larger Treeshaking effort with more PR's to come**


This PR has a few major components to it. Unfortunately, they all need to be checked in at the same time, so this PR cannot be made any smaller, or broken into multiple PR's.

The Changes:
--------------------
- The main change in this PR is the addition of the `dts` plugin to the rollup config. This plugin is being added to generate a bundled typings file (MicrosoftTeams.d.ts) for the library. This was previously being done by the webpack plugin, however for some reason (that I have not been able to determine the cause of, likely due to the inner implementation of webpack), the webpack typings bundle was not working properly with the treeshakable code (which will be coming soon in subsequent PR's). I was previously using just the unbundled tsc generated typings files however, that caused an issue with the typed-dependency-tester. As such, a rollup typings bundler is needed to be added. There were a few other issues that needed to be resolved in order for the rollup dts plugin to work properly, with the changes outlined below: 
- There are a few instances throughout the codebase where we use the syntax `export import foo = namespace.bar`. This syntax is outdated with esm modules and so the dts() plugin would error when encountering it. In order to keep the same functionality, I had to replace the syntax with named imports and exports. This cannot be done from within a namespace, so I had to go ahead and remove the namespaces for files that are referenced in these problematic lines (App, AppInitialization, and Settings). 
- Since the app namespace was removed, all files that import the app namespace directly from the app file and not from the index file needed to have their references updated.
- Since the rollup dts plugin is no generating the typings file, we can remove the webpack plugin that was previously being used to generate the bundled typings file.
- There are also a few various whitespace changes auto-generated by prettier when I saved the files

_With the removal of the namespaces, there are not many code changes to the capability files, however there is significant whitespace changes. To make reviewing the PR simpler, I recommend hiding the whitespace changes, which you can enable by selecting the gear icon when viewing the changes_