### PR TITLE
noahdarveau/batch of treeshaking changes for capabilites

### DIFF
--- a/change/@microsoft-teams-js-ee20dd5c-0ffc-4208-bd96-53224dc7e062.json
+++ b/change/@microsoft-teams-js-ee20dd5c-0ffc-4208-bd96-53224dc7e062.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Made the `appInstallDialog`, `authentication`, `barCode`, `calendar`, `call`, and `clipboard` files treeshakable",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/appHelpers.ts
+++ b/packages/teams-js/src/internal/appHelpers.ts
@@ -11,7 +11,7 @@ import { getLogger } from '../internal/telemetry';
 import { isNullOrUndefined } from '../internal/typeCheckUtilities';
 import { compareSDKVersions, inServerSideRenderingEnvironment, runWithTimeout } from '../internal/utils';
 import * as app from '../public/app';
-import { authentication } from '../public/authentication';
+import * as authentication from '../public/authentication';
 import { FrameContexts } from '../public/constants';
 import { dialog } from '../public/dialog';
 import { menus } from '../public/menus';

--- a/packages/teams-js/src/public/appInstallDialog.ts
+++ b/packages/teams-js/src/public/appInstallDialog.ts
@@ -10,58 +10,56 @@ import { runtime } from './runtime';
  */
 const appInstallDialogTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
 
-export namespace appInstallDialog {
-  /** Represents set of parameters needed to open the appInstallDialog. */
-  export interface OpenAppInstallDialogParams {
-    /** A unique identifier for the app being installed. */
-    appId: string;
-  }
+/** Represents set of parameters needed to open the appInstallDialog. */
+export interface OpenAppInstallDialogParams {
+  /** A unique identifier for the app being installed. */
+  appId: string;
+}
 
-  /**
-   * Displays a dialog box that allows users to install a specific app within the host environment.
-   *
-   * @param openAPPInstallDialogParams - See {@link OpenAppInstallDialogParams | OpenAppInstallDialogParams} for more information.
-   */
-  export function openAppInstallDialog(openAPPInstallDialogParams: OpenAppInstallDialogParams): Promise<void> {
-    return new Promise((resolve) => {
-      ensureInitialized(
-        runtime,
-        FrameContexts.content,
-        FrameContexts.sidePanel,
-        FrameContexts.settings,
-        FrameContexts.task,
-        FrameContexts.stage,
-        FrameContexts.meetingStage,
+/**
+ * Displays a dialog box that allows users to install a specific app within the host environment.
+ *
+ * @param openAPPInstallDialogParams - See {@link OpenAppInstallDialogParams | OpenAppInstallDialogParams} for more information.
+ */
+export function openAppInstallDialog(openAPPInstallDialogParams: OpenAppInstallDialogParams): Promise<void> {
+  return new Promise((resolve) => {
+    ensureInitialized(
+      runtime,
+      FrameContexts.content,
+      FrameContexts.sidePanel,
+      FrameContexts.settings,
+      FrameContexts.task,
+      FrameContexts.stage,
+      FrameContexts.meetingStage,
+    );
+    if (!isSupported()) {
+      throw new Error('Not supported');
+    }
+    const apiVersionTag = getApiVersionTag(
+      appInstallDialogTelemetryVersionNumber,
+      ApiName.AppInstallDialog_OpenAppInstallDialog,
+    );
+    if (runtime.isLegacyTeams) {
+      resolve(
+        sendAndHandleStatusAndReason(
+          apiVersionTag,
+          'executeDeepLink',
+          createTeamsDeepLinkForAppInstallDialog(openAPPInstallDialogParams.appId),
+        ),
       );
-      if (!isSupported()) {
-        throw new Error('Not supported');
-      }
-      const apiVersionTag = getApiVersionTag(
-        appInstallDialogTelemetryVersionNumber,
-        ApiName.AppInstallDialog_OpenAppInstallDialog,
-      );
-      if (runtime.isLegacyTeams) {
-        resolve(
-          sendAndHandleStatusAndReason(
-            apiVersionTag,
-            'executeDeepLink',
-            createTeamsDeepLinkForAppInstallDialog(openAPPInstallDialogParams.appId),
-          ),
-        );
-      } else {
-        sendMessageToParent(apiVersionTag, 'appInstallDialog.openAppInstallDialog', [openAPPInstallDialogParams]);
-        resolve();
-      }
-    });
-  }
+    } else {
+      sendMessageToParent(apiVersionTag, 'appInstallDialog.openAppInstallDialog', [openAPPInstallDialogParams]);
+      resolve();
+    }
+  });
+}
 
-  /**
-   * Checks if the appInstallDialog capability is supported by the host
-   * @returns boolean to represent whether the appInstallDialog capability is supported
-   *
-   * @throws Error if {@linkcode app.initialize} has not successfully completed
-   */
-  export function isSupported(): boolean {
-    return ensureInitialized(runtime) && runtime.supports.appInstallDialog ? true : false;
-  }
+/**
+ * Checks if the appInstallDialog capability is supported by the host
+ * @returns boolean to represent whether the appInstallDialog capability is supported
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ */
+export function isSupported(): boolean {
+  return ensureInitialized(runtime) && runtime.supports.appInstallDialog ? true : false;
 }

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -26,462 +26,461 @@ import { runtime } from './runtime';
 const authenticationTelemetryVersionNumber_v1: ApiVersionNumber = ApiVersionNumber.V_1;
 const authenticationTelemetryVersionNumber_v2: ApiVersionNumber = ApiVersionNumber.V_2;
 
-export namespace authentication {
-  let authHandlers: { success: (string) => void; fail: (string) => void } | undefined;
-  let authWindowMonitor: number | undefined;
+let authHandlers: { success: (string) => void; fail: (string) => void } | undefined;
+let authWindowMonitor: number | undefined;
 
-  /**
-   * @hidden
-   * @internal
-   * Limited to Microsoft-internal use; automatically called when library is initialized
-   */
-  export function initialize(): void {
-    registerHandler(
-      getApiVersionTag(
-        authenticationTelemetryVersionNumber_v1,
-        ApiName.Authentication_RegisterAuthenticateSuccessHandler,
-      ),
-      'authentication.authenticate.success',
-      handleSuccess,
-      false,
-    );
-    registerHandler(
-      getApiVersionTag(
-        authenticationTelemetryVersionNumber_v1,
-        ApiName.Authentication_RegisterAuthenticateFailureHandler,
-      ),
-      'authentication.authenticate.failure',
-      handleFailure,
-      false,
-    );
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use; automatically called when library is initialized
+ */
+export function initialize(): void {
+  registerHandler(
+    getApiVersionTag(
+      authenticationTelemetryVersionNumber_v1,
+      ApiName.Authentication_RegisterAuthenticateSuccessHandler,
+    ),
+    'authentication.authenticate.success',
+    handleSuccess,
+    false,
+  );
+  registerHandler(
+    getApiVersionTag(
+      authenticationTelemetryVersionNumber_v1,
+      ApiName.Authentication_RegisterAuthenticateFailureHandler,
+    ),
+    'authentication.authenticate.failure',
+    handleFailure,
+    false,
+  );
+}
+
+let authParams: AuthenticateParameters | undefined;
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, this function has been deprecated in favor of a Promise-based pattern using {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>}
+ *
+ * Registers handlers to be called with the result of an authentication flow triggered using {@link authentication.authenticate authentication.authenticate(authenticateParameters?: AuthenticateParameters): void}
+ *
+ * @param authenticateParameters - Configuration for authentication flow pop-up result communication
+ */
+export function registerAuthenticationHandlers(authenticateParameters: AuthenticateParameters): void {
+  authParams = authenticateParameters;
+}
+
+/**
+ * Initiates an authentication flow which requires a new window.
+ * There are two primary uses for this function:
+ * 1. When your app needs to authenticate using a 3rd-party identity provider (not Microsoft Entra ID)
+ * 2. When your app needs to show authentication UI that is blocked from being shown in an iframe (e.g., Microsoft Entra consent prompts)
+ *
+ * For more details, see [Enable authentication using third-party OAuth provider](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/auth-flow-tab)
+ *
+ * This function is *not* needed for "standard" Microsoft Entra SSO usage. Using {@link getAuthToken} is usually sufficient in that case. For more, see
+ * [Enable SSO for tab apps](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/tab-sso-overview))
+ *
+ * @remarks
+ * The authentication flow must start and end from the same domain, otherwise success and failure messages won't be returned to the window that initiated the call.
+ * The [Teams authentication flow](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/auth-flow-tab) starts and ends at an endpoint on
+ * your own service (with a redirect round-trip to the 3rd party identity provider in the middle).
+ *
+ * @param authenticateParameters - Parameters describing the authentication window used for executing the authentication flow
+ *
+ * @returns `Promise` that will be fulfilled with the result from the authentication pop-up, if successful. The string in this result is provided in the parameter
+ * passed by your app when it calls {@link authentication.notifySuccess authentication.notifySuccess(result?: string): void} in the pop-up window after returning from the identity provider redirect.
+ *
+ * @throws `Error` if the authentication request fails or is canceled by the user. This error is provided in the parameter passed by your app when it calls
+ * {@link authentication.notifyFailure authentication.notifyFailure(result?: string): void} in the pop-up window after returning from the identity provider redirect. However, in some cases it can also be provided by
+ * the infrastructure depending on the failure (e.g., a user cancelation)
+ *
+ */
+export function authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise<string>;
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} instead.
+ *
+ * The documentation for {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} applies
+ * to this function.
+ * The one difference is that instead of the result being returned via the `Promise`, the result is returned to the callback functions provided in the
+ * `authenticateParameters` parameter.
+ *
+ * @param authenticateParameters - Parameters describing the authentication window used for executing the authentication flow and callbacks used for indicating the result
+ *
+ */
+export function authenticate(authenticateParameters?: AuthenticateParameters): void;
+export function authenticate(authenticateParameters?: AuthenticateParameters): Promise<string> {
+  const isDifferentParamsInCall: boolean = authenticateParameters !== undefined;
+  const authenticateParams: AuthenticateParameters | undefined = isDifferentParamsInCall
+    ? authenticateParameters
+    : authParams;
+  if (!authenticateParams) {
+    throw new Error('No parameters are provided for authentication');
   }
-
-  let authParams: AuthenticateParameters | undefined;
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, this function has been deprecated in favor of a Promise-based pattern using {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>}
-   *
-   * Registers handlers to be called with the result of an authentication flow triggered using {@link authentication.authenticate authentication.authenticate(authenticateParameters?: AuthenticateParameters): void}
-   *
-   * @param authenticateParameters - Configuration for authentication flow pop-up result communication
-   */
-  export function registerAuthenticationHandlers(authenticateParameters: AuthenticateParameters): void {
-    authParams = authenticateParameters;
-  }
-
-  /**
-   * Initiates an authentication flow which requires a new window.
-   * There are two primary uses for this function:
-   * 1. When your app needs to authenticate using a 3rd-party identity provider (not Microsoft Entra ID)
-   * 2. When your app needs to show authentication UI that is blocked from being shown in an iframe (e.g., Microsoft Entra consent prompts)
-   *
-   * For more details, see [Enable authentication using third-party OAuth provider](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/auth-flow-tab)
-   *
-   * This function is *not* needed for "standard" Microsoft Entra SSO usage. Using {@link getAuthToken} is usually sufficient in that case. For more, see
-   * [Enable SSO for tab apps](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/tab-sso-overview))
-   *
-   * @remarks
-   * The authentication flow must start and end from the same domain, otherwise success and failure messages won't be returned to the window that initiated the call.
-   * The [Teams authentication flow](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/auth-flow-tab) starts and ends at an endpoint on
-   * your own service (with a redirect round-trip to the 3rd party identity provider in the middle).
-   *
-   * @param authenticateParameters - Parameters describing the authentication window used for executing the authentication flow
-   *
-   * @returns `Promise` that will be fulfilled with the result from the authentication pop-up, if successful. The string in this result is provided in the parameter
-   * passed by your app when it calls {@link authentication.notifySuccess authentication.notifySuccess(result?: string): void} in the pop-up window after returning from the identity provider redirect.
-   *
-   * @throws `Error` if the authentication request fails or is canceled by the user. This error is provided in the parameter passed by your app when it calls
-   * {@link authentication.notifyFailure authentication.notifyFailure(result?: string): void} in the pop-up window after returning from the identity provider redirect. However, in some cases it can also be provided by
-   * the infrastructure depending on the failure (e.g., a user cancelation)
-   *
-   */
-  export function authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise<string>;
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} instead.
-   *
-   * The documentation for {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} applies
-   * to this function.
-   * The one difference is that instead of the result being returned via the `Promise`, the result is returned to the callback functions provided in the
-   * `authenticateParameters` parameter.
-   *
-   * @param authenticateParameters - Parameters describing the authentication window used for executing the authentication flow and callbacks used for indicating the result
-   *
-   */
-  export function authenticate(authenticateParameters?: AuthenticateParameters): void;
-  export function authenticate(authenticateParameters?: AuthenticateParameters): Promise<string> {
-    const isDifferentParamsInCall: boolean = authenticateParameters !== undefined;
-    const authenticateParams: AuthenticateParameters | undefined = isDifferentParamsInCall
-      ? authenticateParameters
-      : authParams;
-    if (!authenticateParams) {
-      throw new Error('No parameters are provided for authentication');
-    }
-    ensureInitialized(
-      runtime,
-      FrameContexts.content,
-      FrameContexts.sidePanel,
-      FrameContexts.settings,
-      FrameContexts.remove,
-      FrameContexts.task,
-      FrameContexts.stage,
-      FrameContexts.meetingStage,
-    );
-    const apiVersionTag =
-      authenticateParams.successCallback || authenticateParams.failureCallback
-        ? getApiVersionTag(authenticationTelemetryVersionNumber_v1, ApiName.Authentication_Authenticate)
-        : getApiVersionTag(authenticationTelemetryVersionNumber_v2, ApiName.Authentication_Authenticate);
-    return authenticateHelper(apiVersionTag, authenticateParams)
-      .then((value: string) => {
-        try {
-          if (authenticateParams && authenticateParams.successCallback) {
-            authenticateParams.successCallback(value);
-            return '';
-          }
-          return value;
-        } finally {
-          if (!isDifferentParamsInCall) {
-            authParams = undefined;
-          }
-        }
-      })
-      .catch((err: Error) => {
-        try {
-          if (authenticateParams && authenticateParams.failureCallback) {
-            authenticateParams.failureCallback(err.message);
-            return '';
-          }
-          throw err;
-        } finally {
-          if (!isDifferentParamsInCall) {
-            authParams = undefined;
-          }
-        }
-      });
-  }
-
-  function authenticateHelper(apiVersionTag: string, authenticateParameters: AuthenticateParameters): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
-      if (GlobalVars.hostClientType !== HostClientType.web) {
-        // Convert any relative URLs into absolute URLs before sending them over to the parent window.
-        const fullyQualifiedURL: URL = fullyQualifyUrlString(authenticateParameters.url);
-        validateUrl(fullyQualifiedURL);
-
-        // Ask the parent window to open an authentication window with the parameters provided by the caller.
-        resolve(
-          sendMessageToParentAsync<[boolean, string]>(apiVersionTag, 'authentication.authenticate', [
-            fullyQualifiedURL.href,
-            authenticateParameters.width,
-            authenticateParameters.height,
-            authenticateParameters.isExternal,
-          ]).then(([success, response]: [boolean, string]) => {
-            if (success) {
-              return response;
-            } else {
-              throw new Error(response);
-            }
-          }),
-        );
-      } else {
-        // Open an authentication window with the parameters provided by the caller.
-        authHandlers = {
-          success: resolve,
-          fail: reject,
-        };
-        openAuthenticationWindow(authenticateParameters);
-      }
-    });
-  }
-
-  /**
-   * Requests an Microsoft Entra token to be issued on behalf of your app in an SSO flow.
-   * The token is acquired from the cache if it is not expired. Otherwise a request is sent to Microsoft Entra to
-   * obtain a new token.
-   * This function is used to enable SSO scenarios. See [Enable SSO for tab apps](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/tab-sso-overview)
-   * for more details.
-   *
-   * @param authTokenRequest - An optional set of values that configure the token request.
-   *
-   * @returns `Promise` that will be resolved with the token, if successful.
-   *
-   * @throws `Error` if the request fails in some way
-   */
-  export function getAuthToken(authTokenRequest?: AuthTokenRequestParameters): Promise<string>;
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link authentication.getAuthToken authentication.getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise\<string\>} instead.
-   *
-   * The documentation {@link authentication.getAuthToken authentication.getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise\<string\>} applies to this
-   * function as well. The one difference when using this function is that the result is provided in the callbacks in the `authTokenRequest` parameter
-   * instead of as a `Promise`.
-   *
-   * @param authTokenRequest - An optional set of values that configure the token request.
-   * It contains callbacks to call in case of success/failure
-   */
-  export function getAuthToken(authTokenRequest?: AuthTokenRequest): void;
-  export function getAuthToken(authTokenRequest?: AuthTokenRequest): Promise<string> {
-    ensureInitializeCalled();
-    const apiVersionTag =
-      authTokenRequest && (authTokenRequest.successCallback || authTokenRequest.failureCallback)
-        ? getApiVersionTag(authenticationTelemetryVersionNumber_v1, ApiName.Authentication_GetAuthToken)
-        : getApiVersionTag(authenticationTelemetryVersionNumber_v2, ApiName.Authentication_GetAuthToken);
-    return getAuthTokenHelper(apiVersionTag, authTokenRequest)
-      .then((value: string) => {
-        if (authTokenRequest && authTokenRequest.successCallback) {
-          authTokenRequest.successCallback(value);
+  ensureInitialized(
+    runtime,
+    FrameContexts.content,
+    FrameContexts.sidePanel,
+    FrameContexts.settings,
+    FrameContexts.remove,
+    FrameContexts.task,
+    FrameContexts.stage,
+    FrameContexts.meetingStage,
+  );
+  const apiVersionTag =
+    authenticateParams.successCallback || authenticateParams.failureCallback
+      ? getApiVersionTag(authenticationTelemetryVersionNumber_v1, ApiName.Authentication_Authenticate)
+      : getApiVersionTag(authenticationTelemetryVersionNumber_v2, ApiName.Authentication_Authenticate);
+  return authenticateHelper(apiVersionTag, authenticateParams)
+    .then((value: string) => {
+      try {
+        if (authenticateParams && authenticateParams.successCallback) {
+          authenticateParams.successCallback(value);
           return '';
         }
         return value;
-      })
-      .catch((err: Error) => {
-        if (authTokenRequest && authTokenRequest.failureCallback) {
-          authTokenRequest.failureCallback(err.message);
+      } finally {
+        if (!isDifferentParamsInCall) {
+          authParams = undefined;
+        }
+      }
+    })
+    .catch((err: Error) => {
+      try {
+        if (authenticateParams && authenticateParams.failureCallback) {
+          authenticateParams.failureCallback(err.message);
           return '';
         }
         throw err;
-      });
-  }
+      } finally {
+        if (!isDifferentParamsInCall) {
+          authParams = undefined;
+        }
+      }
+    });
+}
 
-  function getAuthTokenHelper(apiVersionTag: string, authTokenRequest?: AuthTokenRequest): Promise<string> {
-    return new Promise<[boolean, string]>((resolve) => {
+function authenticateHelper(apiVersionTag: string, authenticateParameters: AuthenticateParameters): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    if (GlobalVars.hostClientType !== HostClientType.web) {
+      // Convert any relative URLs into absolute URLs before sending them over to the parent window.
+      const fullyQualifiedURL: URL = fullyQualifyUrlString(authenticateParameters.url);
+      validateUrl(fullyQualifiedURL);
+
+      // Ask the parent window to open an authentication window with the parameters provided by the caller.
       resolve(
-        sendMessageToParentAsync(apiVersionTag, 'authentication.getAuthToken', [
-          authTokenRequest?.resources,
-          authTokenRequest?.claims,
-          authTokenRequest?.silent,
-          authTokenRequest?.tenantId,
-        ]),
+        sendMessageToParentAsync<[boolean, string]>(apiVersionTag, 'authentication.authenticate', [
+          fullyQualifiedURL.href,
+          authenticateParameters.width,
+          authenticateParameters.height,
+          authenticateParameters.isExternal,
+        ]).then(([success, response]: [boolean, string]) => {
+          if (success) {
+            return response;
+          } else {
+            throw new Error(response);
+          }
+        }),
       );
-    }).then(([success, result]: [boolean, string]) => {
-      if (success) {
-        return result;
-      } else {
-        throw new Error(result);
-      }
-    });
-  }
-
-  /**
-   * @hidden
-   * Requests the decoded Microsoft Entra user identity on behalf of the app.
-   *
-   * @returns Promise that resolves with the {@link UserProfile}.
-   *
-   * @throws `Error` object in case of any problems, the most likely of which is that the calling app does not have appropriate permissions
-   * to call this method.
-   *
-   * @internal
-   * Limited to Microsoft-internal use
-   */
-  export function getUser(): Promise<UserProfile>;
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link authentication.getUser authentication.getUser(): Promise\<UserProfile\>} instead.
-   *
-   * @hidden
-   * Requests the decoded Microsoft Entra user identity on behalf of the app.
-   *
-   * @param userRequest - It passes success/failure callbacks in the userRequest object(deprecated)
-   *
-   * @throws `Error` object in case of any problems, the most likely of which is that the calling app does not have appropriate permissions
-   * to call this method.
-   *
-   * @internal
-   * Limited to Microsoft-internal use
-   */
-  export function getUser(userRequest: UserRequest): void;
-  export function getUser(userRequest?: UserRequest): Promise<UserProfile | null> {
-    ensureInitializeCalled();
-    const apiVersionTag =
-      userRequest && (userRequest.successCallback || userRequest.failureCallback)
-        ? getApiVersionTag(authenticationTelemetryVersionNumber_v1, ApiName.Authentication_GetUser)
-        : getApiVersionTag(authenticationTelemetryVersionNumber_v2, ApiName.Authentication_GetUser);
-    return getUserHelper(apiVersionTag)
-      .then((value: UserProfile) => {
-        if (userRequest && userRequest.successCallback) {
-          userRequest.successCallback(value);
-          return null;
-        }
-        return value;
-      })
-      .catch((err: SdkError) => {
-        const errorMessage = `Error returned, code = ${err.errorCode}, message = ${err.message}`;
-        if (userRequest && userRequest.failureCallback) {
-          userRequest.failureCallback(errorMessage);
-          return null;
-        }
-        throw new Error(errorMessage);
-      });
-  }
-
-  function getUserHelper(apiVersionTag: string): Promise<UserProfile> {
-    return new Promise<[boolean, UserProfile | SdkError]>((resolve) => {
-      resolve(sendMessageToParentAsync(apiVersionTag, 'authentication.getUser'));
-    }).then(([success, result]: [boolean, UserProfile | SdkError]) => {
-      if (success) {
-        return result as UserProfile;
-      } else {
-        throw result;
-      }
-    });
-  }
-
-  function closeAuthenticationWindow(): void {
-    // Stop monitoring the authentication window
-    stopAuthenticationWindowMonitor();
-    // Try to close the authentication window and clear all properties associated with it
-    try {
-      if (Communication.childWindow) {
-        Communication.childWindow.close();
-      }
-    } finally {
-      Communication.childWindow = null;
-      Communication.childOrigin = null;
-    }
-  }
-
-  /**
-   * Different browsers handle authentication flows in pop-up windows differently.
-   * Firefox and Safari, which use Quantum and WebKit browser engines respectively, block the use of 'window.open' for pop-up windows.
-   * Any chrome-based browser (Chrome, Edge, Brave, etc.) opens a new browser window without any user-prompts.
-   * To ensure consistent behavior across all browsers, consider using the following function to create a new authentication window.
-   *
-   * @param authenticateParameters - Parameters describing the authentication window used for executing the authentication flow.
-   */
-  function openAuthenticationWindow(authenticateParameters: AuthenticateParameters): void {
-    // Close the previously opened window if we have one
-    closeAuthenticationWindow();
-    // Start with a sensible default size
-    let width = authenticateParameters.width || 600;
-    let height = authenticateParameters.height || 400;
-    // Ensure that the new window is always smaller than our app's window so that it never fully covers up our app
-    width = Math.min(width, Communication.currentWindow.outerWidth - 400);
-    height = Math.min(height, Communication.currentWindow.outerHeight - 200);
-
-    // Convert any relative URLs into absolute URLs before sending them over to the parent window
-    const fullyQualifiedURL = fullyQualifyUrlString(authenticateParameters.url.replace('{oauthRedirectMethod}', 'web'));
-    validateUrl(fullyQualifiedURL);
-
-    // We are running in the browser, so we need to center the new window ourselves
-    let left: number =
-      typeof Communication.currentWindow.screenLeft !== 'undefined'
-        ? Communication.currentWindow.screenLeft
-        : Communication.currentWindow.screenX;
-    let top: number =
-      typeof Communication.currentWindow.screenTop !== 'undefined'
-        ? Communication.currentWindow.screenTop
-        : Communication.currentWindow.screenY;
-    left += Communication.currentWindow.outerWidth / 2 - width / 2;
-    top += Communication.currentWindow.outerHeight / 2 - height / 2;
-    // Open a child window with a desired set of standard browser features
-    Communication.childWindow = Communication.currentWindow.open(
-      fullyQualifiedURL.href,
-      '_blank',
-      'toolbar=no, location=yes, status=no, menubar=no, scrollbars=yes, top=' +
-        top +
-        ', left=' +
-        left +
-        ', width=' +
-        width +
-        ', height=' +
-        height,
-    );
-    if (Communication.childWindow) {
-      // Start monitoring the authentication window so that we can detect if it gets closed before the flow completes
-      startAuthenticationWindowMonitor();
     } else {
-      // If we failed to open the window, fail the authentication flow
-      handleFailure('FailedToOpenWindow');
+      // Open an authentication window with the parameters provided by the caller.
+      authHandlers = {
+        success: resolve,
+        fail: reject,
+      };
+      openAuthenticationWindow(authenticateParameters);
     }
-  }
+  });
+}
 
-  function stopAuthenticationWindowMonitor(): void {
-    if (authWindowMonitor) {
-      clearInterval(authWindowMonitor);
-      authWindowMonitor = 0;
-    }
-    removeHandler('initialize');
-    removeHandler('navigateCrossDomain');
-  }
-
-  function startAuthenticationWindowMonitor(): void {
-    // Stop the previous window monitor if one is running
-    stopAuthenticationWindowMonitor();
-    // Create an interval loop that
-    // - Notifies the caller of failure if it detects that the authentication window is closed
-    // - Keeps pinging the authentication window while it is open to re-establish
-    //   contact with any pages along the authentication flow that need to communicate
-    //   with us
-    authWindowMonitor = Communication.currentWindow.setInterval(() => {
-      if (!Communication.childWindow || Communication.childWindow.closed) {
-        handleFailure('CancelledByUser');
-      } else {
-        const savedChildOrigin = Communication.childOrigin;
-        try {
-          Communication.childOrigin = '*';
-          sendMessageEventToChild('ping');
-        } finally {
-          Communication.childOrigin = savedChildOrigin;
-        }
+/**
+ * Requests an Microsoft Entra token to be issued on behalf of your app in an SSO flow.
+ * The token is acquired from the cache if it is not expired. Otherwise a request is sent to Microsoft Entra to
+ * obtain a new token.
+ * This function is used to enable SSO scenarios. See [Enable SSO for tab apps](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/tab-sso-overview)
+ * for more details.
+ *
+ * @param authTokenRequest - An optional set of values that configure the token request.
+ *
+ * @returns `Promise` that will be resolved with the token, if successful.
+ *
+ * @throws `Error` if the request fails in some way
+ */
+export function getAuthToken(authTokenRequest?: AuthTokenRequestParameters): Promise<string>;
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link authentication.getAuthToken authentication.getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise\<string\>} instead.
+ *
+ * The documentation {@link authentication.getAuthToken authentication.getAuthToken(authTokenRequest: AuthTokenRequestParameters): Promise\<string\>} applies to this
+ * function as well. The one difference when using this function is that the result is provided in the callbacks in the `authTokenRequest` parameter
+ * instead of as a `Promise`.
+ *
+ * @param authTokenRequest - An optional set of values that configure the token request.
+ * It contains callbacks to call in case of success/failure
+ */
+export function getAuthToken(authTokenRequest?: AuthTokenRequest): void;
+export function getAuthToken(authTokenRequest?: AuthTokenRequest): Promise<string> {
+  ensureInitializeCalled();
+  const apiVersionTag =
+    authTokenRequest && (authTokenRequest.successCallback || authTokenRequest.failureCallback)
+      ? getApiVersionTag(authenticationTelemetryVersionNumber_v1, ApiName.Authentication_GetAuthToken)
+      : getApiVersionTag(authenticationTelemetryVersionNumber_v2, ApiName.Authentication_GetAuthToken);
+  return getAuthTokenHelper(apiVersionTag, authTokenRequest)
+    .then((value: string) => {
+      if (authTokenRequest && authTokenRequest.successCallback) {
+        authTokenRequest.successCallback(value);
+        return '';
       }
-    }, 100);
-    // Set up an initialize-message handler that gives the authentication window its frame context
-    registerHandler(
-      getApiVersionTag(
-        authenticationTelemetryVersionNumber_v1,
-        ApiName.Authentication_AuthenticationWindow_RegisterInitializeHandler,
-      ),
-      'initialize',
-      () => {
-        return [FrameContexts.authentication, GlobalVars.hostClientType];
-      },
-    );
-    // Set up a navigateCrossDomain message handler that blocks cross-domain re-navigation attempts
-    // in the authentication window. We could at some point choose to implement this method via a call to
-    // authenticationWindow.location.href = url; however, we would first need to figure out how to
-    // validate the URL against the tab's list of valid domains.
-    registerHandler(
-      getApiVersionTag(
-        authenticationTelemetryVersionNumber_v1,
-        ApiName.Authentication_AuthenticationWindow_RegisterNavigateCrossDomainHandler,
-      ),
-      'navigateCrossDomain',
-      () => {
-        return false;
-      },
-    );
-  }
+      return value;
+    })
+    .catch((err: Error) => {
+      if (authTokenRequest && authTokenRequest.failureCallback) {
+        authTokenRequest.failureCallback(err.message);
+        return '';
+      }
+      throw err;
+    });
+}
 
-  /**
-   * When using {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>}, the
-   * window that was opened to execute the authentication flow should call this method after authentiction to notify the caller of
-   * {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} that the
-   * authentication request was successful.
-   *
-   * @remarks
-   * This function is usable only from the authentication window.
-   * This call causes the authentication window to be closed.
-   *
-   * @param result - Specifies a result for the authentication. If specified, the frame that initiated the authentication pop-up receives
-   * this value in its callback or via the `Promise` return value
-   */
-  export function notifySuccess(result?: string): void;
-  /**
-   * @deprecated
-   * This function used to have an unused optional second parameter called callbackUrl. Because it was not used, it has been removed.
-   * Please use the {@link authentication.notifySuccess authentication.notifySuccess(result?: string): void} instead.
-   */
-  export function notifySuccess(result?: string, _callbackUrl?: string): void {
-    ensureInitialized(runtime, FrameContexts.authentication);
-    const apiVersionTag = _callbackUrl
-      ? getApiVersionTag(authenticationTelemetryVersionNumber_v1, ApiName.Authentication_NotifySuccess)
-      : getApiVersionTag(authenticationTelemetryVersionNumber_v2, ApiName.Authentication_NotifySuccess);
-    sendMessageToParent(apiVersionTag, 'authentication.authenticate.success', [result]);
-    // Wait for the message to be sent before closing the window
-    waitForMessageQueue(Communication.parentWindow, () => setTimeout(() => Communication.currentWindow.close(), 200));
-  }
+function getAuthTokenHelper(apiVersionTag: string, authTokenRequest?: AuthTokenRequest): Promise<string> {
+  return new Promise<[boolean, string]>((resolve) => {
+    resolve(
+      sendMessageToParentAsync(apiVersionTag, 'authentication.getAuthToken', [
+        authTokenRequest?.resources,
+        authTokenRequest?.claims,
+        authTokenRequest?.silent,
+        authTokenRequest?.tenantId,
+      ]),
+    );
+  }).then(([success, result]: [boolean, string]) => {
+    if (success) {
+      return result;
+    } else {
+      throw new Error(result);
+    }
+  });
+}
 
-  /**
+/**
+ * @hidden
+ * Requests the decoded Microsoft Entra user identity on behalf of the app.
+ *
+ * @returns Promise that resolves with the {@link UserProfile}.
+ *
+ * @throws `Error` object in case of any problems, the most likely of which is that the calling app does not have appropriate permissions
+ * to call this method.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function getUser(): Promise<UserProfile>;
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link authentication.getUser authentication.getUser(): Promise\<UserProfile\>} instead.
+ *
+ * @hidden
+ * Requests the decoded Microsoft Entra user identity on behalf of the app.
+ *
+ * @param userRequest - It passes success/failure callbacks in the userRequest object(deprecated)
+ *
+ * @throws `Error` object in case of any problems, the most likely of which is that the calling app does not have appropriate permissions
+ * to call this method.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function getUser(userRequest: UserRequest): void;
+export function getUser(userRequest?: UserRequest): Promise<UserProfile | null> {
+  ensureInitializeCalled();
+  const apiVersionTag =
+    userRequest && (userRequest.successCallback || userRequest.failureCallback)
+      ? getApiVersionTag(authenticationTelemetryVersionNumber_v1, ApiName.Authentication_GetUser)
+      : getApiVersionTag(authenticationTelemetryVersionNumber_v2, ApiName.Authentication_GetUser);
+  return getUserHelper(apiVersionTag)
+    .then((value: UserProfile) => {
+      if (userRequest && userRequest.successCallback) {
+        userRequest.successCallback(value);
+        return null;
+      }
+      return value;
+    })
+    .catch((err: SdkError) => {
+      const errorMessage = `Error returned, code = ${err.errorCode}, message = ${err.message}`;
+      if (userRequest && userRequest.failureCallback) {
+        userRequest.failureCallback(errorMessage);
+        return null;
+      }
+      throw new Error(errorMessage);
+    });
+}
+
+function getUserHelper(apiVersionTag: string): Promise<UserProfile> {
+  return new Promise<[boolean, UserProfile | SdkError]>((resolve) => {
+    resolve(sendMessageToParentAsync(apiVersionTag, 'authentication.getUser'));
+  }).then(([success, result]: [boolean, UserProfile | SdkError]) => {
+    if (success) {
+      return result as UserProfile;
+    } else {
+      throw result;
+    }
+  });
+}
+
+function closeAuthenticationWindow(): void {
+  // Stop monitoring the authentication window
+  stopAuthenticationWindowMonitor();
+  // Try to close the authentication window and clear all properties associated with it
+  try {
+    if (Communication.childWindow) {
+      Communication.childWindow.close();
+    }
+  } finally {
+    Communication.childWindow = null;
+    Communication.childOrigin = null;
+  }
+}
+
+/**
+ * Different browsers handle authentication flows in pop-up windows differently.
+ * Firefox and Safari, which use Quantum and WebKit browser engines respectively, block the use of 'window.open' for pop-up windows.
+ * Any chrome-based browser (Chrome, Edge, Brave, etc.) opens a new browser window without any user-prompts.
+ * To ensure consistent behavior across all browsers, consider using the following function to create a new authentication window.
+ *
+ * @param authenticateParameters - Parameters describing the authentication window used for executing the authentication flow.
+ */
+function openAuthenticationWindow(authenticateParameters: AuthenticateParameters): void {
+  // Close the previously opened window if we have one
+  closeAuthenticationWindow();
+  // Start with a sensible default size
+  let width = authenticateParameters.width || 600;
+  let height = authenticateParameters.height || 400;
+  // Ensure that the new window is always smaller than our app's window so that it never fully covers up our app
+  width = Math.min(width, Communication.currentWindow.outerWidth - 400);
+  height = Math.min(height, Communication.currentWindow.outerHeight - 200);
+
+  // Convert any relative URLs into absolute URLs before sending them over to the parent window
+  const fullyQualifiedURL = fullyQualifyUrlString(authenticateParameters.url.replace('{oauthRedirectMethod}', 'web'));
+  validateUrl(fullyQualifiedURL);
+
+  // We are running in the browser, so we need to center the new window ourselves
+  let left: number =
+    typeof Communication.currentWindow.screenLeft !== 'undefined'
+      ? Communication.currentWindow.screenLeft
+      : Communication.currentWindow.screenX;
+  let top: number =
+    typeof Communication.currentWindow.screenTop !== 'undefined'
+      ? Communication.currentWindow.screenTop
+      : Communication.currentWindow.screenY;
+  left += Communication.currentWindow.outerWidth / 2 - width / 2;
+  top += Communication.currentWindow.outerHeight / 2 - height / 2;
+  // Open a child window with a desired set of standard browser features
+  Communication.childWindow = Communication.currentWindow.open(
+    fullyQualifiedURL.href,
+    '_blank',
+    'toolbar=no, location=yes, status=no, menubar=no, scrollbars=yes, top=' +
+      top +
+      ', left=' +
+      left +
+      ', width=' +
+      width +
+      ', height=' +
+      height,
+  );
+  if (Communication.childWindow) {
+    // Start monitoring the authentication window so that we can detect if it gets closed before the flow completes
+    startAuthenticationWindowMonitor();
+  } else {
+    // If we failed to open the window, fail the authentication flow
+    handleFailure('FailedToOpenWindow');
+  }
+}
+
+function stopAuthenticationWindowMonitor(): void {
+  if (authWindowMonitor) {
+    clearInterval(authWindowMonitor);
+    authWindowMonitor = 0;
+  }
+  removeHandler('initialize');
+  removeHandler('navigateCrossDomain');
+}
+
+function startAuthenticationWindowMonitor(): void {
+  // Stop the previous window monitor if one is running
+  stopAuthenticationWindowMonitor();
+  // Create an interval loop that
+  // - Notifies the caller of failure if it detects that the authentication window is closed
+  // - Keeps pinging the authentication window while it is open to re-establish
+  //   contact with any pages along the authentication flow that need to communicate
+  //   with us
+  authWindowMonitor = Communication.currentWindow.setInterval(() => {
+    if (!Communication.childWindow || Communication.childWindow.closed) {
+      handleFailure('CancelledByUser');
+    } else {
+      const savedChildOrigin = Communication.childOrigin;
+      try {
+        Communication.childOrigin = '*';
+        sendMessageEventToChild('ping');
+      } finally {
+        Communication.childOrigin = savedChildOrigin;
+      }
+    }
+  }, 100);
+  // Set up an initialize-message handler that gives the authentication window its frame context
+  registerHandler(
+    getApiVersionTag(
+      authenticationTelemetryVersionNumber_v1,
+      ApiName.Authentication_AuthenticationWindow_RegisterInitializeHandler,
+    ),
+    'initialize',
+    () => {
+      return [FrameContexts.authentication, GlobalVars.hostClientType];
+    },
+  );
+  // Set up a navigateCrossDomain message handler that blocks cross-domain re-navigation attempts
+  // in the authentication window. We could at some point choose to implement this method via a call to
+  // authenticationWindow.location.href = url; however, we would first need to figure out how to
+  // validate the URL against the tab's list of valid domains.
+  registerHandler(
+    getApiVersionTag(
+      authenticationTelemetryVersionNumber_v1,
+      ApiName.Authentication_AuthenticationWindow_RegisterNavigateCrossDomainHandler,
+    ),
+    'navigateCrossDomain',
+    () => {
+      return false;
+    },
+  );
+}
+
+/**
+ * When using {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>}, the
+ * window that was opened to execute the authentication flow should call this method after authentiction to notify the caller of
+ * {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} that the
+ * authentication request was successful.
+ *
+ * @remarks
+ * This function is usable only from the authentication window.
+ * This call causes the authentication window to be closed.
+ *
+ * @param result - Specifies a result for the authentication. If specified, the frame that initiated the authentication pop-up receives
+ * this value in its callback or via the `Promise` return value
+ */
+export function notifySuccess(result?: string): void;
+/**
+ * @deprecated
+ * This function used to have an unused optional second parameter called callbackUrl. Because it was not used, it has been removed.
+ * Please use the {@link authentication.notifySuccess authentication.notifySuccess(result?: string): void} instead.
+ */
+export function notifySuccess(result?: string, _callbackUrl?: string): void {
+  ensureInitialized(runtime, FrameContexts.authentication);
+  const apiVersionTag = _callbackUrl
+    ? getApiVersionTag(authenticationTelemetryVersionNumber_v1, ApiName.Authentication_NotifySuccess)
+    : getApiVersionTag(authenticationTelemetryVersionNumber_v2, ApiName.Authentication_NotifySuccess);
+  sendMessageToParent(apiVersionTag, 'authentication.authenticate.success', [result]);
+  // Wait for the message to be sent before closing the window
+  waitForMessageQueue(Communication.parentWindow, () => setTimeout(() => Communication.currentWindow.close(), 200));
+}
+
+/**
    * When using {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>}, the
    * window that was opened to execute the authentication flow should call this method after authentiction to notify the caller of
    * {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} that the
@@ -496,320 +495,319 @@ export namespace authentication {
    * this value in its callback or via the `Promise` return value
    * @param _callbackUrl - This parameter is deprecated and unused
    */
-  export function notifyFailure(result?: string): void;
-  /**
-   * @deprecated
-   * This function used to have an unused optional second parameter called callbackUrl. Because it was not used, it has been removed.
-   * Please use the {@link authentication.notifyFailure authentication.notifyFailure(result?: string): void} instead.
-   */
-  export function notifyFailure(reason?: string, _callbackUrl?: string): void {
-    ensureInitialized(runtime, FrameContexts.authentication);
-    const apiVersionTag = _callbackUrl
-      ? getApiVersionTag(authenticationTelemetryVersionNumber_v1, ApiName.Authentication_NotifyFailure)
-      : getApiVersionTag(authenticationTelemetryVersionNumber_v2, ApiName.Authentication_NotifyFailure);
-    sendMessageToParent(apiVersionTag, 'authentication.authenticate.failure', [reason]);
-    // Wait for the message to be sent before closing the window
-    waitForMessageQueue(Communication.parentWindow, () => setTimeout(() => Communication.currentWindow.close(), 200));
-  }
+export function notifyFailure(result?: string): void;
+/**
+ * @deprecated
+ * This function used to have an unused optional second parameter called callbackUrl. Because it was not used, it has been removed.
+ * Please use the {@link authentication.notifyFailure authentication.notifyFailure(result?: string): void} instead.
+ */
+export function notifyFailure(reason?: string, _callbackUrl?: string): void {
+  ensureInitialized(runtime, FrameContexts.authentication);
+  const apiVersionTag = _callbackUrl
+    ? getApiVersionTag(authenticationTelemetryVersionNumber_v1, ApiName.Authentication_NotifyFailure)
+    : getApiVersionTag(authenticationTelemetryVersionNumber_v2, ApiName.Authentication_NotifyFailure);
+  sendMessageToParent(apiVersionTag, 'authentication.authenticate.failure', [reason]);
+  // Wait for the message to be sent before closing the window
+  waitForMessageQueue(Communication.parentWindow, () => setTimeout(() => Communication.currentWindow.close(), 200));
+}
 
-  function handleSuccess(result?: string): void {
-    try {
-      if (authHandlers) {
-        authHandlers.success(result);
-      }
-    } finally {
-      authHandlers = undefined;
-      closeAuthenticationWindow();
+function handleSuccess(result?: string): void {
+  try {
+    if (authHandlers) {
+      authHandlers.success(result);
     }
+  } finally {
+    authHandlers = undefined;
+    closeAuthenticationWindow();
   }
+}
 
-  function handleFailure(reason?: string): void {
-    try {
-      if (authHandlers) {
-        authHandlers.fail(new Error(reason));
-      }
-    } finally {
-      authHandlers = undefined;
-      closeAuthenticationWindow();
+function handleFailure(reason?: string): void {
+  try {
+    if (authHandlers) {
+      authHandlers.fail(new Error(reason));
     }
+  } finally {
+    authHandlers = undefined;
+    closeAuthenticationWindow();
   }
+}
 
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, this interface has been deprecated in favor of leveraging the `Promise` returned from {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>}
+ *-------------------------
+ * Used in {@link AuthenticateParameters} and {@link AuthTokenRequest}
+ */
+export interface LegacyCallBacks {
   /**
    * @deprecated
-   * As of TeamsJS v2.0.0, this interface has been deprecated in favor of leveraging the `Promise` returned from {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>}
-   *-------------------------
-   * Used in {@link AuthenticateParameters} and {@link AuthTokenRequest}
-   */
-  export interface LegacyCallBacks {
-    /**
-     * @deprecated
-     * As of TeamsJS v2.0.0, this property has been deprecated in favor of a Promise-based pattern.
-     *
-     * A function that is called if the request succeeds.
-     */
-    successCallback?: (result: string) => void;
-    /**
-     * @deprecated
-     * As of TeamsJS v2.0.0, this property has been deprecated in favor of a Promise-based pattern.
-     *
-     * A function that is called if the request fails, with the reason for the failure.
-     */
-    failureCallback?: (reason: string) => void;
-  }
-
-  /**
-   * Describes the authentication pop-up parameters
-   */
-  export interface AuthenticatePopUpParameters {
-    /**
-     * The URL for the authentication pop-up.
-     */
-    url: string;
-    /**
-     * The preferred width for the pop-up. This value can be ignored if outside the acceptable bounds.
-     */
-    width?: number;
-    /**
-     * The preferred height for the pop-up. This value can be ignored if outside the acceptable bounds.
-     */
-    height?: number;
-    /**
-     * Some identity providers restrict their authentication pages from being displayed in embedded browsers (e.g., a web view inside of a native application)
-     * If the identity provider you are using prevents embedded browser usage, this flag should be set to `true` to enable the authentication page specified in
-     * the {@link url} property to be opened in an external browser.
-     * If this flag is `false`, the page will be opened directly within the current hosting application.
-     *
-     * This flag is ignored when the host for the application is a web app (as opposed to a native application) as the behavior is unnecessary in a web-only
-     * environment without an embedded browser.
-     */
-    isExternal?: boolean;
-  }
-
-  /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} and
-   * the associated {@link AuthenticatePopUpParameters} instead.
+   * As of TeamsJS v2.0.0, this property has been deprecated in favor of a Promise-based pattern.
    *
-   * @see {@link LegacyCallBacks}
+   * A function that is called if the request succeeds.
    */
-  export type AuthenticateParameters = AuthenticatePopUpParameters & LegacyCallBacks;
-
-  /**
-   * Describes authentication token request parameters
-   */
-  export interface AuthTokenRequestParameters {
-    /**
-     * @hidden
-     * @internal
-     * An list of resources for which to acquire the access token; only for internal Microsoft usage
-     */
-    resources?: string[];
-    /**
-     * An optional list of claims which to pass to Microsoft Entra when requesting the access token.
-     */
-    claims?: string[];
-    /**
-     * An optional flag indicating whether to attempt the token acquisition silently or allow a prompt to be shown.
-     */
-    silent?: boolean;
-    /**
-     * An optional identifier of the home tenant for which to acquire the access token for (used in cross-tenant shared channels).
-     */
-    tenantId?: string;
-  }
-
+  successCallback?: (result: string) => void;
   /**
    * @deprecated
-   * As of TeamsJS v2.0.0, please use {@link AuthTokenRequestParameters} instead.
+   * As of TeamsJS v2.0.0, this property has been deprecated in favor of a Promise-based pattern.
+   *
+   * A function that is called if the request fails, with the reason for the failure.
    */
-  export type AuthTokenRequest = AuthTokenRequestParameters & LegacyCallBacks;
+  failureCallback?: (reason: string) => void;
+}
 
+/**
+ * Describes the authentication pop-up parameters
+ */
+export interface AuthenticatePopUpParameters {
+  /**
+   * The URL for the authentication pop-up.
+   */
+  url: string;
+  /**
+   * The preferred width for the pop-up. This value can be ignored if outside the acceptable bounds.
+   */
+  width?: number;
+  /**
+   * The preferred height for the pop-up. This value can be ignored if outside the acceptable bounds.
+   */
+  height?: number;
+  /**
+   * Some identity providers restrict their authentication pages from being displayed in embedded browsers (e.g., a web view inside of a native application)
+   * If the identity provider you are using prevents embedded browser usage, this flag should be set to `true` to enable the authentication page specified in
+   * the {@link url} property to be opened in an external browser.
+   * If this flag is `false`, the page will be opened directly within the current hosting application.
+   *
+   * This flag is ignored when the host for the application is a web app (as opposed to a native application) as the behavior is unnecessary in a web-only
+   * environment without an embedded browser.
+   */
+  isExternal?: boolean;
+}
+
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} and
+ * the associated {@link AuthenticatePopUpParameters} instead.
+ *
+ * @see {@link LegacyCallBacks}
+ */
+export type AuthenticateParameters = AuthenticatePopUpParameters & LegacyCallBacks;
+
+/**
+ * Describes authentication token request parameters
+ */
+export interface AuthTokenRequestParameters {
   /**
    * @hidden
-   *
    * @internal
-   * Limited to Microsoft-internal use
+   * An list of resources for which to acquire the access token; only for internal Microsoft usage
    */
-  export interface UserProfile {
-    /**
-     * @hidden
-     * The intended recipient of the token. The application that receives the token must verify that the audience
-     * value is correct and reject any tokens intended for a different audience.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    aud: string;
-    /**
-     * @hidden
-     * Identifies how the subject of the token was authenticated.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    amr: string[];
-    /**
-     * @hidden
-     * Stores the time at which the token was issued. It is often used to measure token freshness.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    iat: number;
-    /**
-     * @hidden
-     * Identifies the security token service (STS) that constructs and returns the token. In the tokens that Microsoft Entra
-     * returns, the issuer is sts.windows.net. The GUID in the issuer claim value is the tenant ID of the Microsoft Entra
-     * directory. The tenant ID is an immutable and reliable identifier of the directory.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    iss: string;
-    /**
-     * @hidden
-     * Provides the last name, surname, or family name of the user as defined in the Microsoft Entra user object.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    family_name: string;
-    /**
-     * @hidden
-     * Provides the first or "given" name of the user, as set on the Microsoft Entra user object.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    given_name: string;
-    /**
-     * @hidden
-     * Provides a human-readable value that identifies the subject of the token. This value is not guaranteed to
-     * be unique within a tenant and is designed to be used only for display purposes.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    unique_name: string;
-    /**
-     * @hidden
-     * Contains a unique identifier of an object in Microsoft Entra. This value is immutable and cannot be reassigned or
-     * reused. Use the object ID to identify an object in queries to Microsoft Entra.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    oid: string;
-    /**
-     * @hidden
-     * Identifies the principal about which the token asserts information, such as the user of an application.
-     * This value is immutable and cannot be reassigned or reused, so it can be used to perform authorization
-     * checks safely. Because the subject is always present in the tokens the Microsoft Entra issues, we recommended
-     * using this value in a general-purpose authorization system.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    sub: string;
-    /**
-     * @hidden
-     * An immutable, non-reusable identifier that identifies the directory tenant that issued the token. You can
-     * use this value to access tenant-specific directory resources in a multitenant application. For example,
-     * you can use this value to identify the tenant in a call to the Graph API.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    tid: string;
-    /**
-     * @hidden
-     * Defines the end of the time interval within which a token is valid. The service that validates the token
-     * should verify that the current date is within the token lifetime; otherwise it should reject the token. The
-     * service might allow for up to five minutes beyond the token lifetime to account for any differences in clock
-     * time ("time skew") between Microsoft Entra and the service.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    exp: number;
-    /**
-     * @hidden
-     * Defines the start of the time interval within which a token is valid. The service that validates the token
-     * should verify that the current date is within the token lifetime; otherwise it should reject the token. The
-     * service might allow for up to five minutes beyond the token lifetime to account for any differences in clock
-     * time ("time skew") between Microsoft Entra and the service.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    nbf: number;
-    /**
-     * @hidden
-     * Stores the user name of the user principal.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    upn: string;
-    /**
-     * @hidden
-     * Stores the version number of the token.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    ver: string;
-    /**
-     * @hidden
-     * Stores the data residency of the user.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    dataResidency?: DataResidency;
-  }
+  resources?: string[];
+  /**
+   * An optional list of claims which to pass to Microsoft Entra when requesting the access token.
+   */
+  claims?: string[];
+  /**
+   * An optional flag indicating whether to attempt the token acquisition silently or allow a prompt to be shown.
+   */
+  silent?: boolean;
+  /**
+   * An optional identifier of the home tenant for which to acquire the access token for (used in cross-tenant shared channels).
+   */
+  tenantId?: string;
+}
 
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link AuthTokenRequestParameters} instead.
+ */
+export type AuthTokenRequest = AuthTokenRequestParameters & LegacyCallBacks;
+
+/**
+ * @hidden
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export interface UserProfile {
   /**
    * @hidden
-   * Limited set of data residencies information exposed to 1P application developers
+   * The intended recipient of the token. The application that receives the token must verify that the audience
+   * value is correct and reject any tokens intended for a different audience.
    *
    * @internal
    * Limited to Microsoft-internal use
    */
-  export enum DataResidency {
-    /**
-     * Public
-     */
-    Public = 'public',
-
-    /**
-     * European Union Data Boundary
-     */
-    EUDB = 'eudb',
-
-    /**
-     * Other, stored to cover fields that will not be exposed
-     */
-    Other = 'other',
-  }
-
+  aud: string;
   /**
-   * @deprecated
-   * As of TeamsJS v2.0.0, this interface has been deprecated in favor of a Promise-based pattern.
    * @hidden
-   * Describes the UserRequest. Success callback describes how a successful request is handled.
-   * Failure callback describes how a failed request is handled.
+   * Identifies how the subject of the token was authenticated.
+   *
    * @internal
    * Limited to Microsoft-internal use
    */
-  export interface UserRequest {
-    /**
-     * A function that is called if the token request succeeds, with the resulting token.
-     */
-    successCallback?: (user: UserProfile) => void;
-    /**
-     * A function that is called if the token request fails, with the reason for the failure.
-     */
-    failureCallback?: (reason: string) => void;
-  }
+  amr: string[];
+  /**
+   * @hidden
+   * Stores the time at which the token was issued. It is often used to measure token freshness.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  iat: number;
+  /**
+   * @hidden
+   * Identifies the security token service (STS) that constructs and returns the token. In the tokens that Microsoft Entra
+   * returns, the issuer is sts.windows.net. The GUID in the issuer claim value is the tenant ID of the Microsoft Entra
+   * directory. The tenant ID is an immutable and reliable identifier of the directory.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  iss: string;
+  /**
+   * @hidden
+   * Provides the last name, surname, or family name of the user as defined in the Microsoft Entra user object.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  family_name: string;
+  /**
+   * @hidden
+   * Provides the first or "given" name of the user, as set on the Microsoft Entra user object.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  given_name: string;
+  /**
+   * @hidden
+   * Provides a human-readable value that identifies the subject of the token. This value is not guaranteed to
+   * be unique within a tenant and is designed to be used only for display purposes.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  unique_name: string;
+  /**
+   * @hidden
+   * Contains a unique identifier of an object in Microsoft Entra. This value is immutable and cannot be reassigned or
+   * reused. Use the object ID to identify an object in queries to Microsoft Entra.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  oid: string;
+  /**
+   * @hidden
+   * Identifies the principal about which the token asserts information, such as the user of an application.
+   * This value is immutable and cannot be reassigned or reused, so it can be used to perform authorization
+   * checks safely. Because the subject is always present in the tokens the Microsoft Entra issues, we recommended
+   * using this value in a general-purpose authorization system.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  sub: string;
+  /**
+   * @hidden
+   * An immutable, non-reusable identifier that identifies the directory tenant that issued the token. You can
+   * use this value to access tenant-specific directory resources in a multitenant application. For example,
+   * you can use this value to identify the tenant in a call to the Graph API.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  tid: string;
+  /**
+   * @hidden
+   * Defines the end of the time interval within which a token is valid. The service that validates the token
+   * should verify that the current date is within the token lifetime; otherwise it should reject the token. The
+   * service might allow for up to five minutes beyond the token lifetime to account for any differences in clock
+   * time ("time skew") between Microsoft Entra and the service.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  exp: number;
+  /**
+   * @hidden
+   * Defines the start of the time interval within which a token is valid. The service that validates the token
+   * should verify that the current date is within the token lifetime; otherwise it should reject the token. The
+   * service might allow for up to five minutes beyond the token lifetime to account for any differences in clock
+   * time ("time skew") between Microsoft Entra and the service.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  nbf: number;
+  /**
+   * @hidden
+   * Stores the user name of the user principal.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  upn: string;
+  /**
+   * @hidden
+   * Stores the version number of the token.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  ver: string;
+  /**
+   * @hidden
+   * Stores the data residency of the user.
+   *
+   * @internal
+   * Limited to Microsoft-internal use
+   */
+  dataResidency?: DataResidency;
+}
+
+/**
+ * @hidden
+ * Limited set of data residencies information exposed to 1P application developers
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export enum DataResidency {
+  /**
+   * Public
+   */
+  Public = 'public',
+
+  /**
+   * European Union Data Boundary
+   */
+  EUDB = 'eudb',
+
+  /**
+   * Other, stored to cover fields that will not be exposed
+   */
+  Other = 'other',
+}
+
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, this interface has been deprecated in favor of a Promise-based pattern.
+ * @hidden
+ * Describes the UserRequest. Success callback describes how a successful request is handled.
+ * Failure callback describes how a failed request is handled.
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export interface UserRequest {
+  /**
+   * A function that is called if the token request succeeds, with the resulting token.
+   */
+  successCallback?: (user: UserProfile) => void;
+  /**
+   * A function that is called if the token request fails, with the reason for the failure.
+   */
+  failureCallback?: (reason: string) => void;
 }

--- a/packages/teams-js/src/public/barCode.ts
+++ b/packages/teams-js/src/public/barCode.ts
@@ -16,109 +16,107 @@ const barCodeTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
  *
  * @beta
  */
-export namespace barCode {
+/**
+ * Data structure to customize the barcode scanning experience in scanBarCode API.
+ * All properties in BarCodeConfig are optional and have default values in the platform
+ *
+ * @beta
+ */
+export interface BarCodeConfig {
   /**
-   * Data structure to customize the barcode scanning experience in scanBarCode API.
-   * All properties in BarCodeConfig are optional and have default values in the platform
-   *
-   * @beta
+   * Optional; designates the scan timeout interval in seconds.
+   * Default value is 30 seconds, max allowed value is 60 seconds.
    */
-  export interface BarCodeConfig {
-    /**
-     * Optional; designates the scan timeout interval in seconds.
-     * Default value is 30 seconds, max allowed value is 60 seconds.
-     */
-    timeOutIntervalInSec?: number;
-  }
+  timeOutIntervalInSec?: number;
+}
 
-  /**
-   * Scan Barcode or QRcode using camera
-   *
-   * @param barCodeConfig - input configuration to customize the barcode scanning experience
-   *
-   * @returns a scanned code
-   *
-   * @beta
-   */
-  export function scanBarCode(barCodeConfig: BarCodeConfig): Promise<string> {
-    return new Promise<string>((resolve) => {
-      ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
-      }
-      if (!validateScanBarCodeInput(barCodeConfig)) {
-        throw { errorCode: ErrorCode.INVALID_ARGUMENTS };
-      }
-
-      resolve(
-        sendAndHandleSdkError(
-          getApiVersionTag(barCodeTelemetryVersionNumber, ApiName.BarCode_ScanBarCode),
-          'media.scanBarCode',
-          barCodeConfig,
-        ),
-      );
-    });
-  }
-
-  /**
-   * Checks whether or not media has user permission
-   *
-   * @returns true if the user has granted the app permission to media information, false otherwise
-   *
-   * @beta
-   */
-  export function hasPermission(): Promise<boolean> {
+/**
+ * Scan Barcode or QRcode using camera
+ *
+ * @param barCodeConfig - input configuration to customize the barcode scanning experience
+ *
+ * @returns a scanned code
+ *
+ * @beta
+ */
+export function scanBarCode(barCodeConfig: BarCodeConfig): Promise<string> {
+  return new Promise<string>((resolve) => {
     ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
     if (!isSupported()) {
       throw errorNotSupportedOnPlatform;
     }
-    const permissions: DevicePermission = DevicePermission.Media;
-
-    return new Promise<boolean>((resolve) => {
-      resolve(
-        sendAndHandleSdkError(
-          getApiVersionTag(barCodeTelemetryVersionNumber, ApiName.BarCode_HasPermission),
-          'permissions.has',
-          permissions,
-        ),
-      );
-    });
-  }
-
-  /**
-   * Requests user permission for media
-   *
-   * @returns true if the user has granted the app permission to the media, false otherwise
-   *
-   * @beta
-   */
-  export function requestPermission(): Promise<boolean> {
-    ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
-    if (!isSupported()) {
-      throw errorNotSupportedOnPlatform;
+    if (!validateScanBarCodeInput(barCodeConfig)) {
+      throw { errorCode: ErrorCode.INVALID_ARGUMENTS };
     }
-    const permissions: DevicePermission = DevicePermission.Media;
 
-    return new Promise<boolean>((resolve) => {
-      resolve(
-        sendAndHandleSdkError(
-          getApiVersionTag(barCodeTelemetryVersionNumber, ApiName.BarCode_RequestPermission),
-          'permissions.request',
-          permissions,
-        ),
-      );
-    });
-  }
+    resolve(
+      sendAndHandleSdkError(
+        getApiVersionTag(barCodeTelemetryVersionNumber, ApiName.BarCode_ScanBarCode),
+        'media.scanBarCode',
+        barCodeConfig,
+      ),
+    );
+  });
+}
 
-  /**
-   * Checks if barCode capability is supported by the host
-   * @returns boolean to represent whether the barCode capability is supported
-   *
-   * @throws Error if {@linkcode app.initialize} has not successfully completed
-   *
-   * @beta
-   */
-  export function isSupported(): boolean {
-    return ensureInitialized(runtime) && runtime.supports.barCode && runtime.supports.permissions ? true : false;
+/**
+ * Checks whether or not media has user permission
+ *
+ * @returns true if the user has granted the app permission to media information, false otherwise
+ *
+ * @beta
+ */
+export function hasPermission(): Promise<boolean> {
+  ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+  if (!isSupported()) {
+    throw errorNotSupportedOnPlatform;
   }
+  const permissions: DevicePermission = DevicePermission.Media;
+
+  return new Promise<boolean>((resolve) => {
+    resolve(
+      sendAndHandleSdkError(
+        getApiVersionTag(barCodeTelemetryVersionNumber, ApiName.BarCode_HasPermission),
+        'permissions.has',
+        permissions,
+      ),
+    );
+  });
+}
+
+/**
+ * Requests user permission for media
+ *
+ * @returns true if the user has granted the app permission to the media, false otherwise
+ *
+ * @beta
+ */
+export function requestPermission(): Promise<boolean> {
+  ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+  if (!isSupported()) {
+    throw errorNotSupportedOnPlatform;
+  }
+  const permissions: DevicePermission = DevicePermission.Media;
+
+  return new Promise<boolean>((resolve) => {
+    resolve(
+      sendAndHandleSdkError(
+        getApiVersionTag(barCodeTelemetryVersionNumber, ApiName.BarCode_RequestPermission),
+        'permissions.request',
+        permissions,
+      ),
+    );
+  });
+}
+
+/**
+ * Checks if barCode capability is supported by the host
+ * @returns boolean to represent whether the barCode capability is supported
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
+ * @beta
+ */
+export function isSupported(): boolean {
+  return ensureInitialized(runtime) && runtime.supports.barCode && runtime.supports.permissions ? true : false;
 }

--- a/packages/teams-js/src/public/calendar.ts
+++ b/packages/teams-js/src/public/calendar.ts
@@ -13,93 +13,91 @@ const calendarTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 /**
  * Interact with the user's calendar, including opening calendar items and composing meetings.
  */
-export namespace calendar {
-  /**
-   * Opens a calendar item.
-   *
-   * @param openCalendarItemParams - object containing unique ID of the calendar item to be opened.
-   */
-  export function openCalendarItem(openCalendarItemParams: OpenCalendarItemParams): Promise<void> {
-    return new Promise<void>((resolve) => {
-      ensureInitialized(runtime, FrameContexts.content);
-      if (!isSupported()) {
-        throw new Error('Not supported');
-      }
+/**
+ * Opens a calendar item.
+ *
+ * @param openCalendarItemParams - object containing unique ID of the calendar item to be opened.
+ */
+export function openCalendarItem(openCalendarItemParams: OpenCalendarItemParams): Promise<void> {
+  return new Promise<void>((resolve) => {
+    ensureInitialized(runtime, FrameContexts.content);
+    if (!isSupported()) {
+      throw new Error('Not supported');
+    }
 
-      if (!openCalendarItemParams.itemId || !openCalendarItemParams.itemId.trim()) {
-        throw new Error('Must supply an itemId to openCalendarItem');
-      }
+    if (!openCalendarItemParams.itemId || !openCalendarItemParams.itemId.trim()) {
+      throw new Error('Must supply an itemId to openCalendarItem');
+    }
 
+    resolve(
+      sendAndHandleStatusAndReason(
+        getApiVersionTag(calendarTelemetryVersionNumber, ApiName.Calendar_OpenCalendarItem),
+        'calendar.openCalendarItem',
+        openCalendarItemParams,
+      ),
+    );
+  });
+}
+
+/**
+ * Compose a new meeting in the user's calendar.
+ *
+ * @param composeMeetingParams - object containing various properties to set up the meeting details.
+ */
+export function composeMeeting(composeMeetingParams: ComposeMeetingParams): Promise<void> {
+  return new Promise<void>((resolve) => {
+    ensureInitialized(runtime, FrameContexts.content);
+    if (!isSupported()) {
+      throw new Error('Not supported');
+    }
+    const apiVersionTag = getApiVersionTag(calendarTelemetryVersionNumber, ApiName.Calendar_ComposeMeeting);
+    if (runtime.isLegacyTeams) {
       resolve(
         sendAndHandleStatusAndReason(
-          getApiVersionTag(calendarTelemetryVersionNumber, ApiName.Calendar_OpenCalendarItem),
-          'calendar.openCalendarItem',
-          openCalendarItemParams,
+          apiVersionTag,
+          'executeDeepLink',
+          createTeamsDeepLinkForCalendar(
+            composeMeetingParams.attendees,
+            composeMeetingParams.startTime,
+            composeMeetingParams.endTime,
+            composeMeetingParams.subject,
+            composeMeetingParams.content,
+          ),
         ),
       );
-    });
-  }
+    } else {
+      resolve(sendAndHandleStatusAndReason(apiVersionTag, 'calendar.composeMeeting', composeMeetingParams));
+    }
+  });
+}
 
-  /**
-   * Compose a new meeting in the user's calendar.
-   *
-   * @param composeMeetingParams - object containing various properties to set up the meeting details.
-   */
-  export function composeMeeting(composeMeetingParams: ComposeMeetingParams): Promise<void> {
-    return new Promise<void>((resolve) => {
-      ensureInitialized(runtime, FrameContexts.content);
-      if (!isSupported()) {
-        throw new Error('Not supported');
-      }
-      const apiVersionTag = getApiVersionTag(calendarTelemetryVersionNumber, ApiName.Calendar_ComposeMeeting);
-      if (runtime.isLegacyTeams) {
-        resolve(
-          sendAndHandleStatusAndReason(
-            apiVersionTag,
-            'executeDeepLink',
-            createTeamsDeepLinkForCalendar(
-              composeMeetingParams.attendees,
-              composeMeetingParams.startTime,
-              composeMeetingParams.endTime,
-              composeMeetingParams.subject,
-              composeMeetingParams.content,
-            ),
-          ),
-        );
-      } else {
-        resolve(sendAndHandleStatusAndReason(apiVersionTag, 'calendar.composeMeeting', composeMeetingParams));
-      }
-    });
-  }
+/**
+ * Checks if the calendar capability is supported by the host
+ * @returns boolean to represent whether the calendar capability is supported
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ */
+export function isSupported(): boolean {
+  return ensureInitialized(runtime) && runtime.supports.calendar ? true : false;
+}
 
-  /**
-   * Checks if the calendar capability is supported by the host
-   * @returns boolean to represent whether the calendar capability is supported
-   *
-   * @throws Error if {@linkcode app.initialize} has not successfully completed
-   */
-  export function isSupported(): boolean {
-    return ensureInitialized(runtime) && runtime.supports.calendar ? true : false;
-  }
+/** Open calendar item parameters. */
+export interface OpenCalendarItemParams {
+  /** An unique base64-encoded string id that represents the event's unique identifier of the calendar item to be opened. */
+  itemId: string;
+}
 
-  /** Open calendar item parameters. */
-  export interface OpenCalendarItemParams {
-    /** An unique base64-encoded string id that represents the event's unique identifier of the calendar item to be opened. */
-    itemId: string;
-  }
+/** Compose meeting parameters */
 
-  /** Compose meeting parameters */
-
-  export interface ComposeMeetingParams {
-    /** An array of email addresses, user name, or user id of the attendees to invite to the meeting. */
-    attendees?: string[];
-    /** The start time of the meeting in MM/DD/YYYY HH:MM:SS format. */
-    startTime?: string;
-    /** The end time of the meeting in MM/DD/YYYY HH:MM:SS format. */
-    endTime?: string;
-    /** The subject line of the meeting. */
-    subject?: string;
-    /** The body content of the meeting. */
-    content?: string;
-  }
+export interface ComposeMeetingParams {
+  /** An array of email addresses, user name, or user id of the attendees to invite to the meeting. */
+  attendees?: string[];
+  /** The start time of the meeting in MM/DD/YYYY HH:MM:SS format. */
+  startTime?: string;
+  /** The end time of the meeting in MM/DD/YYYY HH:MM:SS format. */
+  endTime?: string;
+  /** The subject line of the meeting. */
+  subject?: string;
+  /** The body content of the meeting. */
+  content?: string;
 }

--- a/packages/teams-js/src/public/call.ts
+++ b/packages/teams-js/src/public/call.ts
@@ -14,88 +14,86 @@ const callTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 /**
  * Used to interact with call functionality, including starting calls with other users.
  */
-export namespace call {
-  /** Modalities that can be associated with a call. */
-  export enum CallModalities {
-    /** Indicates that the modality is unknown or undefined. */
-    Unknown = 'unknown',
-    /** Indicates that the call includes audio. */
-    Audio = 'audio',
-    /** Indicates that the call includes video. */
-    Video = 'video',
-    /** Indicates that the call includes video-based screen sharing. */
-    VideoBasedScreenSharing = 'videoBasedScreenSharing',
-    /** Indicates that the call includes data sharing or messaging. */
-    Data = 'data',
-  }
+/** Modalities that can be associated with a call. */
+export enum CallModalities {
+  /** Indicates that the modality is unknown or undefined. */
+  Unknown = 'unknown',
+  /** Indicates that the call includes audio. */
+  Audio = 'audio',
+  /** Indicates that the call includes video. */
+  Video = 'video',
+  /** Indicates that the call includes video-based screen sharing. */
+  VideoBasedScreenSharing = 'videoBasedScreenSharing',
+  /** Indicates that the call includes data sharing or messaging. */
+  Data = 'data',
+}
 
-  /** Represents parameters for {@link startCall | StartCall}. */
-  export interface StartCallParams {
-    /**
-     * Comma-separated list of user IDs representing the participants of the call.
-     *
-     * @remarks
-     * Currently the User ID field supports the Microsoft Entra UserPrincipalName,
-     * typically an email address, or in case of a PSTN call, it supports a pstn
-     * mri 4:\<phonenumber>.
-     */
-    targets: string[];
-    /**
-     * List of modalities for the call. Defaults to [“audio”].
-     */
-    requestedModalities?: CallModalities[];
-    /**
-     * An optional parameter that informs about the source of the deep link
-     */
-    source?: string;
-  }
-
+/** Represents parameters for {@link startCall | StartCall}. */
+export interface StartCallParams {
   /**
-   * Starts a call with other users
+   * Comma-separated list of user IDs representing the participants of the call.
    *
-   * @param startCallParams - Parameters for the call
-   *
-   * @throws Error if call capability is not supported
-   * @throws Error if host notifies of a failed start call attempt in a legacy Teams environment
-   * @returns always true if the host notifies of a successful call inititation
+   * @remarks
+   * Currently the User ID field supports the Microsoft Entra UserPrincipalName,
+   * typically an email address, or in case of a PSTN call, it supports a pstn
+   * mri 4:\<phonenumber>.
    */
-  export function startCall(startCallParams: StartCallParams): Promise<boolean> {
-    const apiVersionTag = getApiVersionTag(callTelemetryVersionNumber, ApiName.Call_StartCall);
-    return new Promise((resolve) => {
-      ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
-      }
-      if (runtime.isLegacyTeams) {
-        resolve(
-          sendAndUnwrap(
-            apiVersionTag,
-            'executeDeepLink',
-            createTeamsDeepLinkForCall(
-              startCallParams.targets,
-              startCallParams.requestedModalities?.includes(CallModalities.Video),
-              startCallParams.source,
-            ),
-          ).then((result: boolean) => {
-            if (!result) {
-              throw new Error(errorCallNotStarted);
-            }
-            return result;
-          }),
-        );
-      } else {
-        return sendMessageToParent(apiVersionTag, 'call.startCall', [startCallParams], resolve);
-      }
-    });
-  }
-
+  targets: string[];
   /**
-   * Checks if the call capability is supported by the host
-   * @returns boolean to represent whether the call capability is supported
-   *
-   * @throws Error if {@linkcode app.initialize} has not successfully completed
+   * List of modalities for the call. Defaults to [“audio”].
    */
-  export function isSupported(): boolean {
-    return ensureInitialized(runtime) && runtime.supports.call ? true : false;
-  }
+  requestedModalities?: CallModalities[];
+  /**
+   * An optional parameter that informs about the source of the deep link
+   */
+  source?: string;
+}
+
+/**
+ * Starts a call with other users
+ *
+ * @param startCallParams - Parameters for the call
+ *
+ * @throws Error if call capability is not supported
+ * @throws Error if host notifies of a failed start call attempt in a legacy Teams environment
+ * @returns always true if the host notifies of a successful call inititation
+ */
+export function startCall(startCallParams: StartCallParams): Promise<boolean> {
+  const apiVersionTag = getApiVersionTag(callTelemetryVersionNumber, ApiName.Call_StartCall);
+  return new Promise((resolve) => {
+    ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+    if (!isSupported()) {
+      throw errorNotSupportedOnPlatform;
+    }
+    if (runtime.isLegacyTeams) {
+      resolve(
+        sendAndUnwrap(
+          apiVersionTag,
+          'executeDeepLink',
+          createTeamsDeepLinkForCall(
+            startCallParams.targets,
+            startCallParams.requestedModalities?.includes(CallModalities.Video),
+            startCallParams.source,
+          ),
+        ).then((result: boolean) => {
+          if (!result) {
+            throw new Error(errorCallNotStarted);
+          }
+          return result;
+        }),
+      );
+    } else {
+      return sendMessageToParent(apiVersionTag, 'call.startCall', [startCallParams], resolve);
+    }
+  });
+}
+
+/**
+ * Checks if the call capability is supported by the host
+ * @returns boolean to represent whether the call capability is supported
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ */
+export function isSupported(): boolean {
+  return ensureInitialized(runtime) && runtime.supports.call ? true : false;
 }

--- a/packages/teams-js/src/public/clipboard.ts
+++ b/packages/teams-js/src/public/clipboard.ts
@@ -17,95 +17,89 @@ const clipboardTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
  *
  * @beta
  */
-export namespace clipboard {
-  /**
-   * Function to copy data to clipboard.
-   * @remarks
-   * Note: clipboard.write only supports Text, HTML, PNG, and JPEG data format.
-   *       MIME type for Text -> `text/plain`, HTML -> `text/html`, PNG/JPEG -> `image/(png | jpeg)`
-   *       Also, JPEG will be converted to PNG image when copying to clipboard.
-   *
-   * @param blob - A Blob object representing the data to be copied to clipboard.
-   * @returns A string promise which resolves to success message from the clipboard or
-   *          rejects with error stating the reason for failure.
-   */
-  export async function write(blob: Blob): Promise<void> {
-    ensureInitialized(
-      runtime,
-      FrameContexts.content,
-      FrameContexts.meetingStage,
-      FrameContexts.task,
-      FrameContexts.settings,
-      FrameContexts.stage,
-      FrameContexts.sidePanel,
-    );
-    if (!isSupported()) {
-      throw errorNotSupportedOnPlatform;
-    }
-    if (!(blob.type && Object.values(ClipboardSupportedMimeType).includes(blob.type as ClipboardSupportedMimeType))) {
-      throw new Error(
-        `Blob type ${blob.type} is not supported. Supported blob types are ${Object.values(
-          ClipboardSupportedMimeType,
-        )}`,
-      );
-    }
-    const base64StringContent = await utils.getBase64StringFromBlob(blob);
-    const writeParams: ClipboardParams = {
-      mimeType: blob.type as ClipboardSupportedMimeType,
-      content: base64StringContent,
-    };
-    return sendAndHandleSdkError(
-      getApiVersionTag(clipboardTelemetryVersionNumber, ApiName.Clipboard_Write),
-      'clipboard.writeToClipboard',
-      writeParams,
+/**
+ * Function to copy data to clipboard.
+ * @remarks
+ * Note: clipboard.write only supports Text, HTML, PNG, and JPEG data format.
+ *       MIME type for Text -> `text/plain`, HTML -> `text/html`, PNG/JPEG -> `image/(png | jpeg)`
+ *       Also, JPEG will be converted to PNG image when copying to clipboard.
+ *
+ * @param blob - A Blob object representing the data to be copied to clipboard.
+ * @returns A string promise which resolves to success message from the clipboard or
+ *          rejects with error stating the reason for failure.
+ */
+export async function write(blob: Blob): Promise<void> {
+  ensureInitialized(
+    runtime,
+    FrameContexts.content,
+    FrameContexts.meetingStage,
+    FrameContexts.task,
+    FrameContexts.settings,
+    FrameContexts.stage,
+    FrameContexts.sidePanel,
+  );
+  if (!isSupported()) {
+    throw errorNotSupportedOnPlatform;
+  }
+  if (!(blob.type && Object.values(ClipboardSupportedMimeType).includes(blob.type as ClipboardSupportedMimeType))) {
+    throw new Error(
+      `Blob type ${blob.type} is not supported. Supported blob types are ${Object.values(ClipboardSupportedMimeType)}`,
     );
   }
+  const base64StringContent = await utils.getBase64StringFromBlob(blob);
+  const writeParams: ClipboardParams = {
+    mimeType: blob.type as ClipboardSupportedMimeType,
+    content: base64StringContent,
+  };
+  return sendAndHandleSdkError(
+    getApiVersionTag(clipboardTelemetryVersionNumber, ApiName.Clipboard_Write),
+    'clipboard.writeToClipboard',
+    writeParams,
+  );
+}
 
-  /**
-   * Function to read data from clipboard.
-   *
-   * @returns A promise blob which resolves to the data read from the clipboard or
-   *          rejects stating the reason for failure.
-   *          Note: Returned blob type will contain one of the MIME type `image/png`, `text/plain` or `text/html`.
-   */
-  export async function read(): Promise<Blob> {
-    ensureInitialized(
-      runtime,
-      FrameContexts.content,
-      FrameContexts.meetingStage,
-      FrameContexts.task,
-      FrameContexts.settings,
-      FrameContexts.stage,
-      FrameContexts.sidePanel,
-    );
-    const apiVersionTag = getApiVersionTag(clipboardTelemetryVersionNumber, ApiName.Clipboard_Read);
-    if (!isSupported()) {
-      throw errorNotSupportedOnPlatform;
-    }
-    const response = await sendAndHandleSdkError(apiVersionTag, 'clipboard.readFromClipboard');
-    if (typeof response === 'string') {
-      const data = JSON.parse(response) as ClipboardParams;
-      return utils.base64ToBlob(data.mimeType, data.content);
-    } else {
-      return response as Blob;
-    }
+/**
+ * Function to read data from clipboard.
+ *
+ * @returns A promise blob which resolves to the data read from the clipboard or
+ *          rejects stating the reason for failure.
+ *          Note: Returned blob type will contain one of the MIME type `image/png`, `text/plain` or `text/html`.
+ */
+export async function read(): Promise<Blob> {
+  ensureInitialized(
+    runtime,
+    FrameContexts.content,
+    FrameContexts.meetingStage,
+    FrameContexts.task,
+    FrameContexts.settings,
+    FrameContexts.stage,
+    FrameContexts.sidePanel,
+  );
+  const apiVersionTag = getApiVersionTag(clipboardTelemetryVersionNumber, ApiName.Clipboard_Read);
+  if (!isSupported()) {
+    throw errorNotSupportedOnPlatform;
   }
+  const response = await sendAndHandleSdkError(apiVersionTag, 'clipboard.readFromClipboard');
+  if (typeof response === 'string') {
+    const data = JSON.parse(response) as ClipboardParams;
+    return utils.base64ToBlob(data.mimeType, data.content);
+  } else {
+    return response as Blob;
+  }
+}
 
-  /**
-   * Checks if clipboard capability is supported by the host
-   * @returns boolean to represent whether the clipboard capability is supported
-   *
-   * @throws Error if {@linkcode app.initialize} has not successfully completed
-   *
-   * @beta
-   */
-  export function isSupported(): boolean {
-    if (GlobalVars.isFramelessWindow) {
-      return ensureInitialized(runtime) && runtime.supports.clipboard ? true : false;
-    } else {
-      return ensureInitialized(runtime) && navigator && navigator.clipboard && runtime.supports.clipboard
-        ? true
-        : false;
-    }
+/**
+ * Checks if clipboard capability is supported by the host
+ * @returns boolean to represent whether the clipboard capability is supported
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
+ * @beta
+ */
+export function isSupported(): boolean {
+  if (GlobalVars.isFramelessWindow) {
+    return ensureInitialized(runtime) && runtime.supports.clipboard ? true : false;
+  } else {
+    return ensureInitialized(runtime) && navigator && navigator.clipboard && runtime.supports.clipboard ? true : false;
   }
 }

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -1,4 +1,4 @@
-export { authentication } from './authentication';
+export * as authentication from './authentication';
 export {
   ChannelType,
   DialogDimension,
@@ -43,10 +43,10 @@ export {
 export * as app from './app';
 export { AppId } from './appId';
 export { EmailAddress } from './emailAddress';
-export { appInstallDialog } from './appInstallDialog';
-export { barCode } from './barCode';
+export * as appInstallDialog from './appInstallDialog';
+export * as barCode from './barCode';
 export { chat, OpenGroupChatRequest, OpenSingleChatRequest } from './chat';
-export { clipboard } from './clipboard';
+export * as clipboard from './clipboard';
 export { dialog } from './dialog';
 export { nestedAppAuth } from './nestedAppAuth';
 export { geoLocation } from './geoLocation';
@@ -65,7 +65,7 @@ export { secondaryBrowser } from './secondaryBrowser';
 export { location } from './location';
 export { meeting } from './meeting';
 export { monetization } from './monetization';
-export { calendar } from './calendar';
+export * as calendar from './calendar';
 export { mail } from './mail';
 export { teamsCore } from './teamsAPIs';
 export { people } from './people';
@@ -77,7 +77,7 @@ export { stageView } from './stageView';
 export { version } from './version';
 export { visualMedia } from './visualMedia';
 export { webStorage } from './webStorage';
-export { call } from './call';
+export * as call from './call';
 export * as appInitialization from './appInitialization';
 export { thirdPartyCloudStorage } from './thirdPartyCloudStorage';
 export {

--- a/packages/teams-js/test/public/authentication.spec.ts
+++ b/packages/teams-js/test/public/authentication.spec.ts
@@ -5,7 +5,7 @@ import { DOMMessageEvent } from '../../src/internal/interfaces';
 import * as internalUtils from '../../src/internal/utils';
 import { ErrorCode, FrameContexts, HostClientType, SdkError } from '../../src/public';
 import * as app from '../../src/public/app';
-import { authentication } from '../../src/public/authentication';
+import * as authentication from '../../src/public/authentication';
 import { Utils } from '../utils';
 
 /* eslint-disable */

--- a/packages/teams-js/test/public/barCode.spec.ts
+++ b/packages/teams-js/test/public/barCode.spec.ts
@@ -2,7 +2,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import * as app from '../../src/public/app';
-import { barCode } from '../../src/public/barCode';
+import * as barCode from '../../src/public/barCode';
 import { errorNotSupportedOnPlatform, FrameContexts, HostClientType } from '../../src/public/constants';
 import { ErrorCode } from '../../src/public/interfaces';
 import { setUnitializedRuntime } from '../../src/public/runtime';

--- a/packages/teams-js/test/public/calendar.spec.ts
+++ b/packages/teams-js/test/public/calendar.spec.ts
@@ -2,7 +2,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { FrameContexts } from '../../src/public';
 import * as app from '../../src/public/app';
-import { calendar } from '../../src/public/calendar';
+import * as calendar from '../../src/public/calendar';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { validateCalendarDeepLinkPrefix } from '../internal/deepLinkUtilities.spec';
 import { Utils } from '../utils';


### PR DESCRIPTION
**This PR is part of the larger Treeshaking effort, with more PRs to come in the future**

This PR removes the namespaces of the following files, which will enable them to be treeshaken:
- appInstallDialog
- authentication
- barCode
- calendar
- call
- clipboard

None of these files have any sub-capabilities that need to be taken out or have any complicated helpers that could add complexity to the work that needs to be done to make them treeshakable. Just removing the namespaces should be all the work that is needed. Also included in the PR is updating the references wherever these capabilities are referenced directly from their file and not the index file

_With the removal of the namespaces, there are not many code changes to the capability files, however there is significant whitespace changes. To make reviewing the PR simpler, I recommend hiding the whitespace changes, which you can enable by selecting the gear icon when viewing the changes_
