### PR TITLE
Added JSON.Stringfy function to convert potential json format msg

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -48,7 +48,7 @@ function handleMessageFromMockedHost(msg: MessageEvent): void {
     console.warn('Unrecognized message format received by app, message being ignored. Message: %o', msg);
     return;
   }
-  console.log(`Received message from test host: ${msg.data}`);
+  console.log(`Received message from test host: ${JSON.stringify(msg.data)}`);
   // Handle messages that are correctly formatted and for func values we recognize
   switch (msg.data) {
     case 'app.initialize':


### PR DESCRIPTION
## Description

Though all of API calls from testing host will be string format, but listener in test app will listen to all of messages, including response from Web Host SDK. Some of responses are in JSON format. It does no harm for testing, but in case people want to know what it is, I added one line to stringfy those kind of data.