### PR TITLE
noahdarveau/dialog treeshaking changes

### DIFF
--- a/change/@microsoft-teams-js-35af1950-5f26-4ffe-8c68-6ca569870710.json
+++ b/change/@microsoft-teams-js-35af1950-5f26-4ffe-8c68-6ca569870710.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Made the `dialog` file treeshakable",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/appHelpers.ts
+++ b/packages/teams-js/src/internal/appHelpers.ts
@@ -13,7 +13,7 @@ import { compareSDKVersions, inServerSideRenderingEnvironment, runWithTimeout } 
 import * as app from '../public/app/app';
 import * as authentication from '../public/authentication';
 import { FrameContexts } from '../public/constants';
-import { dialog } from '../public/dialog';
+import { dialog } from '../public/dialog/dialog';
 import { menus } from '../public/menus';
 import { pages } from '../public/pages';
 import {

--- a/packages/teams-js/src/internal/appHelpers.ts
+++ b/packages/teams-js/src/internal/appHelpers.ts
@@ -13,7 +13,7 @@ import { compareSDKVersions, inServerSideRenderingEnvironment, runWithTimeout } 
 import * as app from '../public/app/app';
 import * as authentication from '../public/authentication';
 import { FrameContexts } from '../public/constants';
-import { dialog } from '../public/dialog/dialog';
+import * as dialog from '../public/dialog/dialog';
 import { menus } from '../public/menus';
 import { pages } from '../public/pages';
 import {

--- a/packages/teams-js/src/internal/dialogHelpers.ts
+++ b/packages/teams-js/src/internal/dialogHelpers.ts
@@ -4,11 +4,12 @@
 
 import { ensureInitialized } from '../internal/internalAPIs';
 import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
-import { AdaptiveCardDialogInfo, BotAdaptiveCardDialogInfo } from '../public/interfaces';
 import { dialog } from '../public/dialog/dialog';
+import { AdaptiveCardDialogInfo, BotAdaptiveCardDialogInfo } from '../public/interfaces';
 import { BotUrlDialogInfo, DialogInfo, DialogSize, UrlDialogInfo } from '../public/interfaces';
 import { runtime } from '../public/runtime';
 import { sendMessageToParent } from './communication';
+import { GlobalVars } from './globalVars';
 import { registerHandler, removeHandler } from './handlers';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from './telemetry';
 
@@ -126,4 +127,20 @@ export function getDialogInfoFromBotAdaptiveCardDialogInfo(
   const dialogInfo: DialogInfo = getDialogInfoFromAdaptiveCardDialogInfo(botAdaptiveCardDialogInfo);
   dialogInfo.completionBotId = botAdaptiveCardDialogInfo.completionBotId;
   return dialogInfo;
+}
+
+export const storedMessages: string[] = [];
+
+export function handleDialogMessage(message: string): void {
+  if (!GlobalVars.frameContext) {
+    // GlobalVars.frameContext is currently not set
+    return;
+  }
+
+  if (GlobalVars.frameContext === FrameContexts.task) {
+    storedMessages.push(message);
+  } else {
+    // Not in task FrameContext, remove 'messageForChild' handler
+    removeHandler('messageForChild');
+  }
 }

--- a/packages/teams-js/src/internal/dialogHelpers.ts
+++ b/packages/teams-js/src/internal/dialogHelpers.ts
@@ -4,7 +4,7 @@
 
 import { ensureInitialized } from '../internal/internalAPIs';
 import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
-import { dialog } from '../public/dialog/dialog';
+import * as dialog from '../public/dialog/dialog';
 import { AdaptiveCardDialogInfo, BotAdaptiveCardDialogInfo } from '../public/interfaces';
 import { BotUrlDialogInfo, DialogInfo, DialogSize, UrlDialogInfo } from '../public/interfaces';
 import { runtime } from '../public/runtime';

--- a/packages/teams-js/src/internal/dialogHelpers.ts
+++ b/packages/teams-js/src/internal/dialogHelpers.ts
@@ -3,7 +3,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { ensureInitialized } from '../internal/internalAPIs';
-import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
+import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
+import { AdaptiveCardDialogInfo, BotAdaptiveCardDialogInfo } from '../public/interfaces';
 import { dialog } from '../public/dialog/dialog';
 import { BotUrlDialogInfo, DialogInfo, DialogSize, UrlDialogInfo } from '../public/interfaces';
 import { runtime } from '../public/runtime';
@@ -91,4 +92,38 @@ export function urlSubmitHelper(apiVersionTag: string, result?: string | object,
     result,
     appIds ? (Array.isArray(appIds) ? appIds : [appIds]) : [],
   ]);
+}
+
+/**
+ * @hidden
+ * Hide from docs
+ * --------
+ * Convert AdaptiveCardDialogInfo to DialogInfo to send the information to host in {@linkcode adaptiveCard.open} API.
+ *
+ * @internal
+ */
+export function getDialogInfoFromAdaptiveCardDialogInfo(adaptiveCardDialogInfo: AdaptiveCardDialogInfo): DialogInfo {
+  const dialogInfo: DialogInfo = {
+    card: adaptiveCardDialogInfo.card,
+    height: adaptiveCardDialogInfo.size ? adaptiveCardDialogInfo.size.height : DialogDimension.Small,
+    width: adaptiveCardDialogInfo.size ? adaptiveCardDialogInfo.size.width : DialogDimension.Small,
+    title: adaptiveCardDialogInfo.title,
+  };
+  return dialogInfo;
+}
+
+/**
+ * @hidden
+ * Hide from docs
+ * --------
+ * Convert BotAdaptiveCardDialogInfo to DialogInfo to send the information to host in {@linkcode adaptiveCard.open} API.
+ *
+ * @internal
+ */
+export function getDialogInfoFromBotAdaptiveCardDialogInfo(
+  botAdaptiveCardDialogInfo: BotAdaptiveCardDialogInfo,
+): DialogInfo {
+  const dialogInfo: DialogInfo = getDialogInfoFromAdaptiveCardDialogInfo(botAdaptiveCardDialogInfo);
+  dialogInfo.completionBotId = botAdaptiveCardDialogInfo.completionBotId;
+  return dialogInfo;
 }

--- a/packages/teams-js/src/internal/dialogHelpers.ts
+++ b/packages/teams-js/src/internal/dialogHelpers.ts
@@ -1,0 +1,94 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { ensureInitialized } from '../internal/internalAPIs';
+import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
+import * as dialog from '../public/dialog';
+import { BotUrlDialogInfo, DialogInfo, DialogSize, UrlDialogInfo } from '../public/interfaces';
+import { runtime } from '../public/runtime';
+import { sendMessageToParent } from './communication';
+import { registerHandler, removeHandler } from './handlers';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from './telemetry';
+
+/**
+ * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
+ */
+const dialogTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
+
+export function updateResizeHelper(apiVersionTag: string, dimensions: DialogSize): void {
+  ensureInitialized(
+    runtime,
+    FrameContexts.content,
+    FrameContexts.sidePanel,
+    FrameContexts.task,
+    FrameContexts.meetingStage,
+  );
+  if (!dialog.update.isSupported()) {
+    throw errorNotSupportedOnPlatform;
+  }
+  sendMessageToParent(apiVersionTag, 'tasks.updateTask', [dimensions]);
+}
+
+export function urlOpenHelper(
+  apiVersionTag: string,
+  urlDialogInfo: UrlDialogInfo,
+  submitHandler?: dialog.DialogSubmitHandler,
+  messageFromChildHandler?: dialog.PostMessageChannel,
+): void {
+  ensureInitialized(runtime, FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
+  if (!dialog.url.isSupported()) {
+    throw errorNotSupportedOnPlatform;
+  }
+
+  if (messageFromChildHandler) {
+    registerHandler(
+      getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_Url_RegisterMessageForParentHandler),
+      'messageForParent',
+      messageFromChildHandler,
+    );
+  }
+  const dialogInfo: DialogInfo = dialog.url.getDialogInfoFromUrlDialogInfo(urlDialogInfo);
+  sendMessageToParent(apiVersionTag, 'tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
+    submitHandler?.({ err, result });
+    removeHandler('messageForParent');
+  });
+}
+
+export function botUrlOpenHelper(
+  apiVersionTag: string,
+  urlDialogInfo: BotUrlDialogInfo,
+  submitHandler?: dialog.DialogSubmitHandler,
+  messageFromChildHandler?: dialog.PostMessageChannel,
+): void {
+  ensureInitialized(runtime, FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
+  if (!dialog.url.bot.isSupported()) {
+    throw errorNotSupportedOnPlatform;
+  }
+
+  if (messageFromChildHandler) {
+    registerHandler(
+      getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_Url_Bot_RegisterMessageForParentHandler),
+      'messageForParent',
+      messageFromChildHandler,
+    );
+  }
+  const dialogInfo: DialogInfo = dialog.url.getDialogInfoFromBotUrlDialogInfo(urlDialogInfo);
+  sendMessageToParent(apiVersionTag, 'tasks.startTask', [dialogInfo], (err: string, result: string | object) => {
+    submitHandler?.({ err, result });
+    removeHandler('messageForParent');
+  });
+}
+
+export function urlSubmitHelper(apiVersionTag: string, result?: string | object, appIds?: string | string[]): void {
+  ensureInitialized(runtime, FrameContexts.task);
+  if (!dialog.url.isSupported()) {
+    throw errorNotSupportedOnPlatform;
+  }
+
+  // Send tasks.completeTask instead of tasks.submitTask message for backward compatibility with Mobile clients
+  sendMessageToParent(apiVersionTag, 'tasks.completeTask', [
+    result,
+    appIds ? (Array.isArray(appIds) ? appIds : [appIds]) : [],
+  ]);
+}

--- a/packages/teams-js/src/internal/dialogHelpers.ts
+++ b/packages/teams-js/src/internal/dialogHelpers.ts
@@ -4,7 +4,7 @@
 
 import { ensureInitialized } from '../internal/internalAPIs';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
-import * as dialog from '../public/dialog/dialog';
+import { dialog } from '../public/dialog/dialog';
 import { BotUrlDialogInfo, DialogInfo, DialogSize, UrlDialogInfo } from '../public/interfaces';
 import { runtime } from '../public/runtime';
 import { sendMessageToParent } from './communication';
@@ -14,7 +14,7 @@ import { ApiName, ApiVersionNumber, getApiVersionTag } from './telemetry';
 /**
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
-const dialogTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
+export const dialogTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 
 export function updateResizeHelper(apiVersionTag: string, dimensions: DialogSize): void {
   ensureInitialized(

--- a/packages/teams-js/src/internal/dialogHelpers.ts
+++ b/packages/teams-js/src/internal/dialogHelpers.ts
@@ -4,7 +4,7 @@
 
 import { ensureInitialized } from '../internal/internalAPIs';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
-import * as dialog from '../public/dialog';
+import * as dialog from '../public/dialog/dialog';
 import { BotUrlDialogInfo, DialogInfo, DialogSize, UrlDialogInfo } from '../public/interfaces';
 import { runtime } from '../public/runtime';
 import { sendMessageToParent } from './communication';

--- a/packages/teams-js/src/public/dialog/adaptiveCard/adaptiveCard.ts
+++ b/packages/teams-js/src/public/dialog/adaptiveCard/adaptiveCard.ts
@@ -8,7 +8,6 @@ import { errorNotSupportedOnPlatform, FrameContexts } from '../../constants';
 import { AdaptiveCardDialogInfo, DialogInfo } from '../../interfaces';
 import { runtime } from '../../runtime';
 import { DialogSubmitHandler } from '../dialog';
-import * as url from '../url/url';
 import * as bot from './bot';
 
 /**
@@ -22,7 +21,7 @@ import * as bot from './bot';
  * This function cannot be called from inside of a dialog
  *
  * @param adaptiveCardDialogInfo - An object containing the parameters of the dialog module {@link AdaptiveCardDialogInfo}.
- * @param submitHandler - Handler that triggers when a dialog calls the {@linkcode url.submit} function or when the user closes the dialog.
+ * @param submitHandler - Handler that triggers when a dialog fires an [Action.Submit](https://adaptivecards.io/explorer/Action.Submit.html) or when the user closes the dialog.
  *
  * @beta
  */

--- a/packages/teams-js/src/public/dialog/adaptiveCard/adaptiveCard.ts
+++ b/packages/teams-js/src/public/dialog/adaptiveCard/adaptiveCard.ts
@@ -1,18 +1,65 @@
-import { sendMessageToParent } from '../../internal/communication';
-import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from '../../internal/dialogHelpers';
-import { GlobalVars } from '../../internal/globalVars';
-import { registerHandler, removeHandler } from '../../internal/handlers';
-import { ensureInitialized } from '../../internal/internalAPIs';
-import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
-import { isHostAdaptiveCardSchemaVersionUnsupported } from '../../internal/utils';
-import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../constants';
-import {
-  AdaptiveCardDialogInfo,
-  BotAdaptiveCardDialogInfo,
-  BotUrlDialogInfo,
-  DialogInfo,
-  DialogSize,
-  M365ContentAction,
-  UrlDialogInfo,
-} from '../interfaces';
-import { runtime } from '../runtime';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { sendMessageToParent } from '../../../internal/communication';
+import { dialogTelemetryVersionNumber, getDialogInfoFromAdaptiveCardDialogInfo } from '../../../internal/dialogHelpers';
+import { ensureInitialized } from '../../../internal/internalAPIs';
+import { ApiName, getApiVersionTag } from '../../../internal/telemetry';
+import { isHostAdaptiveCardSchemaVersionUnsupported } from '../../../internal/utils';
+import { errorNotSupportedOnPlatform, FrameContexts } from '../../constants';
+import { AdaptiveCardDialogInfo, DialogInfo } from '../../interfaces';
+import { runtime } from '../../runtime';
+import { DialogSubmitHandler } from '../dialog';
+import * as url from '../url/url';
+import * as bot from './bot';
+
+/**
+ * Subcapability for interacting with adaptive card dialogs
+ * @beta
+ */
+/**
+ * Allows app to open an adaptive card based dialog.
+ *
+ * @remarks
+ * This function cannot be called from inside of a dialog
+ *
+ * @param adaptiveCardDialogInfo - An object containing the parameters of the dialog module {@link AdaptiveCardDialogInfo}.
+ * @param submitHandler - Handler that triggers when a dialog calls the {@linkcode url.submit} function or when the user closes the dialog.
+ *
+ * @beta
+ */
+export function open(adaptiveCardDialogInfo: AdaptiveCardDialogInfo, submitHandler?: DialogSubmitHandler): void {
+  ensureInitialized(runtime, FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
+  if (!isSupported()) {
+    throw errorNotSupportedOnPlatform;
+  }
+  const dialogInfo: DialogInfo = getDialogInfoFromAdaptiveCardDialogInfo(adaptiveCardDialogInfo);
+  sendMessageToParent(
+    getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_AdaptiveCard_Open),
+    'tasks.startTask',
+    [dialogInfo],
+    (err: string, result: string | object) => {
+      submitHandler?.({ err, result });
+    },
+  );
+}
+
+/**
+ * Checks if dialog.adaptiveCard module is supported by the host
+ *
+ * @returns boolean to represent whether dialog.adaptiveCard module is supported
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
+ * @beta
+ */
+export function isSupported(): boolean {
+  const isAdaptiveCardVersionSupported =
+    runtime.hostVersionsInfo &&
+    runtime.hostVersionsInfo.adaptiveCardSchemaVersion &&
+    !isHostAdaptiveCardSchemaVersionUnsupported(runtime.hostVersionsInfo.adaptiveCardSchemaVersion);
+  return (
+    ensureInitialized(runtime) &&
+    (isAdaptiveCardVersionSupported && runtime.supports.dialog && runtime.supports.dialog.card) !== undefined
+  );
+}
+
+export { bot };

--- a/packages/teams-js/src/public/dialog/adaptiveCard/adaptiveCard.ts
+++ b/packages/teams-js/src/public/dialog/adaptiveCard/adaptiveCard.ts
@@ -1,0 +1,18 @@
+import { sendMessageToParent } from '../../internal/communication';
+import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from '../../internal/dialogHelpers';
+import { GlobalVars } from '../../internal/globalVars';
+import { registerHandler, removeHandler } from '../../internal/handlers';
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
+import { isHostAdaptiveCardSchemaVersionUnsupported } from '../../internal/utils';
+import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../constants';
+import {
+  AdaptiveCardDialogInfo,
+  BotAdaptiveCardDialogInfo,
+  BotUrlDialogInfo,
+  DialogInfo,
+  DialogSize,
+  M365ContentAction,
+  UrlDialogInfo,
+} from '../interfaces';
+import { runtime } from '../runtime';

--- a/packages/teams-js/src/public/dialog/adaptiveCard/bot.ts
+++ b/packages/teams-js/src/public/dialog/adaptiveCard/bot.ts
@@ -1,0 +1,18 @@
+import { sendMessageToParent } from '../../internal/communication';
+import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from '../../internal/dialogHelpers';
+import { GlobalVars } from '../../internal/globalVars';
+import { registerHandler, removeHandler } from '../../internal/handlers';
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
+import { isHostAdaptiveCardSchemaVersionUnsupported } from '../../internal/utils';
+import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../constants';
+import {
+  AdaptiveCardDialogInfo,
+  BotAdaptiveCardDialogInfo,
+  BotUrlDialogInfo,
+  DialogInfo,
+  DialogSize,
+  M365ContentAction,
+  UrlDialogInfo,
+} from '../interfaces';
+import { runtime } from '../runtime';

--- a/packages/teams-js/src/public/dialog/adaptiveCard/bot.ts
+++ b/packages/teams-js/src/public/dialog/adaptiveCard/bot.ts
@@ -1,18 +1,66 @@
-import { sendMessageToParent } from '../../internal/communication';
-import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from '../../internal/dialogHelpers';
-import { GlobalVars } from '../../internal/globalVars';
-import { registerHandler, removeHandler } from '../../internal/handlers';
-import { ensureInitialized } from '../../internal/internalAPIs';
-import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
-import { isHostAdaptiveCardSchemaVersionUnsupported } from '../../internal/utils';
-import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../constants';
+import { sendMessageToParent } from '../../../internal/communication';
 import {
-  AdaptiveCardDialogInfo,
-  BotAdaptiveCardDialogInfo,
-  BotUrlDialogInfo,
-  DialogInfo,
-  DialogSize,
-  M365ContentAction,
-  UrlDialogInfo,
-} from '../interfaces';
-import { runtime } from '../runtime';
+  dialogTelemetryVersionNumber,
+  getDialogInfoFromBotAdaptiveCardDialogInfo,
+} from '../../../internal/dialogHelpers';
+import { ensureInitialized } from '../../../internal/internalAPIs';
+import { ApiName, getApiVersionTag } from '../../../internal/telemetry';
+import { isHostAdaptiveCardSchemaVersionUnsupported } from '../../../internal/utils';
+import { errorNotSupportedOnPlatform, FrameContexts } from '../../constants';
+import { BotAdaptiveCardDialogInfo, DialogInfo } from '../../interfaces';
+import { runtime } from '../../runtime';
+import { DialogSubmitHandler } from '../dialog';
+
+/**
+ * Module for interaction with adaptive card dialogs that need to communicate with the bot framework
+ *
+ * @beta
+ */
+/**
+ * Allows an app to open an adaptive card-based dialog module using bot.
+ *
+ * @param botAdaptiveCardDialogInfo - An object containing the parameters of the dialog module including completionBotId.
+ * @param submitHandler - Handler that triggers when the dialog has been submitted or closed.
+ *
+ * @beta
+ */
+export function open(botAdaptiveCardDialogInfo: BotAdaptiveCardDialogInfo, submitHandler?: DialogSubmitHandler): void {
+  ensureInitialized(runtime, FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
+  if (!isSupported()) {
+    throw errorNotSupportedOnPlatform;
+  }
+
+  const dialogInfo: DialogInfo = getDialogInfoFromBotAdaptiveCardDialogInfo(botAdaptiveCardDialogInfo);
+
+  sendMessageToParent(
+    getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_AdaptiveCard_Bot_Open),
+    'tasks.startTask',
+    [dialogInfo],
+    (err: string, result: string | object) => {
+      submitHandler?.({ err, result });
+    },
+  );
+}
+
+/**
+ * Checks if dialog.adaptiveCard.bot capability is supported by the host
+ *
+ * @returns boolean to represent whether dialog.adaptiveCard.bot is supported
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
+ * @beta
+ */
+export function isSupported(): boolean {
+  const isAdaptiveCardVersionSupported =
+    runtime.hostVersionsInfo &&
+    runtime.hostVersionsInfo.adaptiveCardSchemaVersion &&
+    !isHostAdaptiveCardSchemaVersionUnsupported(runtime.hostVersionsInfo.adaptiveCardSchemaVersion);
+  return (
+    ensureInitialized(runtime) &&
+    (isAdaptiveCardVersionSupported &&
+      runtime.supports.dialog &&
+      runtime.supports.dialog.card &&
+      runtime.supports.dialog.card.bot) !== undefined
+  );
+}

--- a/packages/teams-js/src/public/dialog/dialog.ts
+++ b/packages/teams-js/src/public/dialog/dialog.ts
@@ -2,400 +2,111 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { sendMessageToParent } from '../../internal/communication';
-import {
-  botUrlOpenHelper,
-  dialogTelemetryVersionNumber,
-  updateResizeHelper,
-  urlOpenHelper,
-  urlSubmitHelper,
-} from '../../internal/dialogHelpers';
+import { dialogTelemetryVersionNumber } from '../../internal/dialogHelpers';
 import { GlobalVars } from '../../internal/globalVars';
 import { registerHandler, removeHandler } from '../../internal/handlers';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ApiName, getApiVersionTag } from '../../internal/telemetry';
-import { isHostAdaptiveCardSchemaVersionUnsupported } from '../../internal/utils';
-import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../constants';
-import {
-  AdaptiveCardDialogInfo,
-  BotAdaptiveCardDialogInfo,
-  BotUrlDialogInfo,
-  DialogInfo,
-  DialogSize,
-  M365ContentAction,
-  UrlDialogInfo,
-} from '../interfaces';
+import { FrameContexts } from '../constants';
 import { runtime } from '../runtime';
+import * as adaptiveCard from './adaptiveCard/adaptiveCard';
 import * as update from './update';
-import * as url from './url';
-import * as adaptiveCard from './adaptiveCard';
+import * as url from './url/url';
 
 /**
  * This group of capabilities enables apps to show modal dialogs. There are two primary types of dialogs: URL-based dialogs and [Adaptive Card](https://learn.microsoft.com/adaptive-cards/) dialogs.
  * Both types of dialogs are shown on top of your app, preventing interaction with your app while they are displayed.
  * - URL-based dialogs allow you to specify a URL from which the contents will be shown inside the dialog.
- *   - For URL dialogs, use the functions and interfaces in the {@link dialog.url} namespace.
+ *   - For URL dialogs, use the functions and interfaces in the {@link url} module.
  * - Adaptive Card-based dialogs allow you to provide JSON describing an Adaptive Card that will be shown inside the dialog.
- *   - For Adaptive Card dialogs, use the functions and interfaces in the {@link dialog.adaptiveCard} namespace.
+ *   - For Adaptive Card dialogs, use the functions and interfaces in the {@link adaptiveCard} module.
  *
  * @remarks Note that dialogs were previously called "task modules". While they have been renamed for clarity, the functionality has been maintained.
  * For more details, see [Dialogs](https://learn.microsoft.com/microsoftteams/platform/task-modules-and-cards/what-are-task-modules)
  *
  * @beta
  */
-export namespace dialog {
+/**
+ * Data Structure to represent the SDK response when dialog closes
+ *
+ * @beta
+ */
+export interface ISdkResponse {
   /**
-   * Data Structure to represent the SDK response when dialog closes
-   *
-   * @beta
+   * Error in case there is a failure before dialog submission
    */
-  export interface ISdkResponse {
-    /**
-     * Error in case there is a failure before dialog submission
-     */
-    err?: string;
-
-    /**
-     * Value provided in the `result` parameter by the dialog when the {@linkcode url.submit} function
-     * was called.
-     * If the dialog was closed by the user without submitting (e.g., using a control in the corner
-     * of the dialog), this value will be `undefined` here.
-     */
-    result?: string | object;
-  }
+  err?: string;
 
   /**
-   * Handler used to receive and process messages sent between a dialog and the app that launched it
-   * @beta
+   * Value provided in the `result` parameter by the dialog when the {@linkcode url.submit} function
+   * was called.
+   * If the dialog was closed by the user without submitting (e.g., using a control in the corner
+   * of the dialog), this value will be `undefined` here.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  export type PostMessageChannel = (message: any) => void;
-
-  /**
-   * Handler used for receiving results when a dialog closes, either the value passed by {@linkcode url.submit}
-   * or an error if the dialog was closed by the user.
-   *
-   * @see {@linkcode ISdkResponse}
-   *
-   * @beta
-   */
-  export type DialogSubmitHandler = (result: ISdkResponse) => void;
-  const storedMessages: string[] = [];
-
-  /**
-   * @hidden
-   * Hide from docs because this function is only used during initialization
-   *
-   * Adds register handlers for messageForChild upon initialization and only in the tasks FrameContext. {@link FrameContexts.task}
-   * Function is called during app initialization
-   * @internal
-   * Limited to Microsoft-internal use
-   *
-   * @beta
-   */
-  export function initialize(): void {
-    registerHandler(
-      getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_RegisterMessageForChildHandler),
-      'messageForChild',
-      handleDialogMessage,
-      false,
-    );
-  }
-
-  function handleDialogMessage(message: string): void {
-    if (!GlobalVars.frameContext) {
-      // GlobalVars.frameContext is currently not set
-      return;
-    }
-
-    if (GlobalVars.frameContext === FrameContexts.task) {
-      storedMessages.push(message);
-    } else {
-      // Not in task FrameContext, remove 'messageForChild' handler
-      removeHandler('messageForChild');
-    }
-  }
-
-  export namespace url {
-    /**
-     * Allows app to open a url based dialog.
-     *
-     * @remarks
-     * This function cannot be called from inside of a dialog
-     *
-     * @param urlDialogInfo - An object containing the parameters of the dialog module.
-     * @param submitHandler - Handler that triggers when a dialog calls the {@linkcode submit} function or when the user closes the dialog.
-     * @param messageFromChildHandler - Handler that triggers if dialog sends a message to the app.
-     *
-     * @beta
-     */
-    export function open(
-      urlDialogInfo: UrlDialogInfo,
-      submitHandler?: DialogSubmitHandler,
-      messageFromChildHandler?: PostMessageChannel,
-    ): void {
-      urlOpenHelper(
-        getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_Url_Open),
-        urlDialogInfo,
-        submitHandler,
-        messageFromChildHandler,
-      );
-    }
-
-    /**
-     * Submit the dialog module and close the dialog
-     *
-     * @remarks
-     * This function is only intended to be called from code running within the dialog. Calling it from outside the dialog will have no effect.
-     *
-     * @param result - The result to be sent to the bot or the app. Typically a JSON object or a serialized version of it,
-     *  If this function is called from a dialog while {@link M365ContentAction} is set in the context object by the host, result will be ignored
-     *
-     * @param appIds - Valid application(s) that can receive the result of the submitted dialogs. Specifying this parameter helps prevent malicious apps from retrieving the dialog result. Multiple app IDs can be specified because a web app from a single underlying domain can power multiple apps across different environments and branding schemes.
-     *
-     * @beta
-     */
-    export function submit(result?: string | object, appIds?: string | string[]): void {
-      urlSubmitHelper(getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_Url_Submit), result, appIds);
-    }
-
-    /**
-     * Checks if dialog.url module is supported by the host
-     *
-     * @returns boolean to represent whether dialog.url module is supported
-     *
-     * @throws Error if {@linkcode app.initialize} has not successfully completed
-     *
-     * @beta
-     */
-    export function isSupported(): boolean {
-      return ensureInitialized(runtime) && (runtime.supports.dialog && runtime.supports.dialog.url) !== undefined;
-    }
-
-    /**
-     * @hidden
-     *
-     * Convert UrlDialogInfo to DialogInfo to send the information to host in {@linkcode open} API.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    export function getDialogInfoFromUrlDialogInfo(urlDialogInfo: UrlDialogInfo): DialogInfo {
-      const dialogInfo: DialogInfo = {
-        url: urlDialogInfo.url,
-        height: urlDialogInfo.size ? urlDialogInfo.size.height : DialogDimension.Small,
-        width: urlDialogInfo.size ? urlDialogInfo.size.width : DialogDimension.Small,
-        title: urlDialogInfo.title,
-        fallbackUrl: urlDialogInfo.fallbackUrl,
-      };
-      return dialogInfo;
-    }
-
-    /**
-     * @hidden
-     *
-     * Convert BotUrlDialogInfo to DialogInfo to send the information to host in {@linkcode bot.open} API.
-     *
-     * @internal
-     * Limited to Microsoft-internal use
-     */
-    export function getDialogInfoFromBotUrlDialogInfo(botUrlDialogInfo: BotUrlDialogInfo): DialogInfo {
-      const dialogInfo: DialogInfo = getDialogInfoFromUrlDialogInfo(botUrlDialogInfo);
-      dialogInfo.completionBotId = botUrlDialogInfo.completionBotId;
-      return dialogInfo;
-    }
-  }
-
-  /**
-   * This function currently serves no purpose and should not be used. All functionality that used
-   * to be covered by this method is now in subcapabilities and those isSupported methods should be
-   * used directly.
-   *
-   * @hidden
-   */
-  export function isSupported(): boolean {
-    return ensureInitialized(runtime) && runtime.supports.dialog ? true : false;
-  }
-
-  /**
-   * Namespace to update the dialog
-   *
-   * @beta
-   */
-  export namespace update {
-    /**
-     * Update dimensions - height/width of a dialog.
-     *
-     * @param dimensions - An object containing width and height properties.
-     *
-     * @beta
-     */
-    export function resize(dimensions: DialogSize): void {
-      updateResizeHelper(getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_Update_Resize), dimensions);
-    }
-
-    /**
-     * Checks if dialog.update capability is supported by the host
-     * @returns boolean to represent whether dialog.update capabilty is supported
-     *
-     * @throws Error if {@linkcode app.initialize} has not successfully completed
-     *
-     * @beta
-     */
-    export function isSupported(): boolean {
-      return ensureInitialized(runtime) && runtime.supports.dialog
-        ? runtime.supports.dialog.update
-          ? true
-          : false
-        : false;
-    }
-  }
-
-  /**
-   * Subcapability for interacting with adaptive card dialogs
-   * @beta
-   */
-  export namespace adaptiveCard {
-    /**
-     * Allows app to open an adaptive card based dialog.
-     *
-     * @remarks
-     * This function cannot be called from inside of a dialog
-     *
-     * @param adaptiveCardDialogInfo - An object containing the parameters of the dialog module {@link AdaptiveCardDialogInfo}.
-     * @param submitHandler - Handler that triggers when a dialog calls the {@linkcode url.submit} function or when the user closes the dialog.
-     *
-     * @beta
-     */
-    export function open(adaptiveCardDialogInfo: AdaptiveCardDialogInfo, submitHandler?: DialogSubmitHandler): void {
-      ensureInitialized(runtime, FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
-      if (!isSupported()) {
-        throw errorNotSupportedOnPlatform;
-      }
-      const dialogInfo: DialogInfo = getDialogInfoFromAdaptiveCardDialogInfo(adaptiveCardDialogInfo);
-      sendMessageToParent(
-        getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_AdaptiveCard_Open),
-        'tasks.startTask',
-        [dialogInfo],
-        (err: string, result: string | object) => {
-          submitHandler?.({ err, result });
-        },
-      );
-    }
-
-    /**
-     * Checks if dialog.adaptiveCard module is supported by the host
-     *
-     * @returns boolean to represent whether dialog.adaptiveCard module is supported
-     *
-     * @throws Error if {@linkcode app.initialize} has not successfully completed
-     *
-     * @beta
-     */
-    export function isSupported(): boolean {
-      const isAdaptiveCardVersionSupported =
-        runtime.hostVersionsInfo &&
-        runtime.hostVersionsInfo.adaptiveCardSchemaVersion &&
-        !isHostAdaptiveCardSchemaVersionUnsupported(runtime.hostVersionsInfo.adaptiveCardSchemaVersion);
-      return (
-        ensureInitialized(runtime) &&
-        (isAdaptiveCardVersionSupported && runtime.supports.dialog && runtime.supports.dialog.card) !== undefined
-      );
-    }
-
-    /**
-     * Namespace for interaction with adaptive card dialogs that need to communicate with the bot framework
-     *
-     * @beta
-     */
-    export namespace bot {
-      /**
-       * Allows an app to open an adaptive card-based dialog module using bot.
-       *
-       * @param botAdaptiveCardDialogInfo - An object containing the parameters of the dialog module including completionBotId.
-       * @param submitHandler - Handler that triggers when the dialog has been submitted or closed.
-       *
-       * @beta
-       */
-      export function open(
-        botAdaptiveCardDialogInfo: BotAdaptiveCardDialogInfo,
-        submitHandler?: DialogSubmitHandler,
-      ): void {
-        ensureInitialized(runtime, FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
-        if (!isSupported()) {
-          throw errorNotSupportedOnPlatform;
-        }
-
-        const dialogInfo: DialogInfo = getDialogInfoFromBotAdaptiveCardDialogInfo(botAdaptiveCardDialogInfo);
-
-        sendMessageToParent(
-          getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_AdaptiveCard_Bot_Open),
-          'tasks.startTask',
-          [dialogInfo],
-          (err: string, result: string | object) => {
-            submitHandler?.({ err, result });
-          },
-        );
-      }
-
-      /**
-       * Checks if dialog.adaptiveCard.bot capability is supported by the host
-       *
-       * @returns boolean to represent whether dialog.adaptiveCard.bot is supported
-       *
-       * @throws Error if {@linkcode app.initialize} has not successfully completed
-       *
-       * @beta
-       */
-      export function isSupported(): boolean {
-        const isAdaptiveCardVersionSupported =
-          runtime.hostVersionsInfo &&
-          runtime.hostVersionsInfo.adaptiveCardSchemaVersion &&
-          !isHostAdaptiveCardSchemaVersionUnsupported(runtime.hostVersionsInfo.adaptiveCardSchemaVersion);
-        return (
-          ensureInitialized(runtime) &&
-          (isAdaptiveCardVersionSupported &&
-            runtime.supports.dialog &&
-            runtime.supports.dialog.card &&
-            runtime.supports.dialog.card.bot) !== undefined
-        );
-      }
-    }
-
-    /**
-     * @hidden
-     * Hide from docs
-     * --------
-     * Convert AdaptiveCardDialogInfo to DialogInfo to send the information to host in {@linkcode adaptiveCard.open} API.
-     *
-     * @internal
-     */
-    function getDialogInfoFromAdaptiveCardDialogInfo(adaptiveCardDialogInfo: AdaptiveCardDialogInfo): DialogInfo {
-      const dialogInfo: DialogInfo = {
-        card: adaptiveCardDialogInfo.card,
-        height: adaptiveCardDialogInfo.size ? adaptiveCardDialogInfo.size.height : DialogDimension.Small,
-        width: adaptiveCardDialogInfo.size ? adaptiveCardDialogInfo.size.width : DialogDimension.Small,
-        title: adaptiveCardDialogInfo.title,
-      };
-      return dialogInfo;
-    }
-
-    /**
-     * @hidden
-     * Hide from docs
-     * --------
-     * Convert BotAdaptiveCardDialogInfo to DialogInfo to send the information to host in {@linkcode adaptiveCard.open} API.
-     *
-     * @internal
-     */
-    function getDialogInfoFromBotAdaptiveCardDialogInfo(
-      botAdaptiveCardDialogInfo: BotAdaptiveCardDialogInfo,
-    ): DialogInfo {
-      const dialogInfo: DialogInfo = getDialogInfoFromAdaptiveCardDialogInfo(botAdaptiveCardDialogInfo);
-      dialogInfo.completionBotId = botAdaptiveCardDialogInfo.completionBotId;
-      return dialogInfo;
-    }
-  }
-
-  export { adaptiveCard, url, update };
+  result?: string | object;
 }
+
+/**
+ * Handler used to receive and process messages sent between a dialog and the app that launched it
+ * @beta
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PostMessageChannel = (message: any) => void;
+
+/**
+ * Handler used for receiving results when a dialog closes, either the value passed by {@linkcode url.submit}
+ * or an error if the dialog was closed by the user.
+ *
+ * @see {@linkcode ISdkResponse}
+ *
+ * @beta
+ */
+export type DialogSubmitHandler = (result: ISdkResponse) => void;
+const storedMessages: string[] = [];
+
+/**
+ * @hidden
+ * Hide from docs because this function is only used during initialization
+ *
+ * Adds register handlers for messageForChild upon initialization and only in the tasks FrameContext. {@link FrameContexts.task}
+ * Function is called during app initialization
+ * @internal
+ * Limited to Microsoft-internal use
+ *
+ * @beta
+ */
+export function initialize(): void {
+  registerHandler(
+    getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_RegisterMessageForChildHandler),
+    'messageForChild',
+    handleDialogMessage,
+    false,
+  );
+}
+
+function handleDialogMessage(message: string): void {
+  if (!GlobalVars.frameContext) {
+    // GlobalVars.frameContext is currently not set
+    return;
+  }
+
+  if (GlobalVars.frameContext === FrameContexts.task) {
+    storedMessages.push(message);
+  } else {
+    // Not in task FrameContext, remove 'messageForChild' handler
+    removeHandler('messageForChild');
+  }
+}
+
+/**
+ * This function currently serves no purpose and should not be used. All functionality that used
+ * to be covered by this method is now in subcapabilities and those isSupported methods should be
+ * used directly.
+ *
+ * @hidden
+ */
+export function isSupported(): boolean {
+  return ensureInitialized(runtime) && runtime.supports.dialog ? true : false;
+}
+
+export { adaptiveCard, url, update };

--- a/packages/teams-js/src/public/dialog/dialog.ts
+++ b/packages/teams-js/src/public/dialog/dialog.ts
@@ -2,14 +2,14 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { sendMessageToParent } from '../internal/communication';
-import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from '../internal/dialogHelpers';
-import { GlobalVars } from '../internal/globalVars';
-import { registerHandler, removeHandler } from '../internal/handlers';
-import { ensureInitialized } from '../internal/internalAPIs';
-import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { isHostAdaptiveCardSchemaVersionUnsupported } from '../internal/utils';
-import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from './constants';
+import { sendMessageToParent } from '../../internal/communication';
+import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from '../../internal/dialogHelpers';
+import { GlobalVars } from '../../internal/globalVars';
+import { registerHandler, removeHandler } from '../../internal/handlers';
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
+import { isHostAdaptiveCardSchemaVersionUnsupported } from '../../internal/utils';
+import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../constants';
 import {
   AdaptiveCardDialogInfo,
   BotAdaptiveCardDialogInfo,
@@ -18,8 +18,8 @@ import {
   DialogSize,
   M365ContentAction,
   UrlDialogInfo,
-} from './interfaces';
-import { runtime } from './runtime';
+} from '../interfaces';
+import { runtime } from '../runtime';
 
 /**
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY

--- a/packages/teams-js/src/public/dialog/dialog.ts
+++ b/packages/teams-js/src/public/dialog/dialog.ts
@@ -2,8 +2,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { dialogTelemetryVersionNumber } from '../../internal/dialogHelpers';
-import { GlobalVars } from '../../internal/globalVars';
+import { dialogTelemetryVersionNumber, handleDialogMessage } from '../../internal/dialogHelpers';
 import { registerHandler, removeHandler } from '../../internal/handlers';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ApiName, getApiVersionTag } from '../../internal/telemetry';
@@ -62,7 +61,6 @@ export type PostMessageChannel = (message: any) => void;
  * @beta
  */
 export type DialogSubmitHandler = (result: ISdkResponse) => void;
-const storedMessages: string[] = [];
 
 /**
  * @hidden
@@ -82,20 +80,6 @@ export function initialize(): void {
     handleDialogMessage,
     false,
   );
-}
-
-function handleDialogMessage(message: string): void {
-  if (!GlobalVars.frameContext) {
-    // GlobalVars.frameContext is currently not set
-    return;
-  }
-
-  if (GlobalVars.frameContext === FrameContexts.task) {
-    storedMessages.push(message);
-  } else {
-    // Not in task FrameContext, remove 'messageForChild' handler
-    removeHandler('messageForChild');
-  }
 }
 
 /**

--- a/packages/teams-js/src/public/dialog/update.ts
+++ b/packages/teams-js/src/public/dialog/update.ts
@@ -1,18 +1,37 @@
-import { sendMessageToParent } from '../../internal/communication';
-import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from '../../internal/dialogHelpers';
-import { GlobalVars } from '../../internal/globalVars';
-import { registerHandler, removeHandler } from '../../internal/handlers';
+import { dialogTelemetryVersionNumber, updateResizeHelper } from '../../internal/dialogHelpers';
 import { ensureInitialized } from '../../internal/internalAPIs';
-import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
-import { isHostAdaptiveCardSchemaVersionUnsupported } from '../../internal/utils';
-import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../constants';
-import {
-  AdaptiveCardDialogInfo,
-  BotAdaptiveCardDialogInfo,
-  BotUrlDialogInfo,
-  DialogInfo,
-  DialogSize,
-  M365ContentAction,
-  UrlDialogInfo,
-} from '../interfaces';
+import { ApiName, getApiVersionTag } from '../../internal/telemetry';
+import { DialogSize } from '../interfaces';
 import { runtime } from '../runtime';
+
+/**
+ * Module to update the dialog
+ *
+ * @beta
+ */
+/**
+ * Update dimensions - height/width of a dialog.
+ *
+ * @param dimensions - An object containing width and height properties.
+ *
+ * @beta
+ */
+export function resize(dimensions: DialogSize): void {
+  updateResizeHelper(getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_Update_Resize), dimensions);
+}
+
+/**
+ * Checks if dialog.update capability is supported by the host
+ * @returns boolean to represent whether dialog.update capabilty is supported
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
+ * @beta
+ */
+export function isSupported(): boolean {
+  return ensureInitialized(runtime) && runtime.supports.dialog
+    ? runtime.supports.dialog.update
+      ? true
+      : false
+    : false;
+}

--- a/packages/teams-js/src/public/dialog/update.ts
+++ b/packages/teams-js/src/public/dialog/update.ts
@@ -1,0 +1,18 @@
+import { sendMessageToParent } from '../../internal/communication';
+import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from '../../internal/dialogHelpers';
+import { GlobalVars } from '../../internal/globalVars';
+import { registerHandler, removeHandler } from '../../internal/handlers';
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
+import { isHostAdaptiveCardSchemaVersionUnsupported } from '../../internal/utils';
+import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../constants';
+import {
+  AdaptiveCardDialogInfo,
+  BotAdaptiveCardDialogInfo,
+  BotUrlDialogInfo,
+  DialogInfo,
+  DialogSize,
+  M365ContentAction,
+  UrlDialogInfo,
+} from '../interfaces';
+import { runtime } from '../runtime';

--- a/packages/teams-js/src/public/dialog/url/bot.ts
+++ b/packages/teams-js/src/public/dialog/url/bot.ts
@@ -1,0 +1,51 @@
+import { botUrlOpenHelper, dialogTelemetryVersionNumber } from '../../../internal/dialogHelpers';
+import { ensureInitialized } from '../../../internal/internalAPIs';
+import { ApiName, getApiVersionTag } from '../../../internal/telemetry';
+import { BotUrlDialogInfo } from '../../interfaces';
+import { runtime } from '../../runtime';
+import { DialogSubmitHandler, PostMessageChannel } from '../dialog';
+
+/**
+ * Module to open a dialog that sends results to the bot framework
+ *
+ * @beta
+ */
+/**
+ * Allows an app to open a dialog that sends submitted data to a bot.
+ *
+ * @param botUrlDialogInfo - An object containing the parameters of the dialog module including completionBotId.
+ * @param submitHandler - Handler that triggers when the dialog has been submitted or closed.
+ * @param messageFromChildHandler - Handler that triggers if dialog sends a message to the app.
+ *
+ * @returns a function that can be used to send messages to the dialog.
+ *
+ * @beta
+ */
+export function open(
+  botUrlDialogInfo: BotUrlDialogInfo,
+  submitHandler?: DialogSubmitHandler,
+  messageFromChildHandler?: PostMessageChannel,
+): void {
+  botUrlOpenHelper(
+    getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_Url_Bot_Open),
+    botUrlDialogInfo,
+    submitHandler,
+    messageFromChildHandler,
+  );
+}
+
+/**
+ * Checks if dialog.url.bot capability is supported by the host
+ *
+ * @returns boolean to represent whether dialog.url.bot is supported
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
+ * @beta
+ */
+export function isSupported(): boolean {
+  return (
+    ensureInitialized(runtime) &&
+    (runtime.supports.dialog && runtime.supports.dialog.url && runtime.supports.dialog.url.bot) !== undefined
+  );
+}

--- a/packages/teams-js/src/public/dialog/url/parentCommunication.ts
+++ b/packages/teams-js/src/public/dialog/url/parentCommunication.ts
@@ -1,5 +1,5 @@
 import { sendMessageToParent } from '../../../internal/communication';
-import { dialogTelemetryVersionNumber } from '../../../internal/dialogHelpers';
+import { dialogTelemetryVersionNumber, storedMessages } from '../../../internal/dialogHelpers';
 import { registerHandler, removeHandler } from '../../../internal/handlers';
 import { ensureInitialized } from '../../../internal/internalAPIs';
 import { ApiName, getApiVersionTag } from '../../../internal/telemetry';

--- a/packages/teams-js/src/public/dialog/url/parentCommunication.ts
+++ b/packages/teams-js/src/public/dialog/url/parentCommunication.ts
@@ -1,0 +1,116 @@
+import { sendMessageToParent } from '../../../internal/communication';
+import { dialogTelemetryVersionNumber } from '../../../internal/dialogHelpers';
+import { registerHandler, removeHandler } from '../../../internal/handlers';
+import { ensureInitialized } from '../../../internal/internalAPIs';
+import { ApiName, getApiVersionTag } from '../../../internal/telemetry';
+import { errorNotSupportedOnPlatform, FrameContexts } from '../../constants';
+import { runtime } from '../../runtime';
+import { PostMessageChannel } from '../dialog';
+
+/**
+ * Subcapability that allows communication between the dialog and the parent app.
+ *
+ * @remarks
+ * Note that dialog can be invoked from parentless scenarios e.g. Search Message Extensions. The subcapability `parentCommunication` is not supported in such scenarios.
+ *
+ * @beta
+ */
+/**
+ *  Send message to the parent from dialog
+ *
+ * @remarks
+ * This function is only intended to be called from code running within the dialog. Calling it from outside the dialog will have no effect.
+ *
+ * @param message - The message to send to the parent
+ *
+ * @beta
+ */
+export function sendMessageToParentFromDialog(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  message: any,
+): void {
+  ensureInitialized(runtime, FrameContexts.task);
+  if (!isSupported()) {
+    throw errorNotSupportedOnPlatform;
+  }
+
+  sendMessageToParent(
+    getApiVersionTag(
+      dialogTelemetryVersionNumber,
+      ApiName.Dialog_Url_ParentCommunication_SendMessageToParentFromDialog,
+    ),
+    'messageForParent',
+    [message],
+  );
+}
+
+/**
+ *  Send message to the dialog from the parent
+ *
+ * @param message - The message to send
+ *
+ * @beta
+ */
+export function sendMessageToDialog(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  message: any,
+): void {
+  ensureInitialized(runtime, FrameContexts.content, FrameContexts.sidePanel, FrameContexts.meetingStage);
+  if (!isSupported()) {
+    throw errorNotSupportedOnPlatform;
+  }
+
+  sendMessageToParent(
+    getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_Url_ParentCommunication_SendMessageToDialog),
+    'messageForChild',
+    [message],
+  );
+}
+
+/**
+ * Register a listener that will be triggered when a message is received from the app that opened the dialog.
+ *
+ * @remarks
+ * This function is only intended to be called from code running within the dialog. Calling it from outside the dialog will have no effect.
+ *
+ * @param listener - The listener that will be triggered.
+ *
+ * @beta
+ */
+export function registerOnMessageFromParent(listener: PostMessageChannel): void {
+  ensureInitialized(runtime, FrameContexts.task);
+  if (!isSupported()) {
+    throw errorNotSupportedOnPlatform;
+  }
+
+  // We need to remove the original 'messageForChild'
+  // handler since the original does not allow for post messages.
+  // It is replaced by the user specified listener that is passed in.
+  removeHandler('messageForChild');
+  registerHandler(
+    getApiVersionTag(
+      dialogTelemetryVersionNumber,
+      ApiName.Dialog_Url_ParentCommunication_RegisterMessageForChildHandler,
+    ),
+    'messageForChild',
+    listener,
+  );
+  storedMessages.reverse();
+  while (storedMessages.length > 0) {
+    const message = storedMessages.pop();
+    listener(message);
+  }
+}
+
+/**
+ * Checks if dialog.url.parentCommunication capability is supported by the host
+ *
+ * @returns boolean to represent whether dialog.url.parentCommunication capability is supported
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
+ * @beta
+ */
+export function isSupported(): boolean {
+  return ensureInitialized(runtime) && !!runtime.supports.dialog?.url?.parentCommunication;
+}

--- a/packages/teams-js/src/public/dialog/url/url.ts
+++ b/packages/teams-js/src/public/dialog/url/url.ts
@@ -1,18 +1,101 @@
-import { sendMessageToParent } from '../../internal/communication';
-import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from '../../internal/dialogHelpers';
-import { GlobalVars } from '../../internal/globalVars';
-import { registerHandler, removeHandler } from '../../internal/handlers';
-import { ensureInitialized } from '../../internal/internalAPIs';
-import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
-import { isHostAdaptiveCardSchemaVersionUnsupported } from '../../internal/utils';
-import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../constants';
-import {
-  AdaptiveCardDialogInfo,
-  BotAdaptiveCardDialogInfo,
-  BotUrlDialogInfo,
-  DialogInfo,
-  DialogSize,
-  M365ContentAction,
-  UrlDialogInfo,
-} from '../interfaces';
-import { runtime } from '../runtime';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { dialogTelemetryVersionNumber, urlOpenHelper, urlSubmitHelper } from '../../../internal/dialogHelpers';
+import { ensureInitialized } from '../../../internal/internalAPIs';
+import { ApiName, getApiVersionTag } from '../../../internal/telemetry';
+import { DialogDimension } from '../../constants';
+import { BotUrlDialogInfo, DialogInfo, UrlDialogInfo } from '../../interfaces';
+import { M365ContentAction } from '../../interfaces';
+import { runtime } from '../../runtime';
+import { DialogSubmitHandler, PostMessageChannel } from '../dialog';
+import * as bot from './bot';
+import * as parentCommunication from './parentCommunication';
+
+/**
+ * Allows app to open a url based dialog.
+ *
+ * @remarks
+ * This function cannot be called from inside of a dialog
+ *
+ * @param urlDialogInfo - An object containing the parameters of the dialog module.
+ * @param submitHandler - Handler that triggers when a dialog calls the {@linkcode submit} function or when the user closes the dialog.
+ * @param messageFromChildHandler - Handler that triggers if dialog sends a message to the app.
+ *
+ * @beta
+ */
+export function open(
+  urlDialogInfo: UrlDialogInfo,
+  submitHandler?: DialogSubmitHandler,
+  messageFromChildHandler?: PostMessageChannel,
+): void {
+  urlOpenHelper(
+    getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_Url_Open),
+    urlDialogInfo,
+    submitHandler,
+    messageFromChildHandler,
+  );
+}
+
+/**
+ * Submit the dialog module and close the dialog
+ *
+ * @remarks
+ * This function is only intended to be called from code running within the dialog. Calling it from outside the dialog will have no effect.
+ *
+ * @param result - The result to be sent to the bot or the app. Typically a JSON object or a serialized version of it,
+ *  If this function is called from a dialog while {@link M365ContentAction} is set in the context object by the host, result will be ignored
+ *
+ * @param appIds - Valid application(s) that can receive the result of the submitted dialogs. Specifying this parameter helps prevent malicious apps from retrieving the dialog result. Multiple app IDs can be specified because a web app from a single underlying domain can power multiple apps across different environments and branding schemes.
+ *
+ * @beta
+ */
+export function submit(result?: string | object, appIds?: string | string[]): void {
+  urlSubmitHelper(getApiVersionTag(dialogTelemetryVersionNumber, ApiName.Dialog_Url_Submit), result, appIds);
+}
+
+/**
+ * Checks if dialog.url module is supported by the host
+ *
+ * @returns boolean to represent whether dialog.url module is supported
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
+ * @beta
+ */
+export function isSupported(): boolean {
+  return ensureInitialized(runtime) && (runtime.supports.dialog && runtime.supports.dialog.url) !== undefined;
+}
+
+/**
+ * @hidden
+ *
+ * Convert UrlDialogInfo to DialogInfo to send the information to host in {@linkcode open} API.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function getDialogInfoFromUrlDialogInfo(urlDialogInfo: UrlDialogInfo): DialogInfo {
+  const dialogInfo: DialogInfo = {
+    url: urlDialogInfo.url,
+    height: urlDialogInfo.size ? urlDialogInfo.size.height : DialogDimension.Small,
+    width: urlDialogInfo.size ? urlDialogInfo.size.width : DialogDimension.Small,
+    title: urlDialogInfo.title,
+    fallbackUrl: urlDialogInfo.fallbackUrl,
+  };
+  return dialogInfo;
+}
+
+/**
+ * @hidden
+ *
+ * Convert BotUrlDialogInfo to DialogInfo to send the information to host in {@linkcode bot.open} API.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function getDialogInfoFromBotUrlDialogInfo(botUrlDialogInfo: BotUrlDialogInfo): DialogInfo {
+  const dialogInfo: DialogInfo = getDialogInfoFromUrlDialogInfo(botUrlDialogInfo);
+  dialogInfo.completionBotId = botUrlDialogInfo.completionBotId;
+  return dialogInfo;
+}
+
+export { bot, parentCommunication };

--- a/packages/teams-js/src/public/dialog/url/url.ts
+++ b/packages/teams-js/src/public/dialog/url/url.ts
@@ -1,0 +1,18 @@
+import { sendMessageToParent } from '../../internal/communication';
+import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from '../../internal/dialogHelpers';
+import { GlobalVars } from '../../internal/globalVars';
+import { registerHandler, removeHandler } from '../../internal/handlers';
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
+import { isHostAdaptiveCardSchemaVersionUnsupported } from '../../internal/utils';
+import { DialogDimension, errorNotSupportedOnPlatform, FrameContexts } from '../constants';
+import {
+  AdaptiveCardDialogInfo,
+  BotAdaptiveCardDialogInfo,
+  BotUrlDialogInfo,
+  DialogInfo,
+  DialogSize,
+  M365ContentAction,
+  UrlDialogInfo,
+} from '../interfaces';
+import { runtime } from '../runtime';

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -50,7 +50,7 @@ export * as chat from './chat';
 //to keep the named exports so as to not break the existing consumers directly referencing the named exports.
 export { OpenGroupChatRequest, OpenSingleChatRequest } from './chat';
 export * as clipboard from './clipboard';
-export { dialog } from './dialog';
+export { dialog } from './dialog/dialog';
 export { nestedAppAuth } from './nestedAppAuth';
 export * as geoLocation from './geoLocation/geoLocation';
 export { getAdaptiveCardSchemaVersion } from './adaptiveCards';

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -50,7 +50,7 @@ export * as chat from './chat';
 //to keep the named exports so as to not break the existing consumers directly referencing the named exports.
 export { OpenGroupChatRequest, OpenSingleChatRequest } from './chat';
 export * as clipboard from './clipboard';
-export { dialog } from './dialog/dialog';
+export * as dialog from './dialog/dialog';
 export { nestedAppAuth } from './nestedAppAuth';
 export * as geoLocation from './geoLocation/geoLocation';
 export { getAdaptiveCardSchemaVersion } from './adaptiveCards';

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -5,8 +5,8 @@ import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
 import { ChildAppWindow, IAppWindow } from './appWindow';
 import { FrameContexts, TaskModuleDimension } from './constants';
-import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from './dialog';
-import { dialog } from './dialog';
+import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from './dialog/dialog';
+import { dialog } from './dialog/dialog';
 import { BotUrlDialogInfo, DialogInfo, DialogSize, TaskInfo, UrlDialogInfo } from './interfaces';
 import { runtime } from './runtime';
 

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import { sendMessageToParent } from '../internal/communication';
+import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from '../internal/dialogHelpers';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
 import { ChildAppWindow, IAppWindow } from './appWindow';
 import { FrameContexts, TaskModuleDimension } from './constants';
-import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from './dialog/dialog';
-import { dialog } from './dialog/dialog';
+import * as dialog from './dialog/dialog';
 import { BotUrlDialogInfo, DialogInfo, DialogSize, TaskInfo, UrlDialogInfo } from './interfaces';
 import { runtime } from './runtime';
 

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -9,7 +9,7 @@ import {
   FrameContexts,
   minAdaptiveCardVersion,
 } from '../../src/public/constants';
-import { dialog } from '../../src/public/dialog';
+import * as dialog from '../../src/public/dialog/dialog';
 import { AdaptiveCardDialogInfo, BotAdaptiveCardDialogInfo, DialogInfo, DialogSize } from '../../src/public/interfaces';
 import { BotUrlDialogInfo, UrlDialogInfo } from '../../src/public/interfaces';
 import { latestRuntimeApiVersion } from '../../src/public/runtime';


### PR DESCRIPTION
**This PR is part of the larger Treeshaking effort, with more PRs to come in the future**

This PR refactors the `dialog` capability as well as all of its sub-capabilities to make them treeshakable. Since `dialog` has many sub-capabilities, some with their own set of sub-capabilities, it's getting its own PR since there's quite a few changes that had to be made. Those changes being:
- Moved all helper functions and `dialogTelemetryVersionNumber` constant to their own file, `dialogHelpers.ts` in the internal folder.
- Moved each sub-capability to their own files and reorganized the file structure to help keep the repo organized.
- Removed the namespaces from each capability file to enable treeshaking

The new folder structure for the `dialog` capability and sub-capabilites is as follows:
```
public
  dialog
    adaptiveCard
      adaptiveCard.ts
      bot.ts
    dialog.ts
    update.ts
    url
      bot.ts
      parentCommunication.ts
      url.ts 
```

One question I have is do you think having the parent capability match the folder name that they are in, or would it make more sense to name them index.ts? For example, would you prefer having the folder `adaptiveCard` contain `adaptiveCard.ts` and `bot.ts`. Or would you prefer the folder `adaptiveCard` contain `index.ts` and `bot.ts`?

_With the removal of the namespaces, there are not many code changes to the capability files, however there is significant whitespace changes. To make reviewing the PR simpler, I recommend hiding the whitespace changes, which you can enable by selecting the gear icon when viewing the changes_