### PR TITLE
Change alert to text in the box for e2e testing

### DIFF
--- a/apps/teams-test-app/src/components/TeamsCoreAPIs.tsx
+++ b/apps/teams-test-app/src/components/TeamsCoreAPIs.tsx
@@ -81,9 +81,9 @@ const RegisterBeforeUnloadHandler = (): React.ReactElement =>
         withPromise: async (delay, setResult) => {
           teamsCore.registerBeforeUnloadHandler((readyToUnload): boolean => {
             setTimeout(() => {
+              setResult('beforeUnload received');
               readyToUnload();
             }, delay);
-            alert(`beforeUnload received; calling readyToUnload in ${delay / 1000} seconds`);
             setResult('Success');
             return true;
           });
@@ -93,9 +93,9 @@ const RegisterBeforeUnloadHandler = (): React.ReactElement =>
         withCallback: (delay, setResult) => {
           registerBeforeUnloadHandler((readyToUnload): boolean => {
             setTimeout(() => {
+              setResult('beforeUnload received');
               readyToUnload();
             }, delay);
-            alert(`beforeUnload received; calling readyToUnload in ${delay / 1000} seconds`);
             setResult('Success');
             return true;
           });


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

In cypress is it is complicated to test an alert that comes from an iframe. Instead of checking for the alert, we check the text in the box. OR we verify caching by making sure iframe does or does not exist in the dom. 