### PR TITLE
Noahdarveau/docs fix

### DIFF
--- a/change/@microsoft-teams-js-1596e2e2-4f59-44d4-8689-0de41698434f.json
+++ b/change/@microsoft-teams-js-1596e2e2-4f59-44d4-8689-0de41698434f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated namespace level docs to module level",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/private/appEntity.ts
+++ b/packages/teams-js/src/private/appEntity.ts
@@ -16,7 +16,10 @@ const appEntityTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
  *
  * @internal
  * Limited to Microsoft-internal use
+ *
+ * @module
  */
+
 /**
  * @hidden
  *

--- a/packages/teams-js/src/private/appEntity.ts
+++ b/packages/teams-js/src/private/appEntity.ts
@@ -1,3 +1,13 @@
+/**
+ * @hidden
+ * Module to interact with the application entities specific part of the SDK.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ *
+ * @module
+ */
+
 import { sendMessageToParent } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -9,16 +19,6 @@ import { runtime } from '../public/runtime';
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const appEntityTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
-
-/**
- * @hidden
- * Module to interact with the application entities specific part of the SDK.
- *
- * @internal
- * Limited to Microsoft-internal use
- *
- * @module
- */
 
 /**
  * @hidden

--- a/packages/teams-js/src/private/conversations.ts
+++ b/packages/teams-js/src/private/conversations.ts
@@ -130,7 +130,10 @@ export interface ConversationResponse {
  *
  * @internal
  * Limited to Microsoft-internal use
+ *
+ * @module
  */
+
 /**
  * @hidden
  * Hide from docs

--- a/packages/teams-js/src/private/conversations.ts
+++ b/packages/teams-js/src/private/conversations.ts
@@ -1,3 +1,13 @@
+/**
+ * @hidden
+ * Module to interact with the conversational subEntities inside the tab
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ *
+ * @module
+ */
+
 import { sendAndHandleStatusAndReason, sendAndUnwrap, sendMessageToParent } from '../internal/communication';
 import { registerHandler, removeHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -123,16 +133,6 @@ export interface ConversationResponse {
    */
   entityId?: string;
 }
-
-/**
- * @hidden
- * Module to interact with the conversational subEntities inside the tab
- *
- * @internal
- * Limited to Microsoft-internal use
- *
- * @module
- */
 
 /**
  * @hidden

--- a/packages/teams-js/src/private/copilot/eligibility.ts
+++ b/packages/teams-js/src/private/copilot/eligibility.ts
@@ -14,7 +14,9 @@ const copilotLogger = getLogger('copilot');
  * User information required by specific apps
  * @internal
  * Limited to Microsoft-internal use
+ * @module
  */
+
 /**
  * @hidden
  * @internal

--- a/packages/teams-js/src/private/copilot/eligibility.ts
+++ b/packages/teams-js/src/private/copilot/eligibility.ts
@@ -1,3 +1,12 @@
+/**
+ * @beta
+ * @hidden
+ * User information required by specific apps
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
 import { sendAndUnwrap } from '../../internal/communication';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag, getLogger } from '../../internal/telemetry';
@@ -7,15 +16,6 @@ import { runtime } from '../../public/runtime';
 
 const copilotTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 const copilotLogger = getLogger('copilot');
-
-/**
- * @beta
- * @hidden
- * User information required by specific apps
- * @internal
- * Limited to Microsoft-internal use
- * @module
- */
 
 /**
  * @hidden

--- a/packages/teams-js/src/private/externalAppAuthentication.ts
+++ b/packages/teams-js/src/private/externalAppAuthentication.ts
@@ -18,7 +18,9 @@ const externalAppAuthenticationTelemetryVersionNumber: ApiVersionNumber = ApiVer
  * Module to delegate authentication and message extension requests to the host
  * @internal
  * Limited to Microsoft-internal use
+ * @module
  */
+
 /*********** BEGIN REQUEST TYPE ************/
 /**
  * @hidden

--- a/packages/teams-js/src/private/externalAppAuthentication.ts
+++ b/packages/teams-js/src/private/externalAppAuthentication.ts
@@ -1,3 +1,11 @@
+/**
+ * @hidden
+ * Module to delegate authentication and message extension requests to the host
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
 import { sendMessageToParentAsync } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ResponseHandler } from '../internal/responseHandler';
@@ -12,14 +20,6 @@ import { ISerializable } from '../public/serializable.interface';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const externalAppAuthenticationTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * @hidden
- * Module to delegate authentication and message extension requests to the host
- * @internal
- * Limited to Microsoft-internal use
- * @module
- */
 
 /*********** BEGIN REQUEST TYPE ************/
 /**

--- a/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
+++ b/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
@@ -15,7 +15,9 @@ const externalAppAuthenticationTelemetryVersionNumber: ApiVersionNumber = ApiVer
  * @internal
  * Limited to Microsoft-internal use
  * @beta
+ * @module
  */
+
 /**
  * @beta
  * @hidden

--- a/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
+++ b/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
@@ -1,3 +1,12 @@
+/**
+ * @hidden
+ * Module to delegate authentication requests to the host for custom engine agents
+ * @internal
+ * Limited to Microsoft-internal use
+ * @beta
+ * @module
+ */
+
 import { callFunctionInHost, callFunctionInHostAndHandleResponse } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -8,15 +17,6 @@ import { runtime } from '../public/runtime';
 import * as externalAppAuthentication from './externalAppAuthentication';
 
 const externalAppAuthenticationTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * @hidden
- * Module to delegate authentication requests to the host for custom engine agents
- * @internal
- * Limited to Microsoft-internal use
- * @beta
- * @module
- */
 
 /**
  * @beta

--- a/packages/teams-js/src/private/externalAppCardActions.ts
+++ b/packages/teams-js/src/private/externalAppCardActions.ts
@@ -1,3 +1,11 @@
+/**
+ * @hidden
+ * Module to delegate adaptive card action execution to the host
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
 import { sendMessageToParentAsync } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -10,14 +18,6 @@ import { ExternalAppErrorCode } from './constants';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const externalAppCardActionsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * @hidden
- * Module to delegate adaptive card action execution to the host
- * @internal
- * Limited to Microsoft-internal use
- * @module
- */
 
 /**
  * @hidden

--- a/packages/teams-js/src/private/externalAppCardActions.ts
+++ b/packages/teams-js/src/private/externalAppCardActions.ts
@@ -16,7 +16,9 @@ const externalAppCardActionsTelemetryVersionNumber: ApiVersionNumber = ApiVersio
  * Module to delegate adaptive card action execution to the host
  * @internal
  * Limited to Microsoft-internal use
+ * @module
  */
+
 /**
  * @hidden
  * The type of deeplink action that was executed by the host

--- a/packages/teams-js/src/private/externalAppCardActionsForCEA.ts
+++ b/packages/teams-js/src/private/externalAppCardActionsForCEA.ts
@@ -17,18 +17,21 @@ const externalAppCardActionsTelemetryVersionNumber: ApiVersionNumber = ApiVersio
  * Module to delegate adaptive card action for Custom Engine Agent execution to the host
  * @internal
  * Limited to Microsoft-internal use
-  /**
-   * @beta
-   * @hidden
-   * Delegates an Adaptive Card Action.OpenUrl request to the host for the application with the provided app ID.
-   * @internal
-   * Limited to Microsoft-internal use
-   * @param appId ID of the application the request is intended for. This must be a UUID
-   * @param conversationId To tell the bot what conversation the calls are coming from
-   * @param url The URL to open
-   * @throws Error if the response has not successfully completed
-   * @returns Promise that resolves to ActionOpenUrlType indicating the type of URL that was opened on success and rejects with ActionOpenUrlError if the request fails
-   */
+ * @module
+ * /
+ 
+/**
+ * @beta
+ * @hidden
+ * Delegates an Adaptive Card Action.OpenUrl request to the host for the application with the provided app ID.
+ * @internal
+ * Limited to Microsoft-internal use
+ * @param appId ID of the application the request is intended for. This must be a UUID
+ * @param conversationId To tell the bot what conversation the calls are coming from
+ * @param url The URL to open
+ * @throws Error if the response has not successfully completed
+ * @returns Promise that resolves to ActionOpenUrlType indicating the type of URL that was opened on success and rejects with ActionOpenUrlError if the request fails
+ */
 export async function processActionOpenUrl(
   appId: AppId,
   conversationId: string,

--- a/packages/teams-js/src/private/externalAppCardActionsForCEA.ts
+++ b/packages/teams-js/src/private/externalAppCardActionsForCEA.ts
@@ -1,3 +1,12 @@
+/**
+ * @beta
+ * @hidden
+ * Module to delegate adaptive card action for Custom Engine Agent execution to the host
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
 import { sendAndUnwrap, sendMessageToParentAsync } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -11,15 +20,7 @@ import * as externalAppCardActions from './externalAppCardActions';
  * All of APIs in this capability file should send out API version v2 ONLY
  */
 const externalAppCardActionsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-/**
- * @beta
- * @hidden
- * Module to delegate adaptive card action for Custom Engine Agent execution to the host
- * @internal
- * Limited to Microsoft-internal use
- * @module
- * /
- 
+
 /**
  * @beta
  * @hidden

--- a/packages/teams-js/src/private/externalAppCommands.ts
+++ b/packages/teams-js/src/private/externalAppCommands.ts
@@ -19,7 +19,9 @@ const externalAppCommandsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNu
  * Limited to Microsoft-internal use
  *
  * @beta
+ * @module
  */
+
 /**
  * @hidden
  * The payload of IActionCommandResponse

--- a/packages/teams-js/src/private/externalAppCommands.ts
+++ b/packages/teams-js/src/private/externalAppCommands.ts
@@ -1,3 +1,13 @@
+/**
+ * @hidden
+ * Module to delegate the ActionCommand to the host
+ * @internal
+ * Limited to Microsoft-internal use
+ *
+ * @beta
+ * @module
+ */
+
 import { sendMessageToParentAsync } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -11,16 +21,6 @@ import * as externalAppAuthentication from './externalAppAuthentication';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const externalAppCommandsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * @hidden
- * Module to delegate the ActionCommand to the host
- * @internal
- * Limited to Microsoft-internal use
- *
- * @beta
- * @module
- */
 
 /**
  * @hidden

--- a/packages/teams-js/src/private/files.ts
+++ b/packages/teams-js/src/private/files.ts
@@ -10,7 +10,10 @@ import { runtime } from '../public/runtime';
  * @hidden
  *
  * Module to interact with the files specific part of the SDK.
- *
+ * @module
+ */
+
+/**
  * @internal
  * Limited to Microsoft-internal use
  *

--- a/packages/teams-js/src/private/files.ts
+++ b/packages/teams-js/src/private/files.ts
@@ -1,3 +1,14 @@
+/**
+ * @hidden
+ *
+ * Module to interact with the files specific part of the SDK.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ *
+ * @module
+ */
+
 import { sendMessageToParent } from '../internal/communication';
 import { registerHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -7,16 +18,6 @@ import { ErrorCode, FileOpenPreference, SdkError } from '../public/interfaces';
 import { runtime } from '../public/runtime';
 
 /**
- * @hidden
- *
- * Module to interact with the files specific part of the SDK.
- * @module
- */
-
-/**
- * @internal
- * Limited to Microsoft-internal use
- *
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const filesTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;

--- a/packages/teams-js/src/private/hostEntity/hostEntity.ts
+++ b/packages/teams-js/src/private/hostEntity/hostEntity.ts
@@ -6,10 +6,12 @@ import * as tab from './tab';
  * @hidden
  * @internal
  * @beta
+ * @module
  * Limited to Microsoft-internal use
  *
  * This capability allows an app to associate apps with a host entity, such as a Teams channel or chat, and configure them as needed.
  */
+
 export enum AppTypes {
   edu = 'EDU',
 }

--- a/packages/teams-js/src/private/hostEntity/hostEntity.ts
+++ b/packages/teams-js/src/private/hostEntity/hostEntity.ts
@@ -1,7 +1,3 @@
-import { ensureInitialized } from '../../internal/internalAPIs';
-import { runtime } from '../../public/runtime';
-import * as tab from './tab';
-
 /**
  * @hidden
  * @internal
@@ -11,6 +7,10 @@ import * as tab from './tab';
  *
  * This capability allows an app to associate apps with a host entity, such as a Teams channel or chat, and configure them as needed.
  */
+
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { runtime } from '../../public/runtime';
+import * as tab from './tab';
 
 export enum AppTypes {
   edu = 'EDU',

--- a/packages/teams-js/src/private/hostEntity/tab.ts
+++ b/packages/teams-js/src/private/hostEntity/tab.ts
@@ -17,10 +17,12 @@ const hostEntityTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
  * @hidden
  * @internal
  * @beta
+ * @module
  * Limited to Microsoft-internal use
  *
  * CRUD operations for tabs associated with apps
  */
+
 /**
  * Represents information about a static tab instance
  */

--- a/packages/teams-js/src/private/hostEntity/tab.ts
+++ b/packages/teams-js/src/private/hostEntity/tab.ts
@@ -1,3 +1,13 @@
+/**
+ * @hidden
+ * @internal
+ * @beta
+ * @module
+ * Limited to Microsoft-internal use
+ *
+ * CRUD operations for tabs associated with apps
+ */
+
 import { callFunctionInHostAndHandleResponse } from '../../internal/communication';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ResponseHandler, SimpleTypeResponseHandler } from '../../internal/responseHandler';
@@ -12,16 +22,6 @@ import { AppTypes, HostEntityIds, isSupported as isHostEntitySupported } from '.
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const hostEntityTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * @hidden
- * @internal
- * @beta
- * @module
- * Limited to Microsoft-internal use
- *
- * CRUD operations for tabs associated with apps
- */
 
 /**
  * Represents information about a static tab instance

--- a/packages/teams-js/src/private/logs.ts
+++ b/packages/teams-js/src/private/logs.ts
@@ -1,3 +1,12 @@
+/**
+ * @hidden
+ * Module to interact with the logging part of the SDK.
+ * This object is used to send the app logs on demand to the host client
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+
 import { sendMessageToParent } from '../internal/communication';
 import { registerHandler, removeHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -7,13 +16,6 @@ import { errorNotSupportedOnPlatform } from '../public/constants';
 import { runtime } from '../public/runtime';
 
 /**
- * @hidden
- * Module to interact with the logging part of the SDK.
- * This object is used to send the app logs on demand to the host client
- *
- * @internal
- * Limited to Microsoft-internal use
- *
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const logsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;

--- a/packages/teams-js/src/private/meetingRoom.ts
+++ b/packages/teams-js/src/private/meetingRoom.ts
@@ -1,3 +1,11 @@
+/**
+ * @hidden
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../internal/communication';
 import { registerHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -6,11 +14,6 @@ import { errorNotSupportedOnPlatform } from '../public/constants';
 import { runtime } from '../public/runtime';
 
 /**
- * @hidden
- *
- * @internal
- * Limited to Microsoft-internal use
- *
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const meetingRoomTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;

--- a/packages/teams-js/src/private/messageChannels/messageChannels.ts
+++ b/packages/teams-js/src/private/messageChannels/messageChannels.ts
@@ -11,7 +11,10 @@ import * as telemetry from './telemetry';
  *
  * @internal
  * Limited to Microsoft-internal use
+ *
+ * @module
  */
+
 /**
  * @hidden
  *

--- a/packages/teams-js/src/private/messageChannels/messageChannels.ts
+++ b/packages/teams-js/src/private/messageChannels/messageChannels.ts
@@ -1,8 +1,3 @@
-import { ensureInitialized } from '../../internal/internalAPIs';
-import { runtime } from '../../public/runtime';
-import * as dataLayer from './dataLayer';
-import * as telemetry from './telemetry';
-
 /**
  * @hidden
  * Module to request message ports from the host application.
@@ -14,6 +9,11 @@ import * as telemetry from './telemetry';
  *
  * @module
  */
+
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { runtime } from '../../public/runtime';
+import * as dataLayer from './dataLayer';
+import * as telemetry from './telemetry';
 
 /**
  * @hidden

--- a/packages/teams-js/src/private/notifications.ts
+++ b/packages/teams-js/src/private/notifications.ts
@@ -1,16 +1,20 @@
-import { sendMessageToParent } from '../internal/communication';
-import { ensureInitialized } from '../internal/internalAPIs';
-import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
-import { runtime } from '../public/runtime';
-import { ShowNotificationParameters } from './interfaces';
 /**
  * @hidden
  * Hidden from Docs
  *
  * @internal
  * Limited to Microsoft-internal use
- *
+ * @module
+ */
+
+import { sendMessageToParent } from '../internal/communication';
+import { ensureInitialized } from '../internal/internalAPIs';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
+import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
+import { runtime } from '../public/runtime';
+import { ShowNotificationParameters } from './interfaces';
+
+/**
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const notificationsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;

--- a/packages/teams-js/src/private/otherAppStateChange.ts
+++ b/packages/teams-js/src/private/otherAppStateChange.ts
@@ -7,6 +7,7 @@ import { ErrorCode } from '../public/interfaces';
 import { runtime } from '../public/runtime';
 
 /**
+ * @module
  * @hidden
  * @internal
  * @beta
@@ -16,6 +17,7 @@ import { runtime } from '../public/runtime';
  * *while* the developer's application is running. For example, if the developer wants to be notified
  * when another application has been installed.
  */
+
 /**
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */

--- a/packages/teams-js/src/private/otherAppStateChange.ts
+++ b/packages/teams-js/src/private/otherAppStateChange.ts
@@ -1,11 +1,3 @@
-import { sendMessageToParent } from '../internal/communication';
-import { registerHandler, removeHandler } from '../internal/handlers';
-import { ensureInitialized } from '../internal/internalAPIs';
-import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { isNullOrUndefined } from '../internal/typeCheckUtilities';
-import { ErrorCode } from '../public/interfaces';
-import { runtime } from '../public/runtime';
-
 /**
  * @module
  * @hidden
@@ -17,6 +9,14 @@ import { runtime } from '../public/runtime';
  * *while* the developer's application is running. For example, if the developer wants to be notified
  * when another application has been installed.
  */
+
+import { sendMessageToParent } from '../internal/communication';
+import { registerHandler, removeHandler } from '../internal/handlers';
+import { ensureInitialized } from '../internal/internalAPIs';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
+import { isNullOrUndefined } from '../internal/typeCheckUtilities';
+import { ErrorCode } from '../public/interfaces';
+import { runtime } from '../public/runtime';
 
 /**
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY

--- a/packages/teams-js/src/private/remoteCamera.ts
+++ b/packages/teams-js/src/private/remoteCamera.ts
@@ -1,3 +1,11 @@
+/**
+ * @hidden
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
 import { sendMessageToParent } from '../internal/communication';
 import { registerHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -7,11 +15,6 @@ import { SdkError } from '../public/interfaces';
 import { runtime } from '../public/runtime';
 
 /**
- * @hidden
- *
- * @internal
- * Limited to Microsoft-internal use
- *
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const remoteCameraTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;

--- a/packages/teams-js/src/private/teams/fullTrust/fullTrust.ts
+++ b/packages/teams-js/src/private/teams/fullTrust/fullTrust.ts
@@ -11,10 +11,12 @@ import * as joinedTeams from './joinedTeams';
 const teamsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
 
 /**
+ * @module
  * @hidden
  * @internal
  * Limited to Microsoft-internal use
  */
+
 /**
  * @hidden
  * Allows an app to get the configuration setting value

--- a/packages/teams-js/src/private/teams/fullTrust/fullTrust.ts
+++ b/packages/teams-js/src/private/teams/fullTrust/fullTrust.ts
@@ -1,3 +1,10 @@
+/**
+ * @module
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+
 import { sendAndUnwrap } from '../../../internal/communication';
 import { ensureInitialized } from '../../../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../../internal/telemetry';
@@ -9,13 +16,6 @@ import * as joinedTeams from './joinedTeams';
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const teamsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
-
-/**
- * @module
- * @hidden
- * @internal
- * Limited to Microsoft-internal use
- */
 
 /**
  * @hidden

--- a/packages/teams-js/src/private/teams/fullTrust/joinedTeams.ts
+++ b/packages/teams-js/src/private/teams/fullTrust/joinedTeams.ts
@@ -14,10 +14,12 @@ import { TeamInstanceParameters, UserJoinedTeamsInformation } from '../../interf
 const teamsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
 
 /**
+ * @module
  * @hidden
  * @internal
  * Limited to Microsoft-internal use
  */
+
 /**
  * @hidden
  * Allows an app to retrieve information of all user joined teams

--- a/packages/teams-js/src/private/teams/fullTrust/joinedTeams.ts
+++ b/packages/teams-js/src/private/teams/fullTrust/joinedTeams.ts
@@ -1,3 +1,10 @@
+/**
+ * @module
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+
 import { sendAndUnwrap } from '../../../internal/communication';
 import { getUserJoinedTeamsSupportedAndroidClientVersion } from '../../../internal/constants';
 import { GlobalVars } from '../../../internal/globalVars';
@@ -12,13 +19,6 @@ import { TeamInstanceParameters, UserJoinedTeamsInformation } from '../../interf
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const teamsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
-
-/**
- * @module
- * @hidden
- * @internal
- * Limited to Microsoft-internal use
- */
 
 /**
  * @hidden

--- a/packages/teams-js/src/private/teams/teams.ts
+++ b/packages/teams-js/src/private/teams/teams.ts
@@ -1,11 +1,3 @@
-import { sendMessageToParent } from '../../internal/communication';
-import { ensureInitialized } from '../../internal/internalAPIs';
-import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
-import { errorNotSupportedOnPlatform, FrameContexts } from '../../public/constants';
-import { SdkError } from '../../public/interfaces';
-import { runtime } from '../../public/runtime';
-import * as fullTrust from './fullTrust/fullTrust';
-
 /**
  * @module
  * @hidden
@@ -14,6 +6,14 @@ import * as fullTrust from './fullTrust/fullTrust';
  * @internal
  * Limited to Microsoft-internal use
  */
+
+import { sendMessageToParent } from '../../internal/communication';
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
+import { errorNotSupportedOnPlatform, FrameContexts } from '../../public/constants';
+import { SdkError } from '../../public/interfaces';
+import { runtime } from '../../public/runtime';
+import * as fullTrust from './fullTrust/fullTrust';
 
 /**
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY

--- a/packages/teams-js/src/private/teams/teams.ts
+++ b/packages/teams-js/src/private/teams/teams.ts
@@ -7,12 +7,15 @@ import { runtime } from '../../public/runtime';
 import * as fullTrust from './fullTrust/fullTrust';
 
 /**
+ * @module
  * @hidden
  * Module to interact with the `teams` specific part of the SDK.
  *
  * @internal
  * Limited to Microsoft-internal use
- *
+ */
+
+/**
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const teamsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;

--- a/packages/teams-js/src/private/videoEffectsEx.ts
+++ b/packages/teams-js/src/private/videoEffectsEx.ts
@@ -17,7 +17,14 @@ import * as videoEffects from '../public/videoEffects';
 /**
  * @hidden
  * Extended video API
+ * @internal
+ * Limited to Microsoft-internal use
  * @beta
+ * @module
+ */
+
+/**
+ * @hidden
  *
  * @internal
  * Limited to Microsoft-internal use

--- a/packages/teams-js/src/private/videoEffectsEx.ts
+++ b/packages/teams-js/src/private/videoEffectsEx.ts
@@ -1,3 +1,12 @@
+/**
+ * @hidden
+ * Extended video API
+ * @internal
+ * Limited to Microsoft-internal use
+ * @beta
+ * @module
+ */
+
 import { sendMessageToParent } from '../internal/communication';
 import { registerHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -15,19 +24,6 @@ import { runtime } from '../public/runtime';
 import * as videoEffects from '../public/videoEffects';
 
 /**
- * @hidden
- * Extended video API
- * @internal
- * Limited to Microsoft-internal use
- * @beta
- * @module
- */
-
-/**
- * @hidden
- *
- * @internal
- * Limited to Microsoft-internal use
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const videoEffectsExTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;

--- a/packages/teams-js/src/public/app/app.ts
+++ b/packages/teams-js/src/public/app/app.ts
@@ -2,6 +2,11 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+/**
+ * Module to interact with app initialization and lifecycle.
+ * @module
+ */
+
 import * as appHelpers from '../../internal/appHelpers';
 import { Communication, sendAndUnwrap, uninitializeCommunication } from '../../internal/communication';
 import { GlobalVars } from '../../internal/globalVars';
@@ -26,11 +31,6 @@ import * as lifecycle from './lifecycle';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const appTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Module to interact with app initialization and lifecycle.
- * @module
- */
 
 const appLogger = getLogger('app');
 

--- a/packages/teams-js/src/public/app/app.ts
+++ b/packages/teams-js/src/public/app/app.ts
@@ -28,7 +28,8 @@ import * as lifecycle from './lifecycle';
 const appTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 
 /**
- * Namespace to interact with app initialization and lifecycle.
+ * Module to interact with app initialization and lifecycle.
+ * @module
  */
 
 const appLogger = getLogger('app');

--- a/packages/teams-js/src/public/app/lifecycle.ts
+++ b/packages/teams-js/src/public/app/lifecycle.ts
@@ -2,14 +2,16 @@ import * as Handlers from '../../internal/handlers'; //Cannot used named imports
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ResumeContext } from '../interfaces';
 import { runtime } from '../runtime';
+
 /**
- * A namespace for enabling the suspension or delayed termination of an app when the user navigates away.
+ * A module for enabling the suspension or delayed termination of an app when the user navigates away.
  * When an app registers for the registerBeforeSuspendOrTerminateHandler, it chooses to delay termination.
  * When an app registers for both registerBeforeSuspendOrTerminateHandler and registerOnResumeHandler, it chooses the suspension of the app .
  * Please note that selecting suspension doesn't guarantee prevention of background termination.
  * The outcome is influenced by factors such as available memory and the number of suspended apps.
  *
  * @beta
+ * @module
  */
 
 /**

--- a/packages/teams-js/src/public/app/lifecycle.ts
+++ b/packages/teams-js/src/public/app/lifecycle.ts
@@ -1,8 +1,3 @@
-import * as Handlers from '../../internal/handlers'; //Cannot used named imports because of conflict with some names
-import { ensureInitialized } from '../../internal/internalAPIs';
-import { ResumeContext } from '../interfaces';
-import { runtime } from '../runtime';
-
 /**
  * A module for enabling the suspension or delayed termination of an app when the user navigates away.
  * When an app registers for the registerBeforeSuspendOrTerminateHandler, it chooses to delay termination.
@@ -13,6 +8,11 @@ import { runtime } from '../runtime';
  * @beta
  * @module
  */
+
+import * as Handlers from '../../internal/handlers'; //Cannot used named imports because of conflict with some names
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { ResumeContext } from '../interfaces';
+import { runtime } from '../runtime';
 
 /**
  * Register on resume handler function type

--- a/packages/teams-js/src/public/appInitialization.ts
+++ b/packages/teams-js/src/public/appInitialization.ts
@@ -6,7 +6,7 @@ import { version } from './version';
 
 /**
  * @deprecated
- * As of TeamsJS v2.0.0, please use {@link app} namespace instead.
+ * As of TeamsJS v2.0.0, please use {@link app} module instead.
  *
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -1,3 +1,10 @@
+/**
+ * Module to interact with the authentication-specific part of the SDK.
+ *
+ * This object is used for starting or completing authentication flows.
+ * @module
+ */
+
 import {
   Communication,
   sendMessageEventToChild,
@@ -13,13 +20,6 @@ import { fullyQualifyUrlString, validateUrl } from '../internal/utils';
 import { FrameContexts, HostClientType } from './constants';
 import { SdkError } from './interfaces';
 import { runtime } from './runtime';
-
-/**
- * Module to interact with the authentication-specific part of the SDK.
- *
- * This object is used for starting or completing authentication flows.
- * @module
- */
 
 /**
  * Exceptional APIs telemetry versioning file: v1 and v2 APIs are mixed together in this file

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -15,9 +15,10 @@ import { SdkError } from './interfaces';
 import { runtime } from './runtime';
 
 /**
- * Namespace to interact with the authentication-specific part of the SDK.
+ * Module to interact with the authentication-specific part of the SDK.
  *
  * This object is used for starting or completing authentication flows.
+ * @module
  */
 
 /**

--- a/packages/teams-js/src/public/barCode.ts
+++ b/packages/teams-js/src/public/barCode.ts
@@ -1,3 +1,10 @@
+/**
+ * Module to interact with the barcode scanning-specific part of the SDK.
+ *
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { validateScanBarCodeInput } from '../internal/mediaUtil';
@@ -10,13 +17,6 @@ import { runtime } from './runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const barCodeTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Module to interact with the barcode scanning-specific part of the SDK.
- *
- * @beta
- * @module
- */
 
 /**
  * Data structure to customize the barcode scanning experience in scanBarCode API.

--- a/packages/teams-js/src/public/barCode.ts
+++ b/packages/teams-js/src/public/barCode.ts
@@ -12,10 +12,12 @@ import { runtime } from './runtime';
 const barCodeTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 
 /**
- * Namespace to interact with the barcode scanning-specific part of the SDK.
+ * Module to interact with the barcode scanning-specific part of the SDK.
  *
  * @beta
+ * @module
  */
+
 /**
  * Data structure to customize the barcode scanning experience in scanBarCode API.
  * All properties in BarCodeConfig are optional and have default values in the platform

--- a/packages/teams-js/src/public/calendar.ts
+++ b/packages/teams-js/src/public/calendar.ts
@@ -12,7 +12,9 @@ const calendarTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 
 /**
  * Interact with the user's calendar, including opening calendar items and composing meetings.
+ * @module
  */
+
 /**
  * Opens a calendar item.
  *

--- a/packages/teams-js/src/public/calendar.ts
+++ b/packages/teams-js/src/public/calendar.ts
@@ -1,3 +1,8 @@
+/**
+ * Interact with the user's calendar, including opening calendar items and composing meetings.
+ * @module
+ */
+
 import { sendAndHandleStatusAndReason } from '../internal/communication';
 import { createTeamsDeepLinkForCalendar } from '../internal/deepLinkUtilities';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -9,11 +14,6 @@ import { runtime } from './runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const calendarTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Interact with the user's calendar, including opening calendar items and composing meetings.
- * @module
- */
 
 /**
  * Opens a calendar item.

--- a/packages/teams-js/src/public/call.ts
+++ b/packages/teams-js/src/public/call.ts
@@ -1,3 +1,8 @@
+/**
+ * Used to interact with call functionality, including starting calls with other users.
+ * @module
+ */
+
 import { sendAndUnwrap, sendMessageToParent } from '../internal/communication';
 import { errorCallNotStarted } from '../internal/constants';
 import { createTeamsDeepLinkForCall } from '../internal/deepLinkUtilities';
@@ -10,11 +15,6 @@ import { runtime } from './runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const callTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Used to interact with call functionality, including starting calls with other users.
- * @module
- */
 
 /** Modalities that can be associated with a call. */
 export enum CallModalities {

--- a/packages/teams-js/src/public/call.ts
+++ b/packages/teams-js/src/public/call.ts
@@ -13,7 +13,9 @@ const callTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 
 /**
  * Used to interact with call functionality, including starting calls with other users.
+ * @module
  */
+
 /** Modalities that can be associated with a call. */
 export enum CallModalities {
   /** Indicates that the modality is unknown or undefined. */

--- a/packages/teams-js/src/public/chat.ts
+++ b/packages/teams-js/src/public/chat.ts
@@ -7,6 +7,7 @@ import { runtime } from '../public/runtime';
 
 /**
  * Describes information needed to start a chat
+ * @module
  */
 
 /**

--- a/packages/teams-js/src/public/chat.ts
+++ b/packages/teams-js/src/public/chat.ts
@@ -1,14 +1,14 @@
+/**
+ * Describes information needed to start a chat
+ * @module
+ */
+
 import { sendAndHandleStatusAndReason } from '../internal/communication';
 import { createTeamsDeepLinkForChat } from '../internal/deepLinkUtilities';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
 import { runtime } from '../public/runtime';
-
-/**
- * Describes information needed to start a chat
- * @module
- */
 
 /**
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY

--- a/packages/teams-js/src/public/clipboard.ts
+++ b/packages/teams-js/src/public/clipboard.ts
@@ -16,7 +16,9 @@ const clipboardTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
  * Interact with the system clipboard
  *
  * @beta
+ * @module
  */
+
 /**
  * Function to copy data to clipboard.
  * @remarks

--- a/packages/teams-js/src/public/clipboard.ts
+++ b/packages/teams-js/src/public/clipboard.ts
@@ -1,3 +1,10 @@
+/**
+ * Interact with the system clipboard
+ *
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../internal/communication';
 import { GlobalVars } from '../internal/globalVars';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -11,13 +18,6 @@ import { runtime } from './runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const clipboardTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Interact with the system clipboard
- *
- * @beta
- * @module
- */
 
 /**
  * Function to copy data to clipboard.

--- a/packages/teams-js/src/public/dialog/adaptiveCard/adaptiveCard.ts
+++ b/packages/teams-js/src/public/dialog/adaptiveCard/adaptiveCard.ts
@@ -13,7 +13,9 @@ import * as bot from './bot';
 /**
  * Subcapability for interacting with adaptive card dialogs
  * @beta
+ * @module
  */
+
 /**
  * Allows app to open an adaptive card based dialog.
  *

--- a/packages/teams-js/src/public/dialog/adaptiveCard/adaptiveCard.ts
+++ b/packages/teams-js/src/public/dialog/adaptiveCard/adaptiveCard.ts
@@ -1,4 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+
+/**
+ * Subcapability for interacting with adaptive card dialogs
+ * @beta
+ * @module
+ */
+
 import { sendMessageToParent } from '../../../internal/communication';
 import { dialogTelemetryVersionNumber, getDialogInfoFromAdaptiveCardDialogInfo } from '../../../internal/dialogHelpers';
 import { ensureInitialized } from '../../../internal/internalAPIs';
@@ -9,12 +16,6 @@ import { AdaptiveCardDialogInfo, DialogInfo } from '../../interfaces';
 import { runtime } from '../../runtime';
 import { DialogSubmitHandler } from '../dialog';
 import * as bot from './bot';
-
-/**
- * Subcapability for interacting with adaptive card dialogs
- * @beta
- * @module
- */
 
 /**
  * Allows app to open an adaptive card based dialog.

--- a/packages/teams-js/src/public/dialog/adaptiveCard/bot.ts
+++ b/packages/teams-js/src/public/dialog/adaptiveCard/bot.ts
@@ -1,3 +1,10 @@
+/**
+ * Module for interaction with adaptive card dialogs that need to communicate with the bot framework
+ *
+ * @beta
+ * @module
+ */
+
 import { sendMessageToParent } from '../../../internal/communication';
 import {
   dialogTelemetryVersionNumber,
@@ -10,13 +17,6 @@ import { errorNotSupportedOnPlatform, FrameContexts } from '../../constants';
 import { BotAdaptiveCardDialogInfo, DialogInfo } from '../../interfaces';
 import { runtime } from '../../runtime';
 import { DialogSubmitHandler } from '../dialog';
-
-/**
- * Module for interaction with adaptive card dialogs that need to communicate with the bot framework
- *
- * @beta
- * @module
- */
 
 /**
  * Allows an app to open an adaptive card-based dialog module using bot.

--- a/packages/teams-js/src/public/dialog/adaptiveCard/bot.ts
+++ b/packages/teams-js/src/public/dialog/adaptiveCard/bot.ts
@@ -15,7 +15,9 @@ import { DialogSubmitHandler } from '../dialog';
  * Module for interaction with adaptive card dialogs that need to communicate with the bot framework
  *
  * @beta
+ * @module
  */
+
 /**
  * Allows an app to open an adaptive card-based dialog module using bot.
  *

--- a/packages/teams-js/src/public/dialog/dialog.ts
+++ b/packages/teams-js/src/public/dialog/dialog.ts
@@ -2,16 +2,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { dialogTelemetryVersionNumber, handleDialogMessage } from '../../internal/dialogHelpers';
-import { registerHandler, removeHandler } from '../../internal/handlers';
-import { ensureInitialized } from '../../internal/internalAPIs';
-import { ApiName, getApiVersionTag } from '../../internal/telemetry';
-import { FrameContexts } from '../constants';
-import { runtime } from '../runtime';
-import * as adaptiveCard from './adaptiveCard/adaptiveCard';
-import * as update from './update';
-import * as url from './url/url';
-
 /**
  * This group of capabilities enables apps to show modal dialogs. There are two primary types of dialogs: URL-based dialogs and [Adaptive Card](https://learn.microsoft.com/adaptive-cards/) dialogs.
  * Both types of dialogs are shown on top of your app, preventing interaction with your app while they are displayed.
@@ -26,6 +16,16 @@ import * as url from './url/url';
  * @beta
  * @module
  */
+
+import { dialogTelemetryVersionNumber, handleDialogMessage } from '../../internal/dialogHelpers';
+import { registerHandler, removeHandler } from '../../internal/handlers';
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { ApiName, getApiVersionTag } from '../../internal/telemetry';
+import { FrameContexts } from '../constants';
+import { runtime } from '../runtime';
+import * as adaptiveCard from './adaptiveCard/adaptiveCard';
+import * as update from './update';
+import * as url from './url/url';
 
 /**
  * Data Structure to represent the SDK response when dialog closes

--- a/packages/teams-js/src/public/dialog/dialog.ts
+++ b/packages/teams-js/src/public/dialog/dialog.ts
@@ -24,7 +24,9 @@ import * as url from './url/url';
  * For more details, see [Dialogs](https://learn.microsoft.com/microsoftteams/platform/task-modules-and-cards/what-are-task-modules)
  *
  * @beta
+ * @module
  */
+
 /**
  * Data Structure to represent the SDK response when dialog closes
  *

--- a/packages/teams-js/src/public/dialog/update.ts
+++ b/packages/teams-js/src/public/dialog/update.ts
@@ -1,15 +1,15 @@
-import { dialogTelemetryVersionNumber, updateResizeHelper } from '../../internal/dialogHelpers';
-import { ensureInitialized } from '../../internal/internalAPIs';
-import { ApiName, getApiVersionTag } from '../../internal/telemetry';
-import { DialogSize } from '../interfaces';
-import { runtime } from '../runtime';
-
 /**
  * Module to update the dialog
  *
  * @beta
  * @module
  */
+
+import { dialogTelemetryVersionNumber, updateResizeHelper } from '../../internal/dialogHelpers';
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { ApiName, getApiVersionTag } from '../../internal/telemetry';
+import { DialogSize } from '../interfaces';
+import { runtime } from '../runtime';
 
 /**
  * Update dimensions - height/width of a dialog.

--- a/packages/teams-js/src/public/dialog/update.ts
+++ b/packages/teams-js/src/public/dialog/update.ts
@@ -8,7 +8,9 @@ import { runtime } from '../runtime';
  * Module to update the dialog
  *
  * @beta
+ * @module
  */
+
 /**
  * Update dimensions - height/width of a dialog.
  *

--- a/packages/teams-js/src/public/dialog/url/bot.ts
+++ b/packages/teams-js/src/public/dialog/url/bot.ts
@@ -9,7 +9,9 @@ import { DialogSubmitHandler, PostMessageChannel } from '../dialog';
  * Module to open a dialog that sends results to the bot framework
  *
  * @beta
+ * @module
  */
+
 /**
  * Allows an app to open a dialog that sends submitted data to a bot.
  *

--- a/packages/teams-js/src/public/dialog/url/bot.ts
+++ b/packages/teams-js/src/public/dialog/url/bot.ts
@@ -1,16 +1,16 @@
-import { botUrlOpenHelper, dialogTelemetryVersionNumber } from '../../../internal/dialogHelpers';
-import { ensureInitialized } from '../../../internal/internalAPIs';
-import { ApiName, getApiVersionTag } from '../../../internal/telemetry';
-import { BotUrlDialogInfo } from '../../interfaces';
-import { runtime } from '../../runtime';
-import { DialogSubmitHandler, PostMessageChannel } from '../dialog';
-
 /**
  * Module to open a dialog that sends results to the bot framework
  *
  * @beta
  * @module
  */
+
+import { botUrlOpenHelper, dialogTelemetryVersionNumber } from '../../../internal/dialogHelpers';
+import { ensureInitialized } from '../../../internal/internalAPIs';
+import { ApiName, getApiVersionTag } from '../../../internal/telemetry';
+import { BotUrlDialogInfo } from '../../interfaces';
+import { runtime } from '../../runtime';
+import { DialogSubmitHandler, PostMessageChannel } from '../dialog';
 
 /**
  * Allows an app to open a dialog that sends submitted data to a bot.

--- a/packages/teams-js/src/public/dialog/url/parentCommunication.ts
+++ b/packages/teams-js/src/public/dialog/url/parentCommunication.ts
@@ -14,7 +14,9 @@ import { PostMessageChannel } from '../dialog';
  * Note that dialog can be invoked from parentless scenarios e.g. Search Message Extensions. The subcapability `parentCommunication` is not supported in such scenarios.
  *
  * @beta
+ * @module
  */
+
 /**
  *  Send message to the parent from dialog
  *

--- a/packages/teams-js/src/public/dialog/url/parentCommunication.ts
+++ b/packages/teams-js/src/public/dialog/url/parentCommunication.ts
@@ -1,12 +1,3 @@
-import { sendMessageToParent } from '../../../internal/communication';
-import { dialogTelemetryVersionNumber, storedMessages } from '../../../internal/dialogHelpers';
-import { registerHandler, removeHandler } from '../../../internal/handlers';
-import { ensureInitialized } from '../../../internal/internalAPIs';
-import { ApiName, getApiVersionTag } from '../../../internal/telemetry';
-import { errorNotSupportedOnPlatform, FrameContexts } from '../../constants';
-import { runtime } from '../../runtime';
-import { PostMessageChannel } from '../dialog';
-
 /**
  * Subcapability that allows communication between the dialog and the parent app.
  *
@@ -16,6 +7,15 @@ import { PostMessageChannel } from '../dialog';
  * @beta
  * @module
  */
+
+import { sendMessageToParent } from '../../../internal/communication';
+import { dialogTelemetryVersionNumber, storedMessages } from '../../../internal/dialogHelpers';
+import { registerHandler, removeHandler } from '../../../internal/handlers';
+import { ensureInitialized } from '../../../internal/internalAPIs';
+import { ApiName, getApiVersionTag } from '../../../internal/telemetry';
+import { errorNotSupportedOnPlatform, FrameContexts } from '../../constants';
+import { runtime } from '../../runtime';
+import { PostMessageChannel } from '../dialog';
 
 /**
  *  Send message to the parent from dialog

--- a/packages/teams-js/src/public/geoLocation/geoLocation.ts
+++ b/packages/teams-js/src/public/geoLocation/geoLocation.ts
@@ -12,10 +12,12 @@ import * as map from './map';
 const geoLocationTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 
 /**
- * Namespace to interact with the geoLocation module-specific part of the SDK. This is the newer version of location module.
+ * Module to interact with the geoLocation module-specific part of the SDK. This is the newer version of location module.
  *
  * @beta
+ * @module
  */
+
 /**
  * Data struture to represent the location information
  *

--- a/packages/teams-js/src/public/geoLocation/geoLocation.ts
+++ b/packages/teams-js/src/public/geoLocation/geoLocation.ts
@@ -1,3 +1,10 @@
+/**
+ * Module to interact with the geoLocation module-specific part of the SDK. This is the newer version of location module.
+ *
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../../internal/communication';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
@@ -10,13 +17,6 @@ import * as map from './map';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const geoLocationTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Module to interact with the geoLocation module-specific part of the SDK. This is the newer version of location module.
- *
- * @beta
- * @module
- */
 
 /**
  * Data struture to represent the location information

--- a/packages/teams-js/src/public/geoLocation/map.ts
+++ b/packages/teams-js/src/public/geoLocation/map.ts
@@ -1,3 +1,10 @@
+/**
+ * Module to interact with the location on map module-specific part of the SDK.
+ *
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../../internal/communication';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
@@ -5,13 +12,6 @@ import { errorNotSupportedOnPlatform, FrameContexts } from '../constants';
 import { ErrorCode } from '../interfaces';
 import { runtime } from '../runtime';
 import { Location } from './geoLocation';
-
-/**
- * Module to interact with the location on map module-specific part of the SDK.
- *
- * @beta
- * @module
- */
 
 /**
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY

--- a/packages/teams-js/src/public/geoLocation/map.ts
+++ b/packages/teams-js/src/public/geoLocation/map.ts
@@ -7,9 +7,10 @@ import { runtime } from '../runtime';
 import { Location } from './geoLocation';
 
 /**
- * Namespace to interact with the location on map module-specific part of the SDK.
+ * Module to interact with the location on map module-specific part of the SDK.
  *
  * @beta
+ * @module
  */
 
 /**

--- a/packages/teams-js/src/public/liveShareHost.ts
+++ b/packages/teams-js/src/public/liveShareHost.ts
@@ -14,7 +14,9 @@ const interactiveTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2
  * For more information, visit https://aka.ms/teamsliveshare
  *
  * @see LiveShareHost
+ * @module
  */
+
 /**
  * @hidden
  * The meeting roles of a user.

--- a/packages/teams-js/src/public/liveShareHost.ts
+++ b/packages/teams-js/src/public/liveShareHost.ts
@@ -1,3 +1,11 @@
+/**
+ * APIs involving Live Share, a framework for building real-time collaborative apps.
+ * For more information, visit https://aka.ms/teamsliveshare
+ *
+ * @see LiveShareHost
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -8,14 +16,6 @@ import { runtime } from './runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const interactiveTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * APIs involving Live Share, a framework for building real-time collaborative apps.
- * For more information, visit https://aka.ms/teamsliveshare
- *
- * @see LiveShareHost
- * @module
- */
 
 /**
  * @hidden

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated
+ * As of 2.1.0, please use geoLocation module.
+ *
+ * Module to interact with the location module-specific part of the SDK.
+ * @module
+ */
+
 import { sendMessageToParent } from '../internal/communication';
 import { locationAPIsRequiredVersion } from '../internal/constants';
 import { ensureInitialized, isCurrentSDKVersionAtLeast } from '../internal/internalAPIs';
@@ -10,14 +18,6 @@ import { runtime } from './runtime';
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const locationTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
-
-/**
- * @deprecated
- * As of 2.1.0, please use geoLocation module.
- *
- * Module to interact with the location module-specific part of the SDK.
- * @module
- */
 
 /** Get location callback function type */
 export type getLocationCallbackFunctionType = (error: SdkError, location: Location) => void;

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -13,10 +13,12 @@ const locationTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
 
 /**
  * @deprecated
- * As of 2.1.0, please use geoLocation namespace.
+ * As of 2.1.0, please use geoLocation module.
  *
  * Module to interact with the location module-specific part of the SDK.
+ * @module
  */
+
 /** Get location callback function type */
 export type getLocationCallbackFunctionType = (error: SdkError, location: Location) => void;
 /** Show location callback function type */
@@ -133,7 +135,7 @@ export function showLocation(location: Location, callback: showLocationCallbackF
 
 /**
  * @deprecated
- * As of 2.1.0, please use geoLocation namespace, and use {@link geoLocation.isSupported geoLocation.isSupported: boolean} to check if geoLocation is supported.
+ * As of 2.1.0, please use geoLocation module, and use {@link geoLocation.isSupported geoLocation.isSupported: boolean} to check if geoLocation is supported.
  *
  * Checks if Location capability is supported by the host
  *

--- a/packages/teams-js/src/public/mail.ts
+++ b/packages/teams-js/src/public/mail.ts
@@ -1,3 +1,8 @@
+/**
+ * Used to interact with mail capability, including opening and composing mail.
+ * @module
+ */
+
 import { sendAndHandleStatusAndReason } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -8,11 +13,6 @@ import { runtime } from './runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const mailTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Used to interact with mail capability, including opening and composing mail.
- * @module
- */
 
 /**
  * Opens a mail message in the host.

--- a/packages/teams-js/src/public/mail.ts
+++ b/packages/teams-js/src/public/mail.ts
@@ -1,8 +1,3 @@
-/**
- * Used to interact with mail capability, including opening and composing mail.
- * @module
- */
-
 import { sendAndHandleStatusAndReason } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -13,6 +8,11 @@ import { runtime } from './runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const mailTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
+
+/**
+ * Used to interact with mail capability, including opening and composing mail.
+ * @module
+ */
 
 /**
  * Opens a mail message in the host.

--- a/packages/teams-js/src/public/mail.ts
+++ b/packages/teams-js/src/public/mail.ts
@@ -1,3 +1,8 @@
+/**
+ * Used to interact with mail capability, including opening and composing mail.
+ * @module
+ */
+
 import { sendAndHandleStatusAndReason } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -9,9 +14,6 @@ import { runtime } from './runtime';
  */
 const mailTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 
-/**
- * Used to interact with mail capability, including opening and composing mail.
- */
 /**
  * Opens a mail message in the host.
  *

--- a/packages/teams-js/src/public/marketplace.ts
+++ b/packages/teams-js/src/public/marketplace.ts
@@ -20,7 +20,9 @@ const marketplaceTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2
  * @hidden
  * Module for an app to support a checkout flow by interacting with the marketplace cart in the host.
  * @beta
+ * @module
  */
+
 /**
  * @hidden
  * the version of the current cart interface

--- a/packages/teams-js/src/public/marketplace.ts
+++ b/packages/teams-js/src/public/marketplace.ts
@@ -1,3 +1,10 @@
+/**
+ * @hidden
+ * Module for an app to support a checkout flow by interacting with the marketplace cart in the host.
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import {
@@ -15,13 +22,6 @@ import { runtime } from './runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const marketplaceTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * @hidden
- * Module for an app to support a checkout flow by interacting with the marketplace cart in the host.
- * @beta
- * @module
- */
 
 /**
  * @hidden

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/explicit-member-accessibility */
 
+/**
+ * Interact with media, including capturing and viewing images.
+ * @module
+ */
+
 import { sendAndHandleSdkError, sendMessageToParent } from '../internal/communication';
 import {
   captureImageMobileSupportVersion,
@@ -38,11 +43,6 @@ import { runtime } from './runtime';
 const mediaTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
 
 const mediaLogger = getLogger('media');
-
-/**
- * Interact with media, including capturing and viewing images.
- * @module
- */
 
 /**
  * Function callback type used when calling {@link media.captureImage}.

--- a/packages/teams-js/src/public/media.ts
+++ b/packages/teams-js/src/public/media.ts
@@ -41,7 +41,9 @@ const mediaLogger = getLogger('media');
 
 /**
  * Interact with media, including capturing and viewing images.
+ * @module
  */
+
 /**
  * Function callback type used when calling {@link media.captureImage}.
  *

--- a/packages/teams-js/src/public/meeting/appShareButton.ts
+++ b/packages/teams-js/src/public/meeting/appShareButton.ts
@@ -1,9 +1,3 @@
-import { sendMessageToParent } from '../../internal/communication';
-import { ensureInitialized } from '../../internal/internalAPIs';
-import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
-import { FrameContexts } from '../constants';
-import { runtime } from '../runtime';
-
 /**
  * Module for functions to control behavior of the app share button
  *
@@ -16,6 +10,12 @@ import { runtime } from '../runtime';
  * @beta
  * @module
  */
+
+import { sendMessageToParent } from '../../internal/communication';
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
+import { FrameContexts } from '../constants';
+import { runtime } from '../runtime';
 
 /**
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY

--- a/packages/teams-js/src/public/meeting/appShareButton.ts
+++ b/packages/teams-js/src/public/meeting/appShareButton.ts
@@ -14,6 +14,7 @@ import { runtime } from '../runtime';
  * Limited to Microsoft-internal use
  *
  * @beta
+ * @module
  */
 
 /**

--- a/packages/teams-js/src/public/meeting/meeting.ts
+++ b/packages/teams-js/src/public/meeting/meeting.ts
@@ -19,7 +19,9 @@ const meetingTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
  * get meeting details, get/update state of mic, sharing app content and more.
  *
  * To learn more, visit https://aka.ms/teamsmeetingapps
+ * @module
  */
+
 /** Error callback function type */
 export type errorCallbackFunctionType = (error: SdkError | null, result: boolean | null) => void;
 /** Get live stream state callback function type */

--- a/packages/teams-js/src/public/meeting/meeting.ts
+++ b/packages/teams-js/src/public/meeting/meeting.ts
@@ -1,3 +1,12 @@
+/**
+ * Interact with meetings, including retrieving meeting details, getting mic status, and sharing app content.
+ * This module is used to handle meeting related functionality like
+ * get meeting details, get/update state of mic, sharing app content and more.
+ *
+ * To learn more, visit https://aka.ms/teamsmeetingapps
+ * @module
+ */
+
 import { sendAndHandleSdkError, sendMessageToParent } from '../../internal/communication';
 import { doesHandlerExist, registerHandler, removeHandler } from '../../internal/handlers';
 import { ensureInitialized } from '../../internal/internalAPIs';
@@ -12,15 +21,6 @@ import * as appShareButton from './appShareButton';
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const meetingTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
-
-/**
- * Interact with meetings, including retrieving meeting details, getting mic status, and sharing app content.
- * This module is used to handle meeting related functionality like
- * get meeting details, get/update state of mic, sharing app content and more.
- *
- * To learn more, visit https://aka.ms/teamsmeetingapps
- * @module
- */
 
 /** Error callback function type */
 export type errorCallbackFunctionType = (error: SdkError | null, result: boolean | null) => void;

--- a/packages/teams-js/src/public/menus.ts
+++ b/packages/teams-js/src/public/menus.ts
@@ -1,3 +1,9 @@
+/**
+ * Module to interact with the menu-specific part of the SDK.
+ * This object is used to show View Configuration, Action Menu and Navigation Bar Menu.
+ * @module
+ */
+
 import { sendMessageToParent } from '../internal/communication';
 import { registerHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -9,12 +15,6 @@ import { errorNotSupportedOnPlatform } from './constants';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const menuTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Module to interact with the menu-specific part of the SDK.
- * This object is used to show View Configuration, Action Menu and Navigation Bar Menu.
- * @module
- */
 
 /**
  * @hidden

--- a/packages/teams-js/src/public/menus.ts
+++ b/packages/teams-js/src/public/menus.ts
@@ -13,7 +13,9 @@ const menuTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 /**
  * Module to interact with the menu-specific part of the SDK.
  * This object is used to show View Configuration, Action Menu and Navigation Bar Menu.
+ * @module
  */
+
 /**
  * @hidden
  * Represents information about item in View Configuration.

--- a/packages/teams-js/src/public/monetization.ts
+++ b/packages/teams-js/src/public/monetization.ts
@@ -1,10 +1,3 @@
-import { sendAndHandleSdkError } from '../internal/communication';
-import { ensureInitialized } from '../internal/internalAPIs';
-import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { callCallbackWithErrorOrResultOrNullFromPromiseAndReturnPromise, InputFunction } from '../internal/utils';
-import { errorNotSupportedOnPlatform, FrameContexts } from './constants';
-import { SdkError } from './interfaces';
-import { runtime } from './runtime';
 /**
  * @hidden
  * Hidden from Docs
@@ -13,6 +6,14 @@ import { runtime } from './runtime';
  * Limited to Microsoft-internal use
  * @module
  */
+
+import { sendAndHandleSdkError } from '../internal/communication';
+import { ensureInitialized } from '../internal/internalAPIs';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
+import { callCallbackWithErrorOrResultOrNullFromPromiseAndReturnPromise, InputFunction } from '../internal/utils';
+import { errorNotSupportedOnPlatform, FrameContexts } from './constants';
+import { SdkError } from './interfaces';
+import { runtime } from './runtime';
 
 /**
  * Exceptional APIs telemetry versioning file: v1 and v2 APIs are mixed together in this file

--- a/packages/teams-js/src/public/monetization.ts
+++ b/packages/teams-js/src/public/monetization.ts
@@ -11,6 +11,7 @@ import { runtime } from './runtime';
  *
  * @internal
  * Limited to Microsoft-internal use
+ * @module
  */
 
 /**

--- a/packages/teams-js/src/public/navigation.ts
+++ b/packages/teams-js/src/public/navigation.ts
@@ -18,6 +18,7 @@ const navigationTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
 
 /**
  * Navigation specific part of the SDK.
+ * @module
  */
 
 /** Navigation on complete handler function type */

--- a/packages/teams-js/src/public/navigation.ts
+++ b/packages/teams-js/src/public/navigation.ts
@@ -1,3 +1,8 @@
+/**
+ * Navigation specific part of the SDK.
+ * @module
+ */
+
 import { ensureInitialized } from '../internal/internalAPIs';
 import {
   backStackNavigateBackHelper,
@@ -15,11 +20,6 @@ import { runtime } from './runtime';
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const navigationTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
-
-/**
- * Navigation specific part of the SDK.
- * @module
- */
 
 /** Navigation on complete handler function type */
 export type onCompleteHandlerFunctionType = (status: boolean, reason?: string) => void;

--- a/packages/teams-js/src/public/nestedAppAuth.ts
+++ b/packages/teams-js/src/public/nestedAppAuth.ts
@@ -1,11 +1,11 @@
-import { ensureInitialized } from '../internal/internalAPIs';
-import { runtime } from './runtime';
-
 /**
  * @beta
  * Nested app auth capabilities
  * @module
  */
+
+import { ensureInitialized } from '../internal/internalAPIs';
+import { runtime } from './runtime';
 
 /**
  * Checks if MSAL-NAA channel recommended by the host

--- a/packages/teams-js/src/public/nestedAppAuth.ts
+++ b/packages/teams-js/src/public/nestedAppAuth.ts
@@ -4,7 +4,9 @@ import { runtime } from './runtime';
 /**
  * @beta
  * Nested app auth capabilities
+ * @module
  */
+
 /**
  * Checks if MSAL-NAA channel recommended by the host
  * @returns true if host is recommending NAA channel and false otherwise

--- a/packages/teams-js/src/public/pages/appButton.ts
+++ b/packages/teams-js/src/public/pages/appButton.ts
@@ -1,3 +1,8 @@
+/**
+ * Provides APIs to interact with the app button part of the SDK.
+ * @module
+ */
+
 import { registerHandlerHelper } from '../../internal/handlers';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { pagesTelemetryVersionNumber } from '../../internal/pagesHelpers';
@@ -5,11 +10,6 @@ import { ApiName, getApiVersionTag } from '../../internal/telemetry';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../constants';
 import { runtime } from '../runtime';
 import { handlerFunctionType } from './pages';
-
-/**
- * Provides APIs to interact with the app button part of the SDK.
- * @module
- */
 
 /**
  * Registers a handler for clicking the app button.

--- a/packages/teams-js/src/public/pages/appButton.ts
+++ b/packages/teams-js/src/public/pages/appButton.ts
@@ -8,7 +8,9 @@ import { handlerFunctionType } from './pages';
 
 /**
  * Provides APIs to interact with the app button part of the SDK.
+ * @module
  */
+
 /**
  * Registers a handler for clicking the app button.
  * Only one handler can be registered at a time. A subsequent registration replaces an existing registration.

--- a/packages/teams-js/src/public/pages/backStack.ts
+++ b/packages/teams-js/src/public/pages/backStack.ts
@@ -1,3 +1,8 @@
+/**
+ * Provides APIs for handling the user's navigational history.
+ * @module
+ */
+
 import { Communication, sendMessageEventToChild, sendMessageToParent } from '../../internal/communication';
 import { registerHandler } from '../../internal/handlers';
 import { ensureInitialized } from '../../internal/internalAPIs';
@@ -7,11 +12,6 @@ import { isNullOrUndefined } from '../../internal/typeCheckUtilities';
 import { errorNotSupportedOnPlatform } from '../constants';
 import { runtime } from '../runtime';
 import { backButtonHandlerFunctionType } from './pages';
-
-/**
- * Provides APIs for handling the user's navigational history.
- * @module
- */
 
 let backButtonPressHandler: (() => boolean) | undefined;
 

--- a/packages/teams-js/src/public/pages/backStack.ts
+++ b/packages/teams-js/src/public/pages/backStack.ts
@@ -10,7 +10,9 @@ import { backButtonHandlerFunctionType } from './pages';
 
 /**
  * Provides APIs for handling the user's navigational history.
+ * @module
  */
+
 let backButtonPressHandler: (() => boolean) | undefined;
 
 /**

--- a/packages/teams-js/src/public/pages/config.ts
+++ b/packages/teams-js/src/public/pages/config.ts
@@ -1,3 +1,9 @@
+/**
+ * Provides APIs to interact with the configuration-specific part of the SDK.
+ * This object is usable only on the configuration frame.
+ * @module
+ */
+
 import { Communication, sendMessageEventToChild, sendMessageToParent } from '../../internal/communication';
 import { registerHandler, registerHandlerHelper } from '../../internal/handlers';
 import { ensureInitialized } from '../../internal/internalAPIs';
@@ -11,12 +17,6 @@ import { isNullOrUndefined } from '../../internal/typeCheckUtilities';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../constants';
 import { runtime } from '../runtime';
 import { handlerFunctionType, InstanceConfig, removeEventType, saveEventType } from './pages';
-
-/**
- * Provides APIs to interact with the configuration-specific part of the SDK.
- * This object is usable only on the configuration frame.
- * @module
- */
 
 let saveHandler: undefined | ((evt: SaveEvent) => void);
 let removeHandler: undefined | ((evt: RemoveEvent) => void);

--- a/packages/teams-js/src/public/pages/config.ts
+++ b/packages/teams-js/src/public/pages/config.ts
@@ -15,7 +15,9 @@ import { handlerFunctionType, InstanceConfig, removeEventType, saveEventType } f
 /**
  * Provides APIs to interact with the configuration-specific part of the SDK.
  * This object is usable only on the configuration frame.
+ * @module
  */
+
 let saveHandler: undefined | ((evt: SaveEvent) => void);
 let removeHandler: undefined | ((evt: RemoveEvent) => void);
 

--- a/packages/teams-js/src/public/pages/currentApp.ts
+++ b/packages/teams-js/src/public/pages/currentApp.ts
@@ -12,7 +12,9 @@ import * as pages from './pages';
  *
  * @remarks
  * If you are looking to navigate to a different app, use {@link pages.navigateToApp}.
+ * @module
  */
+
 /**
  * Parameters provided to the {@link navigateTo} function
  */

--- a/packages/teams-js/src/public/pages/currentApp.ts
+++ b/packages/teams-js/src/public/pages/currentApp.ts
@@ -1,3 +1,11 @@
+/**
+ * Provides functions for navigating within your own app
+ *
+ * @remarks
+ * If you are looking to navigate to a different app, use {@link pages.navigateToApp}.
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../../internal/communication';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { pagesTelemetryVersionNumber } from '../../internal/pagesHelpers';
@@ -6,14 +14,6 @@ import { errorNotSupportedOnPlatform, FrameContexts } from '../constants';
 import { runtime } from '../runtime';
 //eslint-disable-next-line @typescript-eslint/no-unused-vars
 import * as pages from './pages';
-
-/**
- * Provides functions for navigating within your own app
- *
- * @remarks
- * If you are looking to navigate to a different app, use {@link pages.navigateToApp}.
- * @module
- */
 
 /**
  * Parameters provided to the {@link navigateTo} function

--- a/packages/teams-js/src/public/pages/fullTrust.ts
+++ b/packages/teams-js/src/public/pages/fullTrust.ts
@@ -12,7 +12,9 @@ import { runtime } from '../runtime';
  * Provides APIs to interact with the full-trust part of the SDK. Limited to 1P applications
  * @internal
  * Limited to Microsoft-internal use
+ * @module
  */
+
 /**
  * @hidden
  * Hide from docs

--- a/packages/teams-js/src/public/pages/fullTrust.ts
+++ b/packages/teams-js/src/public/pages/fullTrust.ts
@@ -1,10 +1,3 @@
-import { sendMessageToParent } from '../../internal/communication';
-import { ensureInitialized } from '../../internal/internalAPIs';
-import { pagesTelemetryVersionNumber } from '../../internal/pagesHelpers';
-import { ApiName, getApiVersionTag } from '../../internal/telemetry';
-import { errorNotSupportedOnPlatform, FrameContexts } from '../constants';
-import { runtime } from '../runtime';
-
 /**
  * @hidden
  * Hide from docs
@@ -14,6 +7,13 @@ import { runtime } from '../runtime';
  * Limited to Microsoft-internal use
  * @module
  */
+
+import { sendMessageToParent } from '../../internal/communication';
+import { ensureInitialized } from '../../internal/internalAPIs';
+import { pagesTelemetryVersionNumber } from '../../internal/pagesHelpers';
+import { ApiName, getApiVersionTag } from '../../internal/telemetry';
+import { errorNotSupportedOnPlatform, FrameContexts } from '../constants';
+import { runtime } from '../runtime';
 
 /**
  * @hidden

--- a/packages/teams-js/src/public/pages/pages.ts
+++ b/packages/teams-js/src/public/pages/pages.ts
@@ -1,3 +1,8 @@
+/**
+ * Navigation-specific part of the SDK.
+ * @module
+ */
+
 import { appInitializeHelper } from '../../internal/appHelpers';
 import { sendAndHandleStatusAndReason, sendMessageToParent } from '../../internal/communication';
 import { registerHandlerHelper } from '../../internal/handlers';
@@ -26,11 +31,6 @@ import * as config from './config';
 import * as currentApp from './currentApp';
 import * as fullTrust from './fullTrust';
 import * as tabs from './tabs';
-
-/**
- * Navigation-specific part of the SDK.
- * @module
- */
 
 /** Callback function */
 export type handlerFunctionType = () => void;

--- a/packages/teams-js/src/public/pages/pages.ts
+++ b/packages/teams-js/src/public/pages/pages.ts
@@ -29,7 +29,9 @@ import * as tabs from './tabs';
 
 /**
  * Navigation-specific part of the SDK.
+ * @module
  */
+
 /** Callback function */
 export type handlerFunctionType = () => void;
 /** Full screen function */

--- a/packages/teams-js/src/public/pages/tabs.ts
+++ b/packages/teams-js/src/public/pages/tabs.ts
@@ -12,7 +12,9 @@ import { runtime } from '../runtime';
 /**
  * Provides APIs for querying and navigating between contextual tabs of an application. Unlike personal tabs,
  * contextual tabs are pages associated with a specific context, such as channel or chat.
+ * @module
  */
+
 /**
  * Navigates the hosted application to the specified tab instance.
  * @param tabInstance - The destination tab instance.

--- a/packages/teams-js/src/public/pages/tabs.ts
+++ b/packages/teams-js/src/public/pages/tabs.ts
@@ -1,3 +1,9 @@
+/**
+ * Provides APIs for querying and navigating between contextual tabs of an application. Unlike personal tabs,
+ * contextual tabs are pages associated with a specific context, such as channel or chat.
+ * @module
+ */
+
 import { ensureInitialized } from '../../internal/internalAPIs';
 import {
   getMruTabInstancesHelper,
@@ -8,12 +14,6 @@ import {
 import { ApiName, getApiVersionTag } from '../../internal/telemetry';
 import { TabInformation, TabInstance, TabInstanceParameters } from '../interfaces';
 import { runtime } from '../runtime';
-
-/**
- * Provides APIs for querying and navigating between contextual tabs of an application. Unlike personal tabs,
- * contextual tabs are pages associated with a specific context, such as channel or chat.
- * @module
- */
 
 /**
  * Navigates the hosted application to the specified tab instance.

--- a/packages/teams-js/src/public/profile.ts
+++ b/packages/teams-js/src/public/profile.ts
@@ -15,7 +15,9 @@ const profileTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
  * Module for profile related APIs.
  *
  * @beta
+ * @module
  */
+
 /**
  * Opens a profile card at a specified position to show profile information about a persona.
  * @param showProfileRequest The parameters to position the card and identify the target user.

--- a/packages/teams-js/src/public/profile.ts
+++ b/packages/teams-js/src/public/profile.ts
@@ -1,3 +1,10 @@
+/**
+ * Module for profile related APIs.
+ *
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ShowProfileRequestInternal, validateShowProfileRequest } from '../internal/profileUtil';
@@ -10,13 +17,6 @@ import { runtime } from './runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const profileTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Module for profile related APIs.
- *
- * @beta
- * @module
- */
 
 /**
  * Opens a profile card at a specified position to show profile information about a persona.

--- a/packages/teams-js/src/public/search.ts
+++ b/packages/teams-js/src/public/search.ts
@@ -17,7 +17,9 @@ const searchTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
  *
  * This functionality is in Beta.
  * @beta
+ * @module
  */
+
 const onChangeHandlerName = 'search.queryChange';
 const onClosedHandlerName = 'search.queryClose';
 const onExecutedHandlerName = 'search.queryExecute';

--- a/packages/teams-js/src/public/search.ts
+++ b/packages/teams-js/src/public/search.ts
@@ -1,3 +1,13 @@
+/**
+ * Allows your application to interact with the host M365 application's search box.
+ * By integrating your application with the host's search box, users can search
+ * your app using the same search box they use elsewhere in Teams, Outlook, or Office.
+ *
+ * This functionality is in Beta.
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleStatusAndReason, sendMessageToParent } from '../internal/communication';
 import { registerHandler, removeHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -9,16 +19,6 @@ import { runtime } from './runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const searchTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Allows your application to interact with the host M365 application's search box.
- * By integrating your application with the host's search box, users can search
- * your app using the same search box they use elsewhere in Teams, Outlook, or Office.
- *
- * This functionality is in Beta.
- * @beta
- * @module
- */
 
 const onChangeHandlerName = 'search.queryChange';
 const onClosedHandlerName = 'search.queryClose';

--- a/packages/teams-js/src/public/secondaryBrowser.ts
+++ b/packages/teams-js/src/public/secondaryBrowser.ts
@@ -16,7 +16,9 @@ const secondaryBrowserTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumbe
  * For e.g., opening a URL in the host app inside a browser
  *
  * @beta
+ * @module
  */
+
 /**
  * Open a URL in the secondary browser.
  *

--- a/packages/teams-js/src/public/secondaryBrowser.ts
+++ b/packages/teams-js/src/public/secondaryBrowser.ts
@@ -1,3 +1,11 @@
+/**
+ * Module to power up the in-app browser experiences in the host app.
+ * For e.g., opening a URL in the host app inside a browser
+ *
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -10,14 +18,6 @@ import { runtime } from './runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const secondaryBrowserTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Module to power up the in-app browser experiences in the host app.
- * For e.g., opening a URL in the host app inside a browser
- *
- * @beta
- * @module
- */
 
 /**
  * Open a URL in the secondary browser.

--- a/packages/teams-js/src/public/settings.ts
+++ b/packages/teams-js/src/public/settings.ts
@@ -13,11 +13,13 @@ const settingsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
 
 /**
  * @deprecated
- * As of TeamsJS v2.0.0, please use {@link pages.config} namespace instead.
+ * As of TeamsJS v2.0.0, please use {@link pages.config} module instead.
  *
- * Namespace to interact with the settings-specific part of the SDK.
+ * Module to interact with the settings-specific part of the SDK.
  * This object is usable only on the settings frame.
+ * @module
  */
+
 /** Register on remove handler function type */
 export type registerOnRemoveHandlerFunctionType = (evt: RemoveEvent) => void;
 /** Register on save handler function type */

--- a/packages/teams-js/src/public/settings.ts
+++ b/packages/teams-js/src/public/settings.ts
@@ -1,3 +1,12 @@
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link pages.config} module instead.
+ *
+ * Module to interact with the settings-specific part of the SDK.
+ * This object is usable only on the settings frame.
+ * @module
+ */
+
 import { ensureInitialized } from '../internal/internalAPIs';
 import { configSetConfigHelper, configSetValidityStateHelper, getConfigHelper } from '../internal/pagesHelpers';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -10,15 +19,6 @@ import { runtime } from './runtime';
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const settingsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
-
-/**
- * @deprecated
- * As of TeamsJS v2.0.0, please use {@link pages.config} module instead.
- *
- * Module to interact with the settings-specific part of the SDK.
- * This object is usable only on the settings frame.
- * @module
- */
 
 /** Register on remove handler function type */
 export type registerOnRemoveHandlerFunctionType = (evt: RemoveEvent) => void;

--- a/packages/teams-js/src/public/sharing/history.ts
+++ b/packages/teams-js/src/public/sharing/history.ts
@@ -10,7 +10,9 @@ const sharingTelemetryVersionNumber_v2: ApiVersionNumber = ApiVersionNumber.V_2;
  * Module to get the list of content shared in a Teams meeting
  *
  * @beta
+ * @module
  */
+
 /**
  * Represents the data returned when calling {@link sharing.history.getContent}
  *

--- a/packages/teams-js/src/public/sharing/history.ts
+++ b/packages/teams-js/src/public/sharing/history.ts
@@ -1,3 +1,10 @@
+/**
+ * Module to get the list of content shared in a Teams meeting
+ *
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../../internal/communication';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
@@ -5,13 +12,6 @@ import { errorNotSupportedOnPlatform, FrameContexts } from '../constants';
 import { runtime } from '../runtime';
 
 const sharingTelemetryVersionNumber_v2: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Module to get the list of content shared in a Teams meeting
- *
- * @beta
- * @module
- */
 
 /**
  * Represents the data returned when calling {@link sharing.history.getContent}

--- a/packages/teams-js/src/public/sharing/sharing.ts
+++ b/packages/teams-js/src/public/sharing/sharing.ts
@@ -13,7 +13,9 @@ const sharingTelemetryVersionNumber_v2: ApiVersionNumber = ApiVersionNumber.V_2;
 /**
  * Module to open a share dialog for web content.
  * For more info, see [Share to Teams from personal app or tab](https://learn.microsoft.com/microsoftteams/platform/concepts/build-and-test/share-to-teams-from-personal-app-or-tab)
+ * @module
  */
+
 /** shareWebContent callback function type */
 export type shareWebContentCallbackFunctionType = (err?: SdkError) => void;
 

--- a/packages/teams-js/src/public/sharing/sharing.ts
+++ b/packages/teams-js/src/public/sharing/sharing.ts
@@ -1,3 +1,9 @@
+/**
+ * Module to open a share dialog for web content.
+ * For more info, see [Share to Teams from personal app or tab](https://learn.microsoft.com/microsoftteams/platform/concepts/build-and-test/share-to-teams-from-personal-app-or-tab)
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../../internal/communication';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
@@ -9,12 +15,6 @@ import * as history from './history';
 
 const sharingTelemetryVersionNumber_v1: ApiVersionNumber = ApiVersionNumber.V_1;
 const sharingTelemetryVersionNumber_v2: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Module to open a share dialog for web content.
- * For more info, see [Share to Teams from personal app or tab](https://learn.microsoft.com/microsoftteams/platform/concepts/build-and-test/share-to-teams-from-personal-app-or-tab)
- * @module
- */
 
 /** shareWebContent callback function type */
 export type shareWebContentCallbackFunctionType = (err?: SdkError) => void;

--- a/packages/teams-js/src/public/stageView/self.ts
+++ b/packages/teams-js/src/public/stageView/self.ts
@@ -13,7 +13,9 @@ const stageViewTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
  * Module for actions that can be taken by the stage view itself.
  *
  * @beta
+ * @module
  */
+
 /**
  * Closes the current stage view. This function will be a no-op if called from outside of a stage view.
  * @returns Promise that resolves or rejects with an error once the stage view is closed.

--- a/packages/teams-js/src/public/stageView/self.ts
+++ b/packages/teams-js/src/public/stageView/self.ts
@@ -1,3 +1,10 @@
+/**
+ * Module for actions that can be taken by the stage view itself.
+ *
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../../internal/communication';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
@@ -8,13 +15,6 @@ import { runtime } from '../runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const stageViewTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Module for actions that can be taken by the stage view itself.
- *
- * @beta
- * @module
- */
 
 /**
  * Closes the current stage view. This function will be a no-op if called from outside of a stage view.

--- a/packages/teams-js/src/public/stageView/stageView.ts
+++ b/packages/teams-js/src/public/stageView/stageView.ts
@@ -13,8 +13,10 @@ const stageViewTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 /**
  * Module to interact with the stage view specific part of the SDK.
  *
- *  @beta
+ * @beta
+ * @module
  */
+
 /**
  * Parameters to open a stage view.
  */

--- a/packages/teams-js/src/public/stageView/stageView.ts
+++ b/packages/teams-js/src/public/stageView/stageView.ts
@@ -1,3 +1,10 @@
+/**
+ * Module to interact with the stage view specific part of the SDK.
+ *
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../../internal/communication';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
@@ -9,13 +16,6 @@ import * as self from './self';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const stageViewTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Module to interact with the stage view specific part of the SDK.
- *
- * @beta
- * @module
- */
 
 /**
  * Parameters to open a stage view.

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -1,5 +1,15 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
+/**
+ * @deprecated
+ * As of TeamsJS v2.0.0, please use {@link dialog} module instead.
+ *
+ * Module to interact with the task module-specific part of the SDK.
+ * This object is usable only on the content frame.
+ * The tasks module will be deprecated. Please use dialog for future developments.
+ * @module
+ */
+
 import { sendMessageToParent } from '../internal/communication';
 import { botUrlOpenHelper, updateResizeHelper, urlOpenHelper, urlSubmitHelper } from '../internal/dialogHelpers';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -14,16 +24,6 @@ import { runtime } from './runtime';
  * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
 const tasksTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
-
-/**
- * @deprecated
- * As of TeamsJS v2.0.0, please use {@link dialog} module instead.
- *
- * Module to interact with the task module-specific part of the SDK.
- * This object is usable only on the content frame.
- * The tasks module will be deprecated. Please use dialog for future developments.
- * @module
- */
 
 /**
  * Function type that is used to receive the result when a task module is submitted by

--- a/packages/teams-js/src/public/tasks.ts
+++ b/packages/teams-js/src/public/tasks.ts
@@ -17,12 +17,14 @@ const tasksTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
 
 /**
  * @deprecated
- * As of TeamsJS v2.0.0, please use {@link dialog} namespace instead.
+ * As of TeamsJS v2.0.0, please use {@link dialog} module instead.
  *
  * Module to interact with the task module-specific part of the SDK.
  * This object is usable only on the content frame.
  * The tasks module will be deprecated. Please use dialog for future developments.
+ * @module
  */
+
 /**
  * Function type that is used to receive the result when a task module is submitted by
  * calling {@link tasks.submitTask tasks.submitTask(result?: string | object, appIds?: string | string[]): void}

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -9,9 +9,10 @@ import { LoadContext } from './interfaces';
 import { runtime } from './runtime';
 
 /**
- * Namespace containing the set of APIs that support Teams-specific functionalities.
+ * Module containing the set of APIs that support Teams-specific functionalities.
  *
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
+ * @module
  */
 const teamsAPIsTelemetryVersionNumber_v2: ApiVersionNumber = ApiVersionNumber.V_2;
 

--- a/packages/teams-js/src/public/teamsAPIs.ts
+++ b/packages/teams-js/src/public/teamsAPIs.ts
@@ -1,3 +1,8 @@
+/**
+ * Module containing the set of APIs that support Teams-specific functionalities.
+ * @module
+ */
+
 import { GlobalVars } from '../internal/globalVars';
 import * as Handlers from '../internal/handlers'; // Conflict with some names
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -9,10 +14,7 @@ import { LoadContext } from './interfaces';
 import { runtime } from './runtime';
 
 /**
- * Module containing the set of APIs that support Teams-specific functionalities.
- *
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
- * @module
  */
 const teamsAPIsTelemetryVersionNumber_v2: ApiVersionNumber = ApiVersionNumber.V_2;
 

--- a/packages/teams-js/src/public/thirdPartyCloudStorage.ts
+++ b/packages/teams-js/src/public/thirdPartyCloudStorage.ts
@@ -1,3 +1,10 @@
+/**
+ * Extended files API 3P storage providers, features like sending Blob from Teams to 3P app on user
+ * actions like drag and drop to compose
+ * @beta
+ * @module
+ */
+
 import { sendMessageToParent } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { createFile, decodeAttachment } from '../internal/mediaUtil';
@@ -12,13 +19,6 @@ const Files3PLogger = getLogger('thirdPartyCloudStorage');
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const thirdPartyCloudStorageTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Extended files API 3P storage providers, features like sending Blob from Teams to 3P app on user
- * actions like drag and drop to compose
- * @beta
- * @module
- */
 
 /**
  * Interface to assemble file chunks

--- a/packages/teams-js/src/public/thirdPartyCloudStorage.ts
+++ b/packages/teams-js/src/public/thirdPartyCloudStorage.ts
@@ -17,7 +17,9 @@ const thirdPartyCloudStorageTelemetryVersionNumber: ApiVersionNumber = ApiVersio
  * Extended files API 3P storage providers, features like sending Blob from Teams to 3P app on user
  * actions like drag and drop to compose
  * @beta
+ * @module
  */
+
 /**
  * Interface to assemble file chunks
  * @beta

--- a/packages/teams-js/src/public/videoEffects.ts
+++ b/packages/teams-js/src/public/videoEffects.ts
@@ -16,7 +16,9 @@ const videoEffectsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_
 /**
  * Module to support video extensibility of the SDK
  * @beta
+ * @module
  */
+
 const videoPerformanceMonitor = inServerSideRenderingEnvironment()
   ? undefined
   : new VideoPerformanceMonitor(sendMessageToParent);

--- a/packages/teams-js/src/public/videoEffects.ts
+++ b/packages/teams-js/src/public/videoEffects.ts
@@ -1,3 +1,9 @@
+/**
+ * Module to support video extensibility of the SDK
+ * @beta
+ * @module
+ */
+
 import { sendMessageToParent } from '../internal/communication';
 import { registerHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -12,12 +18,6 @@ import { runtime } from './runtime';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const videoEffectsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * Module to support video extensibility of the SDK
- * @beta
- * @module
- */
 
 const videoPerformanceMonitor = inServerSideRenderingEnvironment()
   ? undefined

--- a/packages/teams-js/src/public/visualMedia/image.ts
+++ b/packages/teams-js/src/public/visualMedia/image.ts
@@ -1,3 +1,11 @@
+/**
+ * @hidden
+ * To enable this image capability will let the app developer ask the user to get images from camera/local storage
+ *
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../../internal/communication';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
@@ -10,14 +18,6 @@ import { CameraProps, GalleryProps, VisualMediaFile } from './visualMedia';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const visualMediaTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * @hidden
- * To enable this image capability will let the app developer ask the user to get images from camera/local storage
- *
- * @beta
- * @module
- */
 
 /**
  * @hidden

--- a/packages/teams-js/src/public/visualMedia/image.ts
+++ b/packages/teams-js/src/public/visualMedia/image.ts
@@ -16,7 +16,9 @@ const visualMediaTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2
  * To enable this image capability will let the app developer ask the user to get images from camera/local storage
  *
  * @beta
+ * @module
  */
+
 /**
  * @hidden
  * CameraImageProperties is for the image taken from the camera

--- a/packages/teams-js/src/public/visualMedia/visualMedia.ts
+++ b/packages/teams-js/src/public/visualMedia/visualMedia.ts
@@ -1,3 +1,11 @@
+/**
+ * @hidden
+ * Interact with images. Allows the app developer ask the user to get images from their camera / camera roll / file system.
+ *
+ * @beta
+ * @module
+ */
+
 import { sendAndHandleSdkError } from '../../internal/communication';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../internal/telemetry';
@@ -10,14 +18,6 @@ import * as image from './image';
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
  */
 const visualMediaTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
-
-/**
- * @hidden
- * Interact with images. Allows the app developer ask the user to get images from their camera / camera roll / file system.
- *
- * @beta
- * @module
- */
 
 /**
  * @hidden

--- a/packages/teams-js/src/public/visualMedia/visualMedia.ts
+++ b/packages/teams-js/src/public/visualMedia/visualMedia.ts
@@ -16,7 +16,9 @@ const visualMediaTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2
  * Interact with images. Allows the app developer ask the user to get images from their camera / camera roll / file system.
  *
  * @beta
+ * @module
  */
+
 /**
  * @hidden
  * The required value of the visualMedia files from gallery

--- a/packages/teams-js/src/public/webStorage.ts
+++ b/packages/teams-js/src/public/webStorage.ts
@@ -10,7 +10,9 @@ import { runtime } from './runtime';
  * Contains functionality enabling apps to query properties about how the host manages web storage (`Window.LocalStorage`)
  *
  * @beta
+ * @module
  */
+
 /**
  * Checks if web storage (`Window.LocalStorage`) gets cleared when a user logs out from host
  *

--- a/packages/teams-js/src/public/webStorage.ts
+++ b/packages/teams-js/src/public/webStorage.ts
@@ -1,3 +1,10 @@
+/**
+ * Contains functionality enabling apps to query properties about how the host manages web storage (`Window.LocalStorage`)
+ *
+ * @beta
+ * @module
+ */
+
 import { sendAndUnwrap } from '../internal/communication';
 import { GlobalVars } from '../internal/globalVars';
 import { ensureInitialized } from '../internal/internalAPIs';
@@ -5,13 +12,6 @@ import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemet
 import { getCachedHostName as getCachedHostNameHelper } from '../internal/webStorageHelpers';
 import { errorNotSupportedOnPlatform, HostClientType, HostName } from './constants';
 import { runtime } from './runtime';
-
-/**
- * Contains functionality enabling apps to query properties about how the host manages web storage (`Window.LocalStorage`)
- *
- * @beta
- * @module
- */
 
 /**
  * Checks if web storage (`Window.LocalStorage`) gets cleared when a user logs out from host


### PR DESCRIPTION
After removing the namespaces for the treeshaking work, all of the namespace level comments were not being generated with typedoc as they no longer were attached to an object. This PR adds the `@module` tag to all of these comments so that they continue to be generated. I also updated any remaining usages of the keyword `namespace` to `module`

Edit: Looks like all of the `@module` level comments need to be at the top of the file above the import statements, so I went ahead and moved them as well