### PR TITLE
Supporting isNAAChannelRecommended flag for Legacy Teams Mobile Scenario

### DIFF
--- a/change/@microsoft-teams-js-0bfc106c-dcbd-4193-b604-49700784ee6d.json
+++ b/change/@microsoft-teams-js-0bfc106c-dcbd-4193-b604-49700784ee6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added `nestedAppAuth` capability against a new client version `2.1.1` to support isNAAChannelRecommended for Teams Mobile",
+  "packageName": "@microsoft/teams-js",
+  "email": "singhmanp@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/nestedAppAuth.ts
+++ b/packages/teams-js/src/public/nestedAppAuth.ts
@@ -4,7 +4,9 @@
  * @module
  */
 
+import { GlobalVars } from '../internal/globalVars';
 import { ensureInitialized } from '../internal/internalAPIs';
+import { HostClientType } from './constants';
 import { runtime } from './runtime';
 
 /**
@@ -18,7 +20,24 @@ import { runtime } from './runtime';
 export function isNAAChannelRecommended(): boolean {
   return (
     (ensureInitialized(runtime) &&
-      (runtime.isNAAChannelRecommended || (runtime.supports.nestedAppAuth ? true : false))) ??
+      (runtime.isNAAChannelRecommended || isNAAChannelRecommendedForLegacyTeamsMobile())) ??
     false
+  );
+}
+
+function isNAAChannelRecommendedForLegacyTeamsMobile(): boolean {
+  return ensureInitialized(runtime) &&
+    isHostAndroidOrIOSOrIPadOS() &&
+    runtime.isLegacyTeams &&
+    runtime.supports.nestedAppAuth
+    ? true
+    : false;
+}
+
+function isHostAndroidOrIOSOrIPadOS(): boolean {
+  return (
+    GlobalVars.hostClientType === HostClientType.android ||
+    GlobalVars.hostClientType === HostClientType.ios ||
+    GlobalVars.hostClientType === HostClientType.ipados
   );
 }

--- a/packages/teams-js/src/public/nestedAppAuth.ts
+++ b/packages/teams-js/src/public/nestedAppAuth.ts
@@ -16,5 +16,9 @@ import { runtime } from './runtime';
  * @beta
  */
 export function isNAAChannelRecommended(): boolean {
-  return (ensureInitialized(runtime) && runtime.isNAAChannelRecommended) ?? false;
+  return (
+    (ensureInitialized(runtime) &&
+      (runtime.isNAAChannelRecommended || (runtime.supports.nestedAppAuth ? true : false))) ??
+    false
+  );
 }

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -588,8 +588,14 @@ export const mapTeamsVersionToSupportedCapabilities: Record<string, Array<ICapab
   ],
   '2.0.8': [
     {
-      capability: { sharing: {}, nestedAppAuth: {} },
+      capability: { sharing: {} },
       hostClientTypes: [HostClientType.android, HostClientType.ios],
+    },
+  ],
+  '2.1.1': [
+    {
+      capability: { nestedAppAuth: {} },
+      hostClientTypes: [HostClientType.android, HostClientType.ios, HostClientType.ipados],
     },
   ],
 };

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -588,7 +588,7 @@ export const mapTeamsVersionToSupportedCapabilities: Record<string, Array<ICapab
   ],
   '2.0.8': [
     {
-      capability: { sharing: {} },
+      capability: { sharing: {}, nestedAppAuth: {} },
       hostClientTypes: [HostClientType.android, HostClientType.ios],
     },
   ],

--- a/packages/teams-js/test/public/nestedAppAuth.spec.ts
+++ b/packages/teams-js/test/public/nestedAppAuth.spec.ts
@@ -10,7 +10,7 @@ import { Utils } from '../utils';
 /**
  * Test cases for nested app auth APIs
  */
-describe('nestedAppAuth', () => {
+describe('nestedAppAuth.isNAAChannelRecommended', () => {
   const utils = new Utils();
 
   beforeEach(() => {
@@ -64,7 +64,7 @@ describe('nestedAppAuth', () => {
     expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
   });
 
-  it('should return false; isNAAChannelRecommended: false, ClientType: macos', async () => {
+  it('should return false if isNAAChannelRecommended is false in runtimeConfig for macos client', async () => {
     await utils.initializeWithContext(FrameContexts.content, HostClientType.macos);
     const runtimeConfig: Runtime = {
       apiVersion: 4,
@@ -75,7 +75,7 @@ describe('nestedAppAuth', () => {
     expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
   });
 
-  it('should return false; isNAAChannelRecommended: false, ClientType: desktop', async () => {
+  it('should return false if isNAAChannelRecommended is false in runtimeConfig for desktop client', async () => {
     await utils.initializeWithContext(FrameContexts.content, HostClientType.desktop);
     const runtimeConfig: Runtime = {
       apiVersion: 4,
@@ -86,7 +86,7 @@ describe('nestedAppAuth', () => {
     expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
   });
 
-  it('should return false; isNAAChannelRecommended: false, ClientType: web', async () => {
+  it('should return false if isNAAChannelRecommended is false in runtimeConfig for web client', async () => {
     await utils.initializeWithContext(FrameContexts.content, HostClientType.web);
     const runtimeConfig: Runtime = {
       apiVersion: 4,
@@ -97,7 +97,7 @@ describe('nestedAppAuth', () => {
     expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
   });
 
-  it('should return false; isNAAChannelRecommended: false, isLegacyTeams: false', async () => {
+  it('should return false if isNAAChannelRecommended is false and isLegacyTeams is false in runtimeConfig', async () => {
     await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
     const runtimeConfig: Runtime = {
       apiVersion: 4,
@@ -109,7 +109,7 @@ describe('nestedAppAuth', () => {
     expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
   });
 
-  it('should return false; isNAAChannelRecommended: false, isLegacyTeams: true, ClientType: android, does not supports nestedAppAuth', async () => {
+  it('should return false if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for android client that does not supports nestedAppAuth', async () => {
     await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
     const runtimeConfig: Runtime = {
       apiVersion: 4,
@@ -121,7 +121,7 @@ describe('nestedAppAuth', () => {
     expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
   });
 
-  it('should return true; isNAAChannelRecommended: false, isLegacyTeams: true, ClientType: android, supports nestedAppAuth', async () => {
+  it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for android client that supports nestedAppAuth', async () => {
     await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
     const runtimeConfig: Runtime = {
       apiVersion: 4,
@@ -133,7 +133,7 @@ describe('nestedAppAuth', () => {
     expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
   });
 
-  it('should return true; isNAAChannelRecommended: false, isLegacyTeams: true, ClientType: ios, supports nestedAppAuth', async () => {
+  it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for ios client that supports nestedAppAuth', async () => {
     await utils.initializeWithContext(FrameContexts.content, HostClientType.ios);
     const runtimeConfig: Runtime = {
       apiVersion: 4,
@@ -145,7 +145,7 @@ describe('nestedAppAuth', () => {
     expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
   });
 
-  it('should return true; isNAAChannelRecommended: false, isLegacyTeams: true, ClientType: ipados, supports nestedAppAuth', async () => {
+  it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for ipados client that supports nestedAppAuth', async () => {
     await utils.initializeWithContext(FrameContexts.content, HostClientType.ipados);
     const runtimeConfig: Runtime = {
       apiVersion: 4,

--- a/packages/teams-js/test/public/nestedAppAuth.spec.ts
+++ b/packages/teams-js/test/public/nestedAppAuth.spec.ts
@@ -1,5 +1,5 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
-import { app, FrameContexts, nestedAppAuth } from '../../src/public';
+import { app, FrameContexts, HostClientType, nestedAppAuth } from '../../src/public';
 import { _minRuntimeConfigToUninitialize, Runtime } from '../../src/public/runtime';
 import { Utils } from '../utils';
 
@@ -62,5 +62,98 @@ describe('nestedAppAuth', () => {
     };
     utils.setRuntimeConfig(runtimeConfig);
     expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+  });
+
+  it('should return false; isNAAChannelRecommended: false, ClientType: macos', async () => {
+    await utils.initializeWithContext(FrameContexts.content, HostClientType.macos);
+    const runtimeConfig: Runtime = {
+      apiVersion: 4,
+      supports: {},
+      isNAAChannelRecommended: false,
+    };
+    utils.setRuntimeConfig(runtimeConfig);
+    expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+  });
+
+  it('should return false; isNAAChannelRecommended: false, ClientType: desktop', async () => {
+    await utils.initializeWithContext(FrameContexts.content, HostClientType.desktop);
+    const runtimeConfig: Runtime = {
+      apiVersion: 4,
+      supports: {},
+      isNAAChannelRecommended: false,
+    };
+    utils.setRuntimeConfig(runtimeConfig);
+    expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+  });
+
+  it('should return false; isNAAChannelRecommended: false, ClientType: web', async () => {
+    await utils.initializeWithContext(FrameContexts.content, HostClientType.web);
+    const runtimeConfig: Runtime = {
+      apiVersion: 4,
+      supports: {},
+      isNAAChannelRecommended: false,
+    };
+    utils.setRuntimeConfig(runtimeConfig);
+    expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+  });
+
+  it('should return false; isNAAChannelRecommended: false, isLegacyTeams: false', async () => {
+    await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
+    const runtimeConfig: Runtime = {
+      apiVersion: 4,
+      supports: {},
+      isNAAChannelRecommended: false,
+      isLegacyTeams: false,
+    };
+    utils.setRuntimeConfig(runtimeConfig);
+    expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+  });
+
+  it('should return false; isNAAChannelRecommended: false, isLegacyTeams: true, ClientType: android, does not supports nestedAppAuth', async () => {
+    await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
+    const runtimeConfig: Runtime = {
+      apiVersion: 4,
+      supports: {},
+      isNAAChannelRecommended: false,
+      isLegacyTeams: true,
+    };
+    utils.setRuntimeConfig(runtimeConfig);
+    expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+  });
+
+  it('should return true; isNAAChannelRecommended: false, isLegacyTeams: true, ClientType: android, supports nestedAppAuth', async () => {
+    await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
+    const runtimeConfig: Runtime = {
+      apiVersion: 4,
+      supports: { nestedAppAuth },
+      isNAAChannelRecommended: false,
+      isLegacyTeams: true,
+    };
+    utils.setRuntimeConfig(runtimeConfig);
+    expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+  });
+
+  it('should return true; isNAAChannelRecommended: false, isLegacyTeams: true, ClientType: ios, supports nestedAppAuth', async () => {
+    await utils.initializeWithContext(FrameContexts.content, HostClientType.ios);
+    const runtimeConfig: Runtime = {
+      apiVersion: 4,
+      supports: { nestedAppAuth },
+      isNAAChannelRecommended: false,
+      isLegacyTeams: true,
+    };
+    utils.setRuntimeConfig(runtimeConfig);
+    expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+  });
+
+  it('should return true; isNAAChannelRecommended: false, isLegacyTeams: true, ClientType: ipados, supports nestedAppAuth', async () => {
+    await utils.initializeWithContext(FrameContexts.content, HostClientType.ipados);
+    const runtimeConfig: Runtime = {
+      apiVersion: 4,
+      supports: { nestedAppAuth },
+      isNAAChannelRecommended: false,
+      isLegacyTeams: true,
+    };
+    utils.setRuntimeConfig(runtimeConfig);
+    expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
   });
 });

--- a/packages/teams-js/test/public/runtime.spec.ts
+++ b/packages/teams-js/test/public/runtime.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import { errorRuntimeNotInitialized } from '../../src/internal/constants';
+import { GlobalVars } from '../../src/internal/globalVars';
 import { compareSDKVersions } from '../../src/internal/utils';
 import { app, HostClientType } from '../../src/public';
 import {
@@ -243,6 +244,7 @@ describe('runtime', () => {
 
           for (const clientType of capabilityAdditionsInASpecificVersion.hostClientTypes) {
             await utils.initializeWithContext('content', clientType);
+            GlobalVars.hostClientType = clientType;
             const generatedCapabilityObjectForThisVersion = generateVersionBasedTeamsRuntimeConfig(
               version,
               versionAndPlatformAgnosticTeamsRuntimeConfig,


### PR DESCRIPTION
## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

The current IsNAAChannelRecommeded function that app developers will call, checks the value of the isNAAChannelRecommended flag in the runtime config. For hosts which are using the host sdks, the config object is sent during app initialization which sets the value of the is IsNAAChannelRecommeded flag in the runtime config correctly. For legacy Teams (i.e. Teams app not using the host SDK), the config object is not sent during the app initialization. The runtime config object is created on the JS SDK side. Therefore, a solution is required to return the value of the isNAAChannelRecommended correctly for the legacy Teams scenarios.

### Main changes in the PR:

1. Added the nestedAppAuth capability against the new version in the mapTeamsVersionToSupportedCapabilities in runtime.ts which is used along with versionAndPlatformAgnosticTeamsRuntimeConfig object to create the runtime object for legacy teams scenarios.
2. Along with the check of isNAAChannelRecommended value in the runtime config, an additional condition is added to check the following:  

- the host is Android or iOS or iPadOs 
- the value of isLegacyTeams flag in the runtime 
- Is the nestedAppAuth capability present in the runtime.supports

## Validation

### Validation performed:

1. Validated the isNAAChannelReommended is returning correct value for legacy teams using Teams-test-app

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes
Added unit tests to test the isNAAChannelRecommended against different conditions.

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes