### PR TITLE
noahdarveau/buffer polyfill removal fix

### DIFF
--- a/change/@microsoft-teams-js-4a860473-7a5b-481e-890b-4132b304af2e.json
+++ b/change/@microsoft-teams-js-4a860473-7a5b-481e-890b-4132b304af2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed a bug causing `buffer` polyfill to stil be included",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/rollup.config.mjs
+++ b/packages/teams-js/rollup.config.mjs
@@ -43,7 +43,7 @@ export default [
       typescript(),
       json(),
       commonjs(),
-      nodePolyfills(),
+      nodePolyfills({ exclude: ['node_modules/**'] }),
     ],
     treeshake: {
       moduleSideEffects: [


### PR DESCRIPTION
Added a change to the rollup configuration to exclude `node_modules` from the nodePolyfills plugin. This change should've been included in with the last buffer removal PR, but it was not included.