### PR TITLE
Migrate iOS E2E testing to image MacOS-14-arm64

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,7 +207,7 @@ extends:
             displayName: 'E2E Tests - IOS - Plan A'
             pool:
               name: Azure Pipelines
-              image: internal-macos12
+              image: macos-latest-internal
               os: macOS
             steps:
               - template: tools/yaml-templates/ios-test.yml@self
@@ -219,7 +219,7 @@ extends:
             displayName: 'E2E Tests - IOS - Plan B'
             pool:
               name: Azure Pipelines
-              image: internal-macos12
+              image: macos-latest-internal
               os: macOS
             steps:
               - template: tools/yaml-templates/ios-test.yml@self

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -59,13 +59,13 @@ steps:
     displayName: 'Download localhost certificate'
     inputs:
       secureFile: 'localhostCA.pem'
-  
+
   - task: DownloadSecureFile@1
     name: localhostSSLCertificate
     displayName: 'Download localhost certificate'
     inputs:
       secureFile: 'localhost.test.crt'
-            
+
   - task: DownloadSecureFile@1
     name: localhostSSLKey
     displayName: 'Download localhost key'
@@ -102,25 +102,23 @@ steps:
 
   - bash: |
       # Boot the iOS simulator
-      xcrun simctl boot "iPhone 14 Pro" || true
-      xcrun simctl bootstatus "iPhone 14 Pro" -b
+      xcrun simctl boot "iPhone 15 Pro" || true
+      xcrun simctl bootstatus "iPhone 15 Pro" -b
 
       # Add the root certificate to the booted simulator's keychain
       xcrun simctl keychain booted add-root-cert $(localhostRootCertificate.secureFilePath)
-    displayName: "[iOS] Boot iOS Simulator and Add Root Certificate"
+    displayName: '[iOS] Boot iOS Simulator and Add Root Certificate'
     workingDirectory: '$(System.DefaultWorkingDirectory)'
 
   - task: Bash@3
     displayName: 'iOS UI/E2E Tests'
-    condition: eq(variables['Build.Reason'], 'PullRequest') # Run E2E only for PR builds temporarily until the iOS E2E issue is resolved.
     inputs:
       targetType: inline
-      script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' -screenshot-enabled=\"YES\" -quiet -resultBundlePath TestResults test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
+      script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5' -screenshot-enabled=\"YES\" -quiet -resultBundlePath TestResults test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   - task: Bash@3
     displayName: 'Generate E2E test report'
-    condition: eq(variables['Build.Reason'], 'PullRequest') # Generate E2E test report only for PR builds temporarily until the iOS E2E issue is resolved.
     inputs:
       targetType: inline
       script: |


### PR DESCRIPTION
Migrate image running by iOS E2E test from macOS-12 to macOS-14-arm64. Change Xcode, simulator, simulator OS versions based on what new image provided in YML file.