### PR TITLE
Adding appId validation to CEA APIs

### DIFF
--- a/packages/teams-js/src/internal/appIdValidation.ts
+++ b/packages/teams-js/src/internal/appIdValidation.ts
@@ -1,3 +1,4 @@
+import { AppId } from '../public/appId';
 import { hasScriptTags } from './utils';
 
 /**
@@ -39,4 +40,18 @@ export function doesStringContainNonPrintableCharacters(str: string): boolean {
     const charCode = char.charCodeAt(0);
     return charCode < 32 || charCode > 126;
   });
+}
+
+/**
+ * @hidden
+ * Checks if the incoming app id is an instance of AppId
+ * @param potentialAppId An object to check if it's an instance of AppId
+ * @throws Error with a message describing the violation
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function validateAppIdInstance(potentialAppId: AppId): void {
+  if (!(potentialAppId instanceof AppId)) {
+    throw new Error(`Potential app id (${potentialAppId}) is invalid; it is not an instance of AppId class.`);
+  }
 }

--- a/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
+++ b/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
@@ -1,3 +1,4 @@
+import { validateAppIdInstance } from '../internal/appIdValidation';
 import { callFunctionInHost, callFunctionInHostAndHandleResponse } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -39,7 +40,7 @@ export async function authenticateWithSSO(
     throw errorNotSupportedOnPlatform;
   }
 
-  validateId(conversationId, new Error('conversation id is not valid.'));
+  validateInput(appId, conversationId);
 
   return callFunctionInHost(
     ApiName.ExternalAppAuthenticationForCEA_AuthenticateWithSSO,
@@ -75,7 +76,7 @@ export async function authenticateWithOauth(
     throw errorNotSupportedOnPlatform;
   }
 
-  validateId(conversationId, new Error('conversation id is not valid.'));
+  validateInput(appId, conversationId);
 
   // Ask the parent window to open an authentication window with the parameters provided by the caller.
   return callFunctionInHost(
@@ -121,7 +122,7 @@ export async function authenticateAndResendRequest(
     throw errorNotSupportedOnPlatform;
   }
 
-  validateId(conversationId, new Error('conversation id is not valid.'));
+  validateInput(appId, conversationId);
 
   externalAppAuthentication.validateActionExecuteInvokeRequest(originalRequestInfo);
 
@@ -174,7 +175,7 @@ export async function authenticateWithSSOAndResendRequest(
     throw errorNotSupportedOnPlatform;
   }
 
-  validateId(conversationId, new Error('conversation id is not valid.'));
+  validateInput(appId, conversationId);
 
   externalAppAuthentication.validateActionExecuteInvokeRequest(originalRequestInfo);
 
@@ -210,4 +211,19 @@ export async function authenticateWithSSOAndResendRequest(
  */
 export function isSupported(): boolean {
   return ensureInitialized(runtime) && runtime.supports.externalAppAuthenticationForCEA ? true : false;
+}
+
+/**
+ * @hidden
+ * Checks if the input is valid
+ * @param appId App ID of the app upon whose behalf Copilot is requesting authentication. This must be a UUID.
+ * @param conversationId ConversationId To tell the bot what conversation the calls are coming from
+
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function validateInput(appId: AppId, conversationId: string): void {
+  validateId(conversationId, new Error('conversation id is not valid.'));
+  validateAppIdInstance(appId);
 }

--- a/packages/teams-js/src/private/externalAppCardActionsForCEA.ts
+++ b/packages/teams-js/src/private/externalAppCardActionsForCEA.ts
@@ -1,10 +1,10 @@
 import { sendAndUnwrap, sendMessageToParentAsync } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
-import { validateId } from '../internal/utils';
 import { AppId } from '../public';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
 import { runtime } from '../public/runtime';
+import { validateInput } from './externalAppAuthenticationForCEA';
 import * as externalAppCardActions from './externalAppCardActions';
 
 /**
@@ -38,7 +38,7 @@ export async function processActionOpenUrl(
   if (!isSupported()) {
     throw errorNotSupportedOnPlatform;
   }
-  validateId(conversationId, new Error('conversation id is not valid.'));
+  validateInput(appId, conversationId);
   const [error, response] = await sendMessageToParentAsync<
     [externalAppCardActions.ActionOpenUrlError, externalAppCardActions.ActionOpenUrlType]
   >(
@@ -77,7 +77,7 @@ export async function processActionSubmit(
   if (!isSupported()) {
     throw errorNotSupportedOnPlatform;
   }
-  validateId(conversationId, new Error('conversation id is not valid.'));
+  validateInput(appId, conversationId);
   const error = await sendAndUnwrap<externalAppCardActions.ActionSubmitError | undefined>(
     getApiVersionTag(
       externalAppCardActionsTelemetryVersionNumber,

--- a/packages/teams-js/test/internal/appIdValidation.spec.ts
+++ b/packages/teams-js/test/internal/appIdValidation.spec.ts
@@ -3,8 +3,10 @@ import {
   isStringWithinAppIdLengthLimits,
   maximumValidAppIdLength,
   minimumValidAppIdLength,
+  validateAppIdInstance,
   validateStringAsAppId,
 } from '../../src/internal/appIdValidation';
+import { AppId } from '../../src/public/appId';
 
 describe('doesStringContainNonPrintableCharacters', () => {
   test('should return true for strings with only non-printable characters', () => {
@@ -76,5 +78,45 @@ describe('validateStringAsAppId', () => {
 
   test('should throw error with "printable" in message for app id containing non-printable characters', () => {
     expect(() => validateStringAsAppId('hello\u0080world')).toThrowError(/printable/i);
+  });
+});
+
+describe('validateStringAsAppId', () => {
+  test('should not throw for "valid" app ids', () => {
+    expect(() => validateStringAsAppId('8e6523aa-97f9-49ad-8614-75cae22f6597')).not.toThrow();
+    expect(() => validateStringAsAppId('com.microsoft.teamspace.tab.youtube')).not.toThrow();
+  });
+
+  test('should throw error with "script" in message for app id containing script tag', () => {
+    expect(() => validateStringAsAppId('<script>alert("Hello")</script>')).toThrowError(/script/i);
+  });
+
+  test('should throw error with "length" in message for app id too long or too short', () => {
+    expect(() => validateStringAsAppId('a')).toThrowError(/length/i);
+    expect(() => validateStringAsAppId('a'.repeat(maximumValidAppIdLength))).toThrowError(/length/i);
+  });
+
+  test('should throw error with "printable" in message for app id containing non-printable characters', () => {
+    expect(() => validateStringAsAppId('hello\u0080world')).toThrowError(/printable/i);
+  });
+});
+
+describe('validateAppIdInstance', () => {
+  test('should throw error when appId is an object but not instance of AppId', () => {
+    expect(() => validateAppIdInstance({ Object: 'object' } as unknown as AppId)).toThrowError(
+      'Potential app id ([object Object]) is invalid; it is not an instance of AppId class.',
+    );
+  });
+
+  test('should throw error when appId is an instance of an object other than AppId', () => {
+    class NotAppId {}
+    const notAppIdInstance = new NotAppId();
+    expect(() => validateAppIdInstance(notAppIdInstance as unknown as AppId)).toThrowError(
+      'Potential app id ([object Object]) is invalid; it is not an instance of AppId class.',
+    );
+  });
+  test('should not throw error when appId is an instance of AppId', () => {
+    const appIdInstance = new AppId('app-id-that-does-not-throw');
+    expect(() => validateAppIdInstance(appIdInstance)).not.toThrow();
   });
 });

--- a/packages/teams-js/test/private/externalAppAuthenticationForCEA.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthenticationForCEA.spec.ts
@@ -122,7 +122,7 @@ describe('externalAppAuthenticationForCEA', () => {
           }
           return expect(promise).resolves.toEqual(testResponse);
         });
-        it(`should throw error if the data is not of correct type - ${frameContext}`, async () => {
+        it(`should throw error if the actionExecuteInvokeRequest.data is not of correct type - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthenticationForCEA: {} } });
@@ -142,6 +142,23 @@ describe('externalAppAuthenticationForCEA', () => {
               errorCode: 'INTERNAL_ERROR',
               message: `Invalid data type ${typeof invalidDataRequest.data}. Data must be a primitive or a plain object.`,
             });
+          }
+        });
+        it(`should throw error if the appId is not an instance of AppId class - ${frameContext}`, async () => {
+          expect.assertions(1);
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthenticationForCEA: {} } });
+          try {
+            await externalAppAuthenticationForCEA.authenticateAndResendRequest(
+              {} as unknown as AppId,
+              testConversationId,
+              testAuthRequest,
+              testOriginalRequest,
+            );
+          } catch (e) {
+            expect(e).toEqual(
+              new Error('Potential app id ([object Object]) is invalid; it is not an instance of AppId class.'),
+            );
           }
         });
         it(`should throw error on invalid original request with context - ${frameContext}`, async () => {
@@ -272,6 +289,22 @@ describe('externalAppAuthenticationForCEA', () => {
     });
     Object.values(FrameContexts).forEach((frameContext) => {
       if (allowedFrameContexts.includes(frameContext)) {
+        it(`should throw error if the appId is not an instance of AppId class - ${frameContext}`, async () => {
+          expect.assertions(1);
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthenticationForCEA: {} } });
+          try {
+            await externalAppAuthenticationForCEA.authenticateWithSSO(
+              {} as unknown as AppId,
+              testConversationId,
+              testRequest,
+            );
+          } catch (e) {
+            expect(e).toEqual(
+              new Error('Potential app id ([object Object]) is invalid; it is not an instance of AppId class.'),
+            );
+          }
+        });
         it('should throw error from host', async () => {
           await utils.initializeWithContext(FrameContexts.content);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthenticationForCEA: {} } });
@@ -379,6 +412,24 @@ describe('externalAppAuthenticationForCEA', () => {
     const allowedFrameContexts = [FrameContexts.content];
     Object.values(FrameContexts).forEach((frameContext) => {
       if (allowedFrameContexts.includes(frameContext)) {
+        it(`should throw error if the appId is not an instance of AppId class - ${frameContext}`, async () => {
+          expect.assertions(1);
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthenticationForCEA: {} } });
+          try {
+            await externalAppAuthenticationForCEA.authenticateWithSSOAndResendRequest(
+              {} as unknown as AppId,
+              testConversationId,
+              testAuthRequest,
+              testOriginalRequest,
+            );
+          } catch (e) {
+            expect(e).toEqual(
+              new Error('Potential app id ([object Object]) is invalid; it is not an instance of AppId class.'),
+            );
+          }
+        });
+
         it(`should throw error from host failure in context - ${frameContext}`, async () => {
           expect.assertions(3);
           const testError = {
@@ -450,7 +501,7 @@ describe('externalAppAuthenticationForCEA', () => {
           );
         });
 
-        it(`should throw error if the data is not of correct type - ${frameContext}`, async () => {
+        it(`should throw error if the IActionExecuteInvokeRequest.data is not of correct type - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthenticationForCEA: {} } });
@@ -472,7 +523,6 @@ describe('externalAppAuthenticationForCEA', () => {
             });
           }
         });
-
         it(`should throw error on invalid original request with context - ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
@@ -579,6 +629,22 @@ describe('externalAppAuthenticationForCEA', () => {
 
     Object.values(FrameContexts).forEach((frameContext) => {
       if (allowedFrameContexts.includes(frameContext)) {
+        it(`should throw error if the appId is not an instance of AppId class - ${frameContext}`, async () => {
+          expect.assertions(1);
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppAuthenticationForCEA: {} } });
+          try {
+            await externalAppAuthenticationForCEA.authenticateWithOauth(
+              {} as unknown as AppId,
+              testConversationId,
+              testAuthRequest,
+            );
+          } catch (e) {
+            expect(e).toEqual(
+              new Error('Potential app id ([object Object]) is invalid; it is not an instance of AppId class.'),
+            );
+          }
+        });
         it(`should resolve on success with context - ${frameContext}`, async () => {
           expect.assertions(3);
           await utils.initializeWithContext(frameContext);

--- a/packages/teams-js/test/private/externalAppCardActionsForCEA.spec.ts
+++ b/packages/teams-js/test/private/externalAppCardActionsForCEA.spec.ts
@@ -61,6 +61,23 @@ describe('externalAppCardActionsForCEA', () => {
 
     Object.values(FrameContexts).forEach((frameContext) => {
       if (allowedFrameContexts.includes(frameContext)) {
+        it(`should throw error if the appId is not an instance of AppId class - ${frameContext}`, async () => {
+          expect.assertions(1);
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActionsForCEA: {} } });
+          try {
+            await externalAppCardActionsForCEA.processActionSubmit(
+              {} as unknown as AppId,
+              testConversationId,
+              testActionSubmitPayload,
+            );
+          } catch (e) {
+            expect(e).toEqual(
+              new Error('Potential app id ([object Object]) is invalid; it is not an instance of AppId class.'),
+            );
+          }
+        });
+
         it(`should resolve when called from context - ${frameContext}`, async () => {
           expect.assertions(3);
           await utils.initializeWithContext(frameContext);
@@ -151,6 +168,23 @@ describe('externalAppCardActionsForCEA', () => {
 
     Object.values(FrameContexts).forEach((frameContext) => {
       if (allowedFrameContexts.includes(frameContext)) {
+        it(`should throw error if the appId is not an instance of AppId class - ${frameContext}`, async () => {
+          expect.assertions(1);
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: { externalAppCardActionsForCEA: {} } });
+          try {
+            await externalAppCardActionsForCEA.processActionOpenUrl(
+              {} as unknown as AppId,
+              testConversationId,
+              testUrl,
+            );
+          } catch (e) {
+            expect(e).toEqual(
+              new Error('Potential app id ([object Object]) is invalid; it is not an instance of AppId class.'),
+            );
+          }
+        });
+
         it(`should resolve when called from context - ${frameContext}`, async () => {
           expect.assertions(3);
           await utils.initializeWithContext(frameContext);


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Adding a check to make sure the incoming appId is an instance of AppId class. 

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
