### PR TITLE
noahdarveau/nextjs fix

### DIFF
--- a/change/@microsoft-teams-js-6a4a3b9d-97ef-4dfe-a79c-ea0f69b290d9.json
+++ b/change/@microsoft-teams-js-6a4a3b9d-97ef-4dfe-a79c-ea0f69b290d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed `type: module` from package.json to fix nextjs bug",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -11,7 +11,6 @@
   "main": "./dist/umd/MicrosoftTeams.min.js",
   "typings": "./dist/umd/MicrosoftTeams.d.ts",
   "module": "./dist/esm/packages/teams-js/src/index.js",
-  "type": "module",
   "scripts": {
     "build": "pnpm clean && pnpm lint && pnpm build-rollup && pnpm build-webpack && pnpm docs:validate",
     "build-rollup": "pnpm clean && rollup -c",


### PR DESCRIPTION
Some nextjs apps consuming teams-js builds are failing with the error `TypeError: Cannot set properties of undefined (setting 'microsoftTeams')`. From my investigation, it seems removing the `type: module` line in the `package.json` resolves the issue. A quick test shows removing that line does not impact treeshakability.