### PR TITLE
Noahdarveau/cjs/mjs file extensions

### DIFF
--- a/apps/blazor-test-app/Interop/InteropModuleBase.cs
+++ b/apps/blazor-test-app/Interop/InteropModuleBase.cs
@@ -33,7 +33,7 @@ public abstract class InteropModuleBase
     {
         if (_module == null)
         {
-            _ = await ImportPrerequisiteModuleAsync("./js/MicrosoftTeams.min.js");
+            _ = await ImportPrerequisiteModuleAsync("./js/MicrosoftTeams.min.cjs");
             _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", ModulePath).AsTask();
         }
 

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -10,7 +10,7 @@
     "build:CDN": "pnpm lint && webpack --config webpack.cdn.config.js",
     "build:local": "pnpm lint && webpack --config webpack.local.config.js && pnpm copy",
     "clean": "rimraf ./build",
-    "copy": "shx cp ../../packages/teams-js/dist/umd/MicrosoftTeams.min.js ./build/ && shx cp ../../packages/teams-js/dist/umd/MicrosoftTeams.min.js.map ./build/",
+    "copy": "shx cp ../../packages/teams-js/dist/umd/MicrosoftTeams.min.cjs ./build/ && shx cp ../../packages/teams-js/dist/umd/MicrosoftTeams.min.cjs.map ./build/",
     "lint": "pnpm eslint ./src --max-warnings 0 --fix --ext .tsx",
     "start": "pnpm start:bundle",
     "start:bundle": "webpack serve",

--- a/change/@microsoft-teams-js-92d8698c-fbd3-410c-a3cb-157176d2e85c.json
+++ b/change/@microsoft-teams-js-92d8698c-fbd3-410c-a3cb-157176d2e85c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "added explicit `.cjs` and `.mjs` file extensions to published files",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -8,9 +8,9 @@
     "type": "git",
     "url": "https://github.com/OfficeDev/microsoft-teams-library-js"
   },
-  "main": "./dist/umd/MicrosoftTeams.min.js",
+  "main": "./dist/umd/MicrosoftTeams.min.cjs",
   "typings": "./dist/umd/MicrosoftTeams.d.ts",
-  "module": "./dist/esm/packages/teams-js/src/index.js",
+  "module": "./dist/esm/packages/teams-js/src/index.mjs",
   "scripts": {
     "build": "pnpm clean && pnpm lint && pnpm build-rollup && pnpm build-webpack && pnpm docs:validate",
     "build-rollup": "pnpm clean && rollup -c",

--- a/packages/teams-js/rollup.config.mjs
+++ b/packages/teams-js/rollup.config.mjs
@@ -20,7 +20,7 @@ export default [
       name: '@microsoft/teams-js',
       format: 'es',
       preserveModules: true,
-      entryFileNames: '[name].js',
+      entryFileNames: '[name].cjs',
       sourcemap: false,
       plugins: [terser()],
       globals: {

--- a/packages/teams-js/webpack.config.cjs
+++ b/packages/teams-js/webpack.config.cjs
@@ -84,7 +84,7 @@ module.exports = {
         compiler.hooks.done.tap('wsi-test', () => {
           const manifest = JSON.parse(readFileSync(join(__dirname, 'dist/umd/MicrosoftTeams-manifest.json'), 'utf-8'));
           // If for some reason hash was not generated for the assets, this test will fail in build.
-          expect(manifest['MicrosoftTeams.min.js'].integrity).toMatch(/sha384-.*/);
+          expect(manifest['MicrosoftTeams.min.cjs'].integrity).toMatch(/sha384-.*/);
         });
       },
     },
@@ -94,8 +94,8 @@ module.exports = {
         onEnd: {
           copy: [
             {
-              source: './dist/umd/MicrosoftTeams.min.js',
-              destination: '../../apps/blazor-test-app/wwwroot/js/MicrosoftTeams.min.js',
+              source: './dist/umd/MicrosoftTeams.min.cjs',
+              destination: '../../apps/blazor-test-app/wwwroot/js/MicrosoftTeams.min.cjs',
             },
           ],
         },

--- a/packages/teams-js/webpack.config.cjs
+++ b/packages/teams-js/webpack.config.cjs
@@ -19,7 +19,7 @@ module.exports = {
     'MicrosoftTeams.min': './src/index.ts',
   },
   output: {
-    filename: '[name].js',
+    filename: '[name].cjs',
     // the following setting is required for SRI to work
     crossOriginLoading: 'anonymous',
     path: path.resolve(__dirname, 'dist/umd'),

--- a/tools/bundle-size-tools/bundle-analysis-app/webpack.config.js
+++ b/tools/bundle-size-tools/bundle-analysis-app/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   resolve: {
     modules: ['node_modules'],
-    extensions: ['.ts', '.tsx', '.js', '.jsx', '.cjs', '.mjs'],
+    extensions: ['.ts', '.tsx', '.js', '.jsx'],
     symlinks: true,
   },
   module: {

--- a/tools/bundle-size-tools/bundle-analysis-app/webpack.config.js
+++ b/tools/bundle-size-tools/bundle-analysis-app/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   resolve: {
     modules: ['node_modules'],
-    extensions: ['.ts', '.tsx', '.js', '.jsx'],
+    extensions: ['.ts', '.tsx', '.js', '.jsx', '.cjs', '.mjs'],
     symlinks: true,
   },
   module: {


### PR DESCRIPTION
Now that we have removed the `type: module` line from the package.json, I thought it would be worthwhile to add explicit `.cjs` file extensions to the webpack generated umd bundle and `.mjs` file extensions to the rollup generated esm files to more explicitly signal to consumer's bundlers how to handle each file.