### PR TITLE
Prepare release 2.31.0

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.30.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-8I0Bv4bWDPSX5ZYhJcChnvrBNoieX3zASTxmZ9URwnjEVx70hsrN0ZUy/C46u8dw"
+      src="https://res.cdn.office.net/teams-js/2.31.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-A2y7iMKbK0AQrgKq1YKcLB8XgtyowB2MPzC40KFfA58nQObf6xU3C5NE0cTcis0V"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm lint && webpack",

--- a/change/@microsoft-teams-js-0ad87803-4839-4de4-8f4f-5bbd48980fde.json
+++ b/change/@microsoft-teams-js-0ad87803-4839-4de4-8f4f-5bbd48980fde.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Made the `liveShareHosts`, `location`, `mail`, `marketplace`, media`, `menus`, `monetization`, `nestedAppAuth`, `people`, `search`, `secondaryBrowser`, `tasks`, `teamsAPIs`, and `thirdPartyCloudStorage` files treeshakable",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-0dfea369-ca36-49f5-87e9-4f2825d7c380.json
+++ b/change/@microsoft-teams-js-0dfea369-ca36-49f5-87e9-4f2825d7c380.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Refactored helper functions from app file to their own file",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-1596e2e2-4f59-44d4-8689-0de41698434f.json
+++ b/change/@microsoft-teams-js-1596e2e2-4f59-44d4-8689-0de41698434f.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Updated namespace level docs to module level",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-2f4e536b-d22a-4105-903c-024e6d9a51a5.json
+++ b/change/@microsoft-teams-js-2f4e536b-d22a-4105-903c-024e6d9a51a5.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Made the `pages` file treeshakable",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-3257d0cf-4640-4de7-b7a6-c117e6c4ccbf.json
+++ b/change/@microsoft-teams-js-3257d0cf-4640-4de7-b7a6-c117e6c4ccbf.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Released 2.30.0",
-  "packageName": "@microsoft/teams-js",
-  "email": "erinha@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-35af1950-5f26-4ffe-8c68-6ca569870710.json
+++ b/change/@microsoft-teams-js-35af1950-5f26-4ffe-8c68-6ca569870710.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Made the `dialog` file treeshakable",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-406034a0-0f82-4635-b418-c6ad95bfa0b0.json
+++ b/change/@microsoft-teams-js-406034a0-0f82-4635-b418-c6ad95bfa0b0.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Added validation for `IActionExecuteInvokeRequest.data` element in `ExternalAppAuthentication` and `ExternalAppAuthenticationForCEA` capabilities. The element can be of type primitive or plain object only",
-  "packageName": "@microsoft/teams-js",
-  "email": "lakhveerkaur@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-42d39be6-18d9-4619-ab76-a1360275873c.json
+++ b/change/@microsoft-teams-js-42d39be6-18d9-4619-ab76-a1360275873c.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added new timestamp and handler for analyzing latencies due to message delays between app and hub.",
-  "packageName": "@microsoft/teams-js",
-  "email": "jcardenasr123@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-55399555-fdb1-4b61-accb-5ebed9246795.json
+++ b/change/@microsoft-teams-js-55399555-fdb1-4b61-accb-5ebed9246795.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Made the `videoEffects`, `videoEffectsEx`, `visualMedia`, and `webStorage` files treeshakable",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-557212a2-b959-475f-bba1-df08e64a7c81.json
+++ b/change/@microsoft-teams-js-557212a2-b959-475f-bba1-df08e64a7c81.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Increased the initialize response wait-timeout to 60 sec",
-  "packageName": "@microsoft/teams-js",
-  "email": "niharikad@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-5dd2d28d-3280-4f21-9ef4-572a6de474f6.json
+++ b/change/@microsoft-teams-js-5dd2d28d-3280-4f21-9ef4-572a6de474f6.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Made the `app` (now fully), `chat`, and `geoLocation` files treeshakable",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-6a4a3b9d-97ef-4dfe-a79c-ea0f69b290d9.json
+++ b/change/@microsoft-teams-js-6a4a3b9d-97ef-4dfe-a79c-ea0f69b290d9.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Removed `type: module` from package.json to fix nextjs bug",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-6c75876b-1e4b-4ca0-a7a2-d94204eae9a7.json
+++ b/change/@microsoft-teams-js-6c75876b-1e4b-4ca0-a7a2-d94204eae9a7.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Made the `meeting`, `profile`, sharing`, and `stageView` files treeshakable",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-7805c977-c283-42e2-9e37-bbbf82239930.json
+++ b/change/@microsoft-teams-js-7805c977-c283-42e2-9e37-bbbf82239930.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Replaced `Buffer` with `uint8array-extras` to allow for `buffer` polyfill removal",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-895f30e4-4c57-4645-814a-49fe2ae8e9b8.json
+++ b/change/@microsoft-teams-js-895f30e4-4c57-4645-814a-49fe2ae8e9b8.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added validation for AppId instance in CEA APIs",
-  "packageName": "@microsoft/teams-js",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-9ba1fbf7-8871-42bc-8f38-03e1c4825210.json
+++ b/change/@microsoft-teams-js-9ba1fbf7-8871-42bc-8f38-03e1c4825210.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Changed the `notifySuccess` function to indicate through a promise when the function finished processing in the host.",
-  "packageName": "@microsoft/teams-js",
-  "email": "jcardenasr123@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-a4e76c3e-7ab3-4dd4-9a24-c0c909040b64.json
+++ b/change/@microsoft-teams-js-a4e76c3e-7ab3-4dd4-9a24-c0c909040b64.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Add userClickTimeV2 to app `Context` to provide the timestamp when the user clicked the app using the performance timer API.",
-  "packageName": "@microsoft/teams-js",
-  "email": "jcardenasr123@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-b23ef57f-9184-4659-93c8-48d862788dd3.json
+++ b/change/@microsoft-teams-js-b23ef57f-9184-4659-93c8-48d862788dd3.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Made the `app`, `appInitialization`, and `settings` files treeshakable",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-c23ceb97-a527-4ef9-8714-f4beff7446ec.json
+++ b/change/@microsoft-teams-js-c23ceb97-a527-4ef9-8714-f4beff7446ec.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Made the `copilot`, `hostEntity`, `messageChannels`, and `teams` files treeshakable",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-d467d82e-564d-4b25-b975-b8d07a91a647.json
+++ b/change/@microsoft-teams-js-d467d82e-564d-4b25-b975-b8d07a91a647.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Made the `appEntity`, `conversations`, `copilot`, `externalAppAuthentication`, `externalAppAuthenticationForCEA`, `externalAppCardActions`, `externalAppCardActionsForCEA`, `externalAppCommands`, `files`, `logs`, `meetingRoom`, `notifications`, `otherAppStateChange`, and `remoteCamera` files treeshakable",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-ee20dd5c-0ffc-4208-bd96-53224dc7e062.json
+++ b/change/@microsoft-teams-js-ee20dd5c-0ffc-4208-bd96-53224dc7e062.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Made the `appInstallDialog`, `authentication`, `barCode`, `calendar`, `call`, and `clipboard` files treeshakable",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-f6526430-887f-46bc-bfb4-8c9750214364.json
+++ b/change/@microsoft-teams-js-f6526430-887f-46bc-bfb4-8c9750214364.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Fix building in node 22",
-  "packageName": "@microsoft/teams-js",
-  "email": "jcardenasr123@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-f9ac3559-b7e4-4cdd-bff9-54aecd663d48.json
+++ b/change/@microsoft-teams-js-f9ac3559-b7e4-4cdd-bff9-54aecd663d48.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Made `externalAppAuthenticationForCEA.ts` throw `Error` objects instead of `SdkErrors`.",
-  "packageName": "@microsoft/teams-js",
-  "email": "trharris@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -10,21 +10,12 @@ Wed, 13 Nov 2024 19:22:01 GMT
 
 ### Minor changes
 
-- Made the `appInstallDialog`, `authentication`, `barCode`, `calendar`, `call`, and `clipboard` files treeshakable
+- Made the library treeshakable
 - Made `externalAppAuthenticationForCEA.ts` throw `Error` objects instead of `SdkErrors`.
-- Made the `app`, `appInitialization`, and `settings` files treeshakable
-- Made the `copilot`, `hostEntity`, `messageChannels`, and `teams` files treeshakable
-- Made the `appEntity`, `conversations`, `copilot`, `externalAppAuthentication`, `externalAppAuthenticationForCEA`, `externalAppCardActions`, `externalAppCardActionsForCEA`, `externalAppCommands`, `files`, `logs`, `meetingRoom`, `notifications`, `otherAppStateChange`, and `remoteCamera` files treeshakable
-- Made the `meeting`, `profile`, sharing`, and `stageView` files treeshakable
 - Replaced `Buffer` with `uint8array-extras` to allow for `buffer` polyfill removal
 - Added validation for AppId instance in CEA APIs
 - Changed the `notifySuccess` function to indicate through a promise when the function finished processing in the host.
-- Made the `videoEffects`, `videoEffectsEx`, `visualMedia`, and `webStorage` files treeshakable
-- Made the `app` (now fully), `chat`, and `geoLocation` files treeshakable
-- Made the `dialog` file treeshakable
 - Added new timestamp and handler for analyzing latencies due to message delays between app and hub.
-- Made the `pages` file treeshakable
-- Made the `liveShareHosts`, `location`, `mail`, `marketplace`, media`, `menus`, `monetization`, `nestedAppAuth`, `people`, `search`, `secondaryBrowser`, `tasks`, `teamsAPIs`, and `thirdPartyCloudStorage` files treeshakable
 
 ### Patches
 

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,37 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Mon, 21 Oct 2024 18:11:30 GMT and should not be manually modified.
+This log was last generated on Wed, 13 Nov 2024 19:22:01 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.31.0
+
+Wed, 13 Nov 2024 19:22:01 GMT
+
+### Minor changes
+
+- Made the `appInstallDialog`, `authentication`, `barCode`, `calendar`, `call`, and `clipboard` files treeshakable
+- Made `externalAppAuthenticationForCEA.ts` throw `Error` objects instead of `SdkErrors`.
+- Made the `app`, `appInitialization`, and `settings` files treeshakable
+- Made the `copilot`, `hostEntity`, `messageChannels`, and `teams` files treeshakable
+- Made the `appEntity`, `conversations`, `copilot`, `externalAppAuthentication`, `externalAppAuthenticationForCEA`, `externalAppCardActions`, `externalAppCardActionsForCEA`, `externalAppCommands`, `files`, `logs`, `meetingRoom`, `notifications`, `otherAppStateChange`, and `remoteCamera` files treeshakable
+- Made the `meeting`, `profile`, sharing`, and `stageView` files treeshakable
+- Replaced `Buffer` with `uint8array-extras` to allow for `buffer` polyfill removal
+- Added validation for AppId instance in CEA APIs
+- Changed the `notifySuccess` function to indicate through a promise when the function finished processing in the host.
+- Made the `videoEffects`, `videoEffectsEx`, `visualMedia`, and `webStorage` files treeshakable
+- Made the `app` (now fully), `chat`, and `geoLocation` files treeshakable
+- Made the `dialog` file treeshakable
+- Added new timestamp and handler for analyzing latencies due to message delays between app and hub.
+- Made the `pages` file treeshakable
+- Made the `liveShareHosts`, `location`, `mail`, `marketplace`, media`, `menus`, `monetization`, `nestedAppAuth`, `people`, `search`, `secondaryBrowser`, `tasks`, `teamsAPIs`, and `thirdPartyCloudStorage` files treeshakable
+
+### Patches
+
+- Add userClickTimeV2 to app `Context` to provide the timestamp when the user clicked the app using the performance timer API.
+- Increased the initialize response wait-timeout to 60 sec
+- Removed `type: module` from package.json to fix nextjs bug
+- Added validation for `IActionExecuteInvokeRequest.data` element in `ExternalAppAuthentication` and `ExternalAppAuthenticationForCEA` capabilities. The element can be of type primitive or plain object only
 
 ## 2.30.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.30.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.31.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.30.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-8I0Bv4bWDPSX5ZYhJcChnvrBNoieX3zASTxmZ9URwnjEVx70hsrN0ZUy/C46u8dw"
+  src="https://res.cdn.office.net/teams-js/2.31.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-A2y7iMKbK0AQrgKq1YKcLB8XgtyowB2MPzC40KFfA58nQObf6xU3C5NE0cTcis0V"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.30.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.31.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",


### PR DESCRIPTION
## 2.31.0

Wed, 13 Nov 2024 19:22:01 GMT

### Minor changes

- Made the `appInstallDialog`, `authentication`, `barCode`, `calendar`, `call`, and `clipboard` files treeshakable
- Made `externalAppAuthenticationForCEA.ts` throw `Error` objects instead of `SdkErrors`.
- Made the `app`, `appInitialization`, and `settings` files treeshakable
- Made the `copilot`, `hostEntity`, `messageChannels`, and `teams` files treeshakable
- Made the `appEntity`, `conversations`, `copilot`, `externalAppAuthentication`, `externalAppAuthenticationForCEA`, `externalAppCardActions`, `externalAppCardActionsForCEA`, `externalAppCommands`, `files`, `logs`, `meetingRoom`, `notifications`, `otherAppStateChange`, and `remoteCamera` files treeshakable
- Made the `meeting`, `profile`, sharing`, and `stageView` files treeshakable
- Replaced `Buffer` with `uint8array-extras` to allow for `buffer` polyfill removal
- Added validation for AppId instance in CEA APIs
- Changed the `notifySuccess` function to indicate through a promise when the function finished processing in the host.
- Made the `videoEffects`, `videoEffectsEx`, `visualMedia`, and `webStorage` files treeshakable
- Made the `app` (now fully), `chat`, and `geoLocation` files treeshakable
- Made the `dialog` file treeshakable
- Added new timestamp and handler for analyzing latencies due to message delays between app and hub.
- Made the `pages` file treeshakable
- Made the `liveShareHosts`, `location`, `mail`, `marketplace`, media`, `menus`, `monetization`, `nestedAppAuth`, `people`, `search`, `secondaryBrowser`, `tasks`, `teamsAPIs`, and `thirdPartyCloudStorage` files treeshakable

### Patches

- Add userClickTimeV2 to app `Context` to provide the timestamp when the user clicked the app using the performance timer API.
- Increased the initialize response wait-timeout to 60 sec
- Removed `type: module` from package.json to fix nextjs bug
- Added validation for `IActionExecuteInvokeRequest.data` element in `ExternalAppAuthentication` and `ExternalAppAuthenticationForCEA` capabilities. The element can be of type primitive or plain object only