### PR TITLE
Skip failure on task to install XCTestHTMLReport and only publish result to artifact when the task succeeded

### DIFF
--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -14,11 +14,13 @@ steps:
 
   - task: Bash@3
     displayName: 'Install XCTestHtmlReport for publishing result'
+    id: installXCTestHtmlReport
     inputs:
       targetType: inline
       script: |
         brew install xctesthtmlreport
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
+      continue-on-error: true
       condition: always()
 
   - task: NodeTool@0

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -166,5 +166,5 @@ steps:
     inputs:
       path: '$(agent.buildDirectory)/Logs/$(agent.JobName)/$(agent.JobName)_DebugLogs.zip'
       artifact: iOSDebugLogs - ${{ parameters.testPlan }} - Attempt $(System.JobAttempt)
-    condition: eq(variables['task.iOS_E2E_Test_Task.status'], 'failed')
+    condition: and(eq(variables['task.iOS_E2E_Test_Task.status'], 'failed'), eq(variables['xctestHtmlReportInstalled'], 'Yes'))
     continueOnError: true

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -14,7 +14,6 @@ steps:
 
   - task: Bash@3
     displayName: 'Install XCTestHtmlReport for publishing result'
-    id: installXCTestHtmlReport
     inputs:
       targetType: inline
       script: |

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -144,6 +144,8 @@ steps:
       mergeTestResults: true
     condition: succeededOrFailed()
 
+    # The condition of this task is to say, only when xctestHtmlReportInstall task successfully be executed,
+    # this task will then be executed to publish results to the artifact.
   - bash: |
       output="$(agent.buildDirectory)/Logs/$(agent.JobName)"
       rm -rf "${output}" > /dev/null

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -19,8 +19,10 @@ steps:
       targetType: inline
       script: |
         brew install xctesthtmlreport
+
+        echo "##vso[task.setvariable variable=xctestHtmlReportInstalled]Yes"
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
-      continue-on-error: true
+      continueOnError: true
       condition: always()
 
   - task: NodeTool@0
@@ -154,7 +156,7 @@ steps:
       cd "${output}"
       zip -r "$(agent.JobName)_DebugLogs.zip" .
     displayName: Preparations for publishing results
-    condition: eq(variables['task.iOS_E2E_Test_Task.status'], 'failed')
+    condition: eq(variables['xctestHtmlReportInstalled'], 'Yes')
 
   - task: 1ES.PublishPipelineArtifact@1
     inputs:

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -12,6 +12,11 @@ steps:
     path: iOSHost
     persistCredentials: true
 
+    # the line: echo "##vso[task.setvariable variable=xctestHtmlReportInstalled]Yes"
+    # is to set a self-defined variable to indicate task of this bash file is completing successfully because task may
+    # fail and exit earlier before this line (encounters an error when installing xctesthtmlreport tool)
+    # please use the link below for more information
+    # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops#variables-created-in-a-step-used-in-subsequent-step-conditions
   - task: Bash@3
     displayName: 'Install XCTestHtmlReport for publishing result'
     inputs:


### PR DESCRIPTION
## Description

As title says, this PR is to skip failure on task to install XCTestHTMLReport and only publish result to artifact when the task succeeded, considering we encounter the error as below every day. Pipeline will be considered to be successful even if XCTestHTMLReport fails to be installed since we have a `continueOnError` tag for that.

```dyld[7806]: terminating because inserted dylib '/Users/runner/work/_temp/codeql3000/distribution/codeql/tools/osx64/libtrace.dylib' could not be loaded: tried: '/Users/runner/work/_temp/codeql3000/distribution/codeql/tools/osx64/libtrace.dylib' (fat file, but missing compatible architecture (have 'x86_64,arm64', need 'arm64e')), 
'/System/Volumes/Preboot/Cryptexes/OS/Users/runner/work/_temp/codeql3000/distribution/codeql/tools/osx64/libtrace.dylib' (no such file), '/Users/runner/work/_temp/codeql3000/distribution/codeql/tools/osx64/libtrace.dylib' (fat file, but missing compatible architecture (have 'x86_64,arm64', need 'arm64e'))
dyld[7806]: tried: '/Users/runner/work/_temp/codeql3000/distribution/codeql/tools/osx64/libtrace.dylib' (fat file, but missing compatible architecture (have 'x86_64,arm64', need 'arm64e')), 
'/System/Volumes/Preboot/Cryptexes/OS/Users/runner/work/_temp/codeql3000/distribution/codeql/tools/osx64/libtrace.dylib' (no such file), '/Users/runner/work/_temp/codeql3000/distribution/codeql/tools/osx64/libtrace.dylib' (fat file, but missing compatible architecture (have 'x86_64,arm64', need 'arm64e'))
/Users/runner/work/_temp/939bbdf4-66ff-4572-8b7e-3fdb96cc1197.sh: line 1:  7806 Abort trap: 6           brew install xctesthtmlreport
```

### Main changes in the PR: YML file in iOS

## Validation

Hopefully it works when next time we encounter the same issue.

### Unit Tests added: No

### End-to-end tests added: No

## Additional Requirements

### Change file added: No
