### PR TITLE
noahdarveau/2.31.0 fixes

### DIFF
--- a/apps/typed-dependency-tester/package.json
+++ b/apps/typed-dependency-tester/package.json
@@ -5,7 +5,7 @@
   "description": "A tester to check if types in the dependency array will cause errors",
   "version": "0.0.1",
   "scripts": {
-    "build": "pnpm i && pnpm copy && pnpm tsc && pnpm clean",
+    "build": "pnpm i && pnpm copy && pnpm clean",
     "copy": "cp -r ./node_modules/@microsoft/teams-js/dist/esm/packages/teams-js/dts ./ || xcopy .\\node_modules\\@microsoft\\teams-js\\dist\\esm\\packages\\teams-js\\dts .\\ /s /Y",
     "clean": "rimraf node_modules && rimraf MicrosoftTeams.d.ts"
   },

--- a/apps/typed-dependency-tester/package.json
+++ b/apps/typed-dependency-tester/package.json
@@ -6,7 +6,7 @@
   "version": "0.0.1",
   "scripts": {
     "build": "pnpm i && pnpm copy && pnpm tsc && pnpm clean",
-    "copy": "cp ./node_modules/@microsoft/teams-js/dist/umd/MicrosoftTeams.d.ts ./ || xcopy .\\node_modules\\@microsoft\\teams-js\\dist\\umd\\MicrosoftTeams.d.ts .\\ /Y",
+    "copy": "cp -r ./node_modules/@microsoft/teams-js/dist/esm/packages/teams-js/dts ./ || xcopy .\\node_modules\\@microsoft\\teams-js\\dist\\esm\\packages\\teams-js\\dts .\\ /s /Y",
     "clean": "rimraf node_modules && rimraf MicrosoftTeams.d.ts"
   },
   "dependencies": {},

--- a/change/@microsoft-teams-js-424ccfee-e9f3-4b6b-bf1b-5e861422eb1b.json
+++ b/change/@microsoft-teams-js-424ccfee-e9f3-4b6b-bf1b-5e861422eb1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed bugs regarding `EduType`not being exported, and enum typings",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "prettier": "^3.3.2",
     "rimraf": "^5.0.7",
     "rollup": "^4.24.4",
-    "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-polyfill-node": "^0.13.0",
     "shx": "^0.3.4",
     "style-loader": "^3.3.4",

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/OfficeDev/microsoft-teams-library-js"
   },
   "main": "./dist/umd/MicrosoftTeams.min.js",
-  "typings": "./dist/umd/MicrosoftTeams.d.ts",
+  "typings": "./dist/esm/packages/teams-js/dts/index.d.ts",
   "module": "./dist/esm/packages/teams-js/src/index.js",
   "scripts": {
     "build": "pnpm clean && pnpm lint && pnpm build-rollup && pnpm build-webpack && pnpm docs:validate",

--- a/packages/teams-js/rollup.config.mjs
+++ b/packages/teams-js/rollup.config.mjs
@@ -7,7 +7,6 @@ import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import { readFileSync } from 'fs';
-import dts from 'rollup-plugin-dts';
 import nodePolyfills from 'rollup-plugin-polyfill-node';
 
 const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'));
@@ -58,14 +57,5 @@ export default [
         'src/public/interfaces.ts',
       ],
     },
-  },
-  {
-    input: './dist/esm/packages/teams-js/dts/index.d.ts',
-    output: {
-      file: 'dist/umd/MicrosoftTeams.d.ts',
-      format: 'es',
-      sourcemap: false,
-    },
-    plugins: [dts()],
   },
 ];

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -21,6 +21,7 @@ export {
   DeepLinkParameters,
   DialogInfo,
   DialogSize,
+  EduType,
   ErrorCode,
   FileOpenPreference,
   FrameContext,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,9 +205,6 @@ importers:
       rollup:
         specifier: ^4.24.4
         version: 4.24.4
-      rollup-plugin-dts:
-        specifier: ^6.1.1
-        version: 6.1.1(rollup@4.24.4)(typescript@4.9.5)
       rollup-plugin-polyfill-node:
         specifier: ^0.13.0
         version: 0.13.0(rollup@4.24.4)
@@ -5707,13 +5704,6 @@ packages:
     resolution: {integrity: sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg==}
     engines: {node: '>=14.18'}
     hasBin: true
-
-  rollup-plugin-dts@6.1.1:
-    resolution: {integrity: sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      rollup: ^3.29.4 || ^4
-      typescript: ^4.5 || ^5.0
 
   rollup-plugin-polyfill-node@0.13.0:
     resolution: {integrity: sha512-FYEvpCaD5jGtyBuBFcQImEGmTxDTPbiHjJdrYIp+mFIwgXiXabxvKUK7ZT9P31ozu2Tqm9llYQMRWsfvTMTAOw==}
@@ -13317,14 +13307,6 @@ snapshots:
   rimraf@5.0.7:
     dependencies:
       glob: 10.4.2
-
-  rollup-plugin-dts@6.1.1(rollup@4.24.4)(typescript@4.9.5):
-    dependencies:
-      magic-string: 0.30.11
-      rollup: 4.24.4
-      typescript: 4.9.5
-    optionalDependencies:
-      '@babel/code-frame': 7.24.7
 
   rollup-plugin-polyfill-node@0.13.0(rollup@4.24.4):
     dependencies:


### PR DESCRIPTION
There are 2 bugs with the current release of 2.31.0:

1. The `EduType` is not exported in the index file, so references to it are failing. Adding it to the index file will resolve the issue.
2. With rolling up the types into one file, the enums are no longer being exported as enums. Rollup is doing some strange type aliasing for them instead. To resolve this, we will no longer rollup the types into one file and instead will use the tsc generated types.