### PR TITLE
Release 2.31.1

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.31.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-A2y7iMKbK0AQrgKq1YKcLB8XgtyowB2MPzC40KFfA58nQObf6xU3C5NE0cTcis0V"
+      src="https://res.cdn.office.net/teams-js/2.31.1/js/MicrosoftTeams.min.js"
+      integrity="sha384-ihAqYgEJz9hzEU+HaYodG1aTzjebC/wKXQi1nWKZG7OLAUyOL9ZrzD/SfZu79Jeu"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm lint && webpack",

--- a/change/@microsoft-teams-js-424ccfee-e9f3-4b6b-bf1b-5e861422eb1b.json
+++ b/change/@microsoft-teams-js-424ccfee-e9f3-4b6b-bf1b-5e861422eb1b.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fixed bugs regarding `EduType`not being exported, and enum typings",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-4a860473-7a5b-481e-890b-4132b304af2e.json
+++ b/change/@microsoft-teams-js-4a860473-7a5b-481e-890b-4132b304af2e.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fixed a bug causing `buffer` polyfill to stil be included",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-818caaaa-86eb-4e3d-a84a-0d61028d0307.json
+++ b/change/@microsoft-teams-js-818caaaa-86eb-4e3d-a84a-0d61028d0307.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Released 2.31.0",
-  "packageName": "@microsoft/teams-js",
-  "email": "email not defined",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-e65fa5c8-93f1-4296-b6e3-c44e178f9fca.json
+++ b/change/@microsoft-teams-js-e65fa5c8-93f1-4296-b6e3-c44e178f9fca.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Merged 2.31.0 release branch to main",
-  "packageName": "@microsoft/teams-js",
-  "email": "email not defined",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-ffb2fc8a-bdcc-47d4-bca5-275b9ef549d1.json
+++ b/change/@microsoft-teams-js-ffb2fc8a-bdcc-47d4-bca5-275b9ef549d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Released 2.31.1",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Wed, 13 Nov 2024 19:22:01 GMT and should not be manually modified.
+This log was last generated on Tue, 19 Nov 2024 21:40:10 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.31.1
+
+Tue, 19 Nov 2024 21:40:10 GMT
+
+### Patches
+
+- Fixed a bug causing `buffer` polyfill to stil be included
+- Fixed bugs regarding `EduType`not being exported, and enum typings
 
 ## 2.31.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.31.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.31.1/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.31.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-A2y7iMKbK0AQrgKq1YKcLB8XgtyowB2MPzC40KFfA58nQObf6xU3C5NE0cTcis0V"
+  src="https://res.cdn.office.net/teams-js/2.31.1/js/MicrosoftTeams.min.js"
+  integrity="sha384-ihAqYgEJz9hzEU+HaYodG1aTzjebC/wKXQi1nWKZG7OLAUyOL9ZrzD/SfZu79Jeu"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.31.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.31.1/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",


### PR DESCRIPTION
## 2.31.1

Tue, 19 Nov 2024 21:40:10 GMT

### Patches

- Fixed a bug causing `buffer` polyfill to stil be included
- Fixed bugs regarding `EduType`not being exported, and enum typings