### PR TITLE
Disable iOS E2E pipelines until they can be made stable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -218,26 +218,26 @@ extends:
                   shardNum: 2
                   shardIndex: 1
 
-          - job: E2ETestIOS
-            displayName: 'E2E Tests - IOS - Plan A'
-            pool:
-              name: Azure Pipelines
-              image: macos-latest-internal
-              os: macOS
-            steps:
-              - template: tools/yaml-templates/ios-test.yml@self
-                parameters:
-                  iOSAppHostingSdkGitPath: IOSAppHostingSdk
-                  testPlan: iosE2ETestPlanA
+          # - job: E2ETestIOS
+          #   displayName: 'E2E Tests - IOS - Plan A'
+          #   pool:
+          #     name: Azure Pipelines
+          #     image: macos-latest-internal
+          #     os: macOS
+          #   steps:
+          #     - template: tools/yaml-templates/ios-test.yml@self
+          #       parameters:
+          #         iOSAppHostingSdkGitPath: IOSAppHostingSdk
+          #         testPlan: iosE2ETestPlanA
 
-          - job: E2ETestIOS2
-            displayName: 'E2E Tests - IOS - Plan B'
-            pool:
-              name: Azure Pipelines
-              image: macos-latest-internal
-              os: macOS
-            steps:
-              - template: tools/yaml-templates/ios-test.yml@self
-                parameters:
-                  iOSAppHostingSdkGitPath: IOSAppHostingSdk
-                  testPlan: iosE2ETestPlanB
+          # - job: E2ETestIOS2
+          #   displayName: 'E2E Tests - IOS - Plan B'
+          #   pool:
+          #     name: Azure Pipelines
+          #     image: macos-latest-internal
+          #     os: macOS
+          #   steps:
+          #     - template: tools/yaml-templates/ios-test.yml@self
+          #       parameters:
+          #         iOSAppHostingSdkGitPath: IOSAppHostingSdk
+          #         testPlan: iosE2ETestPlanB


### PR DESCRIPTION
## Description

These jobs are failing near-deterministically due to issues outside of our control having to do with the Mac image we've been given. Disabling these for now, and will open a bug for someone to re-enable them once they can be made stable.
### Main changes in the PR:

Disabled 2 iOS E2E jobs in the pipeline

## Validation

### Validation performed:

None

### Unit Tests added:

No

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No, change doesn't affect code we ship to customers
