### PR TITLE
Add Nested App Auth API sections to the teams test app

### DIFF
--- a/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
+++ b/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
@@ -74,7 +74,7 @@ const NestedAppAuthAPIs = (): ReactElement => {
 
   const SendMessageToNestedAppAuthBridge = (): React.ReactElement =>
     ApiWithTextInput({
-      name: 'SendMessageToNestedAppAuthBridge',
+      name: 'sendMessageToNestedAppAuthBridge',
       title: 'Send NAA Message to NestedAppAuth Bridge',
       onClick: {
         validateInput: validateNAARequestInput,
@@ -104,7 +104,7 @@ const NestedAppAuthAPIs = (): ReactElement => {
 
   const SendMessageToTopWindow = (): React.ReactElement =>
     ApiWithTextInput({
-      name: 'SendMessageToTopWindow',
+      name: 'sendMessageToTopWindow',
       title: 'Send NAA Message to Top Window',
       onClick: {
         validateInput: validateTopWindowNAARequestInput,
@@ -161,9 +161,9 @@ const NestedAppAuthAPIs = (): ReactElement => {
         return;
       }
 
-      const iframeContainer = document.getElementById('nestedChildiframeContainer');
+      const iframeContainer = document.getElementById('nestedChildIframeContainer');
       if (!iframeContainer) {
-        console.error('Container not found: nestedChildiframeContainer');
+        console.error('Container not found: nestedChildIframeContainer');
         return;
       }
 
@@ -189,7 +189,7 @@ const NestedAppAuthAPIs = (): ReactElement => {
           disabled={iframeAdded}
         />
         <div
-          id="nestedChildiframeContainer"
+          id="nestedChildIframeContainer"
           style={{
             marginTop: '2px',
             height: '400px',

--- a/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
+++ b/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
@@ -8,11 +8,11 @@ const NestedAppAuthRequest = JSON.stringify({
   messageType: 'NestedAppAuthRequest',
   method: 'GetToken',
   sendTime: 1732269811006,
-  clientLibrary: 'MetaOS',
+  clientLibrary: 'testOS',
   clientLibraryVersion: '1.0.0',
-  requestId: '684352c2-7ab7-4def-b7e1-56a386c02a0a',
+  requestId: '684352c2-7ab7-4def-b7e1-XXXXXXXXXXX',
   tokenParams: {
-    correlationId: '39dc85fe-9054-11ed-a1eb-0242ac120002',
+    correlationId: '39dc85fe-9054-11ed-a1eb-XXXXXXXXXXX',
   },
 });
 

--- a/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
+++ b/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
@@ -16,6 +16,48 @@ const NestedAppAuthRequest = JSON.stringify({
   },
 });
 
+const validateNAARequestInput = (input): void => {
+  if (!input) {
+    throw new Error('Input is required.');
+  }
+
+  if (input.messageType !== 'NestedAppAuthRequest') {
+    throw new Error('Invalid or missing messageType. Expected "NestedAppAuthRequest".');
+  }
+
+  if (!input.method) {
+    throw new Error('Method name is required in payload');
+  }
+
+  if (!input.requestId) {
+    throw new Error('RequestId is required in payload');
+  }
+};
+
+const validateTopWindowNAARequestInput = (input): void => {
+  if (!input) {
+    throw new Error('Input is required.');
+  }
+
+  if (!input.id) {
+    throw new Error('"id" is required.');
+  }
+
+  if (!input.func) {
+    throw new Error('"func" is required.');
+  }
+
+  if (!input.data) {
+    throw new Error('"data" is required with NAA payload');
+  }
+
+  try {
+    validateNAARequestInput(JSON.parse(input.data));
+  } catch (error) {
+    throw new Error('NAA payload must be a valid JSON');
+  }
+};
+
 type NestedAppAuthBridge = {
   postMessage: (message: string) => void;
   addEventListener: (type: string, listener: (response: unknown) => void) => void;
@@ -35,7 +77,7 @@ const NestedAppAuthAPIs = (): ReactElement => {
       name: 'SendMessageToNestedAppAuthBridge',
       title: 'Send NAA Message to NestedAppAuth Bridge',
       onClick: {
-        validateInput: () => {},
+        validateInput: validateNAARequestInput,
         submit: async (input, setResult) => {
           const bridge = (window as Window & { nestedAppAuthBridge?: NestedAppAuthBridge }).nestedAppAuthBridge;
           if (!bridge) {
@@ -65,7 +107,7 @@ const NestedAppAuthAPIs = (): ReactElement => {
       name: 'SendMessageToTopWindow',
       title: 'Send NAA Message to Top Window',
       onClick: {
-        validateInput: () => {},
+        validateInput: validateTopWindowNAARequestInput,
         submit: async (input, setResult) => {
           try {
             const targetOrigin = 'https://local.teams.office.com:8080';
@@ -119,9 +161,9 @@ const NestedAppAuthAPIs = (): ReactElement => {
         return;
       }
 
-      const iframeContainer = document.getElementById('NestedChildiframeContainer');
+      const iframeContainer = document.getElementById('nestedChildiframeContainer');
       if (!iframeContainer) {
-        console.error('Container not found: NestedChildiframeContainer');
+        console.error('Container not found: nestedChildiframeContainer');
         return;
       }
 
@@ -147,7 +189,7 @@ const NestedAppAuthAPIs = (): ReactElement => {
           disabled={iframeAdded}
         />
         <div
-          id="NestedChildiframeContainer"
+          id="nestedChildiframeContainer"
           style={{
             marginTop: '2px',
             height: '400px',

--- a/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
+++ b/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
@@ -1,8 +1,26 @@
 import { nestedAppAuth } from '@microsoft/teams-js';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 
-import { ApiWithoutInput } from './utils';
+import { ApiWithoutInput, ApiWithTextInput } from './utils';
 import { ModuleWrapper } from './utils/ModuleWrapper';
+
+const NestedAppAuthRequest = JSON.stringify({
+  messageType: 'NestedAppAuthRequest',
+  method: 'GetToken',
+  sendTime: 1732269811006,
+  clientLibrary: 'MetaOS',
+  clientLibraryVersion: '1.0.0',
+  requestId: '684352c2-7ab7-4def-b7e1-56a386c02a0a',
+  tokenParams: {
+    correlationId: '39dc85fe-9054-11ed-a1eb-0242ac120002',
+  },
+});
+
+type NestedAppAuthBridge = {
+  postMessage: (message: string) => void;
+  addEventListener: (type: string, listener: (response: unknown) => void) => void;
+  removeEventListener: (type: string, listener: (response: unknown) => void) => void;
+};
 
 const NestedAppAuthAPIs = (): ReactElement => {
   const CheckIsNAAChannelRecommended = (): ReactElement =>
@@ -12,9 +30,144 @@ const NestedAppAuthAPIs = (): ReactElement => {
       onClick: async () => `NAA channel ${nestedAppAuth.isNAAChannelRecommended() ? 'is' : 'is not'} recommended`,
     });
 
+  const SendMessageToNestedAppAuthBridge = (): React.ReactElement =>
+    ApiWithTextInput({
+      name: 'SendMessageToNestedAppAuthBridge',
+      title: 'Send NAA Message to NestedAppAuth Bridge',
+      onClick: {
+        validateInput: () => {},
+        submit: async (input, setResult) => {
+          const bridge = (window as Window & { nestedAppAuthBridge?: NestedAppAuthBridge }).nestedAppAuthBridge;
+          if (!bridge) {
+            setResult('Bridge not available');
+            return 'Bridge not available';
+          }
+
+          // Define listener for responses
+          const listener = (response: unknown): void => {
+            setResult(JSON.stringify(response, null, 2));
+            bridge.removeEventListener?.('message', listener);
+          };
+
+          // Add event listener
+          bridge.addEventListener?.('message', listener);
+          bridge.postMessage?.(JSON.stringify(input));
+
+          setResult('Message sent successfully, awaiting response...');
+          return 'Message sent successfully';
+        },
+      },
+      defaultInput: NestedAppAuthRequest,
+    });
+
+  const SendMessageToTopWindow = (): React.ReactElement =>
+    ApiWithTextInput({
+      name: 'SendMessageToTopWindow',
+      title: 'Send NAA Message to Top Window',
+      onClick: {
+        validateInput: () => {},
+        submit: async (input, setResult) => {
+          try {
+            const targetOrigin = 'https://local.teams.office.com:8080';
+
+            // Check if window.top is accessible
+            if (!window.top) {
+              setResult('Top window not accessible');
+              return 'Top window not accessible';
+            }
+
+            // Define listener for responses
+            const listener = (event: MessageEvent): void => {
+              // Ensure the message comes from the expected origin
+              if (event.origin !== targetOrigin) {
+                console.warn('Received message from an unexpected origin:', event.origin);
+                return;
+              }
+
+              console.log('Received response from top window:', event.data);
+              setResult(JSON.stringify(event.data, null, 2)); // Pretty-print response
+              window.removeEventListener('message', listener);
+            };
+
+            // Add event listener for messages
+            window.addEventListener('message', listener);
+            window.top.postMessage(input, targetOrigin);
+
+            setResult('Message sent to top window, awaiting response...');
+            return 'Message sent to top window';
+          } catch (error) {
+            console.error('Error sending message to top window:', error);
+            setResult(`Error: ${error}`);
+            return `Error: ${error}`;
+          }
+        },
+      },
+      defaultInput: JSON.stringify({
+        id: '2',
+        func: 'nestedAppAuth.execute',
+        args: [],
+        data: NestedAppAuthRequest,
+      }),
+    });
+
+  const AddChildIframeSection = (): React.ReactElement | null => {
+    const [iframeAdded, setIframeAdded] = useState(false);
+
+    const addChildIframe = (): void => {
+      if (iframeAdded) {
+        console.log('Iframe already added.');
+        return;
+      }
+
+      const iframeContainer = document.getElementById('NestedChildiframeContainer');
+      if (!iframeContainer) {
+        console.error('Container not found: NestedChildiframeContainer');
+        return;
+      }
+
+      const childIframe = document.createElement('iframe');
+      childIframe.src = `${window.location.href}?appInitializationTest=true&groupedMode=NestedAppAuthAPIs`;
+      childIframe.id = 'nestedAuthChildIframe';
+      childIframe.width = '100%';
+      childIframe.height = '400px';
+      childIframe.style.border = 'none';
+
+      iframeContainer.appendChild(childIframe);
+      setIframeAdded(true);
+    };
+
+    return (
+      <div style={{ border: '5px solid black', padding: '2px', margin: '2px' }}>
+        <h2>Add Nested Child Iframe</h2>
+        <input
+          name="button_addNestedChildIframe"
+          type="button"
+          value="Add Child Iframe"
+          onClick={addChildIframe}
+          disabled={iframeAdded}
+        />
+        <div
+          id="NestedChildiframeContainer"
+          style={{
+            marginTop: '2px',
+            height: '400px',
+            border: '2px solid red',
+            overflow: 'hidden',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        ></div>
+      </div>
+    );
+  };
+
   return (
     <ModuleWrapper title="NestedAppAuth">
       <CheckIsNAAChannelRecommended />
+      <SendMessageToNestedAppAuthBridge />
+      <SendMessageToTopWindow />
+      <AddChildIframeSection />
     </ModuleWrapper>
   );
 };


### PR DESCRIPTION
## Description

> Add three new API sections to the Teams test app for UI testing:
> 1. SendMessageToNestedAppAuthBridge - Send a NAA message to the nested app auth bridge.
> 2. SendMessageToTopWindow - Send NAA message to the top window.
> 3. AddChildIframeSection - Add a child nested iframe, which can also call APIs 1 and 2.

### Main changes in the PR:

1. Added SendMessageToNestedAppAuthBridge, SendMessageToTopWindow, AddChildIframeSection in NestedAppAuthAPIs.tsx

## Validation

### Validation performed:

1. Yes, locally using SDK UI testing framework. 

### Unit Tests added:

N/A

### End-to-end tests added:

N/A

## Additional Requirements

### Change file added: N/A

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
