### PR TITLE
Re-enable iOS E2E Testing pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -218,26 +218,26 @@ extends:
                   shardNum: 2
                   shardIndex: 1
 
-          # - job: E2ETestIOS
-          #   displayName: 'E2E Tests - IOS - Plan A'
-          #   pool:
-          #     name: Azure Pipelines
-          #     image: macos-latest-internal
-          #     os: macOS
-          #   steps:
-          #     - template: tools/yaml-templates/ios-test.yml@self
-          #       parameters:
-          #         iOSAppHostingSdkGitPath: IOSAppHostingSdk
-          #         testPlan: iosE2ETestPlanA
+          - job: E2ETestIOS
+            displayName: 'E2E Tests - IOS - Plan A'
+            pool:
+              name: Azure Pipelines
+              image: macos-latest-internal
+              os: macOS
+            steps:
+              - template: tools/yaml-templates/ios-test.yml@self
+                parameters:
+                  iOSAppHostingSdkGitPath: IOSAppHostingSdk
+                  testPlan: iosE2ETestPlanA
 
-          # - job: E2ETestIOS2
-          #   displayName: 'E2E Tests - IOS - Plan B'
-          #   pool:
-          #     name: Azure Pipelines
-          #     image: macos-latest-internal
-          #     os: macOS
-          #   steps:
-          #     - template: tools/yaml-templates/ios-test.yml@self
-          #       parameters:
-          #         iOSAppHostingSdkGitPath: IOSAppHostingSdk
-          #         testPlan: iosE2ETestPlanB
+          - job: E2ETestIOS2
+            displayName: 'E2E Tests - IOS - Plan B'
+            pool:
+              name: Azure Pipelines
+              image: macos-latest-internal
+              os: macOS
+            steps:
+              - template: tools/yaml-templates/ios-test.yml@self
+                parameters:
+                  iOSAppHostingSdkGitPath: IOSAppHostingSdk
+                  testPlan: iosE2ETestPlanB

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -114,7 +114,7 @@ steps:
     displayName: 'iOS UI/E2E Tests'
     inputs:
       targetType: inline
-      script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5' -screenshot-enabled=\"YES\" -quiet -resultBundlePath TestResults test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
+      script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -test-iterations 3 -retry-tests-on-failure -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5' -screenshot-enabled=\"YES\" -quiet -resultBundlePath TestResults test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
       workingDirectory: '$(Agent.BuildDirectory)/iOSHost'
 
   - task: Bash@3


### PR DESCRIPTION
## Description

 It seems like VM providers have finished rolling back and forth and everything is in stable now. Thus, we would like to re-enable E2E testing pipelines and keep monitoring them.