### PR TITLE
Add custom child iframe in teams test app for nested app auth e2e tests

### DIFF
--- a/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
+++ b/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
@@ -175,6 +175,20 @@ const NestedAppAuthAPIs = (): ReactElement => {
 
       iframeContainer.appendChild(childIframe);
       setIframeAdded(true);
+
+      // Send payload to the iframe after it loads
+      childIframe.onload = () => {
+        const payloads = {
+          defaultPayloadForBridge: NestedAppAuthRequest,
+          defaultPayloadForTopWindow: JSON.stringify({
+            id: '2',
+            func: 'nestedAppAuth.execute',
+            args: [],
+            data: NestedAppAuthRequest,
+          }),
+        };
+        childIframe.contentWindow?.postMessage(payloads, window.location.origin);
+      };
     };
 
     return (

--- a/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
+++ b/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
@@ -152,26 +152,25 @@ const NestedAppAuthAPIs = (): ReactElement => {
       }),
     });
 
-  const AddChildIframeSection = (): React.ReactElement | null => {
+  const AddChildIframeSection = (): React.ReactElement => {
     const [iframeAdded, setIframeAdded] = useState(false);
 
     const addChildIframe = (): void => {
       if (iframeAdded) {
-        console.log('Iframe already added.');
         return;
       }
 
       const iframeContainer = document.getElementById('nestedChildIframeContainer');
       if (!iframeContainer) {
-        console.error('Container not found: nestedChildIframeContainer');
+        console.error('Iframe container not found');
         return;
       }
 
       const childIframe = document.createElement('iframe');
-      childIframe.src = `${window.location.href}?appInitializationTest=true&groupedMode=NestedAppAuthAPIs`;
+      childIframe.src = '/naa_childIframe.html';
       childIframe.id = 'nestedAuthChildIframe';
-      childIframe.width = '100%';
-      childIframe.height = '400px';
+      childIframe.style.width = '100%';
+      childIframe.style.height = '400px';
       childIframe.style.border = 'none';
 
       iframeContainer.appendChild(childIframe);
@@ -179,9 +178,18 @@ const NestedAppAuthAPIs = (): ReactElement => {
     };
 
     return (
-      <div style={{ border: '5px solid black', padding: '2px', margin: '2px' }}>
-        <h2>Add Nested Child Iframe</h2>
+      <div
+        className="boxAndButton"
+        id="box_naaNestedChildIframe"
+        style={{
+          border: '5px solid black',
+          padding: '5px',
+          margin: '1px',
+        }}
+      >
+        <h2>Child Iframe</h2>
         <input
+          id="button_addNestedChildIframe"
           name="button_addNestedChildIframe"
           type="button"
           value="Add Child Iframe"
@@ -191,19 +199,14 @@ const NestedAppAuthAPIs = (): ReactElement => {
         <div
           id="nestedChildIframeContainer"
           style={{
-            marginTop: '2px',
-            height: '400px',
-            border: '2px solid red',
-            overflow: 'hidden',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
+            marginTop: '20px',
+            height: '450px',
+            border: '1px solid red',
           }}
-        ></div>
+        />
       </div>
     );
   };
-
   return (
     <ModuleWrapper title="NestedAppAuth">
       <CheckIsNAAChannelRecommended />

--- a/apps/teams-test-app/src/public/naa_childIframe.html
+++ b/apps/teams-test-app/src/public/naa_childIframe.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nested Child Iframe Content</title>
+    <style>
+      .input-container input[type='text'] {
+        margin-top: 10px;
+        padding: 5px;
+        width: 180px;
+      }
+
+      .input-container input[type='button'] {
+        width: 100px;
+      }
+
+      .input-row {
+        display: flex;
+        gap: 5px;
+        margin-bottom: 10px;
+      }
+
+      .response-box {
+        display: flex;
+        margin-top: 10px;
+        border: 1px solid #ccc;
+        padding: 2px;
+        height: 30px;
+      }
+
+      .default-button {
+        margin-left: 0;
+      }
+
+      .section-container h4 {
+        margin-top: 5px;
+        font-size: 16px;
+      }
+
+      .section-container {
+        border: 1px solid #ccc;
+        padding: 15px;
+        margin-bottom: 20px;
+        border-radius: 5px;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <div class="section-container">
+        <h4>NestedAppAuthBridge</h4>
+        <div class="input-row">
+          <input
+            id="input_childPayloadForBridge"
+            name="input_childPayloadForBridge"
+            type="text"
+            placeholder="Payload for NestedAppAuthBridge"
+          />
+          <input
+            id="button_sendPayloadToBridge"
+            name="button_sendPayloadToBridge"
+            type="button"
+            value="Send to NAA Bridge"
+            onClick="sendMessageToBridge()"
+          />
+        </div>
+        <input
+          id="button_defaultPayloadForBridge"
+          name="button_defaultPayloadForBridge"
+          type="button"
+          value="Default"
+          class="default-button"
+          onClick="setDefaultPayloadForBridge()"
+        />
+        <div id="text_bridge_response_for_child" class="response-box">No response yet</div>
+      </div>
+
+      <div class="section-container">
+        <h4>Top Window</h4>
+        <div class="input-row">
+          <input
+            id="input_childPayloadForTopWindow"
+            name="input_childPayloadForTopWindow"
+            type="text"
+            placeholder="Payload for Top Window"
+          />
+          <input
+            id="button_sendPayloadToTopWindow"
+            name="button_sendPayloadToTopWindow"
+            type="button"
+            value="Send to Top Window"
+            onClick="sendMessageToTopWindow()"
+          />
+        </div>
+        <input
+          id="button_defaultPayloadForTopWindow"
+          name="button_defaultPayloadForTopWindow"
+          type="button"
+          value="Default"
+          class="default-button"
+          onClick="setDefaultPayloadForTopWindow()"
+        />
+        <div id="text_topWindow_response_for_child" class="response-box">No response yet</div>
+      </div>
+    </div>
+
+    <script>
+      const targetOrigin = 'https://local.teams.office.com:8080';
+
+      // Utility function to display a response in a given element
+      const displayResponse = (element, message) => {
+        element.innerText = message;
+      };
+
+      // Predefined payloads
+      const defaultPayloadForBridge =
+        '{"messageType":"NestedAppAuthRequest","method":"GetToken","sendTime":1732269811006,"clientLibrary":"testOS","clientLibraryVersion":"1.0.0","requestId":"684352c2-7ab7-4def-b7e1-XXXXXXXXXXX","tokenParams":{"correlationId":"39dc85fe-9054-11ed-a1eb-XXXXXXXXXXX"}}';
+      const defaultPayloadForTopWindow =
+        '{"id":"2","func":"nestedAppAuth.execute","args":[],"data":"{\\"messageType\\":\\"NestedAppAuthRequest\\",\\"method\\":\\"GetToken\\",\\"sendTime\\":1732269811006,\\"clientLibrary\\":\\"testOS\\",\\"clientLibraryVersion\\":\\"1.0.0\\",\\"requestId\\":\\"684352c2-7ab7-4def-b7e1-XXXXXXXXXXX\\",\\"tokenParams\\":{\\"correlationId\\":\\"39dc85fe-9054-11ed-a1eb-XXXXXXXXXXX\\"}}"}';
+
+      // Functions to set default payloads
+      function setDefaultPayloadForBridge() {
+        const inputElement = document.getElementById('input_childPayloadForBridge');
+        if (inputElement) {
+          inputElement.value = defaultPayloadForBridge;
+        }
+      }
+
+      function setDefaultPayloadForTopWindow() {
+        const inputElement = document.getElementById('input_childPayloadForTopWindow');
+        if (inputElement) {
+          inputElement.value = defaultPayloadForTopWindow;
+        }
+      }
+
+      // Send Message to NestedAppAuthBridge
+      function sendMessageToBridge() {
+        const inputElement = document.getElementById('input_childPayloadForBridge');
+        const responseElement = document.getElementById('text_bridge_response_for_child');
+
+        if (!inputElement || !responseElement) return;
+
+        try {
+          // Validate and send the payload
+          const payload = JSON.parse(inputElement.value);
+
+          // Inline validation for NestedAppAuthRequest
+          if (!payload) throw new Error('Input is required.');
+          if (payload.messageType !== 'NestedAppAuthRequest') {
+            throw new Error('Invalid or missing messageType. Expected "NestedAppAuthRequest".');
+          }
+          if (!payload.method) throw new Error('Method name is required in payload.');
+          if (!payload.requestId) throw new Error('RequestId is required in payload.');
+
+          const bridge = window.nestedAppAuthBridge;
+          if (!bridge) {
+            displayResponse(responseElement, 'NAA Bridge not available');
+            return;
+          }
+
+          bridge.postMessage(JSON.stringify(payload));
+          displayResponse(responseElement, 'Message sent to Bridge. Awaiting response...');
+
+          bridge.addEventListener('message', (response) => {
+            displayResponse(responseElement, JSON.stringify(response));
+          });
+        } catch (error) {
+          console.error('Validation error:', error.message);
+          displayResponse(responseElement, `Validation Error: ${error.message}`);
+        }
+      }
+
+      // Send Message to Top Window
+      function sendMessageToTopWindow() {
+        const inputElement = document.getElementById('input_childPayloadForTopWindow');
+        const responseElement = document.getElementById('text_topWindow_response_for_child');
+
+        if (!inputElement || !responseElement) return;
+
+        try {
+          // Validate and send the payload
+          const payload = JSON.parse(inputElement.value);
+
+          // Inline validation for Top Window
+          if (!payload) throw new Error('Input is required.');
+          if (!payload.id) throw new Error('"id" is required.');
+          if (!payload.func) throw new Error('"func" is required.');
+          if (!payload.data) throw new Error('"data" is required with NAA payload.');
+
+          // Validate nested NAA payload in "data"
+          const nestedData = JSON.parse(payload.data);
+          if (nestedData.messageType !== 'NestedAppAuthRequest') {
+            throw new Error('Invalid or missing messageType in NAA payload. Expected "NestedAppAuthRequest".');
+          }
+
+          if (!window.top) {
+            displayResponse(responseElement, 'Top window not accessible');
+            return;
+          }
+
+          window.top.postMessage(payload, targetOrigin);
+          displayResponse(responseElement, 'Message sent to Top Window. Awaiting response...');
+
+          window.addEventListener('message', (event) => {
+            if (event.origin !== targetOrigin) {
+              console.warn('Received message from unexpected origin:', event.origin);
+              return;
+            }
+            displayResponse(responseElement, JSON.stringify(event.data));
+          });
+        } catch (error) {
+          console.error('Validation error:', error.message);
+          displayResponse(responseElement, `Validation Error: ${error.message}`);
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/apps/teams-test-app/src/public/naa_childIframe.html
+++ b/apps/teams-test-app/src/public/naa_childIframe.html
@@ -106,18 +106,29 @@
     </div>
 
     <script>
+      let defaultPayloadForBridge = '';
+      let defaultPayloadForTopWindow = '';
+
+      // Listen for messages from the parent
+      window.addEventListener('message', (event) => {
+        // Validate the origin if known
+        if (event.origin !== window.location.origin) return;
+
+        const data = event.data;
+        if (data.defaultPayloadForBridge) {
+          defaultPayloadForBridge = data.defaultPayloadForBridge;
+        }
+        if (data.defaultPayloadForTopWindow) {
+          defaultPayloadForTopWindow = data.defaultPayloadForTopWindow;
+        }
+      });
+
       const targetOrigin = 'https://local.teams.office.com:8080';
 
       // Utility function to display a response in a given element
       const displayResponse = (element, message) => {
         element.innerText = message;
       };
-
-      // Predefined payloads
-      const defaultPayloadForBridge =
-        '{"messageType":"NestedAppAuthRequest","method":"GetToken","sendTime":1732269811006,"clientLibrary":"testOS","clientLibraryVersion":"1.0.0","requestId":"684352c2-7ab7-4def-b7e1-XXXXXXXXXXX","tokenParams":{"correlationId":"39dc85fe-9054-11ed-a1eb-XXXXXXXXXXX"}}';
-      const defaultPayloadForTopWindow =
-        '{"id":"2","func":"nestedAppAuth.execute","args":[],"data":"{\\"messageType\\":\\"NestedAppAuthRequest\\",\\"method\\":\\"GetToken\\",\\"sendTime\\":1732269811006,\\"clientLibrary\\":\\"testOS\\",\\"clientLibraryVersion\\":\\"1.0.0\\",\\"requestId\\":\\"684352c2-7ab7-4def-b7e1-XXXXXXXXXXX\\",\\"tokenParams\\":{\\"correlationId\\":\\"39dc85fe-9054-11ed-a1eb-XXXXXXXXXXX\\"}}"}';
 
       // Functions to set default payloads
       function setDefaultPayloadForBridge() {
@@ -159,12 +170,12 @@
             return;
           }
 
-          bridge.postMessage(JSON.stringify(payload));
-          displayResponse(responseElement, 'Message sent to Bridge. Awaiting response...');
-
           bridge.addEventListener('message', (response) => {
             displayResponse(responseElement, JSON.stringify(response));
           });
+
+          bridge.postMessage(JSON.stringify(payload));
+          displayResponse(responseElement, 'Message sent to Bridge. Awaiting response...');
         } catch (error) {
           console.error('Validation error:', error.message);
           displayResponse(responseElement, `Validation Error: ${error.message}`);
@@ -199,9 +210,6 @@
             return;
           }
 
-          window.top.postMessage(payload, targetOrigin);
-          displayResponse(responseElement, 'Message sent to Top Window. Awaiting response...');
-
           window.addEventListener('message', (event) => {
             if (event.origin !== targetOrigin) {
               console.warn('Received message from unexpected origin:', event.origin);
@@ -209,6 +217,9 @@
             }
             displayResponse(responseElement, JSON.stringify(event.data));
           });
+
+          window.top.postMessage(payload, targetOrigin);
+          displayResponse(responseElement, 'Message sent to Top Window. Awaiting response...');
         } catch (error) {
           console.error('Validation error:', error.message);
           displayResponse(responseElement, `Validation Error: ${error.message}`);


### PR DESCRIPTION
## Description

> Currently, the same test app is displayed within a nested iframe, which can lead to issues like timeouts for mobile SDKs during testing. Additionally, it may introduce future complications due to initialization steps. This PR removes the dependency on the parent app and replaces it with a custom iframe featuring a minimal design. The custom iframe includes two buttons: one for sending messages to the bridge and another for sending messages to the top window.

### Main changes in the PR:

1. Added naa_childIframe.html.
2. Updated the nested child iframe source to naa_childIframe.html.

## Validation

### Validation performed:

Locally with other SDKs

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

N/A

### End-to-end tests added:

N/A

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| <img width="273" alt="Before" src="https://github.com/user-attachments/assets/562a038b-3b97-4832-affd-5f9983ba9d2a"> | <img width="272" alt="After" src="https://github.com/user-attachments/assets/f50af827-ac73-4c26-ba82-e79939de1dd1">|
