### PR TITLE
Fix publishBuildArtifact task issue

### DIFF
--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -6,6 +6,12 @@ parameters:
     default: iosE2ETestPlan
     type: string
 
+variables:
+  - name: logsDirectory
+    value: '$(agent.buildDirectory)/Logs/$(agent.JobName)'
+  - name: debugLogsZip
+    value: '$(agent.JobName)_DebugLogs.zip'
+
 steps:
   - checkout: self
   - checkout: ${{ parameters.iOSAppHostingSdkGitPath }}
@@ -137,26 +143,26 @@ steps:
 
   - bash: |
       output="$(agent.buildDirectory)/Logs/$(agent.JobName)"
-      rm -rf "${output}" > /dev/null
+      rm -rf "$(logsDirectory)" > /dev/null
 
-      mkdir -p "${output}"
+      mkdir -p "$(logsDirectory)"
 
-      cp -r $(Agent.BuildDirectory)/iOSHost/TestResults "${output}/output.xcresult"
-      xchtmlreport -r ${output}/output.xcresult -j
+      cp -r $(Agent.BuildDirectory)/iOSHost/TestResults "$(logsDirectory)/output.xcresult"
+      xchtmlreport -r $(logsDirectory)/output.xcresult -j
 
 
-      echo "ls -lR ${output}"
-      ls -lR "${output}"
+      echo "ls -lR $(logsDirectory)"
+      ls -lR "$(logsDirectory)"
 
       echo "Zipping logs directory..."
-      cd "$(agent.buildDirectory)/Logs/$(agent.JobName)"
-      zip -r "$(agent.JobName)_DebugLogs.zip" .
+      cd "$(logsDirectory)"
+      zip -r "$(debugLogsZip)" .
     displayName: Preparations for publishing results
     condition: always()
 
   - task: 1ES.PublishPipelineArtifact@1
     inputs:
-      path: '$(agent.buildDirectory)/Logs/$(agent.JobName)/$(agent.JobName)_DebugLogs.zip'
+      path: '$(logsDirectory)/$(debugLogsZip)'
       artifact: iOSDebugLogs - ${{ parameters.testPlan }} - Attempt $(System.JobAttempt)
     condition: always()
     continueOnError: true

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -6,12 +6,6 @@ parameters:
     default: iosE2ETestPlan
     type: string
 
-variables:
-  - name: logsDirectory
-    value: '$(agent.buildDirectory)/Logs/$(agent.JobName)'
-  - name: debugLogsZip
-    value: '$(agent.JobName)_DebugLogs.zip'
-
 steps:
   - checkout: self
   - checkout: ${{ parameters.iOSAppHostingSdkGitPath }}
@@ -143,26 +137,27 @@ steps:
 
   - bash: |
       output="$(agent.buildDirectory)/Logs/$(agent.JobName)"
-      rm -rf "$(logsDirectory)" > /dev/null
 
-      mkdir -p "$(logsDirectory)"
+      rm -rf "${output}" > /dev/null
+      mkdir -p "${output}"
 
-      cp -r $(Agent.BuildDirectory)/iOSHost/TestResults "$(logsDirectory)/output.xcresult"
-      xchtmlreport -r $(logsDirectory)/output.xcresult -j
+      cp -r $(Agent.BuildDirectory)/iOSHost/TestResults "${output}/output.xcresult"
+      xchtmlreport -r ${output}/output.xcresult -j
+      echo "ls -lR ${output}"
 
-
-      echo "ls -lR $(logsDirectory)"
-      ls -lR "$(logsDirectory)"
+      ls -lR "${output}"
+      echo "Zipping logs directory..."
+      cd "$(agent.buildDirectory)/Logs/$(agent.JobName)"
 
       echo "Zipping logs directory..."
-      cd "$(logsDirectory)"
-      zip -r "$(debugLogsZip)" .
+      cd "${output}"
+      zip -r "$(agent.JobName)_DebugLogs.zip" .
     displayName: Preparations for publishing results
     condition: always()
 
   - task: 1ES.PublishPipelineArtifact@1
     inputs:
-      path: '$(logsDirectory)/$(debugLogsZip)'
+      path: '$(agent.buildDirectory)/Logs/$(agent.JobName)/$(agent.JobName)_DebugLogs.zip'
       artifact: iOSDebugLogs - ${{ parameters.testPlan }} - Attempt $(System.JobAttempt)
     condition: always()
     continueOnError: true

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -156,7 +156,7 @@ steps:
 
   - task: 1ES.PublishPipelineArtifact@1
     inputs:
-      pathToPublish: '$(agent.buildDirectory)/Logs/$(agent.JobName)/$(agent.JobName)_DebugLogs.zip'
+      path: '$(agent.buildDirectory)/Logs/$(agent.JobName)/$(agent.JobName)_DebugLogs.zip'
       artifact: iOSDebugLogs - ${{ parameters.testPlan }} - Attempt $(System.JobAttempt)
     condition: always()
     continueOnError: true

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -147,11 +147,16 @@ steps:
 
       echo "ls -lR ${output}"
       ls -lR "${output}"
+
+      echo "Zipping logs directory..."
+      cd "$(agent.buildDirectory)/Logs/$(agent.JobName)"
+      zip -r "$(agent.JobName)_DebugLogs.zip" .
     displayName: Preparations for publishing results
     condition: always()
 
   - task: 1ES.PublishPipelineArtifact@1
     inputs:
-      path: '$(agent.buildDirectory)/Logs'
+      pathToPublish: '$(agent.buildDirectory)/Logs/$(agent.JobName)/$(agent.JobName)_DebugLogs.zip'
       artifact: iOSDebugLogs - ${{ parameters.testPlan }} - Attempt $(System.JobAttempt)
     condition: always()
+    continueOnError: true

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -143,11 +143,8 @@ steps:
 
       cp -r $(Agent.BuildDirectory)/iOSHost/TestResults "${output}/output.xcresult"
       xchtmlreport -r ${output}/output.xcresult -j
-      echo "ls -lR ${output}"
 
-      ls -lR "${output}"
-      echo "Zipping logs directory..."
-      cd "$(agent.buildDirectory)/Logs/$(agent.JobName)"
+      echo "ls -lR ${output}"
 
       echo "Zipping logs directory..."
       cd "${output}"

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -137,14 +137,15 @@ steps:
 
   - bash: |
       output="$(agent.buildDirectory)/Logs/$(agent.JobName)"
-
       rm -rf "${output}" > /dev/null
+
       mkdir -p "${output}"
 
       cp -r $(Agent.BuildDirectory)/iOSHost/TestResults "${output}/output.xcresult"
       xchtmlreport -r ${output}/output.xcresult -j
 
       echo "ls -lR ${output}"
+      ls -lR "${output}"
 
       echo "Zipping logs directory..."
       cd "${output}"

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -112,6 +112,7 @@ steps:
 
   - task: Bash@3
     displayName: 'iOS UI/E2E Tests'
+    name: iOS_E2E_Test_Task
     inputs:
       targetType: inline
       script: "/usr/bin/xcodebuild -configuration Release -workspace /Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace -scheme $(IOSSdkSchemeForTest) -testPlan ${{ parameters.testPlan }} -sdk iphonesimulator -parallel-testing-enabled YES -parallel-testing-worker-count 2 -test-iterations 3 -retry-tests-on-failure -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5' -screenshot-enabled=\"YES\" -quiet -resultBundlePath TestResults test 2>/dev/null\nif [[ $? == 0 ]]; then echo \"E2E Test passes successfully\"; exit 0; else echo \"E2E Test failed\"; exit 1; fi;"
@@ -151,11 +152,11 @@ steps:
       cd "${output}"
       zip -r "$(agent.JobName)_DebugLogs.zip" .
     displayName: Preparations for publishing results
-    condition: always()
+    condition: eq(variables['task.iOS_E2E_Test_Task.status'], 'failed')
 
   - task: 1ES.PublishPipelineArtifact@1
     inputs:
       path: '$(agent.buildDirectory)/Logs/$(agent.JobName)/$(agent.JobName)_DebugLogs.zip'
       artifact: iOSDebugLogs - ${{ parameters.testPlan }} - Attempt $(System.JobAttempt)
-    condition: always()
+    condition: eq(variables['task.iOS_E2E_Test_Task.status'], 'failed')
     continueOnError: true


### PR DESCRIPTION
**Summary**

This pull request addresses an issue with the PublishBuildArtifacts@1 task in the pipeline by zipping the logs directory before publishing. And we changed the logic to only publishing zip files for debugging purpose when E2E test failed.

Based on our observations and experience, we can confirm that when we use new version of Xcode, after E2E test completes and if there is any error, it will create a lot of files all under .xcresult as below (.xcresult has a lot of hidden files on MacOS) 

```
`DebugLogs/output.xcresult/Debug description for `StaticText (Elements matching predicate 'value CONTAINS "Error Error InvalidAuthUrl"')`_1_533C9087-ED7E-4A94-8048-26DD268E2FBA.txt`
```

When we try to publish the artifacts, the task will scan each of them and they may have problems figuring out
1. files with super long name
2. files whose name has some special characters, i.e. `:`

And then they will get stuck here

```
Exception: TF10123: The path 'DebugLogs/output.xcresult/Debug description for `StaticText (Elements matching predicate 'value CONTAINS "Error Error InvalidAuthUrl"')`_1_533C9087-ED7E-4A94-8048-26DD268E2FBA.txt' contains the character '"'. Remove the '"' and try again. 
```

We can neither use lower version of Xcode, nor control the file names be created. Xcode version is coupled with MacOS system and file names are all created by Xcode automatically. However, by zipping this file, it seems like we can prevent them scanning files within .xcresult file and upload them as a whole zip file so that they would not fail. ( However, I still cannot confirm this because the team who built this has not replied to me yet.)

jobs/templates/common-tasks.yml: Added a step to zip the logs directory and updated the PublishBuildArtifacts task to publish the zipped logs file.
