### PR TITLE
noahdarveau/ export conversationResponse

### DIFF
--- a/change/@microsoft-teams-js-81b04f65-2e91-4e2e-b96e-a861166d5c65.json
+++ b/change/@microsoft-teams-js-81b04f65-2e91-4e2e-b96e-a861166d5c65.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added `ConversationResponse` to explicit named exports for back-compat",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/index.ts
+++ b/packages/teams-js/src/private/index.ts
@@ -19,9 +19,9 @@ export {
   openFilePreview,
 } from './privateAPIs';
 export * as conversations from './conversations';
-//It is necessary to export OpenConversationRequest from conversations.ts individually as well
+//It is necessary to export ConversationResponse and OpenConversationRequest from conversations.ts individually as well
 //to keep the named exports so as to not break the existing consumers directly referencing the named exports.
-export { OpenConversationRequest } from './conversations';
+export { ConversationResponse, OpenConversationRequest } from './conversations';
 export * as copilot from './copilot/copilot';
 export * as externalAppAuthentication from './externalAppAuthentication';
 export * as externalAppAuthenticationForCEA from './externalAppAuthenticationForCEA';


### PR DESCRIPTION
A partner team ran into an issue with trying to upgrade to the latest version. The latest version does not have `ConversationResponse` explicitly exported from the index file, so it now must be referenced through `MicrosoftTeams.conversations.ConversationRequest` instead of what they were previously using `MicrosoftTeams.ConversationResponse`. This is a back-compat bug as we don't want any breaking api changes with the treeshaking updates, so I explicitly added `ConversationResponse` to the private index file to facilitate the old reference support.