### PR TITLE
Fix links in package readme file

### DIFF
--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -71,7 +71,7 @@ The [Teams Test App](https://aka.ms/teams-test-app) is used to validate the Team
 
 ## Troubleshooting
 
-If the CDN hash value on the npm page is out of date please refer to [here] (https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/packages/teams-js/README.md) for an up to date version. If you notice this problem, please report that issue to us in [GitHub Issues] (https://github.com/OfficeDev/microsoft-teams-library-js/issues)
+If the CDN hash value on the npm page is out of date please refer to [here](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/packages/teams-js/README.md) for an up to date version. If you notice this problem, please report that issue to us in [GitHub Issues](https://github.com/OfficeDev/microsoft-teams-library-js/issues)
 
 ## Contributing
 


### PR DESCRIPTION
The "troubleshooting" links in the teamsjs package readme file had some markdown syntax errors so they were not showing up as links appropriately. This change fixes the issue by removing the space between the linked text moniker and the URL moniker. This is what it looked like before it was fixed:

![image](https://github.com/user-attachments/assets/392758dc-d90d-4a0b-a129-0cd8457ff686)

Note how you can visible see the brackets around the text-to-be-linked and how you can also see the URL.
