### PR TITLE
noahdarveau/debug polyfill bug fix

### DIFF
--- a/change/@microsoft-teams-js-355651b0-c6d4-47bb-b923-426b9a9a3bae.json
+++ b/change/@microsoft-teams-js-355651b0-c6d4-47bb-b923-426b9a9a3bae.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Explicitly use browser implementation of debug to resolve polyfill issue.",
+  "comment": "Explicitly use browser implementation of `debug` package to resolve polyfill issue.",
   "packageName": "@microsoft/teams-js",
   "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-355651b0-c6d4-47bb-b923-426b9a9a3bae.json
+++ b/change/@microsoft-teams-js-355651b0-c6d4-47bb-b923-426b9a9a3bae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Explicitly use browser implementation of debug to resolve polyfill issue.",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/rollup.config.mjs
+++ b/packages/teams-js/rollup.config.mjs
@@ -36,7 +36,7 @@ export default [
       typescript(),
       json(),
       commonjs(),
-      nodePolyfills({ include: './src/**/*' }),
+      nodePolyfills(),
     ],
     treeshake: {
       moduleSideEffects: [

--- a/packages/teams-js/rollup.config.mjs
+++ b/packages/teams-js/rollup.config.mjs
@@ -22,12 +22,6 @@ export default [
       entryFileNames: '[name].js',
       sourcemap: false,
       plugins: [terser()],
-      globals: {
-        buffer: 'Buffer',
-        tty: 'tty',
-        util: 'util',
-        os: 'os',
-      },
     },
     preserveEntrySignatures: 'strict',
     plugins: [
@@ -42,7 +36,7 @@ export default [
       typescript(),
       json(),
       commonjs(),
-      nodePolyfills(),
+      nodePolyfills({ include: './src/**/*' }),
     ],
     treeshake: {
       moduleSideEffects: [

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -1,5 +1,5 @@
+// We are directly referencing the browser implementation of `debug` to resolve an issue with polyfilling. For a full write-up on the bug please see ADO Bug #9619161
 import { debug as registerLogger, Debugger } from 'debug/src/browser';
-// We are directly referencing the browser implementation of `debug` to resolve an issue with polyfilling. For a full write-up on the bug please see: https://office.visualstudio.com/MetaOS/_workitems/edit/9619161/
 
 import { UUID } from './uuidObject';
 

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -1,5 +1,5 @@
-// We are directly referencing the browser implementation of `debug` to resolve an issue with polyfilling. For a full write-up on the bug please see: https://office.visualstudio.com/MetaOS/_workitems/edit/9619161/
 import { debug as registerLogger, Debugger } from 'debug/src/browser';
+// We are directly referencing the browser implementation of `debug` to resolve an issue with polyfilling. For a full write-up on the bug please see: https://office.visualstudio.com/MetaOS/_workitems/edit/9619161/
 
 import { UUID } from './uuidObject';
 

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -1,3 +1,4 @@
+// We are directly referencing the browser implementation of `debug` to resolve an issue with polyfilling. For a full write-up on the bug please see: https://office.visualstudio.com/MetaOS/_workitems/edit/9619161/
 import { debug as registerLogger, Debugger } from 'debug/src/browser';
 
 import { UUID } from './uuidObject';

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -1,4 +1,4 @@
-import { debug as registerLogger, Debugger } from 'debug';
+import { debug as registerLogger, Debugger } from 'debug/src/browser';
 
 import { UUID } from './uuidObject';
 


### PR DESCRIPTION
With the changes from webpack to rollup, we need to use the rollup-plugin-node-polyfills plugin to include the polyfill for the `buffer` in the final bundle. This plugin scrapes the pakcage for any node.js built-ins and includes the polyfills for them. This has been causing an issue with the `debug` package as it has separate node.js and browser implementations, so it does not need to be polyfilled. It determines which implementation to use by checking if the `process` object is defined or not. The polyfilling plugin is detecting the `process` reference and polyfilling it accordingly, which is breaking the implementation decision. A full write-up about this bug can be found in 9619161 (I recommend giving it a read, it's actually a pretty interesting problem). I noticed in our previous bundles, prior to switching to rollup that this problem was not present as the webpack bundler was always resolving to the code to the browser implementation and removing the node.js implementation all together. As such we can directly reference the browser implementation of `debug` when importing the library to remove the issue stated above. 

In this PR I also removed the `globals` field in the rollup config. That configuration option is only relevant to bundling to umd and iife formats, which we are no longer doing, so it is just dead code that I am removing for cleanliness.