### PR TITLE
Moved uuidObject.ts from internal to public folder in preparation for exporting it

### DIFF
--- a/change/@microsoft-teams-js-6f5afb78-da58-46be-a695-164d19695294.json
+++ b/change/@microsoft-teams-js-6f5afb78-da58-46be-a695-164d19695294.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Moved uuidObject.ts from internal to public folder in preparation for exporting it.",
+  "packageName": "@microsoft/teams-js",
+  "email": "erinha@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -7,6 +7,7 @@ import { FrameContexts } from '../public/constants';
 import { ErrorCode, isSdkError, SdkError } from '../public/interfaces';
 import { latestRuntimeApiVersion } from '../public/runtime';
 import { ISerializable, isSerializable } from '../public/serializable.interface';
+import { UUID as MessageUUID } from '../public/uuidObject';
 import { version } from '../public/version';
 import { GlobalVars } from './globalVars';
 import { callHandler } from './handlers';
@@ -33,7 +34,6 @@ import {
 import { ResponseHandler, SimpleType } from './responseHandler';
 import { getLogger, isFollowingApiVersionTagFormat } from './telemetry';
 import { getCurrentTimestamp, ssrSafeWindow } from './utils';
-import { UUID as MessageUUID } from './uuidObject';
 import { validateOrigin } from './validOrigins';
 
 const communicationLogger = getLogger('communication');

--- a/packages/teams-js/src/internal/hostToAppTelemetry.ts
+++ b/packages/teams-js/src/internal/hostToAppTelemetry.ts
@@ -1,9 +1,9 @@
 import { Debugger } from 'debug';
 
+import { UUID as MessageUUID } from '../public/uuidObject';
 import { handleHostToAppPerformanceMetrics } from './handlers';
 import { CallbackInformation } from './interfaces';
 import { MessageRequest, MessageResponse } from './messageObjects';
-import { UUID as MessageUUID } from './uuidObject';
 
 /**
  * @internal

--- a/packages/teams-js/src/internal/messageObjects.ts
+++ b/packages/teams-js/src/internal/messageObjects.ts
@@ -1,4 +1,4 @@
-import { UUID as MessageUUID } from './uuidObject';
+import { UUID as MessageUUID } from '../public/uuidObject';
 
 /**
  * @internal

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -1,7 +1,7 @@
 // We are directly referencing the browser implementation of `debug` to resolve an issue with polyfilling. For a full write-up on the bug please see ADO Bug #9619161
 import { debug as registerLogger, Debugger } from 'debug/src/browser';
 
-import { UUID } from './uuidObject';
+import { UUID } from '../public/uuidObject';
 
 // Each teamsjs instance gets a unique identifier that will be prepended to every log statement
 export const teamsJsInstanceIdentifier = new UUID();

--- a/packages/teams-js/src/public/uuidObject.ts
+++ b/packages/teams-js/src/public/uuidObject.ts
@@ -1,4 +1,4 @@
-import { generateGUID, validateUuid } from './utils';
+import { generateGUID, validateUuid } from '../internal/utils';
 
 /**
  * @internal

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -5,9 +5,9 @@ import { MessageRequest } from '../../src/internal/messageObjects';
 import { NestedAppAuthMessageEventNames, NestedAppAuthRequest } from '../../src/internal/nestedAppAuthUtils';
 import { ResponseHandler } from '../../src/internal/responseHandler';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../src/internal/telemetry';
-import { UUID } from '../../src/internal/uuidObject';
 import { ErrorCode, FrameContexts, SdkError } from '../../src/public';
 import * as app from '../../src/public/app/app';
+import { UUID } from '../../src/public/uuidObject';
 import { Utils } from '../utils';
 
 jest.mock('../../src/internal/handlers', () => ({

--- a/packages/teams-js/test/internal/utils.spec.ts
+++ b/packages/teams-js/test/internal/utils.spec.ts
@@ -9,9 +9,9 @@ import {
   validateUrl,
   validateUuid,
 } from '../../src/internal/utils';
-import { UUID } from '../../src/internal/uuidObject';
 import { AppId, pages } from '../../src/public';
 import { ClipboardSupportedMimeType } from '../../src/public/interfaces';
+import { UUID } from '../../src/public/uuidObject';
 
 describe('utils', () => {
   test('compareSDKVersions', () => {

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -2,7 +2,6 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { ensureInitialized } from '../../src/internal/internalAPIs';
-import { UUID } from '../../src/internal/uuidObject';
 import { authentication, dialog, menus, pages } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import {
@@ -30,6 +29,7 @@ import {
   runtime,
   versionAndPlatformAgnosticTeamsRuntimeConfig,
 } from '../../src/public/runtime';
+import { UUID } from '../../src/public/uuidObject';
 import { version } from '../../src/public/version';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -4,10 +4,10 @@ import { GlobalVars } from '../src/internal/globalVars';
 import { DOMMessageEvent, ExtendedWindow } from '../src/internal/interfaces';
 import { MessageRequest, SerializedMessageRequest, SerializedMessageResponse } from '../src/internal/messageObjects';
 import { NestedAppAuthRequest } from '../src/internal/nestedAppAuthUtils';
-import { UUID as MessageUUID } from '../src/internal/uuidObject';
 import { HostClientType } from '../src/public';
 import * as app from '../src/public/app/app';
 import { applyRuntimeConfig, IBaseRuntime, setUnitializedRuntime } from '../src/public/runtime';
+import { UUID as MessageUUID } from '../src/public/uuidObject';
 
 function deserializeMessageRequest(serializedMessage: SerializedMessageRequest): MessageRequest {
   const message = {


### PR DESCRIPTION
## Description

Moved uuidObject.ts from internal to public folder in preparation for exporting it.

The UUID type needs to be exported as part of this PR: https://github.com/OfficeDev/microsoft-teams-library-js/pull/2654/files, and in the spirit of small, isolated changes, I'm doing the move separately from the logical changes in the file that will come as part of the other PR.

### Main changes in the PR:

1. Move uuidObject.ts from internal to public.
2. Update import references.

## Validation

### Validation performed:

1. Unit tests pass.

### Unit Tests added:

No, this is just a refactor.

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes

### Related PRs:

[Added customTelemetry subcapability under copilot](https://github.com/OfficeDev/microsoft-teams-library-js/pull/2654/files)

