### PR TITLE
2.33.0 Prerelease

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.32.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-TOLACGjmwQohHyLubBrUeaUjuqYYAxJsVKufxV6VWXWEQepFpamUASNMMIhgJmoW"
+      src="https://res.cdn.office.net/teams-js/2.33.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-hCfPVLNt9JPTceReb/qZGZR7IbUaPeoExYnER2H//kiykKfhcVEMVQiCR0eAtCCs"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm lint && webpack",

--- a/change/@microsoft-teams-js-05b6fda8-1215-45ac-b8c5-338fe7d7f77e.json
+++ b/change/@microsoft-teams-js-05b6fda8-1215-45ac-b8c5-338fe7d7f77e.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added `customTelemetry` capability under `copilot` to send app loading data to the host.",
-  "packageName": "@microsoft/teams-js",
-  "email": "niharikad@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-355651b0-c6d4-47bb-b923-426b9a9a3bae.json
+++ b/change/@microsoft-teams-js-355651b0-c6d4-47bb-b923-426b9a9a3bae.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Explicitly use browser implementation of `debug` package to resolve polyfill issue.",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-4ed021f2-aea4-4a41-84f5-1d1688d7f234.json
+++ b/change/@microsoft-teams-js-4ed021f2-aea4-4a41-84f5-1d1688d7f234.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Released 2.32.0",
-  "packageName": "@microsoft/teams-js",
-  "email": "jadahiya@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-6f5afb78-da58-46be-a695-164d19695294.json
+++ b/change/@microsoft-teams-js-6f5afb78-da58-46be-a695-164d19695294.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Moved uuidObject.ts from internal to public folder in preparation for exporting it.",
-  "packageName": "@microsoft/teams-js",
-  "email": "erinha@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Fri, 13 Dec 2024 20:07:32 GMT and should not be manually modified.
+This log was last generated on Thu, 09 Jan 2025 16:42:36 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.33.0
+
+Thu, 09 Jan 2025 16:42:36 GMT
+
+### Minor changes
+
+- Added `customTelemetry` capability under `copilot` to send app loading data to the host.
+
+### Patches
+
+- Explicitly use browser implementation of `debug` package to resolve polyfill issue.
+- Moved uuidObject.ts from internal to public folder in preparation for exporting it.
 
 ## 2.32.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.32.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.33.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.32.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-TOLACGjmwQohHyLubBrUeaUjuqYYAxJsVKufxV6VWXWEQepFpamUASNMMIhgJmoW"
+  src="https://res.cdn.office.net/teams-js/2.33.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-hCfPVLNt9JPTceReb/qZGZR7IbUaPeoExYnER2H//kiykKfhcVEMVQiCR0eAtCCs"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.32.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.33.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",


### PR DESCRIPTION
Result of `node tools/cli/prerelease.js` command

### Minor changes

- Added `customTelemetry` capability under `copilot` to send app loading data to the host.

### Patches

- Explicitly use browser implementation of `debug` package to resolve polyfill issue.
- Moved uuidObject.ts from internal to public folder in preparation for exporting it.