### PR TITLE
Update prod-release.yml

### DIFF
--- a/tools/releases/prod-release.yml
+++ b/tools/releases/prod-release.yml
@@ -47,18 +47,18 @@ extends:
                 displayName: Use Node 18.x
                 inputs:
                   versionSpec: 18.x
-              - task: PowerShell@2
-                displayName: Update npmrc with NPM-TOKEN
-                inputs:
-                  targetType: 'inline'
-                  script: Set-Content -Path $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed/.npmrc -Value "//registry.npmjs.org/:_authToken=$(NPM-TOKEN)"
-              - task: Npm@1
-                displayName: Publish to npm (tag latest) KV
-                inputs:
-                  command: custom
-                  workingDir: $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed
-                  verbose: false
-                  customCommand: publish --tag latest
+              # - task: PowerShell@2
+              #   displayName: Update npmrc with NPM-TOKEN
+              #   inputs:
+              #     targetType: 'inline'
+              #     script: Set-Content -Path $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed/.npmrc -Value "//registry.npmjs.org/:_authToken=$(NPM-TOKEN)"
+              # - task: Npm@1
+              #   displayName: Publish to npm (tag latest) KV
+              #   inputs:
+              #     command: custom
+              #     workingDir: $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed
+              #     verbose: false
+              #     customCommand: publish --tag latest
               - task: M365CdnAssetsUpload@1
                 displayName: Push teams-js to M365 1CDN (Prod)
                 inputs:


### PR DESCRIPTION
## Description

The release pushed to npm but the CDN step failed. We are going to temporarily disable pushing to npm so we can fix the CDN part of the job.

### Main changes in the PR:

1. Temporarily disable npm releases