### PR TITLE
Update prod-release.yml

### DIFF
--- a/tools/releases/prod-release.yml
+++ b/tools/releases/prod-release.yml
@@ -47,19 +47,19 @@ extends:
                 displayName: Use Node 18.x
                 inputs:
                   versionSpec: 18.x
-              # - task: PowerShell@2
-              #   displayName: Update npmrc with NPM-TOKEN
-              #   inputs:
-              #     targetType: 'inline'
-              #     script: Set-Content -Path $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed/.npmrc -Value "//registry.npmjs.org/:_authToken=$(NPM-TOKEN)"
-              # - task: Npm@1
-              #   displayName: Publish to npm (tag latest) KV
-              #   inputs:
-              #     command: custom
-              #     workingDir: $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed
-              #     verbose: false
-              #     customCommand: publish --tag latest
-              - task: M365CdnAssetsUpload@3
+              - task: PowerShell@2
+                displayName: Update npmrc with NPM-TOKEN
+                inputs:
+                  targetType: 'inline'
+                  script: Set-Content -Path $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed/.npmrc -Value "//registry.npmjs.org/:_authToken=$(NPM-TOKEN)"
+              - task: Npm@1
+                displayName: Publish to npm (tag latest) KV
+                inputs:
+                  command: custom
+                  workingDir: $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed
+                  verbose: false
+                  customCommand: publish --tag latest
+              - task: M365CdnAssetsUpload@1
                 displayName: Push teams-js to M365 1CDN (Prod)
                 inputs:
                   SourcePath: $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/CDNFeed/*


### PR DESCRIPTION
## Description

During the release of teamsjs 2.33.0 we temporarily commented out the "push to npm" step so that we could just retry pushing to CDN (which was initially failing). This PR is reverting that PR so that releases will again go to both npm and CDN.

### Main changes in the PR:

1. Uncomment the section of our release yaml that pushes to npm