### PR TITLE
Update authentication.notifySuccess function documentation with secure usage guidance

### DIFF
--- a/change/@microsoft-teams-js-23b4de1d-348c-4748-90ac-78b4fa7158c7.json
+++ b/change/@microsoft-teams-js-23b4de1d-348c-4748-90ac-78b4fa7158c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated `authentication.notifySuccess` documentation with security guidance",
+  "packageName": "@microsoft/teams-js",
+  "email": "36546967+AE-MS@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -459,18 +459,18 @@ function startAuthenticationWindowMonitor(): void {
  * authentication request was successful.
  *
  * @remarks
- * This function is usable only from the authentication window.
+ * The `result` parameter should **never** contain the token that was received from the identity provider, because a malicious app (rather than your own app) might have opened
+ * the authentication window. If that was the case, passing the token in this parameter would leak it to them. More secure methods for completing the authentication flow include:
+ * - For a purely browser-based experience (e.g., a personal app/tab app), you could store the token in browser local storage and then have your personal app retrieve it once
+ * this `notifySuccess` call is received.
+ * - For a server-based experience (e.g., a message extension), your authentication window could store the token on your service and then generate a unique code passed via this
+ * `result` parameter. The caller can then use the unique code to retrieve the token from your service.
+ *
+ * This function is usable only from an authentication window opened with {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>}.
  * This call causes the authentication window to be closed.
  *
  * @param result - Specifies a result for the authentication. If specified, the frame that initiated the authentication pop-up receives
  * this value in its callback or via the `Promise` return value.
- * NOTE: this result should _never_ contain the token that was received from the identity provider. A rogue app (rather than your own app)
- * could have opened your authentication window. Passing the token in this parameter would leak it to them.
- * Secure ways to complete the authentication flow include:
- * - For a purely browser-based experience (e.g., a personal app/tab app), you can store the token in browser local storage and then have your
- * personal app retrieve it once this notifySuccess call is received
- * - For a server-based experience (e.g., a message extension), your authentication window should store the token on your service and then
- * generate a unique code passed via this result parameter. The caller can then use the unique code to retrieve the token from your service.
  *
  */
 export function notifySuccess(result?: string): void;

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -82,7 +82,7 @@ export function registerAuthenticationHandlers(authenticateParameters: Authentic
  *
  * @remarks
  * The authentication flow must start and end from the same domain, otherwise success and failure messages won't be returned to the window that initiated the call.
- * The [Teams authentication flow](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/auth-flow-tab) starts and ends at an endpoint on
+ * The [authentication flow](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/authentication/auth-flow-tab) starts and ends at an endpoint on
  * your own service (with a redirect round-trip to the 3rd party identity provider in the middle).
  *
  * @param authenticateParameters - Parameters describing the authentication window used for executing the authentication flow
@@ -454,7 +454,7 @@ function startAuthenticationWindowMonitor(): void {
 
 /**
  * When using {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>}, the
- * window that was opened to execute the authentication flow should call this method after authentiction to notify the caller of
+ * window that was opened to execute the authentication flow should call this method after authentication to notify the caller of
  * {@link authentication.authenticate authentication.authenticate(authenticateParameters: AuthenticatePopUpParameters): Promise\<string\>} that the
  * authentication request was successful.
  *
@@ -463,7 +463,15 @@ function startAuthenticationWindowMonitor(): void {
  * This call causes the authentication window to be closed.
  *
  * @param result - Specifies a result for the authentication. If specified, the frame that initiated the authentication pop-up receives
- * this value in its callback or via the `Promise` return value
+ * this value in its callback or via the `Promise` return value.
+ * NOTE: this result should _never_ contain the token that was received from the identity provider. A rogue actor (rather than your own app)
+ * could have opened your authentication window. Passing the token in this parameter would leak it to them.
+ * Potential secure ways to complete the authentication flow include:
+ * - For a purely browser-based experience (e.g., a personal app/tab app), you can store the token in browser local storage and then have your
+ * personal app retrieve it once this notifySuccess call is received
+ * - For a server-based experience (e.g., a message extension), your authentication window should store the token on your service and then
+ * generate a unique code passed via this result parameter. The caller can then use the unique code to retrieve the token from your service.
+ *
  */
 export function notifySuccess(result?: string): void;
 /**

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -464,9 +464,9 @@ function startAuthenticationWindowMonitor(): void {
  *
  * @param result - Specifies a result for the authentication. If specified, the frame that initiated the authentication pop-up receives
  * this value in its callback or via the `Promise` return value.
- * NOTE: this result should _never_ contain the token that was received from the identity provider. A rogue actor (rather than your own app)
+ * NOTE: this result should _never_ contain the token that was received from the identity provider. A rogue app (rather than your own app)
  * could have opened your authentication window. Passing the token in this parameter would leak it to them.
- * Potential secure ways to complete the authentication flow include:
+ * Secure ways to complete the authentication flow include:
  * - For a purely browser-based experience (e.g., a personal app/tab app), you can store the token in browser local storage and then have your
  * personal app retrieve it once this notifySuccess call is received
  * - For a server-based experience (e.g., a message extension), your authentication window should store the token on your service and then


### PR DESCRIPTION
## Description

The `authentication.notifySuccess` function did not explicitly discuss secure usage guidance and this PR adds it.

Separately, I am working with the docs team to get the prose documentation pages ([here](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/authentication/auth-flow-tab) and [here](https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/add-authentication)) updated to be more explicit about this.

The final docs now look like this, after feedback from @JoshuaPartlow:
<img width="745" alt="{6F05D66E-FA63-42CD-B16D-DCB67BDC35E5}" src="https://github.com/user-attachments/assets/27a8cce7-a15d-4e9b-8dd2-e21c082d4103" />
This is obviously the local generation of the docs -- they will be formatted slightly differently on the official site.