### PR TITLE
Updating `validateEmails` function from boolean to void

### DIFF
--- a/change/@microsoft-teams-js-88f21fb3-ced0-4b78-9e79-51cb73b00a0f.json
+++ b/change/@microsoft-teams-js-88f21fb3-ced0-4b78-9e79-51cb73b00a0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated `validateEmails` function to void type for `mail.handoff` sub-capability.",
+  "packageName": "@microsoft/teams-js",
+  "email": "maggiegong@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-88f21fb3-ced0-4b78-9e79-51cb73b00a0f.json
+++ b/change/@microsoft-teams-js-88f21fb3-ced0-4b78-9e79-51cb73b00a0f.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Updated `validateEmails` function to void type for `mail.handoff` sub-capability.",
+  "comment": "Updated `validateEmails` function to `void` type for `mail.handoff` sub-capability.",
   "packageName": "@microsoft/teams-js",
   "email": "maggiegong@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/public/mail/handoff.ts
+++ b/packages/teams-js/src/public/mail/handoff.ts
@@ -52,15 +52,14 @@ export interface ComposeMailParamsWithHandoff {
  *
  * @beta
  */
-function validateEmails(emails?: string[]): boolean {
+function validateEmails(emails?: string[]): void {
   if (!emails || emails.length === 0) {
-    return true; // If the array is undefined or empty, consider it valid
+    return; // If the array is undefined or empty, consider it valid
   }
   // Use validateEmailAddress for each email in the param
   emails.forEach((email) => {
     validateEmailAddress(email); // This will throw an error if the email is invalid
   });
-  return true;
 }
 
 /**
@@ -78,9 +77,9 @@ function validateHandoffComposeMailParams(param: ComposeMailParamsWithHandoff): 
   }
   const composeMailParams = param.composeMailParams;
   if (composeMailParams.type === ComposeMailType.New) {
-    validateEmails(composeMailParams.toRecipients) &&
-      validateEmails(composeMailParams.ccRecipients) &&
-      validateEmails(composeMailParams.bccRecipients);
+    validateEmails(composeMailParams.toRecipients);
+    validateEmails(composeMailParams.ccRecipients);
+    validateEmails(composeMailParams.bccRecipients);
   }
   // For Reply, ReplyAll, and Forward types, no validation needed
 }


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This PR updates the validateEmails function from a boolean return type to void. The validateEmails function will no longer return a value, but it will throw an error if any of the email addresses are invalid.

