### PR TITLE
[Task] Programmatically access the "real" App ID and Manifest Version 

### DIFF
--- a/change/@microsoft-teams-js-136faa15-4005-4e32-8931-382db3d3ab0f.json
+++ b/change/@microsoft-teams-js-136faa15-4005-4e32-8931-382db3d3ab0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added the new parameters to `app.getContext` named `appId` and `manifestVersion`",
+  "packageName": "@microsoft/teams-js",
+  "email": "maggiegong@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/app/app.ts
+++ b/packages/teams-js/src/public/app/app.ts
@@ -816,6 +816,8 @@ function transformLegacyContextToAppContext(legacyContext: LegacyContext): Conte
         ringId: legacyContext.ringId,
       },
       appLaunchId: legacyContext.appLaunchId,
+      appId: legacyContext.appId ? new AppId(legacyContext.appId) : undefined,
+      manifestVersion: legacyContext.manifestVersion,
     },
     page: {
       id: legacyContext.entityId,

--- a/packages/teams-js/src/public/app/app.ts
+++ b/packages/teams-js/src/public/app/app.ts
@@ -15,6 +15,7 @@ import { ensureInitializeCalled } from '../../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag, getLogger } from '../../internal/telemetry';
 import { inServerSideRenderingEnvironment } from '../../internal/utils';
 import * as messageChannels from '../../private/messageChannels/messageChannels';
+import { AppId } from '../appId';
 import { ChannelType, FrameContexts, HostClientType, HostName, TeamType, UserTeamRole } from '../constants';
 import {
   ActionInfo,
@@ -185,6 +186,16 @@ export interface AppInfo {
    * ID for the current visible app which is different for across cached sessions. Used for correlating telemetry data.
    */
   appLaunchId?: string;
+
+  /**
+   * This ID is the unique identifier assigned to the app after deployment and is critical for ensuring the correct app instance is recognized across hosts.
+   */
+  appId?: AppId;
+
+  /**
+   * The version of the manifest that the app is running.
+   */
+  manifestVersion?: string;
 }
 
 /**

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -780,6 +780,22 @@ export interface Context {
    * They help pre-fill the dialog with necessary information (`dialogParameters`) along with other details.
    */
   dialogParameters?: Record<string, string>;
+
+  /**
+   * @deprecated
+   * As of TeamsJS v2.0.0, please use {@link app.AppInfo.appId | app.Context.app.appId} instead
+   *
+   * This ID is the unique identifier assigned to the app after deployment and is critical for ensuring the correct app instance is recognized across hosts.
+   */
+  appId?: string;
+
+  /**
+   * @deprecated
+   * As of TeamsJS v2.0.0, please use {@link app.AppInfo.manifestVersion | app.Context.app.manifestVersion} instead
+   *
+   * The version of the manifest that the app is running.
+   */
+  manifestVersion?: string;
 }
 
 /** Represents the parameters used to share a deep link. */

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -511,6 +511,8 @@ describe('Testing app capability', () => {
             },
           ];
 
+          const mockAppIdString = 'mock.m365testapp.test';
+          const mockManifestVersion = '1.13';
           const contextBridge: Context = {
             actionInfo: {
               actionId: 'actionId',
@@ -568,8 +570,8 @@ describe('Testing app capability', () => {
             appLaunchId: 'appLaunchId',
             userDisplayName: 'someTestUser',
             teamSiteId: 'someSiteId',
-            appId: 'mock.m365testapp.test',
-            manifestVersion: '1.13',
+            appId: mockAppIdString,
+            manifestVersion: mockManifestVersion,
           };
 
           const expectedContext: app.Context = {
@@ -591,8 +593,8 @@ describe('Testing app capability', () => {
                 ringId: 'someRingId',
                 sessionId: 'someSessionId',
               },
-              appId: new AppId('mock.m365testapp.test'),
-              manifestVersion: '1.13',
+              appId: new AppId(mockAppIdString),
+              manifestVersion: mockManifestVersion,
             },
             page: {
               id: 'someEntityId',
@@ -666,9 +668,9 @@ describe('Testing app capability', () => {
           expect(actualContext.actionInfo?.actionObjects.length).toBe(5);
           expect(firstActionItem.secondaryId?.name).toEqual(SecondaryM365ContentIdName.DriveId);
           expect(isM365ContentType(secondActionItem)).toBe(false);
-          const expectedAppId = new AppId('mock.m365testapp.test');
+          const expectedAppId = new AppId(mockAppIdString);
           expect(actualContext.app.appId).toEqual(expectedAppId);
-          expect(actualContext.app.manifestVersion).toBe('1.13');
+          expect(actualContext.app.manifestVersion).toBe(mockManifestVersion);
         });
       });
     });

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -2,7 +2,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { ensureInitialized } from '../../src/internal/internalAPIs';
-import { authentication, dialog, menus, pages } from '../../src/public';
+import { AppId, authentication, dialog, menus, pages } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import {
   ChannelType,
@@ -568,6 +568,8 @@ describe('Testing app capability', () => {
             appLaunchId: 'appLaunchId',
             userDisplayName: 'someTestUser',
             teamSiteId: 'someSiteId',
+            appId: 'mock.m365testapp.test',
+            manifestVersion: '1.13',
           };
 
           const expectedContext: app.Context = {
@@ -589,6 +591,8 @@ describe('Testing app capability', () => {
                 ringId: 'someRingId',
                 sessionId: 'someSessionId',
               },
+              appId: new AppId('mock.m365testapp.test'),
+              manifestVersion: '1.13',
             },
             page: {
               id: 'someEntityId',
@@ -662,6 +666,9 @@ describe('Testing app capability', () => {
           expect(actualContext.actionInfo?.actionObjects.length).toBe(5);
           expect(firstActionItem.secondaryId?.name).toEqual(SecondaryM365ContentIdName.DriveId);
           expect(isM365ContentType(secondActionItem)).toBe(false);
+          const expectedAppId = new AppId('mock.m365testapp.test');
+          expect(actualContext.app.appId).toEqual(expectedAppId);
+          expect(actualContext.app.manifestVersion).toBe('1.13');
         });
       });
     });


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description
Adding the `appId` and `manifestVersion` to `AppInfo` so app can get  `appId` and `manifestVersion`  from `getContext()` API.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Added `appId?: AppId`
2. Add `manifestVersion?: string`


<img width="671" alt="Screenshot 2025-01-23 at 4 18 59 PM" src="https://github.com/user-attachments/assets/9e73e84e-fa76-49e1-9395-6055052cc863" />



