### PR TITLE
[Please Review] Test App calls `App.notifySuccess` automatically within `RegisterOnResumeHandler` if it is not in `customInit` mode

### DIFF
--- a/apps/teams-test-app/src/App.tsx
+++ b/apps/teams-test-app/src/App.tsx
@@ -8,7 +8,7 @@ import { isTestBackCompat } from './components/utils/isTestBackCompat';
 import { SecondRoute } from './pages/SecondRoute';
 import { appInitializationTestQueryParameter, TestApp } from './pages/TestApp';
 
-const urlParams = new URLSearchParams(window.location.search);
+export const urlParams = new URLSearchParams(window.location.search);
 
 // The search url parameter 'origins' is used to get the valid message origins which will be passed to
 // the initialize function and based on the hosts it will allow the origins or not.

--- a/apps/teams-test-app/src/components/AppAPIs.tsx
+++ b/apps/teams-test-app/src/components/AppAPIs.tsx
@@ -10,6 +10,7 @@ import {
 import React, { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { urlParams } from '../App';
 import { ApiWithoutInput, ApiWithTextInput } from './utils';
 import { ModuleWrapper } from './utils/ModuleWrapper';
 
@@ -107,7 +108,9 @@ const RegisterOnResumeHandler = (): React.ReactElement => {
         const route = context.contentUrl;
         // navigate to the correct path based on URL
         navigate(route.pathname);
-        app.notifySuccess();
+        if (!urlParams.has('customInit') || !urlParams.get('customInit')) {
+          app.notifySuccess();
+        }
       });
 
       return 'registered';


### PR DESCRIPTION
## Description

This change is a preparation for App Initialization E2E test on cache app in Web Host SDK. We would like to mock the scenarios when cache app [call / doesn't call] `app.notifySuccess` after it comes out from cache mode. Thus, we need to make this change to make sure we have option under `customInit` test mode.

## Validation

### Validation performed:

1. `onResumeHandler` is used for cache only so no E2E test should be broken because of this change 

### Unit Tests added:  No

### End-to-end tests added: No

## Additional Requirements