### PR TITLE
Disable CodeQL from pipeline level and add it in job level

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ extends:
       codeql:
         compiled:
           enabled: false
-          justificationForDisabling: 'CodeQL has some know issues with arm64 macos. Disabling auto-injection and using manual task'
+          justificationForDisabling: 'CodeQL has some known issues with arm64 macos. Disabling auto-injection and using manual task instead'
     customBuildTags:
       - ES365AIMigrationTooling
     stages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,10 @@ extends:
           - repository: AppHostingSdkV4
           - repository: AndroidAppHostingSdk
           - repository: IOSAppHostingSdk
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: 'CodeQL has some know issues with arm64 macos. Disabling auto-injection and using manual task'
     customBuildTags:
       - ES365AIMigrationTooling
     stages:

--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -60,10 +60,7 @@ steps:
 
   - task: CodeQL3000Init@0
     inputs:
-      ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
         Enabled: true
-      ${{ else }}:
-        Enabled: false
         
   - task: Bash@3
     displayName: 'Install Emulator'

--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -58,6 +58,13 @@ steps:
       script: 'nohup pnpm start-test-app &'
       workingDirectory: '$(ClientSdkProjectDirectory)'
 
+  - task: CodeQL3000Init@0
+    inputs:
+      ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+        Enabled: true
+      ${{ else }}:
+        Enabled: false
+        
   - task: Bash@3
     displayName: 'Install Emulator'
     # This task is flaky, but when it works it almost always completes in under 5 minutes.
@@ -88,6 +95,9 @@ steps:
       script: 'chmod u+x ./gradlew && chmod u+x e2eTest.sh && ./e2eTest.sh ${{ parameters.shardNum }} ${{ parameters.shardIndex }}'
       workingDirectory: '$(Agent.BuildDirectory)/androidHost/apps/orangeandroid'
 
+  - task: CodeQL3000Finalize@0
+    condition: always()
+    
   - task: Bash@3
     displayName: 'Pull Test Artifacts'
     inputs:

--- a/tools/yaml-templates/build-app-host.yml
+++ b/tools/yaml-templates/build-app-host.yml
@@ -75,10 +75,7 @@ steps:
 
   - task: CodeQL3000Init@0
     inputs:
-      ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-        Enabled: true
-      ${{ else }}:
-        Enabled: false
+      Enabled: true
 
   - script: |
       pnpm build

--- a/tools/yaml-templates/build-app-host.yml
+++ b/tools/yaml-templates/build-app-host.yml
@@ -73,6 +73,13 @@ steps:
     workingDirectory: '$(AppHostingSdkProjectDirectory)'
     condition: eq(variables.CYPRESS_CACHE_RESTORED, 'false')
 
+  - task: CodeQL3000Init@0
+    inputs:
+      ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+        Enabled: true
+      ${{ else }}:
+        Enabled: false
+
   - script: |
       pnpm build
     displayName: 'Build app hosting sdk'
@@ -87,7 +94,7 @@ steps:
       pnpm build-force-blazor
     displayName: 'Build client sdk'
     workingDirectory: '$(ClientSdkProjectDirectory)'
-
+    
   - task: CmdLine@2
     displayName: 'Configure host machine'
     inputs:
@@ -95,3 +102,6 @@ steps:
         sudo chmod -R 755 ./ 
         pnpm run setup
       workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+  - task: CodeQL3000Finalize@0
+    condition: always()

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -87,6 +87,13 @@ steps:
       script: 'nohup pnpm start-test-app --server-options-cert $(localhostSSLCertificate.secureFilePath) --server-options-key $(localhostSSLKey.secureFilePath) &'
       workingDirectory: '$(ClientSdkProjectDirectory)'
 
+  - task: CodeQL3000Init@0
+    inputs:
+      ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+        Enabled: true
+      ${{ else }}:
+        Enabled: false
+        
   # Ideally, iOS Host SDK will be built as a dependency before running E2E Test, but there is no harm to build it again for a minute.
   # In practice, building iOS Host SDK before E2E test reduces flaky failure rate comparing to run E2E test directly.
   - task: Xcode@5
@@ -100,7 +107,10 @@ steps:
       xcWorkspacePath: '/Users/runner/work/1/iOSHost/$(IOSSdkWorkspace).xcworkspace'
       xcodeVersion: 'default'
       xcodeBuildArguments: 'CODE_SIGNING_ALLOWED=NO clean build -derivedDataPath "$(agent.buildDirectory)/iOS/DerivedData"'
-
+  
+  - task: CodeQL3000Finalize@0
+    condition: always()
+    
   - task: Bash@3
     displayName: 'Disable Slow Animation'
     inputs:

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -89,10 +89,7 @@ steps:
 
   - task: CodeQL3000Init@0
     inputs:
-      ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-        Enabled: true
-      ${{ else }}:
-        Enabled: false
+      Enabled: true
         
   # Ideally, iOS Host SDK will be built as a dependency before running E2E Test, but there is no harm to build it again for a minute.
   # In practice, building iOS Host SDK before E2E test reduces flaky failure rate comparing to run E2E test directly.


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

**What is codeql, and what the persistent issues it has currently?**
From what I understand in a briefly way,  it is static analysis tool, runs on source codes for all kind of languages, and also traces the build process during to build, to capture any security  vulnerability issues. It creates a DB during its run, which I believe records the scan result, and the DB will be uploaded in the pipeline to be source of different reporting/dashboards.
CodeQL currently has some issues arm64 macos image, which has been known for a while and in the back of codeQL team. This is not super clear what is the issues to me, and there is an existing ICM on codeql


**When it runs in 1ES template?**
CodeQL is injected task if the pipeline is on 1ES template. From our observations, 1ES always injects the run  at the beginning of each task, i.e, before it runs any other tasks like tool installing. When the tool is installing, it may be interferred with codeql, causing the failure (Not exactly know the reason)

**How manual run is different from codeql auto-injection task?**
There is no difference between auto-injected codeQL and manual codeQL task themselves. The only difference is with manual, we/our team can decide when to inject. The workaround is to inject after the tool setup has completed, to let codeql have less interruptions with the build process. A recommended order from CodeQL team:
<img width="270" alt="image" src="https://github.com/user-attachments/assets/3f6062a9-4ef2-4ff2-98bd-27522f40ab20" />

**What is our solution here?**
Disable from pipeline level, and then add manual task at each job level. Please note, Codeql doesn't support job level disable as of today, so in order to disable, we have to do it at pipeline level.

**Will we receive the S360 alerts?**
Given we are disabling the CodeQL at pipeline/repo level. Will we receive S360 alerts? 
The answer should be No. We have confirmed with CodeQL team.  As long as DB is uploaded, S360 will have some results to process, meeting the requirement.  It doesn’t track where the DB is created (from 1ES template, or manual run doesn't matter)

### Main changes in the PR:

1. Disable CodeQL from the pipeline
2. Manually add the task at job level

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
