### PR TITLE
Add field to tag proxied messages.

### DIFF
--- a/change/@microsoft-teams-js-eef39838-66eb-4b2d-8333-7b4194fb0b47.json
+++ b/change/@microsoft-teams-js-eef39838-66eb-4b2d-8333-7b4194fb0b47.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added field to tag child proxied messages.",
+  "packageName": "@microsoft/teams-js",
+  "email": "jcardenasr123@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-eef39838-66eb-4b2d-8333-7b4194fb0b47.json
+++ b/change/@microsoft-teams-js-eef39838-66eb-4b2d-8333-7b4194fb0b47.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "patch",
   "comment": "Added field to tag child proxied messages.",
   "packageName": "@microsoft/teams-js",
   "email": "jcardenasr123@gmail.com",

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -1179,7 +1179,7 @@ function getMessageIdsAsLogString(
  * @internal
  * Limited to Microsoft-internal use
  */
-function proxyChildMessageToParent(message: MessageRequest): void {
+export function proxyChildMessageToParent(message: MessageRequest): void {
   const request = sendMessageToParentHelper(
     getApiVersionTag(ApiVersionNumber.V_2, ApiName.Tasks_StartTask),
     message.func,

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -1179,7 +1179,7 @@ function getMessageIdsAsLogString(
  * @internal
  * Limited to Microsoft-internal use
  */
-export function proxyChildMessageToParent(message: MessageRequest): void {
+function proxyChildMessageToParent(message: MessageRequest): void {
   const request = sendMessageToParentHelper(
     getApiVersionTag(ApiVersionNumber.V_2, ApiName.Tasks_StartTask),
     message.func,

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -415,7 +415,7 @@ export function sendMessageToParent(
   actionName: string,
   args: any[] | undefined,
   callback?: Function,
-  isMessagedProxiedFromChild?: boolean,
+  isProxiedFromChild?: boolean,
 ): void;
 
 /**

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -415,6 +415,7 @@ export function sendMessageToParent(
   actionName: string,
   args: any[] | undefined,
   callback?: Function,
+  isMessagedProxiedFromChild?: boolean,
 ): void;
 
 /**
@@ -430,6 +431,7 @@ export function sendMessageToParent(
   actionName: string,
   argsOrCallback?: any[] | Function,
   callback?: Function,
+  isProxiedFromChild?: boolean,
 ): void {
   let args: any[] | undefined;
   if (argsOrCallback instanceof Function) {
@@ -444,7 +446,7 @@ export function sendMessageToParent(
     );
   }
 
-  const request = sendMessageToParentHelper(apiVersionTag, actionName, args);
+  const request = sendMessageToParentHelper(apiVersionTag, actionName, args, isProxiedFromChild);
   if (callback) {
     CommunicationPrivate.callbacks.set(request.uuid, callback);
   }
@@ -518,10 +520,11 @@ function sendMessageToParentHelper(
   apiVersionTag: string,
   actionName: string,
   args: any[] | undefined,
+  isProxiedFromChild?: boolean,
 ): MessageRequestWithRequiredProperties {
   const logger = sendMessageToParentHelperLogger;
   const targetWindow = Communication.parentWindow;
-  const request = createMessageRequest(apiVersionTag, actionName, args);
+  const request = createMessageRequest(apiVersionTag, actionName, args, isProxiedFromChild);
   HostToAppMessageDelayTelemetry.storeCallbackInformation(request.uuid, {
     name: actionName,
     calledAt: request.timestamp,
@@ -927,6 +930,7 @@ function handleIncomingMessageFromChild(evt: DOMMessageEvent): void {
             sendMessageResponseToChild(message.id, message.uuid, args, isPartialResponse);
           }
         },
+        true,
       );
     }
   }
@@ -1095,6 +1099,7 @@ function createMessageRequest(
   apiVersionTag: string,
   func: string,
   args: any[] | undefined,
+  isProxiedFromChild?: boolean,
 ): MessageRequestWithRequiredProperties {
   const messageId: MessageID = CommunicationPrivate.nextMessageId++;
   const messageUuid: MessageUUID = new MessageUUID();
@@ -1107,6 +1112,7 @@ function createMessageRequest(
     monotonicTimestamp: getCurrentTimestamp(),
     args: args || [],
     apiVersionTag: apiVersionTag,
+    isProxiedFromChild: isProxiedFromChild ?? false,
   };
 }
 

--- a/packages/teams-js/src/internal/messageObjects.ts
+++ b/packages/teams-js/src/internal/messageObjects.ts
@@ -22,6 +22,7 @@ export interface MessageRequest {
   args?: any[];
   apiVersionTag?: string;
   isPartialResponse?: boolean;
+  isProxiedFromChild?: boolean;
 }
 
 /**

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -11,7 +11,9 @@ import { UUID } from '../../src/public/uuidObject';
 import { Utils } from '../utils';
 
 jest.mock('../../src/internal/handlers', () => ({
-  callHandler: jest.fn(),
+  initializeHandlers: jest.fn(),
+  callHandler: jest.fn(() => [false, undefined]),
+  registerHandler: jest.fn(),
 }));
 
 const testApiVersion = getApiVersionTag(ApiVersionNumber.V_1, 'mockedApiName' as ApiName);
@@ -1037,25 +1039,6 @@ describe('Testing communication', () => {
 
       expect(sentMessage.isProxiedFromChild).toBe(false);
     });
-    it('messages proxied from child should be tagged as proxied from child', async () => {
-      communication.initializeCommunication(undefined, testApiVersion);
-      const initializeMessage = utils.findInitializeMessageOrThrow();
-      await utils.respondToMessage(initializeMessage);
-
-      const arg1 = 'testArg1';
-      communication.proxyChildMessageToParent({
-        apiVersionTag: testApiVersion,
-        func: actionName,
-        args: [arg1],
-      });
-
-      const sentMessage = utils.findMessageByFunc(actionName);
-      if (sentMessage === null) {
-        throw new Error('No sent message was found');
-      }
-
-      expect(sentMessage.isProxiedFromChild).toBe(true);
-    });
     it('should not send postMessage until after initialization response received', async () => {
       communication.initializeCommunication(undefined, testApiVersion);
       const initializeMessage = utils.findInitializeMessageOrThrow();
@@ -1073,6 +1056,29 @@ describe('Testing communication', () => {
       if (sentMessage === null) {
         throw new Error('Did not find any message even after initialization response was received');
       }
+    });
+  });
+  describe('childProxyingCommunication', () => {
+    let utils: Utils = new Utils();
+    const actionName = 'test';
+
+    beforeEach(() => {
+      utils = new Utils();
+      communication.uninitializeCommunication();
+      app._initialize(utils.mockWindow);
+    });
+    afterEach(() => {
+      communication.Communication.currentWindow = utils.mockWindow;
+      communication.uninitializeCommunication();
+    });
+
+    it('messages proxied from child should be tagged as proxied from child', async () => {
+      expect.assertions(2);
+      await utils.initializeWithContext('context');
+      await utils.sendMessageFromChildToParentApp(actionName, ['testArg1']);
+      const sentMessage = utils.findMessageByFunc(actionName);
+      expect(sentMessage).not.toBeNull();
+      expect(sentMessage!.isProxiedFromChild).toBe(true);
     });
   });
   describe('sendNestedAuthRequestToTopWindow', () => {

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -664,6 +664,21 @@ describe('Testing communication', () => {
       expect(sentMessage.args.length).toBe(1);
       expect(sentMessage.args[0]).toBe(arg1);
     });
+    it('messages sent from parent should not be tagged as proxied from child', async () => {
+      communication.initializeCommunication(undefined, testApiVersion);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      await utils.respondToMessage(initializeMessage);
+
+      const arg1 = 'testArg1';
+      communication.sendMessageToParentAsync(testApiVersion, actionName, [arg1]);
+
+      const sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage === null) {
+        throw new Error('No sent message was found');
+      }
+
+      expect(sentMessage.isProxiedFromChild).toBe(false);
+    });
     it('should not send postMessage until after initialization response received', async () => {
       communication.initializeCommunication(undefined, testApiVersion);
       const initializeMessage = utils.findInitializeMessageOrThrow();
@@ -1006,6 +1021,36 @@ describe('Testing communication', () => {
       }
       expect(sentMessage.args.length).toBe(1);
       expect(sentMessage.args[0]).toBe(arg1);
+    });
+    it('messages sent from the parent are not tagged as proxied from child', async () => {
+      communication.initializeCommunication(undefined, testApiVersion);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      await utils.respondToMessage(initializeMessage);
+
+      const arg1 = 'testArg1';
+      communication.sendMessageToParent(testApiVersion, actionName, [arg1], undefined);
+
+      const sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage === null) {
+        throw new Error('No sent message was found');
+      }
+
+      expect(sentMessage.isProxiedFromChild).toBe(false);
+    });
+    it('messages proxied from child should be tagged as proxied from child', async () => {
+      communication.initializeCommunication(undefined, testApiVersion);
+      const initializeMessage = utils.findInitializeMessageOrThrow();
+      await utils.respondToMessage(initializeMessage);
+
+      const arg1 = 'testArg1';
+      communication.sendMessageToParent(testApiVersion, actionName, [arg1], undefined, true);
+
+      const sentMessage = utils.findMessageByFunc(actionName);
+      if (sentMessage === null) {
+        throw new Error('No sent message was found');
+      }
+
+      expect(sentMessage.isProxiedFromChild).toBe(true);
     });
     it('should not send postMessage until after initialization response received', async () => {
       communication.initializeCommunication(undefined, testApiVersion);

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -1028,7 +1028,7 @@ describe('Testing communication', () => {
       await utils.respondToMessage(initializeMessage);
 
       const arg1 = 'testArg1';
-      communication.sendMessageToParent(testApiVersion, actionName, [arg1], undefined);
+      communication.sendMessageToParent(testApiVersion, actionName, [arg1]);
 
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {
@@ -1043,7 +1043,11 @@ describe('Testing communication', () => {
       await utils.respondToMessage(initializeMessage);
 
       const arg1 = 'testArg1';
-      communication.sendMessageToParent(testApiVersion, actionName, [arg1], undefined, true);
+      communication.proxyChildMessageToParent({
+        apiVersionTag: testApiVersion,
+        func: actionName,
+        args: [arg1],
+      });
 
       const sentMessage = utils.findMessageByFunc(actionName);
       if (sentMessage === null) {

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -363,6 +363,24 @@ export class Utils {
     return this.sendMessageWithCustomOrigin(func, this.validOrigin, ...args);
   };
 
+  public async sendMessageFromChildToParentApp(func: string, ...args: unknown[]): Promise<void> {
+    if (this.processMessage === null) {
+      throw Error(
+        `Cannot send message calling function ${func} because processMessage function has not been set and is null`,
+      );
+    }
+
+    await this.processMessage({
+      origin: this.validOrigin,
+      source: this.childWindow,
+      data: {
+        id: 'id',
+        func: func,
+        args: args,
+      },
+    } as MessageEvent);
+  }
+
   public respondToFramelessMessage = (event: DOMMessageEvent): void => {
     (this.mockWindow as unknown as ExtendedWindow).onNativeMessage(event);
   };


### PR DESCRIPTION
## Description
This pull requests add a new field to tag messages proxied from child, in order for the Host to differentiate between parent messages and child originated ones.

### Unit Tests added:
Yes

### End-to-end tests added:
No

## Additional Requirements

### Change file added:
Yes
