### PR TITLE
noahdarveau/windows typed-dependency-tester fix

### DIFF
--- a/apps/typed-dependency-tester/package.json
+++ b/apps/typed-dependency-tester/package.json
@@ -6,7 +6,7 @@
   "version": "0.0.1",
   "scripts": {
     "build": "pnpm i && pnpm copy && cd ./types && pnpm tsc && cd ../ && pnpm clean",
-    "copy": "mkdir -p types && cp -R ./node_modules/@microsoft/teams-js/dist/esm/packages/teams-js/dts/* ./types || xcopy .\\node_modules\\@microsoft\\teams-js\\dist\\esm\\* .\\types /Y",
+    "copy": "mkdir types && cp -R ./node_modules/@microsoft/teams-js/dist/esm/packages/teams-js/dts/* ./types || xcopy .\\node_modules\\@microsoft\\teams-js\\dist\\esm\\packages\\teams-js\\dts\\* .\\types /Y /E",
     "clean": "rimraf node_modules && rimraf ./types"
   },
   "dependencies": {


### PR DESCRIPTION
There was a bug with the typed-dependency-tester that was causing windows runs to fail as it wasn't copying all of the files properly. I had to add the `/E` flag to enable recursive copying. I also updated the path so as to not copy over unnecessary files. 