### PR TITLE
noahdarveau/dynamic imports fix

### DIFF
--- a/change/@microsoft-teams-js-2ec25d83-8460-43ca-ae3b-41f2ec1d4b7e.json
+++ b/change/@microsoft-teams-js-2ec25d83-8460-43ca-ae3b-41f2ec1d4b7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Refactored `backstack` initialization to resolve a `pages` bug when dynamically importing teams-js",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/handlers.ts
+++ b/packages/teams-js/src/internal/handlers.ts
@@ -3,10 +3,10 @@
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
 import { FrameContexts } from '../public/constants';
 import { HostToAppPerformanceMetrics, LoadContext, ResumeContext } from '../public/interfaces';
-import * as pages from '../public/pages/pages';
 import { runtime } from '../public/runtime';
 import { Communication, sendMessageEventToChild, sendMessageToParent } from './communication';
 import { ensureInitialized } from './internalAPIs';
+import { initializeBackStackHelper } from './pagesHelpers';
 import { getLogger } from './telemetry';
 import { isNullOrUndefined } from './typeCheckUtilities';
 
@@ -43,7 +43,7 @@ class HandlersPrivate {
     HandlersPrivate.handlers['themeChange'] = handleThemeChange;
     HandlersPrivate.handlers['load'] = handleLoad;
     HandlersPrivate.handlers['beforeUnload'] = handleBeforeUnload;
-    pages.backStack._initialize();
+    initializeBackStackHelper();
   }
 
   /**

--- a/packages/teams-js/src/internal/pagesHelpers.ts
+++ b/packages/teams-js/src/internal/pagesHelpers.ts
@@ -10,13 +10,16 @@ import {
 import * as pages from '../public/pages/pages';
 import { runtime } from '../public/runtime';
 import {
+  Communication,
   sendAndHandleStatusAndReason,
   sendAndHandleStatusAndReasonWithDefaultError,
   sendAndUnwrap,
+  sendMessageEventToChild,
   sendMessageToParent,
 } from './communication';
+import { registerHandler } from './handlers';
 import { ensureInitialized } from './internalAPIs';
-import { ApiVersionNumber } from './telemetry';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from './telemetry';
 
 /**
  * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
@@ -182,4 +185,36 @@ export function convertAppNavigationParametersToNavigateToAppParams(
     appId: params.appId.toString(),
     webUrl: params.webUrl ? params.webUrl.toString() : undefined,
   };
+}
+
+//Back Stack Helpers
+
+let backButtonPressHandler: (() => boolean) | undefined;
+
+export function getBackButtonPressHandler(): (() => boolean) | undefined {
+  return backButtonPressHandler;
+}
+
+export function setBackButtonPressHandler(handler: () => boolean): void {
+  backButtonPressHandler = handler;
+}
+
+export function initializeBackStackHelper(): void {
+  registerHandler(
+    getApiVersionTag(pagesTelemetryVersionNumber, ApiName.Pages_BackStack_RegisterBackButtonPressHandler),
+    'backButtonPress',
+    handleBackButtonPress,
+    false,
+  );
+}
+
+function handleBackButtonPress(): void {
+  if (!backButtonPressHandler || !backButtonPressHandler()) {
+    if (Communication.childWindow) {
+      // If the current window did not handle it let the child window
+      sendMessageEventToChild('backButtonPress', []);
+    } else {
+      pages.backStack.navigateBack();
+    }
+  }
 }


### PR DESCRIPTION
Teams-JS currently has a bug that occurs when library consumers import the library dynamically, such as when using the syntax 
`import('@microsoft/teams-js').then(({ app, pages }) => { //DO STUFF });`, instead of the commonly used static import syntax, `import { app, pages } from '@microsoft/teams-js'`. For some reason that I still am not entirely sure the reason of (and I doubt I'll ever definitively be able to pinpoint, as it pertains to the innerworkings of how ecmascript async module resolution functions), when using rollup to build an app with the dynamic import syntax, it causes an error stating: `Uncaught (in promise) ReferenceError: Cannot access 'backStack' before initialization`. This error is occurring because for some reason, when rollup is generating the bundle, the `backstack` object is being defined _after_ the `pages` object, despite the fact that the `pages` object references the `backstack` object, so when the bundle is parsed by the browser at runtime, it reaches the `backstack` reference in the `pages` object, and sees that it is undefined and throws the error. From what I could find in my investigation, this is most likely due to the large number of circular dependencies in our library, especially surrounding the `pages` capability. I was able to determine that the line in the `handlers.ts` file that calls `pages.backstack._initialize()` was problematic as it was a major contributing factor to the circular dependencies and commenting out that line appeared to alleviate the issue. In order to remove the `pages` reference from `handlers.ts`, I refactored the `backstack` initialization code to be inside a helper file in the `pagesHelpers.ts` file. This way we can have `handlers.ts` call the helper function directly and import `pagesHelpers.ts` instead of `pages.ts`. Since the `_initialization` function in `backstack` is technically an exported api by the library, we have to leave its calling signature unchanged to maintain back compat, so I refactored it to just call the helper function, even if it isn't being used anywhere else in the library anymore after the helper refactor.
