### PR TITLE
Refactor child communication to own module

### DIFF
--- a/change/@microsoft-teams-js-92414722-9f1f-44c2-8b05-2f4c5655b02d.json
+++ b/change/@microsoft-teams-js-92414722-9f1f-44c2-8b05-2f4c5655b02d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Refactored child communication to an isolated module, no functionality change. This will allow apps to tree shake this module.",
+  "packageName": "@microsoft/teams-js",
+  "email": "jcardenasr123@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/childCommunication.ts
+++ b/packages/teams-js/src/internal/childCommunication.ts
@@ -62,7 +62,7 @@ type SetCallbackForRequest = (uuid: MessageUUID, callback: Function) => void;
  * @internal
  * Limited to Microsoft-internal use
  */
-export function shouldMessageBeProxiedToParent(messageSource: Window, messageOrigin: string): boolean {
+export function shouldProcessChildMessage(messageSource: Window, messageOrigin: string): boolean {
   if (!ChildCommunication.window || ChildCommunication.window.closed || messageSource === ChildCommunication.window) {
     ChildCommunication.window = messageSource;
     ChildCommunication.origin = messageOrigin;
@@ -83,7 +83,7 @@ export function shouldMessageBeProxiedToParent(messageSource: Window, messageOri
  * @internal
  * Limited to Microsoft-internal use
  */
-export async function proxyChildMessageToParent(
+export async function handleIncomingMessageFromChild(
   evt: DOMMessageEvent,
   messageSource: Window,
   sendMessageToParentHelper: SendMessageToParentHelper,
@@ -98,7 +98,7 @@ export async function proxyChildMessageToParent(
   flushMessageQueue(ChildCommunication.window, ChildCommunication.origin, ChildCommunication.messageQueue, 'child');
 
   // Handle the message
-  handleIncomingMessageFromChild(evt, sendMessageToParentHelper, setCallbackForRequest);
+  handleIncomingMessage(evt, sendMessageToParentHelper, setCallbackForRequest);
 }
 
 const handleIncomingMessageFromChildLogger = communicationLogger.extend('handleIncomingMessageFromChild');
@@ -107,7 +107,7 @@ const handleIncomingMessageFromChildLogger = communicationLogger.extend('handleI
  * @internal
  * Limited to Microsoft-internal use
  */
-function handleIncomingMessageFromChild(
+function handleIncomingMessage(
   evt: DOMMessageEvent,
   sendMessageToParentHelper: SendMessageToParentHelper,
   setCallbackForRequest: SetCallbackForRequest,

--- a/packages/teams-js/src/internal/childCommunication.ts
+++ b/packages/teams-js/src/internal/childCommunication.ts
@@ -1,0 +1,255 @@
+/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { UUID as MessageUUID } from '../public/uuidObject';
+import { flushMessageQueue, getMessageIdsAsLogString } from './communicationUtils';
+import { callHandler } from './handlers';
+import { DOMMessageEvent } from './interfaces';
+import {
+  deserializeMessageRequest,
+  MessageID,
+  MessageRequest,
+  MessageRequestWithRequiredProperties,
+  MessageResponse,
+  SerializedMessageRequest,
+  serializeMessageResponse,
+} from './messageObjects';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from './telemetry';
+import { getLogger } from './telemetry';
+
+const communicationLogger = getLogger('childProxyingCommunication');
+
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+class ChildCommunication {
+  public static window: Window | null;
+  public static origin: string | null;
+  public static messageQueue: MessageRequest[] = [];
+}
+
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function uninitializeChildCommunication(): void {
+  ChildCommunication.window = null;
+  ChildCommunication.origin = null;
+  ChildCommunication.messageQueue = [];
+}
+
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function shouldEventBeRelayedToChild(): boolean {
+  return !!ChildCommunication.window;
+}
+
+type SendMessageToParentHelper = (
+  apiVersionTag: string,
+  func: string,
+  args?: any[],
+  isProxiedFromChild?: boolean,
+) => MessageRequestWithRequiredProperties;
+
+type SetCallbackForRequest = (uuid: MessageUUID, callback: Function) => void;
+
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function shouldMessageBeProxiedToParent(messageSource: Window, messageOrigin: string): boolean {
+  if (!ChildCommunication.window || ChildCommunication.window.closed || messageSource === ChildCommunication.window) {
+    ChildCommunication.window = messageSource;
+    ChildCommunication.origin = messageOrigin;
+  }
+
+  // Clean up pointers to child windows
+  if (ChildCommunication.window && ChildCommunication.window.closed) {
+    ChildCommunication.window = null;
+    ChildCommunication.origin = null;
+    return false;
+  }
+
+  return ChildCommunication.window === messageSource;
+}
+
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export async function proxyChildMessageToParent(
+  evt: DOMMessageEvent,
+  messageSource: Window,
+  sendMessageToParentHelper: SendMessageToParentHelper,
+  setCallbackForRequest: SetCallbackForRequest,
+): Promise<void> {
+  // Do not do anything if message source does not match child window
+  if (ChildCommunication.window !== messageSource) {
+    return;
+  }
+
+  // If we have any messages in our queue, send them now
+  flushMessageQueue(ChildCommunication.window, ChildCommunication.origin, ChildCommunication.messageQueue, 'child');
+
+  // Handle the message
+  handleIncomingMessageFromChild(evt, sendMessageToParentHelper, setCallbackForRequest);
+}
+
+const handleIncomingMessageFromChildLogger = communicationLogger.extend('handleIncomingMessageFromChild');
+
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+function handleIncomingMessageFromChild(
+  evt: DOMMessageEvent,
+  sendMessageToParentHelper: SendMessageToParentHelper,
+  setCallbackForRequest: SetCallbackForRequest,
+): void {
+  if (evt.data.id === undefined || evt.data.func === undefined) {
+    return;
+  }
+
+  // Try to delegate the request to the proper handler, if defined
+  const message = deserializeMessageRequest(evt.data as SerializedMessageRequest);
+  const [called, result] = callHandler(message.func, message.args);
+
+  // If a handler was called and returned a value, send the response back to the child
+  if (called && typeof result !== 'undefined') {
+    handleIncomingMessageFromChildLogger(
+      'Handler called in response to message %s from child. Returning response from handler to child, action: %s.',
+      getMessageIdsAsLogString(message),
+      message.func,
+    );
+
+    sendMessageResponseToChild(message.id!, message.uuid, Array.isArray(result) ? result : [result]);
+    return;
+  }
+
+  // No handler, proxy to parent
+  handleIncomingMessageFromChildLogger(
+    'No handler for message %s from child found; relaying message on to parent, action: %s. Relayed message will have a new id.',
+    getMessageIdsAsLogString(message),
+    message.func,
+  );
+
+  sendChildMessageToParent(message, sendMessageToParentHelper, setCallbackForRequest);
+}
+
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+function sendChildMessageToParent(
+  message: MessageRequest,
+  sendMessageToParentHelper: SendMessageToParentHelper,
+  setCallbackForRequest: SetCallbackForRequest,
+): void {
+  const request = sendMessageToParentHelper(
+    getApiVersionTag(ApiVersionNumber.V_2, ApiName.Tasks_StartTask),
+    message.func,
+    message.args,
+    true, // Tags message as proxied from child
+  );
+  setCallbackForRequest(request.uuid, (...args: any[]): void => {
+    if (ChildCommunication.window) {
+      const isPartialResponse = args.pop();
+      handleIncomingMessageFromChildLogger(
+        'Message from parent being relayed to child, id: %s',
+        getMessageIdsAsLogString(message),
+      );
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      sendMessageResponseToChild(message.id, message.uuid, args, isPartialResponse);
+    }
+  });
+}
+
+/**
+ * @hidden
+ * Send a response to child for a message request that was from child
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+function sendMessageResponseToChild(
+  id: MessageID,
+  uuid?: MessageUUID,
+  args?: any[],
+  isPartialResponse?: boolean,
+): void {
+  const targetWindow = ChildCommunication.window;
+  const response = createMessageResponse(id, uuid, args, isPartialResponse);
+  const serializedResponse = serializeMessageResponse(response);
+  const targetOrigin = ChildCommunication.origin;
+  if (targetWindow && targetOrigin) {
+    handleIncomingMessageFromChildLogger(
+      'Sending message %s to %s via postMessage, args = %o',
+      getMessageIdsAsLogString(serializedResponse),
+      'child',
+      serializedResponse.args,
+    );
+    targetWindow.postMessage(serializedResponse, targetOrigin);
+  }
+}
+
+/**
+ * @hidden
+ * Send a custom message object that can be sent to child window,
+ * instead of a response message to a child
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function sendMessageEventToChild(actionName: string, args?: any[]): void {
+  const targetWindow = ChildCommunication.window;
+  /* eslint-disable-next-line strict-null-checks/all */ /* Fix tracked by 5730662 */
+  const customEvent = createMessageEvent(actionName, args);
+  const targetOrigin = ChildCommunication.origin;
+
+  // If the target window isn't closed and we already know its origin, send the message right away; otherwise,
+  // queue the message and send it after the origin is established
+  if (targetWindow && targetOrigin) {
+    targetWindow.postMessage(customEvent, targetOrigin);
+  } else {
+    ChildCommunication.messageQueue.push(customEvent);
+  }
+}
+
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+function createMessageResponse(
+  id: MessageID,
+  uuid?: MessageUUID,
+  args?: unknown[] | undefined,
+  isPartialResponse?: boolean,
+): MessageResponse {
+  return {
+    id: id,
+    uuid: uuid,
+    args: args || [],
+    isPartialResponse,
+  };
+}
+
+/**
+ * @hidden
+ * Creates a message object without any id and api version, used for custom actions being sent to child frame/window
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+function createMessageEvent(func: string, args?: unknown[]): MessageRequest {
+  return {
+    func: func,
+    args: args || [],
+  };
+}

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -704,8 +704,8 @@ async function shouldProcessIncomingMessage(messageSource: Window, messageOrigin
  * Limited to Microsoft-internal use
  */
 function updateRelationships(messageSource: Window, messageOrigin: string): void {
-  // Determine whether the source of the message is our parent and update our
-  // window and origin pointer accordingly
+  // Determine if the source of the message is our parent and update our window and
+  // origin pointer accordingly.
   // For frameless windows (i.e mobile), there is no parent frame
   if (
     !GlobalVars.isFramelessWindow &&
@@ -715,7 +715,7 @@ function updateRelationships(messageSource: Window, messageOrigin: string): void
     Communication.parentOrigin = messageOrigin;
   }
 
-  // Clean up pointers to closed parent and child windows
+  // Clean up pointers to closed parent windows
   if (Communication.parentWindow && Communication.parentWindow.closed) {
     Communication.parentWindow = null;
     Communication.parentOrigin = null;

--- a/packages/teams-js/src/internal/communicationUtils.ts
+++ b/packages/teams-js/src/internal/communicationUtils.ts
@@ -1,0 +1,54 @@
+import { UUID as MessageUUID } from '../public/uuidObject';
+import { MessageRequest, SerializedMessageRequest, serializeMessageRequest } from './messageObjects';
+import { getLogger } from './telemetry';
+
+interface MessageWithUUIDOrID {
+  uuidAsString?: string;
+  uuid?: MessageUUID;
+  id?: number | undefined;
+}
+
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function getMessageIdsAsLogString(message: MessageWithUUIDOrID): string {
+  if (message.uuidAsString !== undefined) {
+    return `${message.uuidAsString} (legacy id: ${message.id})`;
+  }
+  if (message.uuid !== undefined) {
+    return `${message.uuid.toString()} (legacy id: ${message.id})`;
+  }
+  return `legacy id: ${message.id} (no uuid)`;
+}
+
+const flushMessageQueueLogger = getLogger('flushMessageQueue');
+
+/**
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export function flushMessageQueue(
+  targetWindow: Window | null,
+  targetOrigin: string | null,
+  targetMessageQueue: MessageRequest[],
+  target: 'top' | 'parent' | 'child',
+): void {
+  if (!targetWindow || !targetOrigin || targetMessageQueue.length === 0) {
+    return;
+  }
+  while (targetMessageQueue.length > 0) {
+    const messageRequest = targetMessageQueue.shift();
+    if (messageRequest) {
+      const request: SerializedMessageRequest = serializeMessageRequest(messageRequest);
+      flushMessageQueueLogger(
+        'Flushing message %s from %s message queue via postMessage.',
+        getMessageIdsAsLogString(request),
+        target,
+      );
+
+      targetWindow.postMessage(request, targetOrigin);
+    }
+  }
+}

--- a/packages/teams-js/src/internal/communicationUtils.ts
+++ b/packages/teams-js/src/internal/communicationUtils.ts
@@ -26,6 +26,7 @@ export function getMessageIdsAsLogString(message: MessageWithUUIDOrID): string {
 const flushMessageQueueLogger = getLogger('flushMessageQueue');
 
 /**
+ * @hidden
  * @internal
  * Limited to Microsoft-internal use
  */

--- a/packages/teams-js/src/internal/pagesHelpers.ts
+++ b/packages/teams-js/src/internal/pagesHelpers.ts
@@ -9,12 +9,11 @@ import {
 } from '../public/interfaces';
 import * as pages from '../public/pages/pages';
 import { runtime } from '../public/runtime';
+import { sendMessageEventToChild, shouldEventBeRelayedToChild } from './childCommunication';
 import {
-  Communication,
   sendAndHandleStatusAndReason,
   sendAndHandleStatusAndReasonWithDefaultError,
   sendAndUnwrap,
-  sendMessageEventToChild,
   sendMessageToParent,
 } from './communication';
 import { registerHandler } from './handlers';
@@ -210,7 +209,7 @@ export function initializeBackStackHelper(): void {
 
 function handleBackButtonPress(): void {
   if (!backButtonPressHandler || !backButtonPressHandler()) {
-    if (Communication.childWindow) {
+    if (shouldEventBeRelayedToChild()) {
       // If the current window did not handle it let the child window
       sendMessageEventToChild('backButtonPress', []);
     } else {

--- a/packages/teams-js/src/private/privateAPIs.ts
+++ b/packages/teams-js/src/private/privateAPIs.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Communication, sendMessageEventToChild, sendMessageToParent } from '../internal/communication';
+import { sendMessageEventToChild, shouldEventBeRelayedToChild } from '../internal/childCommunication';
+import { sendMessageToParent } from '../internal/communication';
 import { registerHandler } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -57,8 +58,7 @@ export function sendCustomMessage(actionName: string, args?: any[], callback?: (
 
 /**
  * @hidden
- * Sends a custom action MessageEvent to a child iframe/window, only if you are not using auth popup.
- * Otherwise it will go to the auth popup (which becomes the child)
+ * Sends a custom action MessageEvent to a child iframe/window.
  *
  * @param actionName - Specifies name of the custom action to be sent
  * @param args - Specifies additional arguments passed to the action
@@ -71,9 +71,10 @@ export function sendCustomEvent(actionName: string, args?: any[]): void {
   ensureInitialized(runtime);
 
   //validate childWindow
-  if (!Communication.childWindow) {
+  if (!shouldEventBeRelayedToChild()) {
     throw new Error('The child window has not yet been initialized or is not present');
   }
+
   sendMessageEventToChild(actionName, args);
 }
 

--- a/packages/teams-js/src/public/pages/config.ts
+++ b/packages/teams-js/src/public/pages/config.ts
@@ -4,7 +4,8 @@
  * @module
  */
 
-import { Communication, sendMessageEventToChild, sendMessageToParent } from '../../internal/communication';
+import { sendMessageEventToChild, shouldEventBeRelayedToChild } from '../../internal/childCommunication';
+import { sendMessageToParent } from '../../internal/communication';
 import { registerHandler, registerHandlerHelper } from '../../internal/handlers';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import {
@@ -161,7 +162,7 @@ function handleSave(result?: SaveParameters): void {
   const saveEventType = new SaveEventImpl(result);
   if (saveHandler) {
     saveHandler(saveEventType);
-  } else if (Communication.childWindow) {
+  } else if (shouldEventBeRelayedToChild()) {
     sendMessageEventToChild('settings.save', [result]);
   } else {
     // If no handler is registered, we assume success.
@@ -271,7 +272,7 @@ function handleRemove(): void {
   const removeEventType = new RemoveEventImpl();
   if (removeHandler) {
     removeHandler(removeEventType);
-  } else if (Communication.childWindow) {
+  } else if (shouldEventBeRelayedToChild()) {
     sendMessageEventToChild('settings.remove', []);
   } else {
     // If no handler is registered, we assume success.

--- a/packages/teams-js/test/internal/childCommunication.spec.ts
+++ b/packages/teams-js/test/internal/childCommunication.spec.ts
@@ -1,0 +1,158 @@
+import {
+  proxyChildMessageToParent,
+  sendMessageEventToChild,
+  shouldEventBeRelayedToChild,
+  shouldMessageBeProxiedToParent,
+  uninitializeChildCommunication,
+} from '../../src/internal/childCommunication';
+import { uninitializeCommunication } from '../../src/internal/communication';
+import { DOMMessageEvent } from '../../src/internal/interfaces';
+import * as app from '../../src/public/app/app';
+import { Utils } from '../utils';
+
+describe('childCommunication', () => {
+  let utils = new Utils();
+  let childOrigin = '';
+  let mockOrigin = '';
+
+  beforeEach(() => {
+    utils = new Utils();
+    childOrigin = utils.childWindow.location.origin;
+    mockOrigin = utils.mockWindow.location.origin;
+  });
+
+  afterEach(() => {
+    uninitializeCommunication();
+  });
+
+  describe('uninitializeChildCommunication', () => {
+    it('after un-initializing should avoid message event relaying to child apps', () => {
+      // this will set the child window
+      shouldMessageBeProxiedToParent(utils.childWindow, childOrigin);
+      expect(shouldEventBeRelayedToChild()).toBe(true);
+
+      uninitializeChildCommunication();
+
+      expect(shouldEventBeRelayedToChild()).toBe(false);
+    });
+
+    it('after un-initializing new child messages will be proxied to a new window', () => {
+      expect(shouldMessageBeProxiedToParent(utils.childWindow, childOrigin)).toBe(true);
+      expect(shouldMessageBeProxiedToParent(utils.mockWindow, mockOrigin)).toBe(false);
+
+      uninitializeChildCommunication();
+
+      expect(shouldMessageBeProxiedToParent(utils.mockWindow, mockOrigin)).toBe(true);
+    });
+  });
+
+  describe('shouldEventBeRelayedToChild', () => {
+    it('should return false if child window is not initialized', () => {
+      expect(shouldEventBeRelayedToChild()).toBe(false);
+    });
+
+    it('should return true if child window is initialized', () => {
+      shouldMessageBeProxiedToParent(utils.childWindow, childOrigin);
+      expect(shouldEventBeRelayedToChild()).toBe(true);
+    });
+  });
+
+  describe('shouldMessageBeProxiedToParent', () => {
+    it('should return true if its the first message from a child window', () => {
+      expect(shouldMessageBeProxiedToParent(utils.childWindow, childOrigin)).toBe(true);
+    });
+
+    it('should return false if child window is closed', () => {
+      expect(shouldMessageBeProxiedToParent(utils.childWindow, childOrigin)).toBe(true);
+
+      utils.childWindow.closed = true;
+      expect(shouldMessageBeProxiedToParent(utils.childWindow, childOrigin)).toBe(false);
+    });
+
+    it('should return false if child window is not the source of the message', () => {
+      expect(shouldMessageBeProxiedToParent(utils.childWindow, childOrigin)).toBe(true);
+      expect(shouldMessageBeProxiedToParent(utils.mockWindow, mockOrigin)).toBe(false);
+    });
+
+    it('should return true if previous child window is closed and new child message is received', () => {
+      expect(shouldMessageBeProxiedToParent(utils.childWindow, childOrigin)).toBe(true);
+
+      utils.childWindow.closed = true;
+      expect(shouldMessageBeProxiedToParent(utils.mockWindow, mockOrigin)).toBe(true);
+    });
+  });
+
+  describe('sendMessageEventToChild', () => {
+    it('it should send message event to child window', () => {
+      // Set child window
+      shouldMessageBeProxiedToParent(utils.childWindow, childOrigin);
+
+      // Send event
+      sendMessageEventToChild('event1');
+
+      // Should have received previous messages
+      expect(utils.childMessages).toContainEqual({ func: 'event1', args: [] });
+    });
+
+    it('should add message to queue if child window is not set', () => {
+      sendMessageEventToChild('test1');
+      sendMessageEventToChild('test2');
+
+      // Set child window
+      shouldMessageBeProxiedToParent(utils.childWindow, childOrigin);
+
+      // Trigger queue to be flushed
+      proxyChildMessageToParent({ data: {} } as DOMMessageEvent, utils.childWindow, jest.fn(), jest.fn());
+
+      // Should have received previous messages
+      expect(utils.childMessages).toContainEqual({ func: 'test1', args: [] });
+      expect(utils.childMessages).toContainEqual({ func: 'test2', args: [] });
+    });
+  });
+
+  describe('proxyChildMessageToParent', () => {
+    afterEach(() => {
+      app._uninitialize();
+    });
+
+    it('messages proxied from child should be tagged as proxied from child', async () => {
+      expect.assertions(1);
+      await utils.initializeWithContext('context');
+      await utils.sendMessageFromChild('test1', ['testArg1']);
+      const sentMessage = utils.findMessageByActionName('test1');
+      expect(sentMessage.isProxiedFromChild).toBe(true);
+    });
+
+    it('messages that do not come from the parent are assumed from a child app and proxied to the parent', async () => {
+      expect.assertions(1);
+      await utils.initializeWithContext('context');
+      await utils.sendMessageFromChild('test1', ['testArg1']);
+      const sentMessage = utils.findMessageByFunc('test1');
+      expect(sentMessage).not.toBeNull();
+    });
+
+    it('only messages of active child window are proxied to the parent', async () => {
+      expect.assertions(2);
+      await utils.initializeWithContext('context');
+
+      // Send message from active child window
+      await utils.sendMessageFromChild('test1', ['testArg1']);
+      const sentMessage = utils.findMessageByFunc('test1');
+      expect(sentMessage).not.toBeNull();
+
+      // Send message from other child window
+      await utils.sendCustomMessage(
+        utils.validOrigin,
+        {
+          postMessage: jest.fn(),
+          close: jest.fn(),
+          closed: false,
+        },
+        'test2',
+        'testArg2',
+      );
+      const secondMessage = utils.findMessageByFunc('test2');
+      expect(secondMessage).toBeNull();
+    });
+  });
+});

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -1014,29 +1014,6 @@ describe('Testing communication', () => {
       }
     });
   });
-  describe('childProxyingCommunication', () => {
-    let utils: Utils = new Utils();
-    const actionName = 'test';
-
-    beforeEach(() => {
-      utils = new Utils();
-      communication.uninitializeCommunication();
-      app._initialize(utils.mockWindow);
-    });
-    afterEach(() => {
-      communication.Communication.currentWindow = utils.mockWindow;
-      communication.uninitializeCommunication();
-    });
-
-    it('messages proxied from child should be tagged as proxied from child', async () => {
-      expect.assertions(2);
-      await utils.initializeWithContext('context');
-      await utils.sendMessageFromChildToParentApp(actionName, ['testArg1']);
-      const sentMessage = utils.findMessageByFunc(actionName);
-      expect(sentMessage).not.toBeNull();
-      expect(sentMessage!.isProxiedFromChild).toBe(true);
-    });
-  });
   describe('sendNestedAuthRequestToTopWindow', () => {
     let utils: Utils = new Utils();
     const requestName = 'nestedAppAuth.execute';

--- a/packages/teams-js/test/internal/communicationUtils.spec.ts
+++ b/packages/teams-js/test/internal/communicationUtils.spec.ts
@@ -1,0 +1,59 @@
+import { flushMessageQueue, getMessageIdsAsLogString } from '../../src/internal/communicationUtils';
+import { UUID } from '../../src/public';
+
+describe('communicationUtils', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getMessageIdsAsLogString', () => {
+    it('if uuidAsString field is set, it should return it in log', () => {
+      const message = { uuidAsString: 'uuidAsString', id: 3 };
+      const result = getMessageIdsAsLogString(message);
+      expect(result).toBe('uuidAsString (legacy id: 3)');
+    });
+
+    it('if uuid field is set, is should return it as a string in the log', () => {
+      const mockUUID = { toString: jest.fn(() => 'uuid') } as unknown as UUID;
+      const message = { uuid: mockUUID, id: 3 };
+      const result = getMessageIdsAsLogString(message);
+      expect(mockUUID.toString).toHaveBeenCalled();
+      expect(result).toBe('uuid (legacy id: 3)');
+    });
+
+    it('if only id is present it should return it in log', () => {
+      const message = { id: 3 };
+      const result = getMessageIdsAsLogString(message);
+      expect(result).toBe('legacy id: 3 (no uuid)');
+    });
+  });
+
+  describe('flushMessageQueue', () => {
+    it('if target window is null it should not change target queue', () => {
+      const targetWindow = null;
+      const targetOrigin = 'origin';
+      const targetMessageQueue = [{ id: 1, func: 'func' }];
+      const target = 'top';
+      flushMessageQueue(targetWindow, targetOrigin, targetMessageQueue, target);
+      expect(targetMessageQueue).toEqual([{ id: 1, func: 'func' }]);
+    });
+
+    it('if target origin is null it should not change target queue', () => {
+      const targetWindow = { postMessage: jest.fn() } as unknown as Window;
+      const targetOrigin = null;
+      const targetMessageQueue = [{ id: 1, func: 'func' }];
+      const target = 'top';
+      flushMessageQueue(targetWindow, targetOrigin, targetMessageQueue, target);
+      expect(targetMessageQueue).toEqual([{ id: 1, func: 'func' }]);
+    });
+
+    it('if target window and origin are not null it should empty the target queue in-place', () => {
+      const targetWindow = { postMessage: jest.fn() } as unknown as Window;
+      const targetOrigin = 'origin';
+      const targetMessageQueue = [{ id: 1, func: 'func' }];
+      const target = 'top';
+      flushMessageQueue(targetWindow, targetOrigin, targetMessageQueue, target);
+      expect(targetMessageQueue).toEqual([]);
+    });
+  });
+});

--- a/packages/teams-js/test/private/privateAPIs.spec.ts
+++ b/packages/teams-js/test/private/privateAPIs.spec.ts
@@ -61,7 +61,7 @@ describe('AppSDK-privateAPIs', () => {
 
   unSupportedDomains.forEach((unSupportedDomain) => {
     it('should reject utils.messages from unsupported domain: ' + unSupportedDomain, async () => {
-      await utils.initializeWithContext('content', null, ['http://invalid.origin.com']);
+      await utils.initializeWithContext('content', undefined, ['http://invalid.origin.com']);
       let callbackCalled = false;
       app.getContext().then(() => {
         callbackCalled = true;
@@ -71,11 +71,11 @@ describe('AppSDK-privateAPIs', () => {
       expect(getContextMessage).not.toBeNull();
 
       callbackCalled = false;
-      await utils.processMessage({
+      await utils.processMessage!({
         origin: unSupportedDomain,
         source: utils.mockWindow.parent,
         data: {
-          id: getContextMessage.id,
+          id: getContextMessage!.id,
           args: [
             {
               groupId: 'someMaliciousValue',
@@ -125,17 +125,17 @@ describe('AppSDK-privateAPIs', () => {
 
   supportedDomains.forEach((supportedDomain) => {
     it('should allow utils.messages from supported domain ' + supportedDomain, async () => {
-      await utils.initializeWithContext('content', null, ['https://tasks.office.com', 'https://www.example.com']);
+      await utils.initializeWithContext('content', undefined, ['https://tasks.office.com', 'https://www.example.com']);
       const contextPromise = app.getContext();
 
       const getContextMessage = utils.findMessageByFunc('getContext');
       expect(getContextMessage).not.toBeNull();
 
-      utils.processMessage({
+      utils.processMessage!({
         origin: supportedDomain,
         source: utils.mockWindow.parent,
         data: {
-          id: getContextMessage.id,
+          id: getContextMessage!.id,
           args: [
             {
               groupId: 'someMaliciousValue',
@@ -155,11 +155,11 @@ describe('AppSDK-privateAPIs', () => {
     const initMessage = utils.findMessageByFunc('initialize');
     expect(initMessage).not.toBeNull();
 
-    utils.processMessage({
+    utils.processMessage!({
       origin: 'https://some-malicious-site.com',
       source: utils.mockWindow.parent,
       data: {
-        id: initMessage.id,
+        id: initMessage!.id,
         args: ['content'],
       } as MessageResponse,
     } as MessageEvent);
@@ -171,11 +171,11 @@ describe('AppSDK-privateAPIs', () => {
       return;
     });
 
-    utils.processMessage({
+    utils.processMessage!({
       origin: 'http://some-invalid-origin.com',
       source: utils.mockWindow.parent,
       data: {
-        id: initMessage.id,
+        id: initMessage!.id,
         args: ['content'],
       } as MessageResponse,
     } as MessageEvent);
@@ -192,6 +192,7 @@ describe('AppSDK-privateAPIs', () => {
   });
 
   it('should successfully handle calls queued before init completes', async () => {
+    expect.assertions(4);
     const initPromise = app.initialize();
 
     // Another call made before the init response
@@ -199,8 +200,7 @@ describe('AppSDK-privateAPIs', () => {
 
     // Only the init call went out
     expect(utils.messages.length).toBe(1);
-    const initMessage = utils.findMessageByFunc('initialize');
-    expect(initMessage).not.toBeNull();
+    const initMessage = utils.findMessageByActionName('initialize');
     expect(utils.findMessageByFunc('getContext')).toBeNull();
 
     // init completes
@@ -336,6 +336,7 @@ describe('AppSDK-privateAPIs', () => {
   });
 
   it('should only call callbacks once', async () => {
+    expect.assertions(1);
     await utils.initializeWithContext('content');
 
     let callbackCalled = 0;
@@ -343,8 +344,7 @@ describe('AppSDK-privateAPIs', () => {
       callbackCalled++;
     });
 
-    const getContextMessage = utils.findMessageByFunc('getContext');
-    expect(getContextMessage).not.toBeNull();
+    const getContextMessage = utils.findMessageByActionName('getContext');
 
     const expectedContext: Context = {
       locale: 'someLocale',
@@ -393,7 +393,7 @@ describe('AppSDK-privateAPIs', () => {
     utils.initializeAsFrameless(['https://www.example.com']);
 
     // Simulate recieving a child message as a frameless window
-    await utils.processMessage({
+    await utils.processMessage!({
       origin: 'https://www.example.com',
       source: utils.childWindow,
       data: {
@@ -408,10 +408,11 @@ describe('AppSDK-privateAPIs', () => {
   });
 
   it('should properly pass partial responses to nested child frames ', async () => {
+    expect.assertions(5);
     utils.initializeAsFrameless(['https://www.example.com']);
 
     // Simulate recieving a child message as a frameless window
-    await utils.processMessage({
+    await utils.processMessage!({
       origin: 'https://www.example.com',
       source: utils.childWindow,
       data: {
@@ -422,8 +423,8 @@ describe('AppSDK-privateAPIs', () => {
     } as MessageEvent);
 
     // Send a partial response back
-    const parentMessage = utils.findMessageByFunc('testPartialFunc1');
-    await utils.respondToNativeMessage(parentMessage, true, {});
+    const parentMessage = utils.findMessageByActionName('testPartialFunc1');
+    utils.respondToNativeMessage(parentMessage, true, {});
 
     // The child window should properly receive the partial response plus
     // the original event
@@ -433,7 +434,7 @@ describe('AppSDK-privateAPIs', () => {
     expect(secondChildMessage.isPartialResponse).toBeTruthy();
 
     // Pass the final response (non partial)
-    await utils.respondToNativeMessage(parentMessage, false, {});
+    utils.respondToNativeMessage(parentMessage, false, {});
 
     // The child window should properly receive the non-partial response
     expect(utils.childMessages.length).toBe(3);
@@ -442,8 +443,8 @@ describe('AppSDK-privateAPIs', () => {
   });
 
   it('Proxy messages to child window', async () => {
-    await utils.initializeWithContext('content', null, ['https://teams.microsoft.com']);
-    await utils.processMessage({
+    await utils.initializeWithContext('content', undefined, ['https://teams.microsoft.com']);
+    await utils.processMessage!({
       origin: 'https://outlook.office.com',
       source: utils.childWindow,
       data: {
@@ -462,27 +463,26 @@ describe('AppSDK-privateAPIs', () => {
 
   describe('sendCustomMessage', () => {
     it('should successfully pass message and provided arguments', async () => {
+      expect.assertions(1);
       await utils.initializeWithContext('content');
 
       sendCustomMessage('customMessage', ['arg1', 2, 3.0, true]);
 
-      const message = utils.findMessageByFunc('customMessage');
-      expect(message).not.toBeNull();
+      const message = utils.findMessageByActionName('customMessage');
       expect(message.args).toEqual(['arg1', 2, 3.0, true]);
     });
   });
 
   describe('sendCustomMessageToChild', () => {
     it('should successfully pass message and provided arguments', async () => {
-      await utils.initializeWithContext('content', null, ['https://tasks.office.com']);
+      await utils.initializeWithContext('content', undefined, ['https://tasks.office.com']);
 
       //trigger child window setup
       //trigger processing of message received from child
-      await utils.processMessage({
+      await utils.processMessage!({
         origin: 'https://tasks.office.com',
         source: utils.childWindow,
         data: {
-          id: null,
           func: 'customAction1',
           args: ['arg1', 123, 4.5, true],
         } as MessageRequest,
@@ -493,7 +493,7 @@ describe('AppSDK-privateAPIs', () => {
 
       const message = utils.findMessageInChildByFunc(customActionName);
       expect(message).not.toBeNull();
-      expect(message.args).toEqual(['arg1', 234, 12.3, true]);
+      expect(message!.args).toEqual(['arg1', 234, 12.3, true]);
     });
   });
 
@@ -502,8 +502,8 @@ describe('AppSDK-privateAPIs', () => {
       await utils.initializeWithContext('content');
 
       const customActionName = 'customAction1';
-      let callbackCalled = false,
-        callbackArgs: any[] = null;
+      let callbackCalled = false;
+      let callbackArgs: any[] | null = null;
       registerCustomHandler(customActionName, (...args) => {
         callbackCalled = true;
         callbackArgs = args;
@@ -516,11 +516,11 @@ describe('AppSDK-privateAPIs', () => {
     });
 
     it('should successfully pass message and provided arguments of customAction from child', async () => {
-      await utils.initializeWithContext('content', null, ['https://tasks.office.com']);
+      await utils.initializeWithContext('content', undefined, ['https://tasks.office.com']);
 
       const customActionName = 'customAction2';
-      let callbackCalled = false,
-        callbackArgs: any[] = null;
+      let callbackCalled = false;
+      let callbackArgs: any[] | null = null;
       registerCustomHandler(customActionName, (...args) => {
         callbackCalled = true;
         callbackArgs = args;
@@ -528,11 +528,11 @@ describe('AppSDK-privateAPIs', () => {
       });
 
       //trigger processing of message received from child
-      await utils.processMessage({
+      await utils.processMessage!({
         origin: 'https://tasks.office.com',
         source: utils.childWindow,
         data: {
-          id: null,
+          id: 3,
           func: customActionName,
           args: ['arg1', 123, 4.5, true],
         } as MessageRequest,
@@ -543,11 +543,11 @@ describe('AppSDK-privateAPIs', () => {
     });
 
     it('should not process be invoked due to invalid origin message from child window', async () => {
-      await utils.initializeWithContext('content', null, ['https://tasks.office.com']);
+      await utils.initializeWithContext('content', undefined, ['https://tasks.office.com']);
 
       const customActionName = 'customAction2';
-      let callbackCalled = false,
-        callbackArgs: any[] = null;
+      let callbackCalled = false;
+      let callbackArgs: any[] | null = null;
       registerCustomHandler(customActionName, (...args) => {
         callbackCalled = true;
         callbackArgs = args;
@@ -555,11 +555,10 @@ describe('AppSDK-privateAPIs', () => {
       });
 
       //trigger processing of message received from child
-      await utils.processMessage({
+      await utils.processMessage!({
         origin: 'https://tasks.office.net',
         source: utils.childWindow,
         data: {
-          id: null,
           func: customActionName,
           args: ['arg1', 123, 4.5, true],
         } as MessageRequest,
@@ -592,28 +591,28 @@ describe('AppSDK-privateAPIs', () => {
     Object.values(FrameContexts).forEach((context) => {
       if (allowedContexts.some((allowedContexts) => allowedContexts === context)) {
         it('should successfully open a file preview with content frameContext', async () => {
+          expect.assertions(16);
           await utils.initializeWithContext(context);
 
           openFilePreview(openFilePreviewParams);
 
-          const message = utils.findMessageByFunc('openFilePreview');
-          expect(message).not.toBeNull();
-          expect(message.args.length).toBe(15);
-          expect(message.args[0]).toBe('someEntityId');
-          expect(message.args[1]).toBe('someTitle');
-          expect(message.args[2]).toBe('someDescription');
-          expect(message.args[3]).toBe('someType');
-          expect(message.args[4]).toBe('someObjectUrl');
-          expect(message.args[5]).toBe('someDownloadUrl');
-          expect(message.args[6]).toBe('someWebPreviewUrl');
-          expect(message.args[7]).toBe('someWebEditUrl');
-          expect(message.args[8]).toBe('someBaseUrl');
-          expect(message.args[9]).toBe(true);
-          expect(message.args[10]).toBe('someSubEntityId');
-          expect(message.args[11]).toBe('view');
-          expect(message.args[12]).toBe(FileOpenPreference.Web);
-          expect(message.args[13]).toBe('someConversationId');
-          expect(message.args[14]).toBe(1024);
+          const message = utils.findMessageByActionName('openFilePreview');
+          expect(message.args?.length).toBe(15);
+          expect(message.args?.[0]).toBe('someEntityId');
+          expect(message.args?.[1]).toBe('someTitle');
+          expect(message.args?.[2]).toBe('someDescription');
+          expect(message.args?.[3]).toBe('someType');
+          expect(message.args?.[4]).toBe('someObjectUrl');
+          expect(message.args?.[5]).toBe('someDownloadUrl');
+          expect(message.args?.[6]).toBe('someWebPreviewUrl');
+          expect(message.args?.[7]).toBe('someWebEditUrl');
+          expect(message.args?.[8]).toBe('someBaseUrl');
+          expect(message.args?.[9]).toBe(true);
+          expect(message.args?.[10]).toBe('someSubEntityId');
+          expect(message.args?.[11]).toBe('view');
+          expect(message.args?.[12]).toBe(FileOpenPreference.Web);
+          expect(message.args?.[13]).toBe('someConversationId');
+          expect(message.args?.[14]).toBe(1024);
         });
       } else {
         it(`remoteCamera.registerOnCapableParticipantsChangeHandler should not allow calls when initialized with ${context} context`, async () => {

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -136,6 +136,9 @@ export class Utils {
         return;
       },
       closed: false,
+      location: {
+        origin: this.validOrigin,
+      },
     };
   }
 
@@ -363,20 +366,24 @@ export class Utils {
     return this.sendMessageWithCustomOrigin(func, this.validOrigin, ...args);
   };
 
-  public async sendMessageFromChildToParentApp(func: string, ...args: unknown[]): Promise<void> {
+  public async sendMessageFromChild(func: string, ...args: unknown[]): Promise<void> {
+    await this.sendCustomMessage(this.childWindow.location.origin, this.childWindow, func, args);
+  }
+
+  public async sendCustomMessage(origin: string, window: unknown, func: string, ...args: unknown[]): Promise<void> {
     if (this.processMessage === null) {
       throw Error(
-        `Cannot send message calling function ${func} because processMessage function has not been set and is null`,
+        `Cannot send message with function ${func} because processMessage function has not been set and is null`,
       );
     }
 
     await this.processMessage({
-      origin: this.validOrigin,
-      source: this.childWindow,
+      origin,
+      source: window,
       data: {
-        id: 'id',
-        func: func,
-        args: args,
+        id: 3,
+        func,
+        args,
       },
     } as MessageEvent);
   }


### PR DESCRIPTION
## Description
This pull request refactors all the child communication to an isolated module. Although this allows for clear and independent separation for how child proxying works, this is mostly done so in a next PR we can tree shake this module with a feature flag. There is no particular functionality change introduced in this pull request.

### Main changes in the PR:

1. Refactor child communication to an isolated module.
2. Added proper unit tests to detail how child proxying and child event relaying works.

## Validation

### Validation performed:

1. Ran set of tests.
2. Ran child app to see if everything worked as usual.

### Unit Tests added:
Yes

### End-to-end tests added:

No

## Additional Requirements

### Change file added:
Yes

### Next/remaining steps:
A follow-up PR will make add a feature flag for using this module, which would then make it so all child proxying code is removed in the final bundle if not needed.
