### PR TITLE
Add "authId" and "connectionName" properties to ExternalAppAuthenticationForCEA.authenticateWithSSOAndResendRequest

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/ExternalAppAuthenticationForCEAAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/ExternalAppAuthenticationForCEAAPIs.tsx
@@ -161,6 +161,8 @@ const AuthenticateWithSSOAndResendRequestForCEA = (): React.ReactElement =>
     conversationId: string;
     authTokenRequest: externalAppAuthentication.AuthTokenRequestParameters;
     originalRequestInfo: externalAppAuthentication.IActionExecuteInvokeRequest;
+    authId: string;
+    connectionName: string;
   }>({
     name: 'authenticateWithSSOAndResendRequestForCEA',
     title: 'Authenticate With SSO And Resend Request',
@@ -178,6 +180,12 @@ const AuthenticateWithSSOAndResendRequestForCEA = (): React.ReactElement =>
         if (!input.originalRequestInfo) {
           throw new Error('originalRequestInfo is required');
         }
+        if (!input.authId) {
+          throw new Error('authId is required');
+        }
+        if (!input.connectionName) {
+          throw new Error('connectionName is required');
+        }
       },
       submit: async (input) => {
         const result = await externalAppAuthenticationForCEA.authenticateWithSSOAndResendRequest(
@@ -185,6 +193,8 @@ const AuthenticateWithSSOAndResendRequestForCEA = (): React.ReactElement =>
           input.conversationId,
           input.authTokenRequest,
           input.originalRequestInfo,
+          input.authId,
+          input.connectionName,
         );
         return JSON.stringify(result);
       },
@@ -203,6 +213,8 @@ const AuthenticateWithSSOAndResendRequestForCEA = (): React.ReactElement =>
         verb: 'verb1',
         data: 'data1',
       },
+      authId: 'authId',
+      connectionName: 'connectionName',
     }),
   });
 

--- a/apps/teams-test-app/src/components/privateApis/ExternalAppAuthenticationForCEAAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/ExternalAppAuthenticationForCEAAPIs.tsx
@@ -159,10 +159,8 @@ const AuthenticateWithSSOAndResendRequestForCEA = (): React.ReactElement =>
   ApiWithTextInput<{
     appId: string;
     conversationId: string;
-    authTokenRequest: externalAppAuthentication.AuthTokenRequestParameters;
+    authTokenRequest: externalAppAuthenticationForCEA.AuthTokenRequestParametersForCEA;
     originalRequestInfo: externalAppAuthentication.IActionExecuteInvokeRequest;
-    authId: string;
-    connectionName: string;
   }>({
     name: 'authenticateWithSSOAndResendRequestForCEA',
     title: 'Authenticate With SSO And Resend Request',
@@ -180,10 +178,10 @@ const AuthenticateWithSSOAndResendRequestForCEA = (): React.ReactElement =>
         if (!input.originalRequestInfo) {
           throw new Error('originalRequestInfo is required');
         }
-        if (!input.authId) {
+        if (!input.authTokenRequest.authId) {
           throw new Error('authId is required');
         }
-        if (!input.connectionName) {
+        if (!input.authTokenRequest.connectionName) {
           throw new Error('connectionName is required');
         }
       },
@@ -193,8 +191,6 @@ const AuthenticateWithSSOAndResendRequestForCEA = (): React.ReactElement =>
           input.conversationId,
           input.authTokenRequest,
           input.originalRequestInfo,
-          input.authId,
-          input.connectionName,
         );
         return JSON.stringify(result);
       },
@@ -205,6 +201,8 @@ const AuthenticateWithSSOAndResendRequestForCEA = (): React.ReactElement =>
       authTokenRequest: {
         claims: ['https://graph.microsoft.com'],
         silent: true,
+        authId: 'authId',
+        connectionName: 'connectionName',
       },
       originalRequestInfo: {
         requestType: 'ActionExecuteInvokeRequest',
@@ -213,8 +211,6 @@ const AuthenticateWithSSOAndResendRequestForCEA = (): React.ReactElement =>
         verb: 'verb1',
         data: 'data1',
       },
-      authId: 'authId',
-      connectionName: 'connectionName',
     }),
   });
 

--- a/change/@microsoft-teams-js-b91fc37f-8189-4031-aec5-bedd6699cba1.json
+++ b/change/@microsoft-teams-js-b91fc37f-8189-4031-aec5-bedd6699cba1.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Added \"authId\" and \"connectionName\" parameters to `ExternalAppAuthenticationForCEA.authenticateWithSSOAndResendRequest`",
+  "comment": "Added \"authId\" and \"connectionName\" parameters to `authTokenRequest` in `ExternalAppAuthenticationForCEA.authenticateWithSSOAndResendRequest`",
   "packageName": "@microsoft/teams-js",
   "email": "jeklouda@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-b91fc37f-8189-4031-aec5-bedd6699cba1.json
+++ b/change/@microsoft-teams-js-b91fc37f-8189-4031-aec5-bedd6699cba1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added \"authId\" and \"connectionName\" parameters to `ExternalAppAuthenticationForCEA.authenticateWithSSOAndResendRequest`",
+  "packageName": "@microsoft/teams-js",
+  "email": "jeklouda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
+++ b/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
@@ -161,6 +161,8 @@ export async function authenticateAndResendRequest(
  * @param conversationId ConversationId To tell the bot what conversation the calls are coming from
  * @param authTokenRequest Parameters for SSO authentication
  * @param originalRequestInfo Information about the original request that should be resent
+ * @param id Id to complete the request
+ * @param connectionName Connection name to complete the request
  * @throws InvokeError if the host encounters an error while authenticating or resending the request
  * @returns A promise that resolves to the IActionExecuteResponse from the application backend and rejects with InvokeError if the host encounters an error while authenticating or resending the request
  */

--- a/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
+++ b/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
@@ -152,6 +152,24 @@ export async function authenticateAndResendRequest(
 }
 
 /**
+ * @hidden
+ * Parameters for SSO authentication. This interface is used exclusively with the externalAppAuthentication APIs
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export type AuthTokenRequestParametersForCEA = externalAppAuthentication.AuthTokenRequestParameters & {
+  /**
+   * Id to complete the request
+   */
+  authId: string;
+
+  /**
+   * Connection name to complete the request
+   */
+  connectionName: string;
+};
+
+/**
  * @beta
  * @hidden
  * Signals to the host to perform SSO authentication for the application specified by the app ID and then resend the request to the application backend with the authentication result and originalRequestInfo
@@ -161,18 +179,14 @@ export async function authenticateAndResendRequest(
  * @param conversationId ConversationId To tell the bot what conversation the calls are coming from
  * @param authTokenRequest Parameters for SSO authentication
  * @param originalRequestInfo Information about the original request that should be resent
- * @param id Id to complete the request
- * @param connectionName Connection name to complete the request
  * @throws InvokeError if the host encounters an error while authenticating or resending the request
  * @returns A promise that resolves to the IActionExecuteResponse from the application backend and rejects with InvokeError if the host encounters an error while authenticating or resending the request
  */
 export async function authenticateWithSSOAndResendRequest(
   appId: AppId,
   conversationId: string,
-  authTokenRequest: externalAppAuthentication.AuthTokenRequestParameters,
+  authTokenRequest: AuthTokenRequestParametersForCEA,
   originalRequestInfo: externalAppAuthentication.IActionExecuteInvokeRequest,
-  authId: string,
-  connectionName: string,
 ): Promise<externalAppAuthentication.IActionExecuteResponse> {
   ensureInitialized(runtime, FrameContexts.content);
 
@@ -193,10 +207,10 @@ export async function authenticateWithSSOAndResendRequest(
       appId,
       conversationId,
       new externalAppAuthentication.SerializableActionExecuteInvokeRequest(originalRequestInfo),
+      authTokenRequest.authId,
+      authTokenRequest.connectionName,
       authTokenRequest.claims,
       authTokenRequest.silent,
-      authId,
-      connectionName,
     ],
     new externalAppAuthentication.ActionExecuteResponseHandler(),
     getApiVersionTag(

--- a/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
+++ b/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
@@ -169,6 +169,8 @@ export async function authenticateWithSSOAndResendRequest(
   conversationId: string,
   authTokenRequest: externalAppAuthentication.AuthTokenRequestParameters,
   originalRequestInfo: externalAppAuthentication.IActionExecuteInvokeRequest,
+  authId: string,
+  connectionName: string,
 ): Promise<externalAppAuthentication.IActionExecuteResponse> {
   ensureInitialized(runtime, FrameContexts.content);
 
@@ -191,6 +193,8 @@ export async function authenticateWithSSOAndResendRequest(
       new externalAppAuthentication.SerializableActionExecuteInvokeRequest(originalRequestInfo),
       authTokenRequest.claims,
       authTokenRequest.silent,
+      authId,
+      connectionName,
     ],
     new externalAppAuthentication.ActionExecuteResponseHandler(),
     getApiVersionTag(

--- a/packages/teams-js/test/private/externalAppAuthenticationForCEA.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthenticationForCEA.spec.ts
@@ -26,6 +26,8 @@ describe('externalAppAuthenticationForCEA', () => {
   const stringified = '01b92759-b43a-4085-ac22-7772d94bb7a9';
   const testAppId = new AppId(stringified);
   const testConversationId = '01b92759-b43a-4085-ac22-777777777777';
+  const testAuthId = 'testAuthId';
+  const testConnectionName = 'testConnectionName';
 
   const testOriginalRequest: externalAppAuthentication.IActionExecuteInvokeRequest = {
     requestType: externalAppAuthentication.OriginalRequestType.ActionExecuteInvokeRequest,
@@ -388,6 +390,8 @@ describe('externalAppAuthenticationForCEA', () => {
           testConversationId,
           testAuthRequest,
           testOriginalRequest,
+          testAuthId,
+          testConnectionName,
         );
       } catch (e) {
         expect(e).toEqual(new Error(errorLibraryNotInitialized));
@@ -404,6 +408,8 @@ describe('externalAppAuthenticationForCEA', () => {
           testConversationId,
           testAuthRequest,
           testOriginalRequest,
+          testAuthId,
+          testConnectionName,
         );
       } catch (e) {
         expect(e).toEqual(errorNotSupportedOnPlatform);
@@ -422,6 +428,8 @@ describe('externalAppAuthenticationForCEA', () => {
               testConversationId,
               testAuthRequest,
               testOriginalRequest,
+              testAuthId,
+              testConnectionName,
             );
           } catch (e) {
             expect(e).toEqual(
@@ -443,6 +451,8 @@ describe('externalAppAuthenticationForCEA', () => {
             testConversationId,
             testAuthRequest,
             testOriginalRequest,
+            testAuthId,
+            testConnectionName,
           );
 
           const message = utils.findMessageByFunc(
@@ -456,6 +466,8 @@ describe('externalAppAuthenticationForCEA', () => {
               testOriginalRequest,
               testAuthRequest.claims,
               testAuthRequest.silent,
+              testAuthId,
+              testConnectionName,
             ]);
             // eslint-disable-next-line strict-null-checks/all
             utils.respondToMessage(message, testError);
@@ -474,6 +486,8 @@ describe('externalAppAuthenticationForCEA', () => {
             testConversationId,
             testAuthRequest,
             testOriginalRequest,
+            testAuthId,
+            testConnectionName,
           );
 
           const message = utils.findMessageByFunc(
@@ -491,6 +505,8 @@ describe('externalAppAuthenticationForCEA', () => {
               testOriginalRequest,
               testAuthRequest.claims,
               testAuthRequest.silent,
+              testAuthId,
+              testConnectionName,
             ]);
 
             // eslint-disable-next-line strict-null-checks/all
@@ -515,6 +531,8 @@ describe('externalAppAuthenticationForCEA', () => {
               testConversationId,
               testAuthRequest,
               invalidDataRequest,
+              testAuthId,
+              testConnectionName,
             );
           } catch (e) {
             expect(e).toEqual({
@@ -533,6 +551,8 @@ describe('externalAppAuthenticationForCEA', () => {
               testConversationId,
               testAuthRequest,
               testOriginalRequestWithInvalidType,
+              testAuthId,
+              testConnectionName,
             );
           } catch (e) {
             expect(e).toEqual({
@@ -557,6 +577,8 @@ describe('externalAppAuthenticationForCEA', () => {
             testConversationId,
             testAuthRequest,
             testOriginalRequest,
+            testAuthId,
+            testConnectionName,
           );
 
           const message = utils.findMessageByFunc(
@@ -570,6 +592,8 @@ describe('externalAppAuthenticationForCEA', () => {
               testOriginalRequest,
               testAuthRequest.claims,
               testAuthRequest.silent,
+              testAuthId,
+              testConnectionName,
             ]);
             // eslint-disable-next-line strict-null-checks/all
             utils.respondToMessage(message, testResponse);
@@ -586,6 +610,8 @@ describe('externalAppAuthenticationForCEA', () => {
               testConversationId,
               testAuthRequest,
               testOriginalRequest,
+              testAuthId,
+              testConnectionName,
             ),
           ).rejects.toThrow(
             new Error(

--- a/packages/teams-js/test/private/externalAppAuthenticationForCEA.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthenticationForCEA.spec.ts
@@ -377,9 +377,11 @@ describe('externalAppAuthenticationForCEA', () => {
   });
 
   describe('authenticateWithSSOAndResendRequest', () => {
-    const testAuthRequest = {
+    const testAuthRequest: externalAppAuthenticationForCEA.AuthTokenRequestParametersForCEA = {
       claims: ['claims'],
       silent: true,
+      authId: testAuthId,
+      connectionName: testConnectionName,
     };
     it('should not allow calls before initialization', async () => {
       expect.assertions(1);
@@ -390,8 +392,6 @@ describe('externalAppAuthenticationForCEA', () => {
           testConversationId,
           testAuthRequest,
           testOriginalRequest,
-          testAuthId,
-          testConnectionName,
         );
       } catch (e) {
         expect(e).toEqual(new Error(errorLibraryNotInitialized));
@@ -408,8 +408,6 @@ describe('externalAppAuthenticationForCEA', () => {
           testConversationId,
           testAuthRequest,
           testOriginalRequest,
-          testAuthId,
-          testConnectionName,
         );
       } catch (e) {
         expect(e).toEqual(errorNotSupportedOnPlatform);
@@ -428,8 +426,6 @@ describe('externalAppAuthenticationForCEA', () => {
               testConversationId,
               testAuthRequest,
               testOriginalRequest,
-              testAuthId,
-              testConnectionName,
             );
           } catch (e) {
             expect(e).toEqual(
@@ -451,8 +447,6 @@ describe('externalAppAuthenticationForCEA', () => {
             testConversationId,
             testAuthRequest,
             testOriginalRequest,
-            testAuthId,
-            testConnectionName,
           );
 
           const message = utils.findMessageByFunc(
@@ -464,10 +458,10 @@ describe('externalAppAuthenticationForCEA', () => {
               testAppId.toString(),
               testConversationId,
               testOriginalRequest,
-              testAuthRequest.claims,
-              testAuthRequest.silent,
               testAuthId,
               testConnectionName,
+              testAuthRequest.claims,
+              testAuthRequest.silent,
             ]);
             // eslint-disable-next-line strict-null-checks/all
             utils.respondToMessage(message, testError);
@@ -486,8 +480,6 @@ describe('externalAppAuthenticationForCEA', () => {
             testConversationId,
             testAuthRequest,
             testOriginalRequest,
-            testAuthId,
-            testConnectionName,
           );
 
           const message = utils.findMessageByFunc(
@@ -503,10 +495,10 @@ describe('externalAppAuthenticationForCEA', () => {
               testAppId.toString(),
               testConversationId,
               testOriginalRequest,
-              testAuthRequest.claims,
-              testAuthRequest.silent,
               testAuthId,
               testConnectionName,
+              testAuthRequest.claims,
+              testAuthRequest.silent,
             ]);
 
             // eslint-disable-next-line strict-null-checks/all
@@ -531,8 +523,6 @@ describe('externalAppAuthenticationForCEA', () => {
               testConversationId,
               testAuthRequest,
               invalidDataRequest,
-              testAuthId,
-              testConnectionName,
             );
           } catch (e) {
             expect(e).toEqual({
@@ -551,8 +541,6 @@ describe('externalAppAuthenticationForCEA', () => {
               testConversationId,
               testAuthRequest,
               testOriginalRequestWithInvalidType,
-              testAuthId,
-              testConnectionName,
             );
           } catch (e) {
             expect(e).toEqual({
@@ -577,8 +565,6 @@ describe('externalAppAuthenticationForCEA', () => {
             testConversationId,
             testAuthRequest,
             testOriginalRequest,
-            testAuthId,
-            testConnectionName,
           );
 
           const message = utils.findMessageByFunc(
@@ -590,10 +576,10 @@ describe('externalAppAuthenticationForCEA', () => {
               testAppId.toString(),
               testConversationId,
               testOriginalRequest,
-              testAuthRequest.claims,
-              testAuthRequest.silent,
               testAuthId,
               testConnectionName,
+              testAuthRequest.claims,
+              testAuthRequest.silent,
             ]);
             // eslint-disable-next-line strict-null-checks/all
             utils.respondToMessage(message, testResponse);
@@ -610,8 +596,6 @@ describe('externalAppAuthenticationForCEA', () => {
               testConversationId,
               testAuthRequest,
               testOriginalRequest,
-              testAuthId,
-              testConnectionName,
             ),
           ).rejects.toThrow(
             new Error(


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This PR adds "authId" and "connectionName" parameters to the `ExternalAppAuthenticationForCEA.authenticateWithSSOAndResendRequest` API. These parameters are required from the app to complete the original request.

### Main changes in the PR:

1. Add "authId" and "connectionName" parameters to the `authenticateWithSSOAndResendRequest` function in `packages/teams-js/src/private/externalAppAuthenticationForCEA.ts`.

## Validation

### Validation performed:

1. Tested against corresponding changes in the host SDK.

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes, updated existing tests to use new parameters

### End-to-end tests added:

No, added on host SDK

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes