### PR TITLE
Add two new AppType enums to support Townhall App Filtering

### DIFF
--- a/change/@microsoft-teams-js-ee0a1dbc-9fd6-4e2d-82bd-bc431674f89e.json
+++ b/change/@microsoft-teams-js-ee0a1dbc-9fd6-4e2d-82bd-bc431674f89e.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add new AppTypes enum values to filter base and streaming townhalls.",
+  "comment": "Added new `AppTypes` enum values to filter base and streaming townhalls.",
   "packageName": "@microsoft/teams-js",
   "email": "cmachart@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-ee0a1dbc-9fd6-4e2d-82bd-bc431674f89e.json
+++ b/change/@microsoft-teams-js-ee0a1dbc-9fd6-4e2d-82bd-bc431674f89e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add new AppTypes enum values to filter base and streaming townhalls.",
+  "packageName": "@microsoft/teams-js",
+  "email": "cmachart@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/hostEntity/hostEntity.ts
+++ b/packages/teams-js/src/private/hostEntity/hostEntity.ts
@@ -14,6 +14,8 @@ import * as tab from './tab';
 
 export enum AppTypes {
   edu = 'EDU',
+  baseTownhall = 'BASE_TOWNHALL',
+  streamingTownhall = 'STREAMING_TOWNHALL',
 }
 
 /**

--- a/packages/teams-js/src/private/hostEntity/hostEntity.ts
+++ b/packages/teams-js/src/private/hostEntity/hostEntity.ts
@@ -14,7 +14,13 @@ import * as tab from './tab';
 
 export enum AppTypes {
   edu = 'EDU',
+  /**
+   * Enum to indicate apps should be filtered for base Townhall.
+   */
   baseTownhall = 'BASE_TOWNHALL',
+  /**
+   * Enum to indicate apps should be filtered for streaming Townhall.
+   */
   streamingTownhall = 'STREAMING_TOWNHALL',
 }
 

--- a/packages/teams-js/test/private/hostEntity.spec.ts
+++ b/packages/teams-js/test/private/hostEntity.spec.ts
@@ -1,7 +1,6 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import * as hostEntity from '../../src/private/hostEntity/hostEntity';
-import { AppTypes } from '../../src/private/hostEntity/hostEntity';
 import { ErrorCode, FrameContexts } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';

--- a/packages/teams-js/test/private/hostEntity.spec.ts
+++ b/packages/teams-js/test/private/hostEntity.spec.ts
@@ -1,6 +1,7 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import * as hostEntity from '../../src/private/hostEntity/hostEntity';
+import { AppTypes } from '../../src/private/hostEntity/hostEntity';
 import { ErrorCode, FrameContexts } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
@@ -97,6 +98,21 @@ describe('hostEntity', () => {
           const message = utils.findMessageByFunc('hostEntity.tab.addAndConfigure');
           expect(message).not.toBeNull();
           expect(message?.args).toEqual([mockHostEntity, null]);
+          if (message) {
+            utils.respondToMessage(message, mockConfigurableTab);
+          }
+
+          return expect(promise).resolves.toEqual(mockConfigurableTab);
+        });
+
+        it(`hostEntity.tab.addAndConfigure should be pass message with the expected parameters including appTypes and initialized with ${context} context`, async () => {
+          expect.assertions(3);
+          await utils.initializeWithContext(context);
+          utils.setRuntimeConfig({ apiVersion: 2, supports: { hostEntity: { tab: {} } } });
+          const promise = hostEntity.tab.addAndConfigure(mockHostEntity, [hostEntity.AppTypes.streamingTownhall]);
+          const message = utils.findMessageByFunc('hostEntity.tab.addAndConfigure');
+          expect(message).not.toBeNull();
+          expect(message?.args).toEqual([mockHostEntity, ['STREAMING_TOWNHALL']]);
           if (message) {
             utils.respondToMessage(message, mockConfigurableTab);
           }


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description
Add two new enum values for base and streaming Townhalls to support Townhall app filtering.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Add new AppTypes enums
