### PR TITLE
Disable child proxying by default and add feature flag scaffolding

### DIFF
--- a/change/@microsoft-teams-js-e4e92ce6-5c08-405d-9345-a7464db00ecd.json
+++ b/change/@microsoft-teams-js-e4e92ce6-5c08-405d-9345-a7464db00ecd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Removed child messaging proxying by default to avoid security issues. If an app still needs this pattern, it can be activated through the feature flag function `activateChildProxyingCommunication` which enables child proxying for that app.",
+  "packageName": "@microsoft/teams-js",
+  "email": "31258166+juanscr@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/childCommunication.ts
+++ b/packages/teams-js/src/internal/childCommunication.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { isChildProxyingEnabled } from '../public/featureFlags';
 import { UUID as MessageUUID } from '../public/uuidObject';
 import { flushMessageQueue, getMessageIdsAsLogString } from './communicationUtils';
 import { callHandler } from './handlers';
@@ -45,6 +46,9 @@ export function uninitializeChildCommunication(): void {
  * Limited to Microsoft-internal use
  */
 export function shouldEventBeRelayedToChild(): boolean {
+  if (!isChildProxyingEnabled()) {
+    return false;
+  }
   return !!ChildCommunication.window;
 }
 
@@ -63,6 +67,10 @@ type SetCallbackForRequest = (uuid: MessageUUID, callback: Function) => void;
  * Limited to Microsoft-internal use
  */
 export function shouldProcessChildMessage(messageSource: Window, messageOrigin: string): boolean {
+  if (!isChildProxyingEnabled()) {
+    return false;
+  }
+
   if (!ChildCommunication.window || ChildCommunication.window.closed || messageSource === ChildCommunication.window) {
     ChildCommunication.window = messageSource;
     ChildCommunication.origin = messageOrigin;

--- a/packages/teams-js/src/public/featureFlags.ts
+++ b/packages/teams-js/src/public/featureFlags.ts
@@ -31,7 +31,7 @@ export function resetBuildFeatureFlags(): void {
 }
 
 // Runtime feature flags.
-interface RuntimeFeatureFlags {
+export interface RuntimeFeatureFlags {
   /**
    * Disables origin validation for responses to child windows. When enabled, this flag bypasses security checks that verify the origin of child window that receives the response.
    *
@@ -55,6 +55,10 @@ export function getCurrentFeatureFlagsState(): RuntimeFeatureFlags {
   return runtimeFeatureFlags;
 }
 
+/**
+ * It sets the runtime feature flags to the new feature flags provided.
+ * @param featureFlags The new feature flags to set.
+ */
 export function setFeatureFlagsState(featureFlags: RuntimeFeatureFlags): void {
   runtimeFeatureFlags = featureFlags;
 }

--- a/packages/teams-js/src/public/featureFlags.ts
+++ b/packages/teams-js/src/public/featureFlags.ts
@@ -30,7 +30,9 @@ export function resetBuildFeatureFlags(): void {
   buildFeatureFlags.childProxyingCommunication = false;
 }
 
-// Runtime feature flags.
+/**
+ * Feature flags to activate or deactivate certain features at runtime for an app.
+ */
 export interface RuntimeFeatureFlags {
   /**
    * Disables origin validation for responses to child windows. When enabled, this flag bypasses security checks that verify the origin of child window that receives the response.

--- a/packages/teams-js/src/public/featureFlags.ts
+++ b/packages/teams-js/src/public/featureFlags.ts
@@ -1,0 +1,32 @@
+// All build feature flags are defined inside this object. Any build feature flag must have its own unique getter and setter function. This pattern allows for client apps to treeshake unused code and avoid including code guarded by this feature flags in the final bundle. If this property isn't desired, use the below runtime feature flags object.
+const defaultBuildFeatureFlags = {
+  childProxyingCommunication: false,
+};
+let buildFeatureFlags = defaultBuildFeatureFlags;
+
+/**
+ * This function enables child proxying communication for apps that still needs it.
+ *
+ * @deprecated Child proxying is considered an insecure feature and will be removed in future releases.
+ */
+export function activateChildProxyingCommunication(): void {
+  buildFeatureFlags.childProxyingCommunication = true;
+}
+
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use.
+ */
+export function isChildProxyingEnabled(): boolean {
+  return buildFeatureFlags.childProxyingCommunication;
+}
+
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use.
+ */
+export function resetBuildFeatureFlags(): void {
+  buildFeatureFlags = defaultBuildFeatureFlags;
+}

--- a/packages/teams-js/src/public/featureFlags.ts
+++ b/packages/teams-js/src/public/featureFlags.ts
@@ -30,3 +30,42 @@ export function isChildProxyingEnabled(): boolean {
 export function resetBuildFeatureFlags(): void {
   buildFeatureFlags = defaultBuildFeatureFlags;
 }
+
+// Runtime feature flags.
+interface RuntimeFeatureFlags {
+  /**
+   * Disables origin validation for responses to child windows. When enabled, this flag bypasses security checks that verify the origin of child window that receives the response.
+   *
+   * Default: false
+   */
+  disableEnforceOriginMatchForChildResponses: boolean;
+}
+
+// Default runtime feature flags
+export const defaultFeatureFlags: RuntimeFeatureFlags = {
+  disableEnforceOriginMatchForChildResponses: false,
+} as const;
+
+// Object that stores the current runtime feature flag state
+let runtimeFeatureFlags = defaultFeatureFlags;
+
+/**
+ * @returns The current state of the runtime feature flags.
+ */
+export function getCurrentFeatureFlagsState(): RuntimeFeatureFlags {
+  return runtimeFeatureFlags;
+}
+
+export function setFeatureFlagsState(featureFlags: RuntimeFeatureFlags): void {
+  runtimeFeatureFlags = featureFlags;
+}
+
+/**
+ * It overwrites all the feature flags in the runtime feature flags object with the new feature flags provided.
+ * @param newFeatureFlags The new feature flags to set.
+ * @returns The current state of the runtime feature flags.
+ */
+export function overwriteFeatureFlagsState(newFeatureFlags: Partial<RuntimeFeatureFlags>): RuntimeFeatureFlags {
+  setFeatureFlagsState({ ...runtimeFeatureFlags, ...newFeatureFlags });
+  return getCurrentFeatureFlagsState();
+}

--- a/packages/teams-js/src/public/featureFlags.ts
+++ b/packages/teams-js/src/public/featureFlags.ts
@@ -43,7 +43,7 @@ export interface RuntimeFeatureFlags {
 }
 
 // Default runtime feature flags
-export const defaultFeatureFlags: RuntimeFeatureFlags = {
+const defaultFeatureFlags: RuntimeFeatureFlags = {
   disableEnforceOriginMatchForChildResponses: false,
 } as const;
 

--- a/packages/teams-js/src/public/featureFlags.ts
+++ b/packages/teams-js/src/public/featureFlags.ts
@@ -1,8 +1,7 @@
 // All build feature flags are defined inside this object. Any build feature flag must have its own unique getter and setter function. This pattern allows for client apps to treeshake unused code and avoid including code guarded by this feature flags in the final bundle. If this property isn't desired, use the below runtime feature flags object.
-const defaultBuildFeatureFlags = {
+const buildFeatureFlags = {
   childProxyingCommunication: false,
 };
-let buildFeatureFlags = defaultBuildFeatureFlags;
 
 /**
  * This function enables child proxying communication for apps that still needs it.
@@ -28,7 +27,7 @@ export function isChildProxyingEnabled(): boolean {
  * Limited to Microsoft-internal use.
  */
 export function resetBuildFeatureFlags(): void {
-  buildFeatureFlags = defaultBuildFeatureFlags;
+  buildFeatureFlags.childProxyingCommunication = false;
 }
 
 // Runtime feature flags.

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -57,6 +57,7 @@ export {
   activateChildProxyingCommunication,
   getCurrentFeatureFlagsState,
   overwriteFeatureFlagsState,
+  RuntimeFeatureFlags,
   setFeatureFlagsState,
 } from './featureFlags';
 export * as nestedAppAuth from './nestedAppAuth';

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -53,6 +53,12 @@ export * as chat from './chat';
 export { OpenGroupChatRequest, OpenSingleChatRequest } from './chat';
 export * as clipboard from './clipboard';
 export * as dialog from './dialog/dialog';
+export {
+  activateChildProxyingCommunication,
+  getCurrentFeatureFlagsState,
+  overwriteFeatureFlagsState,
+  setFeatureFlagsState,
+} from './featureFlags';
 export * as nestedAppAuth from './nestedAppAuth';
 export * as geoLocation from './geoLocation/geoLocation';
 export { getAdaptiveCardSchemaVersion } from './adaptiveCards';

--- a/packages/teams-js/test/internal/childCommunication.spec.ts
+++ b/packages/teams-js/test/internal/childCommunication.spec.ts
@@ -9,7 +9,7 @@ import { uninitializeCommunication } from '../../src/internal/communication';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { activateChildProxyingCommunication, overwriteFeatureFlagsState, setFeatureFlagsState } from '../../src/public';
 import * as app from '../../src/public/app/app';
-import { defaultFeatureFlags, resetBuildFeatureFlags } from '../../src/public/featureFlags';
+import { resetBuildFeatureFlags } from '../../src/public/featureFlags';
 import { Utils } from '../utils';
 
 describe('childCommunication', () => {
@@ -223,7 +223,7 @@ describe('childCommunication', () => {
         });
 
         afterEach(() => {
-          setFeatureFlagsState(defaultFeatureFlags);
+          overwriteFeatureFlagsState({ disableEnforceOriginMatchForChildResponses: false });
         });
 
         it('the child window that sent the message receives the response back', async () => {

--- a/packages/teams-js/test/internal/childCommunication.spec.ts
+++ b/packages/teams-js/test/internal/childCommunication.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '../../src/internal/childCommunication';
 import { uninitializeCommunication } from '../../src/internal/communication';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
+import { activateChildProxyingCommunication, resetBuildFeatureFlags } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import { Utils } from '../utils';
 
@@ -25,134 +26,162 @@ describe('childCommunication', () => {
     uninitializeCommunication();
   });
 
-  describe('uninitializeChildCommunication', () => {
-    it('after un-initializing should avoid message event relaying to child apps', () => {
-      // this will set the child window
-      shouldProcessChildMessage(utils.childWindow, childOrigin);
-      expect(shouldEventBeRelayedToChild()).toBe(true);
-
-      uninitializeChildCommunication();
-
-      expect(shouldEventBeRelayedToChild()).toBe(false);
+  describe('childProxyingFeatureFlag off', () => {
+    beforeEach(() => {
+    resetBuildFeatureFlags();
     });
 
-    it('after un-initializing new child messages will be proxied to a new window', () => {
-      expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(true);
-      expect(shouldProcessChildMessage(utils.mockWindow, mockOrigin)).toBe(false);
+    describe('shouldEventBeRelayedToChild', () => {
+      it('should return false', () => {
+        expect(shouldEventBeRelayedToChild()).toBe(false);
+      });
+    });
 
-      uninitializeChildCommunication();
-
-      expect(shouldProcessChildMessage(utils.mockWindow, mockOrigin)).toBe(true);
+    describe('shouldProcessChildMessage', () => {
+      it('should return false', () => {
+        expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(false);
+      });
     });
   });
 
-  describe('shouldEventBeRelayedToChild', () => {
-    it('should return false if child window is not initialized', () => {
-      expect(shouldEventBeRelayedToChild()).toBe(false);
+  describe('childProxyingFeatureFlag on', () => {
+    beforeEach(() => {
+      activateChildProxyingCommunication();
     });
 
-    it('should return true if child window is initialized', () => {
-      shouldProcessChildMessage(utils.childWindow, childOrigin);
-      expect(shouldEventBeRelayedToChild()).toBe(true);
-    });
-  });
-
-  describe('shouldProcessChildMessage', () => {
-    it('should return true if its the first message from a child window', () => {
-      expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(true);
-    });
-
-    it('should return false if child window is closed', () => {
-      expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(true);
-
-      utils.childWindow.closed = true;
-      expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(false);
-    });
-
-    it('should return false if child window is not the source of the message', () => {
-      expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(true);
-      expect(shouldProcessChildMessage(utils.mockWindow, mockOrigin)).toBe(false);
-    });
-
-    it('should return true if previous child window is closed and new child message is received', () => {
-      expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(true);
-
-      utils.childWindow.closed = true;
-      expect(shouldProcessChildMessage(utils.mockWindow, mockOrigin)).toBe(true);
-    });
-  });
-
-  describe('sendMessageEventToChild', () => {
-    it('it should send message event to child window', () => {
-      // Set child window
-      shouldProcessChildMessage(utils.childWindow, childOrigin);
-
-      // Send event
-      sendMessageEventToChild('event1');
-
-      // Should have received previous messages
-      expect(utils.childMessages).toContainEqual({ func: 'event1', args: [] });
-    });
-
-    it('should add message to queue if child window is not set', () => {
-      sendMessageEventToChild('test1');
-      sendMessageEventToChild('test2');
-
-      // Set child window
-      shouldProcessChildMessage(utils.childWindow, childOrigin);
-
-      // Trigger queue to be flushed
-      handleIncomingMessageFromChild({ data: {} } as DOMMessageEvent, utils.childWindow, jest.fn(), jest.fn());
-
-      // Should have received previous messages
-      expect(utils.childMessages).toContainEqual({ func: 'test1', args: [] });
-      expect(utils.childMessages).toContainEqual({ func: 'test2', args: [] });
-    });
-  });
-
-  describe('handleIncomingMessageFromChild', () => {
     afterEach(() => {
-      app._uninitialize();
+      resetBuildFeatureFlags();
     });
 
-    it('messages proxied from child should be tagged as proxied from child', async () => {
-      expect.assertions(1);
-      await utils.initializeWithContext('context');
-      await utils.sendMessageFromChild('test1', ['testArg1']);
-      const sentMessage = utils.findMessageByActionName('test1');
-      expect(sentMessage.isProxiedFromChild).toBe(true);
+    describe('uninitializeChildCommunication', () => {
+      it('after un-initializing should avoid message event relaying to child apps', () => {
+        // this will set the child window
+        shouldProcessChildMessage(utils.childWindow, childOrigin);
+        expect(shouldEventBeRelayedToChild()).toBe(true);
+
+        uninitializeChildCommunication();
+
+        expect(shouldEventBeRelayedToChild()).toBe(false);
+      });
+
+      it('after un-initializing new child messages will be proxied to a new window', () => {
+        expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(true);
+        expect(shouldProcessChildMessage(utils.mockWindow, mockOrigin)).toBe(false);
+
+        uninitializeChildCommunication();
+
+        expect(shouldProcessChildMessage(utils.mockWindow, mockOrigin)).toBe(true);
+      });
     });
 
-    it('messages that do not come from the parent are assumed from a child app and proxied to the parent', async () => {
-      expect.assertions(1);
-      await utils.initializeWithContext('context');
-      await utils.sendMessageFromChild('test1', ['testArg1']);
-      const sentMessage = utils.findMessageByFunc('test1');
-      expect(sentMessage).not.toBeNull();
+    describe('shouldEventBeRelayedToChild', () => {
+      it('should return false if child window is not initialized', () => {
+        expect(shouldEventBeRelayedToChild()).toBe(false);
+      });
+
+      it('should return true if child window is initialized', () => {
+        shouldProcessChildMessage(utils.childWindow, childOrigin);
+        expect(shouldEventBeRelayedToChild()).toBe(true);
+      });
     });
 
-    it('only messages of active child window are proxied to the parent', async () => {
-      expect.assertions(2);
-      await utils.initializeWithContext('context');
+    describe('shouldProcessChildMessage', () => {
+      it('should return true if its the first message from a child window', () => {
+        expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(true);
+      });
 
-      // Send message from active child window
-      await utils.sendMessageFromChild('test1', ['testArg1']);
-      const sentMessage = utils.findMessageByFunc('test1');
-      expect(sentMessage).not.toBeNull();
+      it('should return false if child window is closed', () => {
+        expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(true);
 
-      // Send message from other child window
-      await utils.sendCustomMessage(
-        utils.validOrigin,
-        {
-          postMessage: jest.fn(),
-          close: jest.fn(),
-          closed: false,
-        },
-        'test2',
-        'testArg2',
-      );
-      const secondMessage = utils.findMessageByFunc('test2');
-      expect(secondMessage).toBeNull();
+        utils.childWindow.closed = true;
+        expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(false);
+      });
+
+      it('should return false if child window is not the source of the message', () => {
+        expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(true);
+        expect(shouldProcessChildMessage(utils.mockWindow, mockOrigin)).toBe(false);
+      });
+
+      it('should return true if previous child window is closed and new child message is received', () => {
+        expect(shouldProcessChildMessage(utils.childWindow, childOrigin)).toBe(true);
+
+        utils.childWindow.closed = true;
+        expect(shouldProcessChildMessage(utils.mockWindow, mockOrigin)).toBe(true);
+      });
+    });
+
+    describe('sendMessageEventToChild', () => {
+      it('it should send message event to child window', () => {
+        // Set child window
+        shouldProcessChildMessage(utils.childWindow, childOrigin);
+
+        // Send event
+        sendMessageEventToChild('event1');
+
+        // Should have received previous messages
+        expect(utils.childMessages).toContainEqual({ func: 'event1', args: [] });
+      });
+
+      it('should add message to queue if child window is not set', () => {
+        sendMessageEventToChild('test1');
+        sendMessageEventToChild('test2');
+
+        // Set child window
+        shouldProcessChildMessage(utils.childWindow, childOrigin);
+
+        // Trigger queue to be flushed
+        handleIncomingMessageFromChild({ data: {} } as DOMMessageEvent, utils.childWindow, jest.fn(), jest.fn());
+
+        // Should have received previous messages
+        expect(utils.childMessages).toContainEqual({ func: 'test1', args: [] });
+        expect(utils.childMessages).toContainEqual({ func: 'test2', args: [] });
+      });
+    });
+
+    describe('handleIncomingMessageFromChild', () => {
+      afterEach(() => {
+        app._uninitialize();
+      });
+
+      it('messages proxied from child should be tagged as proxied from child', async () => {
+        expect.assertions(1);
+        await utils.initializeWithContext('context');
+        await utils.sendMessageFromChild('test1', ['testArg1']);
+        const sentMessage = utils.findMessageByActionName('test1');
+        expect(sentMessage.isProxiedFromChild).toBe(true);
+      });
+
+      it('messages that do not come from the parent are assumed from a child app and proxied to the parent', async () => {
+        expect.assertions(1);
+        await utils.initializeWithContext('context');
+        await utils.sendMessageFromChild('test1', ['testArg1']);
+        const sentMessage = utils.findMessageByFunc('test1');
+        expect(sentMessage).not.toBeNull();
+      });
+
+      it('only messages of active child window are proxied to the parent', async () => {
+        expect.assertions(2);
+        await utils.initializeWithContext('context');
+
+        // Send message from active child window
+        await utils.sendMessageFromChild('test1', ['testArg1']);
+        const sentMessage = utils.findMessageByFunc('test1');
+        expect(sentMessage).not.toBeNull();
+
+        // Send message from other child window
+        await utils.sendCustomMessage(
+          utils.validOrigin,
+          {
+            postMessage: jest.fn(),
+            close: jest.fn(),
+            closed: false,
+          },
+          'test2',
+          'testArg2',
+        );
+        const secondMessage = utils.findMessageByFunc('test2');
+        expect(secondMessage).toBeNull();
+      });
     });
   });
 });

--- a/packages/teams-js/test/internal/childCommunication.spec.ts
+++ b/packages/teams-js/test/internal/childCommunication.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '../../src/internal/childCommunication';
 import { uninitializeCommunication } from '../../src/internal/communication';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
-import { activateChildProxyingCommunication, overwriteFeatureFlagsState, setFeatureFlagsState } from '../../src/public';
+import { activateChildProxyingCommunication, overwriteFeatureFlagsState } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import { resetBuildFeatureFlags } from '../../src/public/featureFlags';
 import { Utils } from '../utils';

--- a/packages/teams-js/test/private/privateAPIs.spec.ts
+++ b/packages/teams-js/test/private/privateAPIs.spec.ts
@@ -7,9 +7,10 @@ import {
   sendCustomEvent,
   sendCustomMessage,
 } from '../../src/private/privateAPIs';
-import { activateChildProxyingCommunication, resetBuildFeatureFlags } from '../../src/public';
+import { activateChildProxyingCommunication } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import { FrameContexts, HostClientType, HostName, TeamType } from '../../src/public/constants';
+import { resetBuildFeatureFlags } from '../../src/public/featureFlags';
 import { Context, FileOpenPreference } from '../../src/public/interfaces';
 import { Utils } from '../utils';
 

--- a/packages/teams-js/test/private/privateAPIs.spec.ts
+++ b/packages/teams-js/test/private/privateAPIs.spec.ts
@@ -7,6 +7,7 @@ import {
   sendCustomEvent,
   sendCustomMessage,
 } from '../../src/private/privateAPIs';
+import { activateChildProxyingCommunication, resetBuildFeatureFlags } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import { FrameContexts, HostClientType, HostName, TeamType } from '../../src/public/constants';
 import { Context, FileOpenPreference } from '../../src/public/interfaces';
@@ -27,6 +28,7 @@ describe('AppSDK-privateAPIs', () => {
     utils.childMessages = [];
     utils.childWindow.closed = false;
     utils.mockWindow.parent = utils.parentWindow;
+    activateChildProxyingCommunication();
 
     // Set a mock window for testing
     app._initialize(utils.mockWindow);
@@ -37,6 +39,7 @@ describe('AppSDK-privateAPIs', () => {
     if (app._uninitialize) {
       app._uninitialize();
     }
+    resetBuildFeatureFlags();
   });
 
   it('should exist in the global namespace', () => {

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -1455,7 +1455,7 @@ describe('Testing pages module', () => {
               validateRequestWithoutArguments(message, 'settings.save.success');
             });
 
-            it('pages.config.registerOnSaveHandler should proxy to childWindow', async () => {
+            it('pages.config.registerOnSaveHandler should not proxy to childWindow', async () => {
               await utils.initializeWithContext(context, undefined, ['https://teams.microsoft.com']);
               pages.config.registerOnSaveHandler(jest.fn());
               await utils.processMessage!({

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -8,6 +8,7 @@ import {
   isAppNavigationParametersObject,
 } from '../../src/internal/pagesHelpers';
 import { getGenericOnCompleteHandler } from '../../src/internal/utils';
+import { activateChildProxyingCommunication, resetBuildFeatureFlags } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import { FrameInfo, ShareDeepLinkParameters, TabInstance, TabInstanceParameters } from '../../src/public/interfaces';
@@ -33,9 +34,11 @@ describe('Testing pages module', () => {
     beforeEach(() => {
       utils = new Utils();
       utils.messages = [];
+      activateChildProxyingCommunication();
     });
     afterEach(() => {
       app._uninitialize();
+      resetBuildFeatureFlags();
     });
 
     describe('Testing pages.returnFocus function', () => {

--- a/packages/teams-js/test/public/pages.spec.ts
+++ b/packages/teams-js/test/public/pages.spec.ts
@@ -8,9 +8,10 @@ import {
   isAppNavigationParametersObject,
 } from '../../src/internal/pagesHelpers';
 import { getGenericOnCompleteHandler } from '../../src/internal/utils';
-import { activateChildProxyingCommunication, resetBuildFeatureFlags } from '../../src/public';
+import { activateChildProxyingCommunication } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
+import { resetBuildFeatureFlags } from '../../src/public/featureFlags';
 import { FrameInfo, ShareDeepLinkParameters, TabInstance, TabInstanceParameters } from '../../src/public/interfaces';
 import * as pages from '../../src/public/pages/pages';
 import { latestRuntimeApiVersion } from '../../src/public/runtime';

--- a/packages/teams-js/test/utils.ts
+++ b/packages/teams-js/test/utils.ts
@@ -243,16 +243,13 @@ export class Utils {
     return initMessage;
   };
 
-  public findMessageInChildByFunc = (func: string): MessageRequest | null => {
-    if (this.childMessages && this.childMessages.length) {
-      for (let i = 0; i < this.childMessages.length; i++) {
-        if (this.childMessages[i].func === func) {
-          return this.childMessages[i];
-        }
-      }
-    }
-    return null;
-  };
+  public findMessageInChildByFunc(func: string): MessageRequest | null {
+    return this.childMessages.find((v) => v.func === func) ?? null;
+  }
+
+  public findMessageResponseInChildById(id: number): MessageRequest | null {
+    return this.childMessages.find((v) => v.id === id) ?? null;
+  }
 
   public respondToMessage = async (
     message: MessageRequest | NestedAppAuthRequest,
@@ -366,26 +363,28 @@ export class Utils {
     return this.sendMessageWithCustomOrigin(func, this.validOrigin, ...args);
   };
 
-  public async sendMessageFromChild(func: string, ...args: unknown[]): Promise<void> {
-    await this.sendCustomMessage(this.childWindow.location.origin, this.childWindow, func, args);
+  public async sendMessageFromChild(func: string, ...args: unknown[]): Promise<number> {
+    return await this.sendCustomMessage(this.childWindow.location.origin, this.childWindow, func, args);
   }
 
-  public async sendCustomMessage(origin: string, window: unknown, func: string, ...args: unknown[]): Promise<void> {
+  public async sendCustomMessage(origin: string, window: unknown, func: string, ...args: unknown[]): Promise<number> {
     if (this.processMessage === null) {
       throw Error(
         `Cannot send message with function ${func} because processMessage function has not been set and is null`,
       );
     }
+    const id = 3;
 
     await this.processMessage({
       origin,
       source: window,
       data: {
-        id: 3,
+        id,
         func,
         args,
       },
     } as MessageEvent);
+    return id;
   }
 
   public respondToFramelessMessage = (event: DOMMessageEvent): void => {


### PR DESCRIPTION
## Description
This pull request aligns with the on-going effort of removing and deprecating child proxying in teams-js. This pull request disables child proxying by default and makes it so any app must opt-in through the `activateChildProxyingCommunication` feature flag function.  Additionally, a security issue which could possibly leak data was fixed and also guarded through a feature flag in case any app still needs this pattern which is unlikely.

Although theoretically this would be considered a "breaking change", I find it unreasonable to bump to `3.0.0` as this is mostly considered a security fix that most apps won't have to do anything. As such, will leave the changefile as minor as the pattern can still be used through feature flags.

### Main changes in the PR:

1. Added scaffolding for build and runtime feature flags in teams-js. Build feature flags are supposed to be static flags that make it so apps that are not using them, do not include that code in their bundle through tree-shaking. Meanwhile, runtime feature flags can be activated at any moment and will not remove the code from the final bundle.
2. Added the `childProxyingCommunication` build feature flag, in order for apps that do not need child proxying to not include that code in their bundle.
3. Added the runtime feature flag `disableEnforceOriginMatchForChildResponses` for disabling the security patch for the child origin match.

## Validation

### Validation performed:

Through test app and unit testing.

### Unit Tests added:

Yes.

### End-to-end tests added:

No.

## Additional Requirements

### Change file added:

Yes.
