### PR TITLE
Add `authId` and `connectionName` parameters to `externalAppAuthenticationForCEA.authenticateWithSSO`

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/ExternalAppAuthenticationForCEAAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/ExternalAppAuthenticationForCEAAPIs.tsx
@@ -62,7 +62,7 @@ const AuthenticateWithSSOForCEA = (): React.ReactElement =>
   ApiWithTextInput<{
     appId: string;
     conversationId: string;
-    authTokenRequest: externalAppAuthentication.AuthTokenRequestParameters;
+    authTokenRequest: externalAppAuthenticationForCEA.AuthTokenRequestParametersForCEA;
   }>({
     name: 'authenticateWithSSOForCEA',
     title: 'Authenticate With SSO',
@@ -76,6 +76,12 @@ const AuthenticateWithSSOForCEA = (): React.ReactElement =>
         }
         if (!input.authTokenRequest) {
           throw new Error('authTokenRequest is required');
+        }
+        if (!input.authTokenRequest.authId) {
+          throw new Error('authId is required');
+        }
+        if (!input.authTokenRequest.connectionName) {
+          throw new Error('connectionName is required');
         }
       },
       submit: async (input) => {

--- a/change/@microsoft-teams-js-12f113ad-4cdf-4b83-a246-5b552959a6fa.json
+++ b/change/@microsoft-teams-js-12f113ad-4cdf-4b83-a246-5b552959a6fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated `externalAppAuthenticationForCEA.authenticateWithSSO` to take `authId` and `connectionName` parameters.",
+  "packageName": "@microsoft/teams-js",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-12f113ad-4cdf-4b83-a246-5b552959a6fa.json
+++ b/change/@microsoft-teams-js-12f113ad-4cdf-4b83-a246-5b552959a6fa.json
@@ -2,6 +2,6 @@
   "type": "minor",
   "comment": "Updated `externalAppAuthenticationForCEA.authenticateWithSSO` to take `authId` and `connectionName` parameters.",
   "packageName": "@microsoft/teams-js",
-  "email": "email not defined",
+  "email": "jeklouda@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
+++ b/packages/teams-js/src/private/externalAppAuthenticationForCEA.ts
@@ -33,7 +33,7 @@ const externalAppAuthenticationTelemetryVersionNumber: ApiVersionNumber = ApiVer
 export async function authenticateWithSSO(
   appId: AppId,
   conversationId: string,
-  authTokenRequest: externalAppAuthentication.AuthTokenRequestParameters,
+  authTokenRequest: AuthTokenRequestParametersForCEA,
 ): Promise<void> {
   ensureInitialized(runtime, FrameContexts.content);
 
@@ -45,7 +45,14 @@ export async function authenticateWithSSO(
 
   return callFunctionInHost(
     ApiName.ExternalAppAuthenticationForCEA_AuthenticateWithSSO,
-    [appId, conversationId, authTokenRequest.claims, authTokenRequest.silent],
+    [
+      appId,
+      conversationId,
+      authTokenRequest.authId,
+      authTokenRequest.connectionName,
+      authTokenRequest.claims,
+      authTokenRequest.silent,
+    ],
     getApiVersionTag(
       externalAppAuthenticationTelemetryVersionNumber,
       ApiName.ExternalAppAuthenticationForCEA_AuthenticateWithSSO,

--- a/packages/teams-js/test/private/externalAppAuthenticationForCEA.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthenticationForCEA.spec.ts
@@ -263,7 +263,12 @@ describe('externalAppAuthenticationForCEA', () => {
   });
 
   describe('authenticateWithSSO', () => {
+    const testAuthId = 'testAuthId';
+    const testConnectionName = 'testConnectionName';
+
     const testRequest = {
+      authId: testAuthId,
+      connectionName: testConnectionName,
       claims: ['claims'],
       silent: true,
     };
@@ -273,7 +278,10 @@ describe('externalAppAuthenticationForCEA', () => {
       expect.assertions(1);
 
       try {
-        await externalAppAuthenticationForCEA.authenticateWithSSO(testAppId, testConversationId, {});
+        await externalAppAuthenticationForCEA.authenticateWithSSO(testAppId, testConversationId, {
+          authId: testAuthId,
+          connectionName: testConnectionName,
+        });
       } catch (e) {
         expect(e).toEqual(new Error(errorLibraryNotInitialized));
       }
@@ -284,7 +292,10 @@ describe('externalAppAuthenticationForCEA', () => {
       utils.setRuntimeConfig({ apiVersion: 2, supports: {} });
       expect.assertions(1);
       try {
-        await externalAppAuthenticationForCEA.authenticateWithSSO(testAppId, testConversationId, {});
+        await externalAppAuthenticationForCEA.authenticateWithSSO(testAppId, testConversationId, {
+          authId: testAuthId,
+          connectionName: testConnectionName,
+        });
       } catch (e) {
         expect(e).toEqual(errorNotSupportedOnPlatform);
       }
@@ -327,6 +338,8 @@ describe('externalAppAuthenticationForCEA', () => {
             expect(message.args).toEqual([
               testAppId.toString(),
               testConversationId,
+              testRequest.authId,
+              testRequest.connectionName,
               testRequest.claims,
               testRequest.silent,
             ]);
@@ -351,6 +364,8 @@ describe('externalAppAuthenticationForCEA', () => {
             expect(message.args).toEqual([
               testAppId.toString(),
               testConversationId,
+              testRequest.authId,
+              testRequest.connectionName,
               testRequest.claims,
               testRequest.silent,
             ]);


### PR DESCRIPTION
These parameters were recently added to the `authenticateWithSSOAndResendRequest` API. They are required on `authenticateWithSSO` as well. This PR adds `authId` and `connectionName` parameters to `externalAppAuthenticationForCEA.authenticateWithSSO`.

## Description

These parameters were recently added to the `authenticateWithSSOAndResendRequest` API. They are required on `authenticateWithSSO` as well. This PR adds `authId` and `connectionName` parameters to `externalAppAuthenticationForCEA.authenticateWithSSO`.

## Validation

### Validation performed:

1. Validated against corresponding changes in host SDK

### Unit Tests added:

Yes

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes