### PR TITLE
Added `getParentOrigin` API to read the parent origin for nested app auth

### DIFF
--- a/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
+++ b/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
@@ -8,6 +8,14 @@
       "type": "callResponse",
       "boxSelector": "#box_checkIsNAAChannelRecommended",
       "expectedTestAppValue": "NAA channel is recommended"
+    },
+    {
+      "title": "nestedAppAuth get parent origin",
+      "type": "callResponse",
+      "version": ">2.35.0",
+      "boxSelector": "#box_getParentOrigin",
+      "platformsExcluded": ["iOS", "Android"],
+      "expectedTestAppValue": "https://local.teams.office.com:8080"
     }
   ]
 }

--- a/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
+++ b/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
@@ -12,7 +12,6 @@
     {
       "title": "nestedAppAuth get parent origin",
       "type": "callResponse",
-      "version": ">2.35.0",
       "boxSelector": "#box_getParentOrigin",
       "platformsExcluded": ["iOS", "Android"],
       "expectedTestAppValue": "https://local.teams.office.com:8080"

--- a/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
+++ b/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
@@ -72,6 +72,13 @@ const NestedAppAuthAPIs = (): ReactElement => {
       onClick: async () => `NAA channel ${nestedAppAuth.isNAAChannelRecommended() ? 'is' : 'is not'} recommended`,
     });
 
+  const GetParentOrigin = (): ReactElement =>
+    ApiWithoutInput({
+      name: 'getParentOrigin',
+      title: 'Get Parent Origin',
+      onClick: async () => `${nestedAppAuth.getParentOrigin()}`,
+    });
+
   const SendMessageToNestedAppAuthBridge = (): React.ReactElement =>
     ApiWithTextInput({
       name: 'sendMessageToNestedAppAuthBridge',
@@ -224,6 +231,7 @@ const NestedAppAuthAPIs = (): ReactElement => {
   return (
     <ModuleWrapper title="NestedAppAuth">
       <CheckIsNAAChannelRecommended />
+      <GetParentOrigin />
       <SendMessageToNestedAppAuthBridge />
       <SendMessageToTopWindow />
       <AddChildIframeSection />

--- a/change/@microsoft-teams-js-09be1eb0-4ad8-4284-9bbb-7092ddd0cb2d.json
+++ b/change/@microsoft-teams-js-09be1eb0-4ad8-4284-9bbb-7092ddd0cb2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added `getParentOrigin` API to read the parent origin for nested app auth",
+  "packageName": "@microsoft/teams-js",
+  "email": "baljesingh@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/nestedAppAuth.ts
+++ b/packages/teams-js/src/public/nestedAppAuth.ts
@@ -4,6 +4,7 @@
  * @module
  */
 
+import { Communication } from '../internal/communication';
 import { GlobalVars } from '../internal/globalVars';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { HostClientType } from './constants';
@@ -23,6 +24,22 @@ export function isNAAChannelRecommended(): boolean {
       (runtime.isNAAChannelRecommended || isNAAChannelRecommendedForLegacyTeamsMobile())) ??
     false
   );
+}
+
+/**
+ * Gets the origin of the parent window if available.
+ * This will be the top-level origin in the case of a parent app.
+ * It is used to pass to the embedded child app to initialize the Nested App Auth bridge.
+
+ * @returns The origin string if available, otherwise null
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
+ * @beta
+ */
+export function getParentOrigin(): string | null {
+  ensureInitialized(runtime);
+  return Communication.parentOrigin;
 }
 
 function isNAAChannelRecommendedForLegacyTeamsMobile(): boolean {

--- a/packages/teams-js/test/public/nestedAppAuth.spec.ts
+++ b/packages/teams-js/test/public/nestedAppAuth.spec.ts
@@ -64,37 +64,21 @@ describe('nestedAppAuth', () => {
       expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
     });
 
-    it('should return false if isNAAChannelRecommended is false in runtimeConfig for macos client', async () => {
-      await utils.initializeWithContext(FrameContexts.content, HostClientType.macos);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: {},
-        isNAAChannelRecommended: false,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
-    });
+    describe('should return false when isNAAChannelRecommended is false across different host clients', () => {
+      const hostClients = [HostClientType.macos, HostClientType.desktop, HostClientType.web];
 
-    it('should return false if isNAAChannelRecommended is false in runtimeConfig for desktop client', async () => {
-      await utils.initializeWithContext(FrameContexts.content, HostClientType.desktop);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: {},
-        isNAAChannelRecommended: false,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
-    });
-
-    it('should return false if isNAAChannelRecommended is false in runtimeConfig for web client', async () => {
-      await utils.initializeWithContext(FrameContexts.content, HostClientType.web);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: {},
-        isNAAChannelRecommended: false,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+      hostClients.forEach((hostClient) => {
+        it(`${hostClient} client`, async () => {
+          await utils.initializeWithContext(FrameContexts.content, hostClient);
+          const runtimeConfig: Runtime = {
+            apiVersion: 4,
+            supports: {},
+            isNAAChannelRecommended: false,
+          };
+          utils.setRuntimeConfig(runtimeConfig);
+          expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+        });
+      });
     });
 
     it('should return false if isNAAChannelRecommended is false and isLegacyTeams is false in runtimeConfig', async () => {
@@ -121,40 +105,22 @@ describe('nestedAppAuth', () => {
       expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
     });
 
-    it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for android client that supports nestedAppAuth', async () => {
-      await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: { nestedAppAuth },
-        isNAAChannelRecommended: false,
-        isLegacyTeams: true,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
-    });
+    describe('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for following clients that supports nestedAppAuth', () => {
+      const hostClients = [HostClientType.ipados, HostClientType.ios, HostClientType.android];
 
-    it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for ios client that supports nestedAppAuth', async () => {
-      await utils.initializeWithContext(FrameContexts.content, HostClientType.ios);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: { nestedAppAuth },
-        isNAAChannelRecommended: false,
-        isLegacyTeams: true,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
-    });
-
-    it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for ipados client that supports nestedAppAuth', async () => {
-      await utils.initializeWithContext(FrameContexts.content, HostClientType.ipados);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: { nestedAppAuth },
-        isNAAChannelRecommended: false,
-        isLegacyTeams: true,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+      hostClients.forEach((hostClient) => {
+        it(`for ${hostClient} client`, async () => {
+          await utils.initializeWithContext(FrameContexts.content, hostClient);
+          const runtimeConfig: Runtime = {
+            apiVersion: 4,
+            supports: { nestedAppAuth },
+            isNAAChannelRecommended: false,
+            isLegacyTeams: true,
+          };
+          utils.setRuntimeConfig(runtimeConfig);
+          expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+        });
+      });
     });
   });
   describe('getParentOrigin', () => {

--- a/packages/teams-js/test/public/nestedAppAuth.spec.ts
+++ b/packages/teams-js/test/public/nestedAppAuth.spec.ts
@@ -10,9 +10,8 @@ import { Utils } from '../utils';
 /**
  * Test cases for nested app auth APIs
  */
-describe('nestedAppAuth.isNAAChannelRecommended', () => {
+describe('nestedAppAuth', () => {
   const utils = new Utils();
-
   beforeEach(() => {
     utils.processMessage = null;
     utils.messages = [];
@@ -27,133 +26,146 @@ describe('nestedAppAuth.isNAAChannelRecommended', () => {
     }
   });
 
-  it('should throw if called before initialization', () => {
-    utils.uninitializeRuntimeConfig();
-    expect(() => nestedAppAuth.isNAAChannelRecommended()).toThrowError(new Error(errorLibraryNotInitialized));
-  });
+  describe('isNAAChannelRecommended', () => {
+    it('should throw if called before initialization', () => {
+      utils.uninitializeRuntimeConfig();
+      expect(() => nestedAppAuth.isNAAChannelRecommended()).toThrowError(new Error(errorLibraryNotInitialized));
+    });
 
-  it('should return true if isNAAChannelRecommended set to true in runtime object', async () => {
-    await utils.initializeWithContext(FrameContexts.content);
-    const runtimeConfig: Runtime = {
-      apiVersion: 4,
-      supports: {},
-      isNAAChannelRecommended: true,
-    };
-    utils.setRuntimeConfig(runtimeConfig);
-    expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
-  });
+    it('should return true if isNAAChannelRecommended set to true in runtime object', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: true,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+    });
 
-  it('should return false if isNAAChannelRecommended set to false in runtime object ', async () => {
-    await utils.initializeWithContext(FrameContexts.content);
-    const runtimeConfig: Runtime = {
-      apiVersion: 4,
-      supports: {},
-      isNAAChannelRecommended: false,
-    };
-    utils.setRuntimeConfig(runtimeConfig);
-    expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
-  });
+    it('should return false if isNAAChannelRecommended set to false in runtime object ', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: false,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+    });
 
-  it('should return false if isNAAChannelRecommended not present in runtime object ', async () => {
-    await utils.initializeWithContext(FrameContexts.content);
-    const runtimeConfig: Runtime = {
-      apiVersion: 4,
-      supports: {},
-    };
-    utils.setRuntimeConfig(runtimeConfig);
-    expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
-  });
+    it('should return false if isNAAChannelRecommended not present in runtime object ', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+    });
 
-  it('should return false if isNAAChannelRecommended is false in runtimeConfig for macos client', async () => {
-    await utils.initializeWithContext(FrameContexts.content, HostClientType.macos);
-    const runtimeConfig: Runtime = {
-      apiVersion: 4,
-      supports: {},
-      isNAAChannelRecommended: false,
-    };
-    utils.setRuntimeConfig(runtimeConfig);
-    expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
-  });
+    it('should return false if isNAAChannelRecommended is false in runtimeConfig for macos client', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.macos);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: false,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+    });
 
-  it('should return false if isNAAChannelRecommended is false in runtimeConfig for desktop client', async () => {
-    await utils.initializeWithContext(FrameContexts.content, HostClientType.desktop);
-    const runtimeConfig: Runtime = {
-      apiVersion: 4,
-      supports: {},
-      isNAAChannelRecommended: false,
-    };
-    utils.setRuntimeConfig(runtimeConfig);
-    expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
-  });
+    it('should return false if isNAAChannelRecommended is false in runtimeConfig for desktop client', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.desktop);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: false,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+    });
 
-  it('should return false if isNAAChannelRecommended is false in runtimeConfig for web client', async () => {
-    await utils.initializeWithContext(FrameContexts.content, HostClientType.web);
-    const runtimeConfig: Runtime = {
-      apiVersion: 4,
-      supports: {},
-      isNAAChannelRecommended: false,
-    };
-    utils.setRuntimeConfig(runtimeConfig);
-    expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
-  });
+    it('should return false if isNAAChannelRecommended is false in runtimeConfig for web client', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.web);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: false,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+    });
 
-  it('should return false if isNAAChannelRecommended is false and isLegacyTeams is false in runtimeConfig', async () => {
-    await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
-    const runtimeConfig: Runtime = {
-      apiVersion: 4,
-      supports: {},
-      isNAAChannelRecommended: false,
-      isLegacyTeams: false,
-    };
-    utils.setRuntimeConfig(runtimeConfig);
-    expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
-  });
+    it('should return false if isNAAChannelRecommended is false and isLegacyTeams is false in runtimeConfig', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: false,
+        isLegacyTeams: false,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+    });
 
-  it('should return false if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for android client that does not supports nestedAppAuth', async () => {
-    await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
-    const runtimeConfig: Runtime = {
-      apiVersion: 4,
-      supports: {},
-      isNAAChannelRecommended: false,
-      isLegacyTeams: true,
-    };
-    utils.setRuntimeConfig(runtimeConfig);
-    expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
-  });
+    it('should return false if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for android client that does not supports nestedAppAuth', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: false,
+        isLegacyTeams: true,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+    });
 
-  it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for android client that supports nestedAppAuth', async () => {
-    await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
-    const runtimeConfig: Runtime = {
-      apiVersion: 4,
-      supports: { nestedAppAuth },
-      isNAAChannelRecommended: false,
-      isLegacyTeams: true,
-    };
-    utils.setRuntimeConfig(runtimeConfig);
-    expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
-  });
+    it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for android client that supports nestedAppAuth', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: { nestedAppAuth },
+        isNAAChannelRecommended: false,
+        isLegacyTeams: true,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+    });
 
-  it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for ios client that supports nestedAppAuth', async () => {
-    await utils.initializeWithContext(FrameContexts.content, HostClientType.ios);
-    const runtimeConfig: Runtime = {
-      apiVersion: 4,
-      supports: { nestedAppAuth },
-      isNAAChannelRecommended: false,
-      isLegacyTeams: true,
-    };
-    utils.setRuntimeConfig(runtimeConfig);
-    expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
-  });
+    it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for ios client that supports nestedAppAuth', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.ios);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: { nestedAppAuth },
+        isNAAChannelRecommended: false,
+        isLegacyTeams: true,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+    });
 
-  it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for ipados client that supports nestedAppAuth', async () => {
-    await utils.initializeWithContext(FrameContexts.content, HostClientType.ipados);
-    const runtimeConfig: Runtime = {
-      apiVersion: 4,
-      supports: { nestedAppAuth },
-      isNAAChannelRecommended: false,
-      isLegacyTeams: true,
-    };
-    utils.setRuntimeConfig(runtimeConfig);
-    expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+    it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for ipados client that supports nestedAppAuth', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.ipados);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: { nestedAppAuth },
+        isNAAChannelRecommended: false,
+        isLegacyTeams: true,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+    });
+  });
+  describe('getParentOrigin', () => {
+    it('should throw if called before initialization', () => {
+      utils.uninitializeRuntimeConfig();
+      expect(() => nestedAppAuth.getParentOrigin()).toThrowError(new Error(errorLibraryNotInitialized));
+    });
+
+    it('should return parentOrigin if initialized and set', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      expect(nestedAppAuth.getParentOrigin()).toBe(utils.validOrigin);
+    });
   });
 });


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Added getParentOrigin so that the app can read its parent origin. TeamsJS already maintains the parent origin internally but never exposed it to the app, as it was never required. However, with the deeply nested auth feature, teamsJS need to expose this API to the parent so it can pass the origin to the child app. The child app can then use this origin to initialize the standalone nested app auth bridge. 

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Export `getParentOrigin()` in `nestedAppAuth.ts`
2. Added `GetParentOrigin` section in teams test app `NestedAppAuthAPIs.tsx`
3. Added UI with "title": "nestedAppAuth get parent origin" in `nestedAppAuth.json`

## Validation

### Validation performed:

1. Tested locally with web sdk and also added UI test. 

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No> Yes

### End-to-end tests added:

<Yes/No> Yes

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
