### PR TITLE
Added support for `isDeeplyNestedAuthSupported` to check if deeply nested auth is supported.

### DIFF
--- a/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
+++ b/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
@@ -17,9 +17,8 @@
       "expectedTestAppValue": "https://local.teams.office.com:8080"
     },
     {
-      "title": "nestedAppAuth isisDeeplyNestedAuthSupported API Call - Success",
+      "title": "nestedAppAuth isDeeplyNestedAuthSupported API Call - Success",
       "type": "callResponse",
-      "version": ">2.35.0",
       "boxSelector": "#box_checkIsDeeplyNestedAuthSupported",
       "hostSdkVersion": {
         "web": ">=7.1.0",

--- a/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
+++ b/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
@@ -19,6 +19,7 @@
     {
       "title": "nestedAppAuth isDeeplyNestedAuthSupported API Call - Success",
       "type": "callResponse",
+      "version": ">2.35.0",
       "boxSelector": "#box_checkIsDeeplyNestedAuthSupported",
       "hostSdkVersion": {
         "web": ">=7.1.0",

--- a/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
+++ b/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
@@ -15,6 +15,18 @@
       "boxSelector": "#box_getParentOrigin",
       "platformsExcluded": ["iOS", "Android"],
       "expectedTestAppValue": "https://local.teams.office.com:8080"
+    },
+    {
+      "title": "nestedAppAuth isisDeeplyNestedAuthSupported API Call - Success",
+      "type": "callResponse",
+      "version": ">2.35.0",
+      "boxSelector": "#box_checkIsDeeplyNestedAuthSupported",
+      "hostSdkVersion": {
+        "web": ">=7.1.0",
+        "android": ">=6.0.0",
+        "ios": ">=6.0.0"
+      },
+      "expectedTestAppValue": "NAA deeply nested auth is supported"
     }
   ]
 }

--- a/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
+++ b/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
@@ -79,6 +79,14 @@ const NestedAppAuthAPIs = (): ReactElement => {
       onClick: async () => `${nestedAppAuth.getParentOrigin()}`,
     });
 
+  const CheckIsDeeplyNestedAuthSupported = (): ReactElement =>
+    ApiWithoutInput({
+      name: 'checkIsDeeplyNestedAuthSupported',
+      title: 'Check Deeply Nested Auth Supported',
+      onClick: async () =>
+        `NAA deeply nested auth ${nestedAppAuth.isDeeplyNestedAuthSupported() ? 'is' : 'is not'} supported`,
+    });
+
   const SendMessageToNestedAppAuthBridge = (): React.ReactElement =>
     ApiWithTextInput({
       name: 'sendMessageToNestedAppAuthBridge',
@@ -232,6 +240,7 @@ const NestedAppAuthAPIs = (): ReactElement => {
     <ModuleWrapper title="NestedAppAuth">
       <CheckIsNAAChannelRecommended />
       <GetParentOrigin />
+      <CheckIsDeeplyNestedAuthSupported />
       <SendMessageToNestedAppAuthBridge />
       <SendMessageToTopWindow />
       <AddChildIframeSection />

--- a/change/@microsoft-teams-js-291c03f0-c69f-4b98-b14a-e8ae1f8da29d.json
+++ b/change/@microsoft-teams-js-291c03f0-c69f-4b98-b14a-e8ae1f8da29d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added support for `isDeeplyNestedAuthSupported` to check if deeply nested auth is supported.",
+  "packageName": "@microsoft/teams-js",
+  "email": "baljesingh@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/nestedAppAuth.ts
+++ b/packages/teams-js/src/public/nestedAppAuth.ts
@@ -42,6 +42,18 @@ export function getParentOrigin(): string | null {
   return Communication.parentOrigin;
 }
 
+/**
+ * Checks if NAA deeply nested scenario supported by the host
+ * @returns true if host supports
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
+ * @beta
+ */
+export function isDeeplyNestedAuthSupported(): boolean {
+  return (ensureInitialized(runtime) && isNAAChannelRecommended() && runtime.isDeeplyNestedAuthSupported) ?? false;
+}
+
 function isNAAChannelRecommendedForLegacyTeamsMobile(): boolean {
   return ensureInitialized(runtime) &&
     isHostAndroidOrIOSOrIPadOSOrVisionOS() &&

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -221,6 +221,7 @@ interface IRuntimeV4 extends IBaseRuntime {
   readonly apiVersion: 4;
   readonly hostVersionsInfo?: HostVersionsInfo;
   readonly isNAAChannelRecommended?: boolean;
+  readonly isDeeplyNestedAuthSupported?: boolean;
   readonly isLegacyTeams?: boolean;
   readonly supports: {
     readonly app?: {
@@ -371,6 +372,7 @@ export let runtime: Runtime | UninitializedRuntime = _uninitializedRuntime;
 export const versionAndPlatformAgnosticTeamsRuntimeConfig: Runtime = {
   apiVersion: 4,
   isNAAChannelRecommended: false,
+  isDeeplyNestedAuthSupported: false,
   hostVersionsInfo: teamsMinAdaptiveCardVersion,
   isLegacyTeams: true,
   supports: {

--- a/packages/teams-js/test/public/nestedAppAuth.spec.ts
+++ b/packages/teams-js/test/public/nestedAppAuth.spec.ts
@@ -196,17 +196,5 @@ describe('Testing nestedAppAuth capability', () => {
       utils.setRuntimeConfig(runtimeConfig);
       expect(nestedAppAuth.isDeeplyNestedAuthSupported()).toBeFalsy();
     });
-
-    it('should return false if isNAAChannelRecommended not present or false in runtime object ', async () => {
-      await utils.initializeWithContext(FrameContexts.content);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: {},
-        isNAAChannelRecommended: false,
-        isDeeplyNestedAuthSupported: true,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isDeeplyNestedAuthSupported()).toBeFalsy();
-    });
   });
 });

--- a/packages/teams-js/test/public/nestedAppAuth.spec.ts
+++ b/packages/teams-js/test/public/nestedAppAuth.spec.ts
@@ -10,7 +10,7 @@ import { Utils } from '../utils';
 /**
  * Test cases for nested app auth APIs
  */
-describe('nestedAppAuth', () => {
+describe('Testing nestedAppAuth capability', () => {
   const utils = new Utils();
   beforeEach(() => {
     utils.processMessage = null;
@@ -26,7 +26,7 @@ describe('nestedAppAuth', () => {
     }
   });
 
-  describe('isNAAChannelRecommended', () => {
+  describe('nestedAppAuth.isNAAChannelRecommended', () => {
     it('should throw if called before initialization', () => {
       utils.uninitializeRuntimeConfig();
       expect(() => nestedAppAuth.isNAAChannelRecommended()).toThrowError(new Error(errorLibraryNotInitialized));
@@ -64,21 +64,37 @@ describe('nestedAppAuth', () => {
       expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
     });
 
-    describe('should return false when isNAAChannelRecommended is false across different host clients', () => {
-      const hostClients = [HostClientType.macos, HostClientType.desktop, HostClientType.web];
+    it('should return false if isNAAChannelRecommended is false in runtimeConfig for macos client', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.macos);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: false,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+    });
 
-      hostClients.forEach((hostClient) => {
-        it(`${hostClient} client`, async () => {
-          await utils.initializeWithContext(FrameContexts.content, hostClient);
-          const runtimeConfig: Runtime = {
-            apiVersion: 4,
-            supports: {},
-            isNAAChannelRecommended: false,
-          };
-          utils.setRuntimeConfig(runtimeConfig);
-          expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
-        });
-      });
+    it('should return false if isNAAChannelRecommended is false in runtimeConfig for desktop client', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.desktop);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: false,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+    });
+
+    it('should return false if isNAAChannelRecommended is false in runtimeConfig for web client', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.web);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: false,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
     });
 
     it('should return false if isNAAChannelRecommended is false and isLegacyTeams is false in runtimeConfig', async () => {
@@ -105,33 +121,92 @@ describe('nestedAppAuth', () => {
       expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
     });
 
-    describe('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for following clients that supports nestedAppAuth', () => {
-      const hostClients = [HostClientType.ipados, HostClientType.ios, HostClientType.android];
+    it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for android client that supports nestedAppAuth', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: { nestedAppAuth },
+        isNAAChannelRecommended: false,
+        isLegacyTeams: true,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+    });
 
-      hostClients.forEach((hostClient) => {
-        it(`for ${hostClient} client`, async () => {
-          await utils.initializeWithContext(FrameContexts.content, hostClient);
-          const runtimeConfig: Runtime = {
-            apiVersion: 4,
-            supports: { nestedAppAuth },
-            isNAAChannelRecommended: false,
-            isLegacyTeams: true,
-          };
-          utils.setRuntimeConfig(runtimeConfig);
-          expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
-        });
-      });
+    it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for ios client that supports nestedAppAuth', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.ios);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: { nestedAppAuth },
+        isNAAChannelRecommended: false,
+        isLegacyTeams: true,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+    });
+
+    it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for ipados client that supports nestedAppAuth', async () => {
+      await utils.initializeWithContext(FrameContexts.content, HostClientType.ipados);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: { nestedAppAuth },
+        isNAAChannelRecommended: false,
+        isLegacyTeams: true,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
     });
   });
-  describe('getParentOrigin', () => {
+  describe('nestedAppAuth.isDeeplyNestedAuthSupported', () => {
     it('should throw if called before initialization', () => {
       utils.uninitializeRuntimeConfig();
-      expect(() => nestedAppAuth.getParentOrigin()).toThrowError(new Error(errorLibraryNotInitialized));
+      expect(() => nestedAppAuth.isDeeplyNestedAuthSupported()).toThrowError(new Error(errorLibraryNotInitialized));
     });
 
-    it('should return parentOrigin if initialized and set', async () => {
+    it('should return true if isDeeplyNestedAuthSupported set to true in runtime object', async () => {
       await utils.initializeWithContext(FrameContexts.content);
-      expect(nestedAppAuth.getParentOrigin()).toBe(utils.validOrigin);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: true,
+        isDeeplyNestedAuthSupported: true,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isDeeplyNestedAuthSupported()).toBeTruthy();
+    });
+
+    it('should return false if isDeeplyNestedAuthSupported set to false in runtime object ', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: false,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isDeeplyNestedAuthSupported()).toBeFalsy();
+    });
+
+    it('should return false if isDeeplyNestedAuthSupported not present in runtime object ', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: true,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isDeeplyNestedAuthSupported()).toBeFalsy();
+    });
+
+    it('should return false if isNAAChannelRecommended not present or false in runtime object ', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        isNAAChannelRecommended: false,
+        isDeeplyNestedAuthSupported: true,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.isDeeplyNestedAuthSupported()).toBeFalsy();
     });
   });
 });

--- a/packages/teams-js/test/public/nestedAppAuth.spec.ts
+++ b/packages/teams-js/test/public/nestedAppAuth.spec.ts
@@ -10,7 +10,7 @@ import { Utils } from '../utils';
 /**
  * Test cases for nested app auth APIs
  */
-describe('Testing nestedAppAuth capability', () => {
+describe('nestedAppAuth', () => {
   const utils = new Utils();
   beforeEach(() => {
     utils.processMessage = null;
@@ -26,7 +26,7 @@ describe('Testing nestedAppAuth capability', () => {
     }
   });
 
-  describe('nestedAppAuth.isNAAChannelRecommended', () => {
+  describe('isNAAChannelRecommended', () => {
     it('should throw if called before initialization', () => {
       utils.uninitializeRuntimeConfig();
       expect(() => nestedAppAuth.isNAAChannelRecommended()).toThrowError(new Error(errorLibraryNotInitialized));
@@ -64,37 +64,21 @@ describe('Testing nestedAppAuth capability', () => {
       expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
     });
 
-    it('should return false if isNAAChannelRecommended is false in runtimeConfig for macos client', async () => {
-      await utils.initializeWithContext(FrameContexts.content, HostClientType.macos);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: {},
-        isNAAChannelRecommended: false,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
-    });
+    describe('should return false when isNAAChannelRecommended is false across different host clients', () => {
+      const hostClients = [HostClientType.macos, HostClientType.desktop, HostClientType.web];
 
-    it('should return false if isNAAChannelRecommended is false in runtimeConfig for desktop client', async () => {
-      await utils.initializeWithContext(FrameContexts.content, HostClientType.desktop);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: {},
-        isNAAChannelRecommended: false,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
-    });
-
-    it('should return false if isNAAChannelRecommended is false in runtimeConfig for web client', async () => {
-      await utils.initializeWithContext(FrameContexts.content, HostClientType.web);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: {},
-        isNAAChannelRecommended: false,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+      hostClients.forEach((hostClient) => {
+        it(`${hostClient} client`, async () => {
+          await utils.initializeWithContext(FrameContexts.content, hostClient);
+          const runtimeConfig: Runtime = {
+            apiVersion: 4,
+            supports: {},
+            isNAAChannelRecommended: false,
+          };
+          utils.setRuntimeConfig(runtimeConfig);
+          expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
+        });
+      });
     });
 
     it('should return false if isNAAChannelRecommended is false and isLegacyTeams is false in runtimeConfig', async () => {
@@ -121,40 +105,22 @@ describe('Testing nestedAppAuth capability', () => {
       expect(nestedAppAuth.isNAAChannelRecommended()).toBeFalsy();
     });
 
-    it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for android client that supports nestedAppAuth', async () => {
-      await utils.initializeWithContext(FrameContexts.content, HostClientType.android);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: { nestedAppAuth },
-        isNAAChannelRecommended: false,
-        isLegacyTeams: true,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
-    });
+    describe('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for following clients that supports nestedAppAuth', () => {
+      const hostClients = [HostClientType.ipados, HostClientType.ios, HostClientType.android];
 
-    it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for ios client that supports nestedAppAuth', async () => {
-      await utils.initializeWithContext(FrameContexts.content, HostClientType.ios);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: { nestedAppAuth },
-        isNAAChannelRecommended: false,
-        isLegacyTeams: true,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
-    });
-
-    it('should return true if isNAAChannelRecommended is false and isLegacyTeams is true in runtimeConfig for ipados client that supports nestedAppAuth', async () => {
-      await utils.initializeWithContext(FrameContexts.content, HostClientType.ipados);
-      const runtimeConfig: Runtime = {
-        apiVersion: 4,
-        supports: { nestedAppAuth },
-        isNAAChannelRecommended: false,
-        isLegacyTeams: true,
-      };
-      utils.setRuntimeConfig(runtimeConfig);
-      expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+      hostClients.forEach((hostClient) => {
+        it(`for ${hostClient} client`, async () => {
+          await utils.initializeWithContext(FrameContexts.content, hostClient);
+          const runtimeConfig: Runtime = {
+            apiVersion: 4,
+            supports: { nestedAppAuth },
+            isNAAChannelRecommended: false,
+            isLegacyTeams: true,
+          };
+          utils.setRuntimeConfig(runtimeConfig);
+          expect(nestedAppAuth.isNAAChannelRecommended()).toBeTruthy();
+        });
+      });
     });
   });
   describe('nestedAppAuth.isDeeplyNestedAuthSupported', () => {
@@ -195,6 +161,17 @@ describe('Testing nestedAppAuth capability', () => {
       };
       utils.setRuntimeConfig(runtimeConfig);
       expect(nestedAppAuth.isDeeplyNestedAuthSupported()).toBeFalsy();
+    });
+  });
+  describe('getParentOrigin', () => {
+    it('should throw if called before initialization', () => {
+      utils.uninitializeRuntimeConfig();
+      expect(() => nestedAppAuth.getParentOrigin()).toThrowError(new Error(errorLibraryNotInitialized));
+    });
+
+    it('should return parentOrigin if initialized and set', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      expect(nestedAppAuth.getParentOrigin()).toBe(utils.validOrigin);
     });
   });
 });


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Added API to get the value of isDeeplyNestedAuthSupported from the runtime object. This is required by a nested child app to determine if deeply nested auth is supported. The parent app can read this value and pass it on to its child app.

### Main changes in the PR:

1. Added `isDeeplyNestedAuthSupported` in Runtime V4.
2. Added UI test in `nestedAppAuth.json`
3. Added unit tests in `nestedAppAuth.spec.ts`
4. Added `CheckIsDeeplyNestedAuthSupported` section in teams test app.
5. Added `isDeeplyNestedAuthSupported()` method in `nestedAppAuth.ts` to get value of isDeeplyNestedAuthSupported from runtime object

## Validation

### Validation performed:

1. Pull the changes. 
2. Run the teams test app. 
3. Click on 'Check Deeply Nested Auth Supported' button and check the value. It should be true because all SDKs supports it. 

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes

### End-to-end tests added:

Yes

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
