### PR TITLE
Disable default nested app auth bridge injection for nested child app

### DIFF
--- a/change/@microsoft-teams-js-1f320a4f-42fe-4144-919b-be5cb7cb3055.json
+++ b/change/@microsoft-teams-js-1f320a4f-42fe-4144-919b-be5cb7cb3055.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disabled default nested app auth bridge injection for nested child app",
+  "packageName": "@microsoft/teams-js",
+  "email": "baljesingh@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/nestedAppAuthUtils.ts
+++ b/packages/teams-js/src/internal/nestedAppAuthUtils.ts
@@ -132,9 +132,7 @@ export function tryPolyfillWithNestedAppAuthBridge(
 
   // Skip injection if this is a nested iframe (i.e., not the top-most app)
   if (window.parent !== window.top) {
-    logger(
-      'Skipping default nestedAppAuthBridge injection because the current window is not a top-most parent app. Use the standalone nested app auth bridge instead.',
-    );
+    logger('Default NAA bridge injection not supported in nested iframe. Use standalone NAA bridge instead.');
     return;
   }
 

--- a/packages/teams-js/src/internal/nestedAppAuthUtils.ts
+++ b/packages/teams-js/src/internal/nestedAppAuthUtils.ts
@@ -130,6 +130,14 @@ export function tryPolyfillWithNestedAppAuthBridge(
     return;
   }
 
+  // Skip injection if this is a nested iframe (i.e., not the top-most app)
+  if (window.parent !== window.top) {
+    logger(
+      'Skipping default nestedAppAuthBridge injection because the current window is not a top-most parent app. Use the standalone nested app auth bridge instead.',
+    );
+    return;
+  }
+
   const parsedClientSupportedSDKVersion = (() => {
     try {
       return JSON.parse(clientSupportedSDKVersion);

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -1866,18 +1866,18 @@ describe('Testing communication', () => {
 
     describe('postMessage', () => {
       it('should post a message when called with a valid NestedAppAuthRequest', async () => {
-        utils.mockWindow.top = utils.topWindow;
+        utils.mockWindow.parent = utils.mockWindow.top;
         await setupNAABridge();
         communication.Communication.currentWindow.nestedAppAuthBridge.postMessage(validMessage);
 
-        expect(utils.topMessages.length).toBe(1);
-        expect(utils.topMessages[0].func).toBe(requestName);
-        expect((utils.topMessages[0] as NestedAppAuthRequest).data).toEqual(validMessage);
+        expect(utils.messages.length).toBe(2);
+        expect(utils.messages[1].func).toBe(requestName);
+        expect((utils.messages[1] as NestedAppAuthRequest).data).toEqual(validMessage);
       });
 
       it('should not post a message when called with an invalid message', async () => {
         const invalidMessage = 'Invalid message';
-        utils.mockWindow.top = utils.topWindow;
+        utils.mockWindow.parent = utils.mockWindow.top;
         await setupNAABridge();
         communication.Communication.currentWindow.nestedAppAuthBridge.postMessage(invalidMessage);
 
@@ -1886,7 +1886,7 @@ describe('Testing communication', () => {
 
       it('should not post a message when called with a valid JSON that is not a NestedAppAuthRequest', async () => {
         const nonRequestMessage = JSON.stringify({ messageType: 'NonRequestMessage' });
-        utils.mockWindow.top = utils.topWindow;
+        utils.mockWindow.parent = utils.mockWindow.top;
         await setupNAABridge();
         communication.Communication.currentWindow.nestedAppAuthBridge.postMessage(nonRequestMessage);
 
@@ -1898,7 +1898,7 @@ describe('Testing communication', () => {
       test('should respond to a valid nestedAppAuthRequest with a nestedAppAuthResponse', async () => {
         const onMessageReceivedCb = jest.fn();
 
-        utils.mockWindow.top = utils.topWindow;
+        utils.mockWindow.parent = utils.mockWindow.top;
         await setupNAABridge();
         communication.Communication.currentWindow.nestedAppAuthBridge.addEventListener('message', onMessageReceivedCb);
 
@@ -1918,7 +1918,7 @@ describe('Testing communication', () => {
       test('should ignore invalid nestedAppAuthResponse', async () => {
         const onMessageReceivedCb = jest.fn();
 
-        utils.mockWindow.top = utils.topWindow;
+        utils.mockWindow.parent = utils.mockWindow.top;
         await setupNAABridge();
         communication.Communication.currentWindow.nestedAppAuthBridge.addEventListener('message', onMessageReceivedCb);
 
@@ -1938,7 +1938,7 @@ describe('Testing communication', () => {
       test('should ignore other SDK messages', async () => {
         const onMessageReceivedCb = jest.fn();
 
-        utils.mockWindow.top = utils.topWindow;
+        utils.mockWindow.parent = utils.mockWindow.top;
         await setupNAABridge();
         communication.Communication.currentWindow.nestedAppAuthBridge.addEventListener('message', onMessageReceivedCb);
 


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> This change skips the default nestedAppAuthBridge injection when the app is running inside a nested iframe (i.e., not the top-most window).

> While TeamsJS does support bridge injection into iframes, the nested app auth flow fails in cross-origin scenarios. Although this issue could be addressed, TeamsJS is already on the path to deprecating parent-child communication, making such fixes less sustainable long-term.

> To avoid these issues, we now skip the default nestedAppAuthBridge injection when the app is running inside a nested iframe. This ensures that nested apps can explicitly use the standalone nested app auth bridge, which is designed to handle these cases in a more reliable and future-proof way.

### Main changes in the PR:

1. Added a check to detect if the current window is a nested iframe (window.parent !== window.top).
2. Skipped the default nestedAppAuthBridge injection for nested iframes to avoid cross-origin issues and support usage of the standalone nested app auth bridge.

## Validation

### Validation performed:


### Unit Tests added:

> Updated.

### End-to-end tests added:

N/A; Existing UI test should work

## Additional Requirements

### Change file added:
Yes
