### PR TITLE
Add `canParentManageNAATrustedOrigins` capability  to check if the parent can manage its list of trusted child origin

### DIFF
--- a/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
+++ b/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
@@ -15,6 +15,13 @@
       "boxSelector": "#box_getParentOrigin",
       "platformsExcluded": ["iOS", "Android"],
       "expectedTestAppValue": "https://local.teams.office.com:8080"
+    },
+    {
+      "title": "nestedAppAuth canParentManageNAATrustedOrigins API Call - Success",
+      "type": "callResponse",
+      "boxSelector": "#box_canParentManageNAATrustedOrigins",
+      "platformsExcluded": ["iOS", "Android"],
+      "expectedTestAppValue": "true"
     }
   ]
 }

--- a/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
+++ b/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
@@ -15,13 +15,6 @@
       "boxSelector": "#box_getParentOrigin",
       "platformsExcluded": ["iOS", "Android"],
       "expectedTestAppValue": "https://local.teams.office.com:8080"
-    },
-    {
-      "title": "nestedAppAuth canParentManageNAATrustedOrigins API Call - Success",
-      "type": "callResponse",
-      "boxSelector": "#box_canParentManageNAATrustedOrigins",
-      "platformsExcluded": ["iOS", "Android"],
-      "expectedTestAppValue": "true"
     }
   ]
 }

--- a/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
+++ b/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
@@ -79,6 +79,13 @@ const NestedAppAuthAPIs = (): ReactElement => {
       onClick: async () => `${nestedAppAuth.getParentOrigin()}`,
     });
 
+  const CanParentManageNAATrustedOrigins = (): ReactElement =>
+    ApiWithoutInput({
+      name: 'canParentManageNAATrustedOrigins',
+      title: 'Can Parent Manage NAA TrustedOrigins list',
+      onClick: async () => `${nestedAppAuth.canParentManageNAATrustedOrigins()}`,
+    });
+
   const SendMessageToNestedAppAuthBridge = (): React.ReactElement =>
     ApiWithTextInput({
       name: 'sendMessageToNestedAppAuthBridge',
@@ -231,6 +238,7 @@ const NestedAppAuthAPIs = (): ReactElement => {
   return (
     <ModuleWrapper title="NestedAppAuth">
       <CheckIsNAAChannelRecommended />
+      <CanParentManageNAATrustedOrigins />
       <GetParentOrigin />
       <SendMessageToNestedAppAuthBridge />
       <SendMessageToTopWindow />

--- a/change/@microsoft-teams-js-01acb692-27b0-4d62-97cb-4cc57a68dbe9.json
+++ b/change/@microsoft-teams-js-01acb692-27b0-4d62-97cb-4cc57a68dbe9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added `canParentManageNAATrustedOrigins` capability to check if the parent can manage its list of trusted child origins for Nested App Auth (NAA). The capability is still awaiting support in one or most host applications. To track availability of this capability across different hosts see https://aka.ms/capmatrix",
+  "packageName": "@microsoft/teams-js",
+  "email": "baljesingh@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/nestedAppAuth.ts
+++ b/packages/teams-js/src/public/nestedAppAuth.ts
@@ -42,6 +42,20 @@ export function getParentOrigin(): string | null {
   return Communication.parentOrigin;
 }
 
+/**
+ * Checks if the parent has the capability to manage its list of trusted child origins
+ * for Nested App Auth (NAA).
+ *
+ * @returns true if parent can manage NAA TrustedOrigins, false otherwise
+ *
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
+ * @beta
+ */
+export function canParentManageNAATrustedOrigins(): boolean {
+  return (ensureInitialized(runtime) && runtime.canParentManageNAATrustedOrigins) ?? false;
+}
+
 function isNAAChannelRecommendedForLegacyTeamsMobile(): boolean {
   return ensureInitialized(runtime) &&
     isHostAndroidOrIOSOrIPadOSOrVisionOS() &&

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -221,6 +221,7 @@ interface IRuntimeV4 extends IBaseRuntime {
   readonly apiVersion: 4;
   readonly hostVersionsInfo?: HostVersionsInfo;
   readonly isNAAChannelRecommended?: boolean;
+  readonly canParentManageNAATrustedOrigins?: boolean;
   readonly isLegacyTeams?: boolean;
   readonly supports: {
     readonly app?: {

--- a/packages/teams-js/test/public/nestedAppAuth.spec.ts
+++ b/packages/teams-js/test/public/nestedAppAuth.spec.ts
@@ -123,6 +123,46 @@ describe('nestedAppAuth', () => {
       });
     });
   });
+  describe('canParentManageNAATrustedOrigins', () => {
+    it('should throw if called before initialization', () => {
+      utils.uninitializeRuntimeConfig();
+      expect(() => nestedAppAuth.canParentManageNAATrustedOrigins()).toThrowError(
+        new Error(errorLibraryNotInitialized),
+      );
+    });
+
+    it('should return true if canParentManageNAATrustedOrigins set to true in runtime object', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        canParentManageNAATrustedOrigins: true,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.canParentManageNAATrustedOrigins()).toBeTruthy();
+    });
+
+    it('should return false if canParentManageNAATrustedOrigins set to false in runtime object ', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+        canParentManageNAATrustedOrigins: false,
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.canParentManageNAATrustedOrigins()).toBeFalsy();
+    });
+
+    it('should return false if canParentManageNAATrustedOrigins not present in runtime object ', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      const runtimeConfig: Runtime = {
+        apiVersion: 4,
+        supports: {},
+      };
+      utils.setRuntimeConfig(runtimeConfig);
+      expect(nestedAppAuth.canParentManageNAATrustedOrigins()).toBeFalsy();
+    });
+  });
   describe('getParentOrigin', () => {
     it('should throw if called before initialization', () => {
       utils.uninitializeRuntimeConfig();


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> This PR introduces a new capability: canParentManageNAATrustedOrigins. This capability checks whether the parent app has the ability to manage its list of trusted child origins specifically for Nested App Auth (NAA) 

> The goal of this change is to support scenarios where the parent app needs to programmatically determine if it can configure or update the trusted origins of child , enhancing flexibility and control in NAA flows.

### Main changes in the PR:

1. Added `canParentManageNAATrustedOrigins` in `runtime.ts`
2. Added `canParentManageNAATrustedOrigins()` in `nestedAppAuth.ts`
3. Added unit test
## Validation

### Validation performed:

1. Yes, locally. 

### Unit Tests added:
Will add later once web SDK release its version with required capability. 

### End-to-end tests added:
Yes

## Additional Requirements

### Change file added:
Yes
