### PR TITLE
Fix pipeline UI test failure caused by newly added `getParentOrigin` API

### DIFF
--- a/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
+++ b/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
@@ -8,13 +8,6 @@
       "type": "callResponse",
       "boxSelector": "#box_checkIsNAAChannelRecommended",
       "expectedTestAppValue": "NAA channel is recommended"
-    },
-    {
-      "title": "nestedAppAuth get parent origin",
-      "type": "callResponse",
-      "boxSelector": "#box_getParentOrigin",
-      "platformsExcluded": ["iOS", "Android"],
-      "expectedTestAppValue": "https://local.teams.office.com:8080"
     }
   ]
 }

--- a/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
+++ b/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
@@ -12,6 +12,7 @@
     {
       "title": "nestedAppAuth get parent origin",
       "type": "callResponse",
+      "version": ">2.35.0",
       "boxSelector": "#box_getParentOrigin",
       "platformsExcluded": ["iOS", "Android"],
       "expectedTestAppValue": "https://local.teams.office.com:8080"

--- a/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
+++ b/apps/teams-test-app/e2e-test-data/nestedAppAuth.json
@@ -8,6 +8,13 @@
       "type": "callResponse",
       "boxSelector": "#box_checkIsNAAChannelRecommended",
       "expectedTestAppValue": "NAA channel is recommended"
+    },
+    {
+      "title": "nestedAppAuth get parent origin",
+      "type": "callResponse",
+      "boxSelector": "#box_getParentOrigin",
+      "platformsExcluded": ["iOS", "Android"],
+      "expectedTestAppValue": "https://local.teams.office.com:8080"
     }
   ]
 }


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Web SDK pipeline is failing because it attempts to fetch a specific version of TeamsJS before initiating the test. A published TeamsJS version that includes this change should be defined, but since TeamsJS hasn't been published yet, the UI test is being removed for now. It will be added back later once the correct version is available.

> Previous change --> https://github.com/OfficeDev/microsoft-teams-library-js/pull/2757

### Main changes in the PR:

1. Remove ui test in `nestedAppAuth.json`.

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
