### PR TITLE
Add support for manageNAATrustedOrigins API

### DIFF
--- a/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
+++ b/apps/teams-test-app/src/components/NestedAppAuthAPIs.tsx
@@ -243,6 +243,42 @@ const NestedAppAuthAPIs = (): ReactElement => {
       </div>
     );
   };
+  const AddTrustedOrigin = (): React.ReactElement =>
+    ApiWithTextInput<string[]>({
+      name: 'NAAAddTrustedOrigin',
+      title: 'Add Trusted Origin',
+      onClick: {
+        validateInput: (input) => {
+          if (!Array.isArray(input) || input.length === 0) {
+            throw new Error('At least one origin is required to delete.');
+          }
+        },
+        submit: async (input) => {
+          const result = await nestedAppAuth.addNAATrustedOrigins(input);
+          return JSON.stringify(result);
+        },
+      },
+      defaultInput: JSON.stringify(['https://contoso.com']),
+    });
+
+  const DeleteTrustedOrigin = (): React.ReactElement =>
+    ApiWithTextInput<string[]>({
+      name: 'NAADeleteTrustedOrigin',
+      title: 'Delete Trusted Origin',
+      onClick: {
+        validateInput: (input) => {
+          if (!Array.isArray(input) || input.length === 0) {
+            throw new Error('At least one origin is required to delete.');
+          }
+        },
+        submit: async (input) => {
+          const result = await nestedAppAuth.deleteNAATrustedOrigins(input);
+          return JSON.stringify(result);
+        },
+      },
+      defaultInput: JSON.stringify(['https://contoso.com']),
+    });
+
   return (
     <ModuleWrapper title="NestedAppAuth">
       <CheckIsNAAChannelRecommended />
@@ -252,6 +288,8 @@ const NestedAppAuthAPIs = (): ReactElement => {
       <SendMessageToNestedAppAuthBridge />
       <SendMessageToTopWindow />
       <AddChildIframeSection />
+      <AddTrustedOrigin />
+      <DeleteTrustedOrigin />
     </ModuleWrapper>
   );
 };

--- a/change/@microsoft-teams-js-a4a5bbd3-a23b-42e1-9116-d8c0d890969c.json
+++ b/change/@microsoft-teams-js-a4a5bbd3-a23b-42e1-9116-d8c0d890969c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added `manageNAATrustedOrigins` capability which allows the top-level parent app to register its child app's origin as trusted for nested app auth. The capability is still awaiting support in one or most host applications. To track availability of this capability across different hosts see https://aka.ms/capmatrix",
+  "packageName": "@microsoft/teams-js",
+  "email": "baljesingh@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -234,6 +234,8 @@ export const enum ApiName {
   Navigation_NavigateCrossDomain = 'navigation.navigateCrossDomain',
   Navigation_NavigateToTab = 'navigation.navigateToTab',
   Navigation_ReturnFocus = 'navigation.returnFocus',
+  NestedAppAuth_Execute = 'nestedAppAuth.execute',
+  NestedAppAuth_ManageNAATrustedOrigins = 'nestedAppAuth.manageNAATrustedOrigins',
   Notifications_ShowNotification = 'notifications.showNotification',
   OtherAppStateChange_Install = 'otherApp.install',
   OtherAppStateChange_UnregisterInstall = 'otherApp.unregisterInstall',

--- a/packages/teams-js/src/public/nestedAppAuth.ts
+++ b/packages/teams-js/src/public/nestedAppAuth.ts
@@ -3,12 +3,32 @@
  * Nested app auth capabilities
  * @module
  */
-
-import { Communication } from '../internal/communication';
+import { callFunctionInHostAndHandleResponse, Communication } from '../internal/communication';
 import { GlobalVars } from '../internal/globalVars';
 import { ensureInitialized } from '../internal/internalAPIs';
-import { HostClientType } from './constants';
+import { ResponseHandler, SimpleType } from '../internal/responseHandler';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
+import { errorNotSupportedOnPlatform, HostClientType } from './constants';
 import { runtime } from './runtime';
+import { ISerializable } from './serializable.interface';
+
+/**
+ * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
+ */
+const hostEntityTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
+
+/**
+ * Response handler for managing NAA Trusted Origins.
+ */
+const trustedOriginResponseHandler: ResponseHandler<string, string> = {
+  validate: (response) => Array.isArray(response) || typeof response === 'object',
+  deserialize: (response) => response,
+};
+
+enum TrustedOriginAction {
+  ADD = 'ADD',
+  DELETE = 'DELETE',
+}
 
 /**
  * Checks if MSAL-NAA channel recommended by the host
@@ -84,4 +104,108 @@ function isHostAndroidOrIOSOrIPadOSOrVisionOS(): boolean {
     GlobalVars.hostClientType === HostClientType.ipados ||
     GlobalVars.hostClientType === HostClientType.visionOS
   );
+}
+
+/**
+ * Registers the origins of child apps as trusted for Nested App Auth (NAA).
+ *
+ * This allows a top-level parent app to specify which child app origins are considered trusted
+ *
+ * @param appOrigins - An array of child app origins to trust (must be a non-empty array).
+ * @returns A Promise resolving with the result of the action.
+ * @throws Error if called from a non-top-level parent or if parameters are invalid.
+ *
+ * @beta
+ */
+export async function addNAATrustedOrigins(appOrigins: string[]): Promise<string> {
+  if (!canParentManageNAATrustedOrigins()) {
+    throw errorNotSupportedOnPlatform;
+  }
+  const normalizedOrigins = appOrigins.map(normalizeOrigin);
+  return manageNAATrustedOrigins(TrustedOriginAction.ADD, normalizedOrigins);
+}
+
+/**
+ * Removes previously trusted child app origins from Nested App Auth (NAA).
+ *
+ * The specified origins will no longer be considered trusted.
+ *
+ * @param appOrigins - An array of child app origins to remove from the trusted list (must be a non-empty array).
+ * @returns A Promise resolving with the result of the action.
+ * @throws Error if called from a non-top-level parent or if parameters are invalid.
+ *
+ * @beta
+ */
+export async function deleteNAATrustedOrigins(appOrigins: string[]): Promise<string> {
+  if (!canParentManageNAATrustedOrigins()) {
+    throw errorNotSupportedOnPlatform;
+  }
+  const normalizedOrigins = appOrigins.map(normalizeOrigin);
+  return manageNAATrustedOrigins(TrustedOriginAction.DELETE, normalizedOrigins);
+}
+
+/**
+ * Performs the specified action (add or delete) on the list of trusted child app origins for Nested App Auth (NAA).
+ *
+ * This function is intended to be called by a top-level parent app to manage which child app origins are considered trusted.
+ *
+ * @param action - The action to perform: 'ADD' or 'DELETE'.
+ * @param appOrigins - An array of origins to add or remove (must be a non-empty array).
+ * @returns A Promise resolving with the result of the action.
+ * @throws Error if called from a non-top-level parent or if parameters are invalid.
+ */
+async function manageNAATrustedOrigins(action: TrustedOriginAction, appOrigins: string[]): Promise<string> {
+  if (window.parent !== window.top) {
+    throw new Error('This API is only available in the top-level parent.');
+  }
+
+  if (!Array.isArray(appOrigins) || appOrigins.length === 0) {
+    throw new Error(`The '${appOrigins}' parameter is required and must be a non-empty array.`);
+  }
+
+  const args: (SimpleType | ISerializable)[] = [new SerializableManageNAATrustedOriginArgs(action, appOrigins)];
+
+  return callFunctionInHostAndHandleResponse(
+    'nestedAppAuth.manageNAATrustedOrigins',
+    args,
+    trustedOriginResponseHandler,
+    getApiVersionTag(hostEntityTelemetryVersionNumber, ApiName.NestedAppAuth_ManageNAATrustedOrigins),
+  );
+}
+
+/**
+ * Normalizes a given origin string by converting it to lowercase and extracting only the origin part.
+ *
+ * @param origin - A string representing a full URL.
+ * @returns The normalized origin (scheme + host + port) in lowercase.
+ * @throws Error if the input is not a valid URL.
+ */
+function normalizeOrigin(origin: string): string {
+  try {
+    const url = new URL(origin);
+    return url.origin.toLowerCase(); // Normalize and return only the origin part
+  } catch (error) {
+    throw new Error(`Invalid origin provided: ${origin}`);
+  }
+}
+
+/**
+ * Serializable arguments for manageNAATrustedOrigins.
+ */
+class SerializableManageNAATrustedOriginArgs implements ISerializable {
+  public constructor(
+    private readonly action: TrustedOriginAction,
+    private readonly appOrigins: string[],
+  ) {}
+
+  /**
+   * Serializes the object to a JSON-compliant format.
+   * @returns JSON representation of the arguments.
+   */
+  public serialize(): object {
+    return {
+      action: this.action,
+      appOrigins: this.appOrigins, // No need for conditional check, always included
+    };
+  }
 }


### PR DESCRIPTION
## Description

> This PR adds two new public APIs under the nestedAppAuth capability:
>1. addNAATrustedOrigins(appOrigins: string[])
>2. deleteNAATrustedOrigins(appOrigins: string[])

>These APIs allow a top-level parent app to manage its list of trusted child origins for Nested App Auth (NAA). They are gated by platform support, and the runtime capability flag canParentManageNAATrustedOrigins() must return true in order for these APIs to be used.

### Main changes in the PR:

1. Added `AddTrustedOrigin` and `DeleteTrustedOrigin ` UI section in teams test app.
2. Exported method `addNAATrustedOrigins` and `deleteNAATrustedOrigins` in `nestedAppAuth.ts`
3. Added unit tests in `nestedAppAuth.spec.ts`
4. Added `NestedAppAuth_ManageNAATrustedOrigins` in `telemetry.ts`
5. 
## Validation

### Validation performed:

1. Pulled the latest changes and built the library locally.
2. Ran the Teams Test App successfully
3. Navigated to the addNAATrustedOrigins section
  3.1. Clicked on "Default" to populate input
  3.2. Clicked "Submit", and confirmed a success message was returned
4. Navigated to the deleteNAATrustedOrigins section
  4.1. Clicked on "Default" to populate input
  4.2. Clicked "Submit", and confirmed success response with the origin that was deleted

### Unit Tests added:
Added

### End-to-end tests added:

Will add later once SDK released with the required capability. 
