### PR TITLE
Added `apiVersion` tag in NAA request and removed `isNAAChannelRecommended` check in `isDeeplyNestedAuthSupported` api

### DIFF
--- a/change/@microsoft-teams-js-96cc4022-2f5e-470e-b7b6-670472eb2f70.json
+++ b/change/@microsoft-teams-js-96cc4022-2f5e-470e-b7b6-670472eb2f70.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added `apiVersion` tag in NAA request and removed `isNAAChannelRecommended` check in `isDeeplyNestedAuthSupported` api",
+  "packageName": "@microsoft/teams-js",
+  "email": "baljesingh@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
       "brotli": false,
       "path": "./packages/teams-js/dist/esm/packages/teams-js/src/index.js",
       "import": "{ app, authentication, pages }",
-      "limit": "57.15 KB"
+      "limit": "57.20 KB"
     },
     {
       "brotli": false,

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -454,11 +454,11 @@ const sendNestedAuthRequestToTopWindowLogger = communicationLogger.extend('sendN
  * @internal
  * Limited to Microsoft-internal use
  */
-export function sendNestedAuthRequestToTopWindow(message: string): NestedAppAuthRequest {
+export function sendNestedAuthRequestToTopWindow(message: string, apiVersionTag: string): NestedAppAuthRequest {
   const logger = sendNestedAuthRequestToTopWindowLogger;
 
   const targetWindow = Communication.topWindow;
-  const request = createNestedAppAuthRequest(message);
+  const request = createNestedAppAuthRequest(message, apiVersionTag);
 
   logger('Message %s information: %o', getMessageIdsAsLogString(request), {
     actionName: request.func,
@@ -999,7 +999,7 @@ function createMessageRequest(
  *
  * @returns {NestedAppAuthRequest} Returns a NestedAppAuthRequest object with a unique id, the function name set to 'nestedAppAuthRequest', the current timestamp, an empty args array, and the provided message as data.
  */
-function createNestedAppAuthRequest(message: string): NestedAppAuthRequest {
+function createNestedAppAuthRequest(message: string, apiVersionTag: string): NestedAppAuthRequest {
   const messageId: MessageID = CommunicationPrivate.nextMessageId++;
   const messageUuid: MessageUUID = new MessageUUID();
   CommunicationPrivate.legacyMessageIdsToUuidMap[messageId] = messageUuid;
@@ -1009,6 +1009,7 @@ function createNestedAppAuthRequest(message: string): NestedAppAuthRequest {
     func: 'nestedAppAuth.execute',
     timestamp: Date.now(),
     monotonicTimestamp: getCurrentTimestamp(),
+    apiVersionTag: apiVersionTag,
     // Since this is a nested app auth request, we don't need to send any args.
     // We avoid overloading the args array with the message to avoid potential issues processing of these messages on the hubSDK.
     args: [],

--- a/packages/teams-js/src/internal/nestedAppAuthUtils.ts
+++ b/packages/teams-js/src/internal/nestedAppAuthUtils.ts
@@ -1,9 +1,10 @@
 import { GlobalVars } from './globalVars';
 import { MessageRequestWithRequiredProperties } from './messageObjects';
-import { getLogger } from './telemetry';
+import { ApiName, ApiVersionNumber, getApiVersionTag, getLogger } from './telemetry';
 
 const nestedAppAuthLogger = getLogger('nestedAppAuthUtils');
 const tryPolyfillWithNestedAppAuthBridgeLogger = nestedAppAuthLogger.extend('tryPolyfillWithNestedAppAuthBridge');
+export const nestedAppAuthTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 
 /**
  * @hidden
@@ -103,7 +104,7 @@ export interface NestedAuthExtendedWindow extends Window {
  */
 type NestedAppAuthBridgeHandlers = {
   onMessage: (evt: MessageEvent, onMessageReceived: (response: string) => void) => void;
-  sendPostMessage: (message: string) => void;
+  sendPostMessage: (message: string, apiVersionTag: string) => void;
 };
 
 /**
@@ -219,8 +220,10 @@ function createNestedAppAuthBridge(
         return;
       }
 
+      const apiVersionTag = getApiVersionTag(nestedAppAuthTelemetryVersionNumber, ApiName.NestedAppAuth_Execute);
+
       // Post the message to the top window
-      sendPostMessage(message);
+      sendPostMessage(message, apiVersionTag);
     },
     removeEventListener: (eventName: string, callback): void => {
       window.removeEventListener(eventName, nestedAppAuthBridgeHandler(callback));

--- a/packages/teams-js/src/private/nestedAppAuth/nestedAppAuthBridge.ts
+++ b/packages/teams-js/src/private/nestedAppAuth/nestedAppAuthBridge.ts
@@ -1,6 +1,8 @@
 import { v4 as generateUUID } from 'uuid';
 
 /**
+ * @beta
+ * @hidden
  * Local version of the Nested App Auth Bridge module.
  *
  * This version is specific to this standalone module and is not tied to the overall TeamsJS SDK version.
@@ -13,6 +15,9 @@ import { v4 as generateUUID } from 'uuid';
  *   if (nestedAppAuthBridge.version.startsWith('1.')) {
  *     // Safe to use with current logic
  *   }
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export const version = '1.0.0';
 
@@ -99,10 +104,15 @@ let topOriginForNAA: string | null = null;
 let isNAALoggerEnabled = false;
 
 /**
+ * @beta
+ * @hidden
  * Initializes the Nested App Auth Bridge.
  * @param window The window object where the bridge will be attached.
  * @param topOrigin The origin of the top-level frame.
  * @param enableLogging - Optional flag to enable internal debug and error logging. Defaults to false.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export function initialize(window: Window | null, topOrigin: string, enableLogging = false): void {
   isNAALoggerEnabled = enableLogging;

--- a/packages/teams-js/src/private/nestedAppAuth/nestedAppAuthBridge.ts
+++ b/packages/teams-js/src/private/nestedAppAuth/nestedAppAuthBridge.ts
@@ -264,7 +264,7 @@ function createNestedAppAuthRequest(data: string): NestedAppAuthRequest {
     uuid: generateUUID(),
     func: 'nestedAppAuth.execute',
     timestamp: timestamp,
-    apiVersionTag: 'v2_nestedAppAuth.execute',
+    apiVersionTag: 'v2_nestedAppAuth.execute', // Hardcoded to avoid coupling with the `ApiName` enum from the TeamsJS core module.
     monotonicTimestamp: timestamp,
     args: [],
     data,

--- a/packages/teams-js/src/private/nestedAppAuth/nestedAppAuthBridge.ts
+++ b/packages/teams-js/src/private/nestedAppAuth/nestedAppAuthBridge.ts
@@ -1,6 +1,19 @@
 import { v4 as generateUUID } from 'uuid';
 
-// Initial version of standalone nested app auth bridge
+/**
+ * Local version of the Nested App Auth Bridge module.
+ *
+ * This version is specific to this standalone module and is not tied to the overall TeamsJS SDK version.
+ * It allows developers to track changes within this module and handle version-based compatibility if needed.
+ *
+ * While not strictly required today, having a version provides flexibility for future updates,
+ * especially if breaking changes are introduced later.
+ *
+ * Example:
+ *   if (nestedAppAuthBridge.version.startsWith('1.')) {
+ *     // Safe to use with current logic
+ *   }
+ */
 export const version = '1.0.0';
 
 /**

--- a/packages/teams-js/src/private/nestedAppAuth/nestedAppAuthBridge.ts
+++ b/packages/teams-js/src/private/nestedAppAuth/nestedAppAuthBridge.ts
@@ -1,5 +1,8 @@
 import { v4 as generateUUID } from 'uuid';
 
+// Initial version of standalone nested app auth bridge
+export const version = '1.0.0';
+
 /**
  * Interface representing a request structure.
  *
@@ -11,6 +14,7 @@ interface NestedAppAuthRequest {
   func: 'nestedAppAuth.execute';
   timestamp: number;
   monotonicTimestamp: number;
+  apiVersionTag?: string;
   args: [];
   data: string;
 }
@@ -260,6 +264,7 @@ function createNestedAppAuthRequest(data: string): NestedAppAuthRequest {
     uuid: generateUUID(),
     func: 'nestedAppAuth.execute',
     timestamp: timestamp,
+    apiVersionTag: 'v2_nestedAppAuth.execute',
     monotonicTimestamp: timestamp,
     args: [],
     data,

--- a/packages/teams-js/src/public/nestedAppAuth.ts
+++ b/packages/teams-js/src/public/nestedAppAuth.ts
@@ -85,7 +85,7 @@ export function canParentManageNAATrustedOrigins(): boolean {
  * @beta
  */
 export function isDeeplyNestedAuthSupported(): boolean {
-  return (ensureInitialized(runtime) && isNAAChannelRecommended() && runtime.isDeeplyNestedAuthSupported) ?? false;
+  return (ensureInitialized(runtime) && runtime.isDeeplyNestedAuthSupported) ?? false;
 }
 
 function isNAAChannelRecommendedForLegacyTeamsMobile(): boolean {

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -1036,7 +1036,7 @@ describe('Testing communication', () => {
       communication.Communication.topWindow = utils.mockWindow.parent;
       communication.Communication.topOrigin = utils.validOrigin;
 
-      communication.sendNestedAuthRequestToTopWindow(message);
+      communication.sendNestedAuthRequestToTopWindow(message, testApiVersion);
 
       expect(utils.messages.length).toBe(1);
       expect(utils.messages[0].id).toBe(0);
@@ -1049,7 +1049,7 @@ describe('Testing communication', () => {
       communication.Communication.topWindow = utils.topWindow;
       communication.Communication.topOrigin = utils.validOrigin;
 
-      communication.sendNestedAuthRequestToTopWindow(message);
+      communication.sendNestedAuthRequestToTopWindow(message, testApiVersion);
 
       expect(utils.topMessages.length).toBe(1);
       expect(utils.topMessages[0].id).toBe(0);


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> This PR includes minor NAA updates:
1. Added the apiVersion tag to the NAA request.
2. Added a version constant to track the bridge version.
3. Removed the isNAAChannelRecommended check in the isDeeplyNestedAuthSupported API.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. Added the apiVersion tag to the NAA request in both the default bridge and the Nested App Auth standalone bridge.
2. Removed the isNAAChannelRecommended() check, as it's not needed.
3. Added a constant for the version in the Nested App Auth bridge to track changes at a granular level.
4. Updated unit tests.

## Validation

### Validation performed:

1. Yes, through teams test app.

### Unit Tests added:

Updated

### End-to-end tests added:

M/A
