### PR TITLE
Added force refresh parameter to get eligbility info API.

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/CopilotAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/CopilotAPIs.tsx
@@ -1,7 +1,7 @@
 import { copilot, UUID } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import { ApiWithoutInput, ApiWithTextInput } from '../utils';
+import { ApiWithCheckboxInput, ApiWithoutInput, ApiWithTextInput } from '../utils';
 import { ModuleWrapper } from '../utils/ModuleWrapper';
 
 const CopilotAPIs = (): ReactElement => {
@@ -14,9 +14,10 @@ const CopilotAPIs = (): ReactElement => {
     });
 
   const GetEligibilityInfo = (): ReactElement =>
-    ApiWithTextInput<boolean>({
+    ApiWithCheckboxInput({
       name: 'getEligibilityInfo',
       title: 'Get the app Eligibility Information',
+      label: 'forceRefresh',
       onClick: async (input: boolean) => {
         const result = await copilot.eligibility.getEligibilityInfo(input);
         return JSON.stringify(result);

--- a/apps/teams-test-app/src/components/privateApis/CopilotAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/CopilotAPIs.tsx
@@ -1,7 +1,7 @@
 import { copilot, UUID } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
-import { ApiWithCheckboxInput, ApiWithoutInput, ApiWithTextInput } from '../utils';
+import { ApiWithoutInput, ApiWithTextInput } from '../utils';
 import { ModuleWrapper } from '../utils/ModuleWrapper';
 
 const CopilotAPIs = (): ReactElement => {
@@ -14,12 +14,11 @@ const CopilotAPIs = (): ReactElement => {
     });
 
   const GetEligibilityInfo = (): ReactElement =>
-    ApiWithCheckboxInput({
+    ApiWithoutInput({
       name: 'getEligibilityInfo',
       title: 'Get the app Eligibility Information',
-      label: 'forceRefresh',
-      onClick: async (input: boolean) => {
-        const result = await copilot.eligibility.getEligibilityInfo(input);
+      onClick: async () => {
+        const result = await copilot.eligibility.getEligibilityInfo();
         return JSON.stringify(result);
       },
     });

--- a/apps/teams-test-app/src/components/privateApis/CopilotAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/CopilotAPIs.tsx
@@ -14,11 +14,11 @@ const CopilotAPIs = (): ReactElement => {
     });
 
   const GetEligibilityInfo = (): ReactElement =>
-    ApiWithoutInput({
+    ApiWithTextInput<boolean>({
       name: 'getEligibilityInfo',
       title: 'Get the app Eligibility Information',
-      onClick: async () => {
-        const result = await copilot.eligibility.getEligibilityInfo();
+      onClick: async (input: boolean) => {
+        const result = await copilot.eligibility.getEligibilityInfo(input);
         return JSON.stringify(result);
       },
     });

--- a/change/@microsoft-teams-js-3bf442f2-393a-43fd-9d52-d09851ea25d4.json
+++ b/change/@microsoft-teams-js-3bf442f2-393a-43fd-9d52-d09851ea25d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added `forceRefresh` optional argument in `getEligibilityInfo` API.",
+  "packageName": "@microsoft/teams-js",
+  "email": "31258166+juanscr@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/copilot/eligibility.ts
+++ b/packages/teams-js/src/private/copilot/eligibility.ts
@@ -34,22 +34,24 @@ export function isSupported(): boolean {
 }
 
 /**
+ *
+ * @param forceRefresh - boolean to represent whether to force refresh the eligibility information
+ * @returns the copilot eligibility information about the user
+ * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
  * @hidden
  * @internal
  * Limited to Microsoft-internal use
  * @beta
- * @returns the copilot eligibility information about the user
- *
- * @throws Error if {@linkcode app.initialize} has not successfully completed
  */
-export async function getEligibilityInfo(): Promise<AppEligibilityInformation> {
+export async function getEligibilityInfo(forceRefresh: boolean = false): Promise<AppEligibilityInformation> {
   ensureInitialized(runtime);
   if (!isSupported()) {
     throw new Error(`Error code: ${errorNotSupportedOnPlatform.errorCode}, message: Not supported on platform`);
   }
 
   // Return the eligibility information if it is already available
-  if (runtime.hostVersionsInfo?.appEligibilityInformation) {
+  if (runtime.hostVersionsInfo?.appEligibilityInformation && !forceRefresh) {
     copilotLogger('Eligibility information is already available on runtime.');
     return runtime.hostVersionsInfo!.appEligibilityInformation;
   }
@@ -59,6 +61,7 @@ export async function getEligibilityInfo(): Promise<AppEligibilityInformation> {
   const response = await sendAndUnwrap<AppEligibilityInformation | SdkError>(
     getApiVersionTag(copilotTelemetryVersionNumber, ApiName.Copilot_Eligibility_GetEligibilityInfo),
     ApiName.Copilot_Eligibility_GetEligibilityInfo,
+    forceRefresh,
   );
 
   if (isSdkError(response)) {

--- a/packages/teams-js/src/private/copilot/eligibility.ts
+++ b/packages/teams-js/src/private/copilot/eligibility.ts
@@ -44,7 +44,7 @@ export function isSupported(): boolean {
  * Limited to Microsoft-internal use
  * @beta
  */
-export async function getEligibilityInfo(forceRefresh: boolean = false): Promise<AppEligibilityInformation> {
+export async function getEligibilityInfo(forceRefresh?: boolean): Promise<AppEligibilityInformation> {
   ensureInitialized(runtime);
   if (!isSupported()) {
     throw new Error(`Error code: ${errorNotSupportedOnPlatform.errorCode}, message: Not supported on platform`);

--- a/packages/teams-js/test/private/copilot.spec.ts
+++ b/packages/teams-js/test/private/copilot.spec.ts
@@ -201,13 +201,22 @@ describe('copilot', () => {
           expect(message.args?.[0]).toBe(true);
         });
 
+        it(`should pass forceRefresh parameter if it exists - with context ${frameContext}`, async () => {
+          expect.assertions(1);
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig(copilotRuntimeConfig);
+          copilot.eligibility.getEligibilityInfo(false);
+          const message = utils.findMessageByActionName('copilot.eligibility.getEligibilityInfo');
+          expect(message.args?.[0]).toBe(false);
+        });
+
         it(`should default forceRefresh parameter to false if not passed - with context ${frameContext}`, async () => {
           expect.assertions(1);
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig(copilotRuntimeConfig);
           copilot.eligibility.getEligibilityInfo();
           const message = utils.findMessageByActionName('copilot.eligibility.getEligibilityInfo');
-          expect(message.args?.[0]).toBe(false);
+          expect(message.args?.[0]).toBe(undefined);
         });
 
         it(`should not throw if featureSet in response is undefined - with context ${frameContext}`, async () => {

--- a/packages/teams-js/test/private/copilot.spec.ts
+++ b/packages/teams-js/test/private/copilot.spec.ts
@@ -192,6 +192,24 @@ describe('copilot', () => {
           return expect(promise).resolves.toEqual(mockedAppEligibilityInformation);
         });
 
+        it(`should pass forceRefresh parameter if it exists - with context ${frameContext}`, async () => {
+          expect.assertions(1);
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig(copilotRuntimeConfig);
+          copilot.eligibility.getEligibilityInfo(true);
+          const message = utils.findMessageByActionName('copilot.eligibility.getEligibilityInfo');
+          expect(message.args?.[0]).toBe(true);
+        });
+
+        it(`should default forceRefresh parameter to false if not passed - with context ${frameContext}`, async () => {
+          expect.assertions(1);
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig(copilotRuntimeConfig);
+          copilot.eligibility.getEligibilityInfo();
+          const message = utils.findMessageByActionName('copilot.eligibility.getEligibilityInfo');
+          expect(message.args?.[0]).toBe(false);
+        });
+
         it(`should not throw if featureSet in response is undefined - with context ${frameContext}`, async () => {
           await utils.initializeWithContext(frameContext);
           utils.setRuntimeConfig(copilotRuntimeConfig);


### PR DESCRIPTION
## Description

New `forceRefresh` argument for the get eligibility information API for forcing a refresh of the eligibility information.

### Main changes in the PR:

1. Add new argument to the `getEligibilityInfo` API.

## Validation

### Validation performed:

1. Ran unit tests.
2. Tested in testing environment.

### Unit Tests added:
Yes

### End-to-end tests added:
No

## Additional Requirements

### Change file added:

Yes.

