### PR TITLE
Fix PR pipeline by switching to Unofficial template

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,13 +43,9 @@ extends:
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
-      image: ubuntu-latest
-      os: linux
+      image: windows-latest
+      os: windows
     sdl:
-      sourceAnalysisPool:
-          name: Azure-Pipelines-1ESPT-ExDShared
-          image: windows-latest
-          os: windows
       eslint:
         configuration: 'required'
         parser: '@typescript-eslint/parser'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,9 +43,13 @@ extends:
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
-      image: windows-2022
-      os: windows
+      image: ubuntu-latest
+      os: linux
     sdl:
+      sourceAnalysisPool:
+          name: Azure-Pipelines-1ESPT-ExDShared
+          image: windows-latest
+          os: windows
       eslint:
         configuration: 'required'
         parser: '@typescript-eslint/parser'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
       name: ISS/metaos-hub-sdk-ios
 
 extends:
-  template: v1/Office.Official.PipelineTemplate.yml@OfficePipelineTemplates
+  template: v1/Office.Unofficial.PipelineTemplate.yml@OfficePipelineTemplates
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

The PR pipeline is currently failing on the SDLSources step because it cannot access a required resource in ADO. I'm not entirely sure why yet, but switching to the "Unofficial" 1ES pipeline template has resolved this issue. The Unofficial template is to be used for PR builds anyway, so even if it didn't resolve the issue we should make this change.

### Main changes in the PR:

1. Switch PR pipeline to Unofficial 1ES pipeline template
2. Switch to windows-latest runner image

## Validation

### Validation performed:

1. Tested pipeline with new settings

### Unit Tests added:

No, pipeline changes only

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

No, pipeline changes only

### Next/remaining steps:

Our PR and build pipelines use the same yml, so we will have to create a new file for the build pipeline that still uses the Official 1ES template. That being said, the build pipeline is also failing the SDLSources step, so more investigation is required to fix our releases.