### PR TITLE
Unblock apps to call dialog.url.submit in mobile

### DIFF
--- a/change/@microsoft-teams-js-06b44e75-5613-4594-a024-dfb68a5d7a05.json
+++ b/change/@microsoft-teams-js-06b44e75-5613-4594-a024-dfb68a5d7a05.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Unblocked apps on Mobile to call `dialog.url.submit` from dialog by allowing this API from `FrameContext.content`.\nThere is a bug in Teams mobile that returns `frameContext.content in dialog instead of `frameContext.task`. Once the bug is fixed, this change will be reverted.",
+  "packageName": "@microsoft/teams-js",
+  "email": "lakhveerkaur@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/copilot/copilot.ts
+++ b/packages/teams-js/src/private/copilot/copilot.ts
@@ -1,4 +1,5 @@
 import * as customTelemetry from './customTelemetry';
 import * as eligibility from './eligibility';
+import * as sidePanel from './sidePanel';
 
-export { customTelemetry, eligibility };
+export { customTelemetry, eligibility, sidePanel };

--- a/packages/teams-js/src/private/copilot/copilot.ts
+++ b/packages/teams-js/src/private/copilot/copilot.ts
@@ -1,5 +1,4 @@
 import * as customTelemetry from './customTelemetry';
 import * as eligibility from './eligibility';
-import * as sidePanel from './sidePanel';
 
-export { customTelemetry, eligibility, sidePanel };
+export { customTelemetry, eligibility };

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -272,7 +272,7 @@ describe('Dialog', () => {
       it('should not allow calls before initialization', () => {
         expect(() => dialog.url.submit()).toThrowError(errorLibraryNotInitialized);
       });
-      const allowedContexts = [FrameContexts.task];
+      const allowedContexts = [FrameContexts.task, FrameContexts.content];
       Object.values(FrameContexts).forEach((context) => {
         if (allowedContexts.some((allowedContexts) => allowedContexts === context)) {
           it(`FRAMELESS: should throw error when dialog is not supported in ${context} context`, async () => {

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -1314,7 +1314,7 @@ describe('Dialog', () => {
       it('should not allow calls before initialization', () => {
         expect(() => dialog.url.submit()).toThrowError(errorLibraryNotInitialized);
       });
-      const allowedContexts = [FrameContexts.task];
+      const allowedContexts = [FrameContexts.content, FrameContexts.task];
       Object.values(FrameContexts).forEach((context) => {
         if (allowedContexts.some((allowedContexts) => allowedContexts === context)) {
           it(`FRAMED: should throw error when dialog is not supported in ${context} context`, async () => {

--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -272,7 +272,7 @@ describe('Dialog', () => {
       it('should not allow calls before initialization', () => {
         expect(() => dialog.url.submit()).toThrowError(errorLibraryNotInitialized);
       });
-      const allowedContexts = [FrameContexts.task, FrameContexts.content];
+      const allowedContexts = [FrameContexts.content, FrameContexts.task];
       Object.values(FrameContexts).forEach((context) => {
         if (allowedContexts.some((allowedContexts) => allowedContexts === context)) {
           it(`FRAMELESS: should throw error when dialog is not supported in ${context} context`, async () => {

--- a/packages/teams-js/test/public/tasks.spec.ts
+++ b/packages/teams-js/test/public/tasks.spec.ts
@@ -268,7 +268,7 @@ describe('tasks', () => {
   });
 
   describe('submitTask', () => {
-    const allowedContexts = [FrameContexts.task, FrameContexts.content];
+    const allowedContexts = [FrameContexts.content, FrameContexts.task];
     it('should not allow calls before initialization', () => {
       expect(() => tasks.submitTask()).toThrowError(new Error(errorLibraryNotInitialized));
     });

--- a/packages/teams-js/test/public/tasks.spec.ts
+++ b/packages/teams-js/test/public/tasks.spec.ts
@@ -268,7 +268,7 @@ describe('tasks', () => {
   });
 
   describe('submitTask', () => {
-    const allowedContexts = [FrameContexts.task];
+    const allowedContexts = [FrameContexts.task, FrameContexts.content];
     it('should not allow calls before initialization', () => {
       expect(() => tasks.submitTask()).toThrowError(new Error(errorLibraryNotInitialized));
     });


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description
Unblocked apps on Mobile to call `dialog.url.submit` from dialog by allowing this API from `FrameContext.content`.\nThere is a bug in Teams mobile that returns `frameContext.content in dialog instead of `frameContext.task`. Once the bug is fixed, this change will be reverted.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
