### PR TITLE
Added `renderingSurface` property to `{app.Page.Context}`

### DIFF
--- a/change/@microsoft-teams-js-96be3430-7bd4-4a40-8554-4be120a97747.json
+++ b/change/@microsoft-teams-js-96be3430-7bd4-4a40-8554-4be120a97747.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added `renderingSurface` property to `{app.Page.Context}` capability.",
+  "packageName": "@microsoft/teams-js",
+  "email": "niharikad@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
       "brotli": false,
       "path": "./packages/teams-js/dist/esm/packages/teams-js/src/index.js",
       "import": "{ app, authentication, pages }",
-      "limit": "57.204 KB"
+      "limit": "57.33 KB"
     },
     {
       "brotli": false,

--- a/packages/teams-js/src/public/app/app.ts
+++ b/packages/teams-js/src/public/app/app.ts
@@ -306,9 +306,10 @@ export interface PageInfo {
   frameContext: FrameContexts;
 
   /**
-   * The surface where the page is loaded
+   * The mode or surface where the page is rendered (e.g. sidePanel, meetingStage, etc.)
+   * This will be used by the app developers in future to know where in the host the app is rendered instead of the frameContext.
    */
-  renderingSurface?: RenderingSurfaces;
+  renderingSurface: RenderingSurfaces | undefined;
 
   /**
    * The developer-defined unique ID for the sub-page this content points to.
@@ -837,7 +838,7 @@ function transformLegacyContextToAppContext(legacyContext: LegacyContext): Conte
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       frameContext: legacyContext.frameContext ? legacyContext.frameContext : GlobalVars.frameContext,
-      renderingSurface: legacyContext.renderingSurface,
+      renderingSurface: legacyContext.renderingSurface ? legacyContext.renderingSurface : undefined,
       subPageId: legacyContext.subEntityId,
       isFullScreen: legacyContext.isFullScreen,
       isMultiWindow: legacyContext.isMultiWindow,

--- a/packages/teams-js/src/public/app/app.ts
+++ b/packages/teams-js/src/public/app/app.ts
@@ -309,7 +309,7 @@ export interface PageInfo {
    * The mode or surface where the page is rendered (e.g. sidePanel, meetingStage, etc.)
    * This will be used by the app developers in future to know where in the host the app is rendered instead of the frameContext.
    */
-  renderingSurface: RenderingSurfaces | undefined;
+  renderingSurface?: RenderingSurfaces;
 
   /**
    * The developer-defined unique ID for the sub-page this content points to.

--- a/packages/teams-js/src/public/app/app.ts
+++ b/packages/teams-js/src/public/app/app.ts
@@ -16,7 +16,15 @@ import { ApiName, ApiVersionNumber, getApiVersionTag, getLogger } from '../../in
 import { inServerSideRenderingEnvironment } from '../../internal/utils';
 import * as messageChannels from '../../private/messageChannels/messageChannels';
 import { AppId } from '../appId';
-import { ChannelType, FrameContexts, HostClientType, HostName, TeamType, UserTeamRole } from '../constants';
+import {
+  ChannelType,
+  FrameContexts,
+  HostClientType,
+  HostName,
+  RenderingSurfaces,
+  TeamType,
+  UserTeamRole,
+} from '../constants';
 import {
   ActionInfo,
   Context as LegacyContext,
@@ -296,6 +304,11 @@ export interface PageInfo {
    * The context where page url is loaded (content, task, setting, remove, sidePanel)
    */
   frameContext: FrameContexts;
+
+  /**
+   * The surface where the page is loaded
+   */
+  renderingSurface?: RenderingSurfaces;
 
   /**
    * The developer-defined unique ID for the sub-page this content points to.
@@ -824,6 +837,7 @@ function transformLegacyContextToAppContext(legacyContext: LegacyContext): Conte
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       frameContext: legacyContext.frameContext ? legacyContext.frameContext : GlobalVars.frameContext,
+      renderingSurface: legacyContext.renderingSurface,
       subPageId: legacyContext.subEntityId,
       isFullScreen: legacyContext.isFullScreen,
       isMultiWindow: legacyContext.isMultiWindow,

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -102,6 +102,10 @@ export enum FrameContexts {
   meetingStage = 'meetingStage',
 }
 
+export enum RenderingSurfaces {
+  copilotSidePanel = 'copilotSidePanel',
+}
+
 /**
  * Indicates the team type, currently used to distinguish between different team
  * types in Office 365 for Education (team types 1, 2, 3, and 4).

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -103,7 +103,12 @@ export enum FrameContexts {
 }
 
 /**
- * The type of surface or mode the app is rendered by the host.
+ * RenderingSurfaces describes the context or surface in which your app is being displayed within the host application.
+ * This parameter allows your app to detect where it is rendered (for example, in a side panel or stage view)
+ * and adjust its behavior or UI accordingly. The intent is to help developers understand the user's context of use,
+ * not the exact pixel size or layout. If a host (such as Outlook Meeting Apps) changes the size of a surface (e.g., makes the side panel larger),
+ * it will still use the same RenderingSurface value. Developers are expected to use responsive UI techniques to adapt to size changes,
+ * since the user's context and intent remain the same even if the surface dimensions change.
  */
 export enum RenderingSurfaces {
   /**

--- a/packages/teams-js/src/public/constants.ts
+++ b/packages/teams-js/src/public/constants.ts
@@ -102,7 +102,13 @@ export enum FrameContexts {
   meetingStage = 'meetingStage',
 }
 
+/**
+ * The type of surface or mode the app is rendered by the host.
+ */
 export enum RenderingSurfaces {
+  /**
+   * The mode the copilot app rendered by the host.
+   */
   copilotSidePanel = 'copilotSidePanel',
 }
 

--- a/packages/teams-js/src/public/index.ts
+++ b/packages/teams-js/src/public/index.ts
@@ -5,6 +5,7 @@ export {
   FrameContexts,
   HostClientType,
   HostName,
+  RenderingSurfaces,
   TaskModuleDimension,
   TeamType,
   UserTeamRole,

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -1,6 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any*/
 
-import { ChannelType, DialogDimension, HostClientType, HostName, TeamType, UserTeamRole } from './constants';
+import {
+  ChannelType,
+  DialogDimension,
+  HostClientType,
+  HostName,
+  RenderingSurfaces,
+  TeamType,
+  UserTeamRole,
+} from './constants';
 import { FrameContexts } from './constants';
 
 /**
@@ -581,6 +589,8 @@ export interface Context {
    * The context where tab url is loaded (content, task, setting, remove, sidePanel)
    */
   frameContext?: FrameContexts;
+
+  renderingSurface?: RenderingSurfaces;
 
   /**
    * @deprecated

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -590,6 +590,12 @@ export interface Context {
    */
   frameContext?: FrameContexts;
 
+  /**
+   * @deprecated
+   * As of TeamsJS v2.0.0, please use {@link app.PageInfo.renderingSurface | app.Context.page.renderingSurface} instead
+   *
+   * The surface where the tab is rendered (sidePanel, meeting, chat, channel)
+   */
   renderingSurface?: RenderingSurfaces;
 
   /**

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -9,6 +9,7 @@ import {
   FrameContexts,
   HostClientType,
   HostName,
+  RenderingSurfaces,
   TeamType,
   UserTeamRole,
 } from '../../src/public/constants';
@@ -412,7 +413,7 @@ describe('Testing app capability', () => {
         message = utils.findMessageByFunc('getContext');
         expect(message).not.toBeNull();
       });
-
+  
       Object.values(FrameContexts).forEach((context) => {
         it(`app.getContext should successfully get frame context in ${context} context`, async () => {
           await utils.initializeWithContext(context);
@@ -556,6 +557,7 @@ describe('Testing app capability', () => {
             isMultiWindow: true,
             isBackgroundLoad: true,
             frameContext: context,
+            renderingSurface: RenderingSurfaces.copilotSidePanel,
             appLaunchId: 'appLaunchId',
             userDisplayName: 'someTestUser',
             teamSiteId: 'someSiteId',
@@ -588,6 +590,7 @@ describe('Testing app capability', () => {
             page: {
               id: 'someEntityId',
               subPageId: 'someSubEntityId',
+              renderingSurface: RenderingSurfaces.copilotSidePanel,
               isFullScreen: true,
               sourceOrigin: 'www.origin.com',
               frameContext: context,


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Added `renderingSurface` property to `{app.Page.Context}` capability. The `Renderingsurfaces' enum for this property only contains 'copilotSidePanel' for now, but in future more values will be added.

This PR increased the teams-js size bundle size from 57.204Kb to 57.33kb. The size increase is justified as we are adding new code to app.ts file. This change does not break the tree shakability.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.


### Unit Tests added: Yes



