### PR TITLE
Remove `Beta` tag from nestedAppAuth.isNAAChannelRecommended API

### DIFF
--- a/change/@microsoft-teams-js-3a3fbb36-90e2-4d00-bb1e-7633a46f3f8c.json
+++ b/change/@microsoft-teams-js-3a3fbb36-90e2-4d00-bb1e-7633a46f3f8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed Beta tag from nestedAppAuth.isNAAChannelRecommended API",
+  "packageName": "@microsoft/teams-js",
+  "email": "baljesingh@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/nestedAppAuth.ts
+++ b/packages/teams-js/src/public/nestedAppAuth.ts
@@ -36,7 +36,6 @@ enum TrustedOriginAction {
  *
  * @throws Error if {@linkcode app.initialize} has not successfully completed
  *
- * @beta
  */
 export function isNAAChannelRecommended(): boolean {
   return (


### PR DESCRIPTION
## Description

> This PR removes the Beta tag from the nestedAppAuth.isNAAChannelRecommended API. The API has been adopted and is already being used by partners in their production environments without issues. Based on this proven stability, we are promoting it from beta to a fully supported API.

### Main changes in the PR:

1. Removed the Beta tag annotation from isNAAChannelRecommended API

## Validation

### Validation performed:

1. Confirmed no functional changes in the API implementation

### Unit Tests added:

No – The functional logic of the API is unchanged. Existing tests already cover the necessary scenarios.

### End-to-end tests added:

NA

## Additional Requirements

### Change file added:

Yes
