### PR TITLE
Supporting isDeeplyNestedAuthSupported flag for Legacy Teams Mobile Scenario

### DIFF
--- a/change/@microsoft-teams-js-ade231c1-27a2-4670-b268-bdfc0daa5b0a.json
+++ b/change/@microsoft-teams-js-ade231c1-27a2-4670-b268-bdfc0daa5b0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added `{namespace}` capability that will {explain capability}. The capability is still awaiting support in one or most host applications. To track availability of this capability across different hosts see https://aka.ms/capmatrix",
+  "packageName": "@microsoft/teams-js",
+  "email": "prpatwa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -151,7 +151,13 @@
       "nanoid": "There is a vulnerability with nanoid versions less than 3.3.8 This package is currently being consumed in @types/webpack and needs to be updated there. For now we will override this until that is fixed.",
       "socks": "There is a vulnerability in the ip package which has no fix. We consume ip via socks (eventually via lerna). Socks released a new version that removed the ip dependency. We are using this newer version of socks to avoid the vulnerability. If ip is ever updated or lerna (or any package in the chain) eventually updates to a version of socks that doesn't depend on ip, we can remove this override",
       "tar": "There is a vulnerability in the tar package which is being used by lerna that hasn't yet been updated. Once this is patched in lerna we can remove this override"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "sharp"
+    ],
+    "onlyBuiltDependencies": [
+      "nx"
+    ]
   },
   "dependencies": {
     "skeleton-buffer": "file:./skeleton-buffer",
@@ -162,7 +168,7 @@
       "brotli": false,
       "path": "./packages/teams-js/dist/esm/packages/teams-js/src/index.js",
       "import": "{ app, authentication, pages }",
-      "limit": "57.204 KB"
+      "limit": "57.32 KB"
     },
     {
       "brotli": false,

--- a/package.json
+++ b/package.json
@@ -151,13 +151,7 @@
       "nanoid": "There is a vulnerability with nanoid versions less than 3.3.8 This package is currently being consumed in @types/webpack and needs to be updated there. For now we will override this until that is fixed.",
       "socks": "There is a vulnerability in the ip package which has no fix. We consume ip via socks (eventually via lerna). Socks released a new version that removed the ip dependency. We are using this newer version of socks to avoid the vulnerability. If ip is ever updated or lerna (or any package in the chain) eventually updates to a version of socks that doesn't depend on ip, we can remove this override",
       "tar": "There is a vulnerability in the tar package which is being used by lerna that hasn't yet been updated. Once this is patched in lerna we can remove this override"
-    },
-    "ignoredBuiltDependencies": [
-      "sharp"
-    ],
-    "onlyBuiltDependencies": [
-      "nx"
-    ]
+    }
   },
   "dependencies": {
     "skeleton-buffer": "file:./skeleton-buffer",

--- a/packages/teams-js/src/public/nestedAppAuth.ts
+++ b/packages/teams-js/src/public/nestedAppAuth.ts
@@ -85,8 +85,8 @@ export function canParentManageNAATrustedOrigins(): boolean {
  */
 export function isDeeplyNestedAuthSupported(): boolean {
   return (
-    ((ensureInitialized(runtime) && runtime.isDeeplyNestedAuthSupported) ||
-      isDeeplyNestedAuthSupportedForLegacyTeamsMobile()) ??
+    (ensureInitialized(runtime) &&
+      (runtime.isDeeplyNestedAuthSupported || isDeeplyNestedAuthSupportedForLegacyTeamsMobile())) ??
     false
   );
 }

--- a/packages/teams-js/src/public/nestedAppAuth.ts
+++ b/packages/teams-js/src/public/nestedAppAuth.ts
@@ -84,7 +84,20 @@ export function canParentManageNAATrustedOrigins(): boolean {
  * @beta
  */
 export function isDeeplyNestedAuthSupported(): boolean {
-  return (ensureInitialized(runtime) && runtime.isDeeplyNestedAuthSupported) ?? false;
+  return (
+    ((ensureInitialized(runtime) && runtime.isDeeplyNestedAuthSupported) ||
+      isDeeplyNestedAuthSupportedForLegacyTeamsMobile()) ??
+    false
+  );
+}
+
+function isDeeplyNestedAuthSupportedForLegacyTeamsMobile(): boolean {
+  return ensureInitialized(runtime) &&
+    isHostAndroidOrIOSOrIPadOSOrVisionOS() &&
+    runtime.isLegacyTeams &&
+    runtime.supports.nestedAppAuth?.deeplyNestedAuth
+    ? true
+    : false;
 }
 
 function isNAAChannelRecommendedForLegacyTeamsMobile(): boolean {

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -277,7 +277,9 @@ interface IRuntimeV4 extends IBaseRuntime {
       readonly dataLayer?: {};
     };
     readonly monetization?: {};
-    readonly nestedAppAuth?: {};
+    readonly nestedAppAuth?: {
+      readonly deeplyNestedAuth?: {};
+    };
     readonly notifications?: {};
     readonly otherAppStateChange?: {};
     readonly pages?: {
@@ -608,6 +610,12 @@ export const mapTeamsVersionToSupportedCapabilities: Record<string, Array<ICapab
   '2.1.1': [
     {
       capability: { nestedAppAuth: {} },
+      hostClientTypes: [HostClientType.android, HostClientType.ios, HostClientType.ipados, HostClientType.visionOS],
+    },
+  ],
+  '2.1.2': [
+    {
+      capability: { nestedAppAuth: { deeplyNestedAuth: {} } },
       hostClientTypes: [HostClientType.android, HostClientType.ios, HostClientType.ipados, HostClientType.visionOS],
     },
   ],

--- a/packages/teams-js/test/public/nestedAppAuth.spec.ts
+++ b/packages/teams-js/test/public/nestedAppAuth.spec.ts
@@ -115,7 +115,7 @@ describe('nestedAppAuth', () => {
           await utils.initializeWithContext(FrameContexts.content, hostClient);
           const runtimeConfig: Runtime = {
             apiVersion: 4,
-            supports: { nestedAppAuth },
+            supports: { nestedAppAuth: {} },
             isNAAChannelRecommended: false,
             isLegacyTeams: true,
           };
@@ -203,6 +203,40 @@ describe('nestedAppAuth', () => {
       };
       utils.setRuntimeConfig(runtimeConfig);
       expect(nestedAppAuth.isDeeplyNestedAuthSupported()).toBeFalsy();
+    });
+    describe('should return true if isDeeplyNestedAuthSupported is false and isLegacyTeams is true in runtimeConfig for following clients that supports nestedAppAuth.deeplyNestedAuth', () => {
+      const hostClients = [HostClientType.ipados, HostClientType.ios, HostClientType.android];
+
+      hostClients.forEach((hostClient) => {
+        it(`for ${hostClient} client`, async () => {
+          await utils.initializeWithContext(FrameContexts.content, hostClient);
+          const runtimeConfig: Runtime = {
+            apiVersion: 4,
+            supports: { nestedAppAuth: { deeplyNestedAuth: {} } },
+            isNAAChannelRecommended: false,
+            isLegacyTeams: true,
+          };
+          utils.setRuntimeConfig(runtimeConfig);
+          expect(nestedAppAuth.isDeeplyNestedAuthSupported()).toBeTruthy();
+        });
+      });
+    });
+    describe('should return false if isDeeplyNestedAuthSupported is false and isLegacyTeams is true in runtimeConfig for following clients that does not support nestedAppAuth.deeplyNestedAuth', () => {
+      const hostClients = [HostClientType.ipados, HostClientType.ios, HostClientType.android];
+
+      hostClients.forEach((hostClient) => {
+        it(`for ${hostClient} client`, async () => {
+          await utils.initializeWithContext(FrameContexts.content, hostClient);
+          const runtimeConfig: Runtime = {
+            apiVersion: 4,
+            supports: { nestedAppAuth: {} },
+            isNAAChannelRecommended: false,
+            isLegacyTeams: true,
+          };
+          utils.setRuntimeConfig(runtimeConfig);
+          expect(nestedAppAuth.isDeeplyNestedAuthSupported()).toBeFalsy();
+        });
+      });
     });
   });
   describe('getParentOrigin', () => {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

The current isDeeplyNestedAuthSupported function that app developers will call, checks the value of the isDeeplyNestedAuthSupported flag in the runtime config. For hosts which are using the host sdks, the config object is sent during app initialization which sets the value of the is isDeeplyNestedAuthSupported flag in the runtime config correctly. For legacy Teams (i.e. Teams app not using the host SDK), the config object is not sent during the app initialization. The runtime config object is created on the JS SDK side. Therefore, a solution is required to return the value of the isDeeplyNestedAuthSupported correctly for the legacy Teams scenarios.

### Main changes in the PR:

Added the nestedAppAuth.deeplyNestedAuth capability against the new version in the mapTeamsVersionToSupportedCapabilities in runtime.ts which is used along with versionAndPlatformAgnosticTeamsRuntimeConfig object to create the runtime object for legacy teams scenarios.
Along with the check of isDeeplyNestedAuthSupported value in the runtime config, an additional condition is added to check the following:
the host is Android or iOS or iPadOs
the value of isLegacyTeams flag in the runtime
Is the nestedAppAuth?.deeplyNestedAuth capability present in the runtime.supports

## Validation

### Validation performed:

1. Validated the isDeeplyNestedAuthSupported is returning correct value for legacy teams using Teams-test-app


### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes
Added unit tests to test the isDeeplyNestedAuthSupported against different conditions.

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | 
![Screenshot_2025-05-14-23-41-15-96_c93d8b93098b4b30ab038c53d04444c3](https://github.com/user-attachments/assets/496f997c-85e5-4242-a3ce-0c8c0dc0d15d)
 |
