### PR TITLE
Added new parameters to open action url dialog.

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/ExternalAppCardActionsForDAAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/ExternalAppCardActionsForDAAPIs.tsx
@@ -19,6 +19,8 @@ const ProcessActionOpenUrlDialog = (): React.ReactElement =>
     appId: string;
     actionOpenUrlDialogInfo: externalAppCardActionsForDA.IActionOpenUrlDialogInfo;
     traceId: string;
+    card: externalAppCardActionsForDA.Card;
+    action: externalAppCardActionsForDA.Action;
   }>({
     name: 'processActionOpenUrlDialogForDA',
     title: 'Process Action OpenUrlDialog For DA',
@@ -43,6 +45,8 @@ const ProcessActionOpenUrlDialog = (): React.ReactElement =>
           new AppId(input.appId),
           actionOpenUrlDialogInfo,
           new UUID(input.traceId),
+          input.card,
+          input.action,
         );
         return 'Completed';
       },

--- a/change/@microsoft-teams-js-1854dd60-6c4c-40e3-a46d-b875a8f99902.json
+++ b/change/@microsoft-teams-js-1854dd60-6c4c-40e3-a46d-b875a8f99902.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added card and action parameters to `actionOpenUrlDialog`.",
+  "packageName": "@microsoft/teams-js",
+  "email": "31258166+juanscr@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/externalAppCardActionsForDA.ts
+++ b/packages/teams-js/src/private/externalAppCardActionsForDA.ts
@@ -15,7 +15,7 @@ import { DialogSize } from '../public';
 import { AppId } from '../public';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
 import { runtime } from '../public/runtime';
-import { ISerializable } from '../public/serializable.interface';
+import { ISerializable, SerializableObject } from '../public/serializable.interface';
 import { UUID, validateUuidInstance } from '../public/uuidObject';
 import { isExternalAppError } from './externalAppErrorHandling';
 
@@ -52,6 +52,20 @@ export interface IActionOpenUrlDialogInfo extends IDialogActionBase {
   url: URL;
 }
 
+export type Card = {
+  /**
+   * The adaptive card ID.
+   */
+  id: string;
+};
+
+export type Action = {
+  /**
+   * The title for the action button.
+   */
+  title: string;
+};
+
 /**
  * @beta
  * @hidden
@@ -61,12 +75,16 @@ export interface IActionOpenUrlDialogInfo extends IDialogActionBase {
  * @param appId ID of the application the request is intended for. This must be a UUID
  * @param actionOpenUrlDialogInfo Information required to open the URL dialog
  * @param traceId The trace identifier used for monitoring and live site investigations
+ * @param card The adaptive card that contains the action
+ * @param action The action that triggered the dialog
  * @returns Promise that resolves when the request is completed and rejects with ExternalAppError if the request fails
  */
 export async function processActionOpenUrlDialog(
   appId: AppId,
   actionOpenUrlDialogInfo: IActionOpenUrlDialogInfo,
   traceId: UUID,
+  card?: Card,
+  action?: Action,
 ): Promise<void> {
   ensureInitialized(runtime, FrameContexts.content);
 
@@ -75,9 +93,17 @@ export async function processActionOpenUrlDialog(
   }
   validateInput(appId, traceId);
 
+  const serializableCard = card ? new SerializableObject(card) : undefined;
+  const serializableAction = action ? new SerializableObject(action) : undefined;
   return callFunctionInHost(
     ApiName.ExternalAppCardActionsForDA_ProcessActionOpenUrlDialog,
-    [appId, new SerializableActionOpenUrlDialogInfo(actionOpenUrlDialogInfo), traceId],
+    [
+      appId,
+      new SerializableActionOpenUrlDialogInfo(actionOpenUrlDialogInfo),
+      traceId,
+      serializableCard,
+      serializableAction,
+    ],
     getApiVersionTag(
       externalAppCardActionsForDATelemetryVersionNumber,
       ApiName.ExternalAppCardActionsForDA_ProcessActionOpenUrlDialog,

--- a/packages/teams-js/src/public/serializable.interface.ts
+++ b/packages/teams-js/src/public/serializable.interface.ts
@@ -1,3 +1,5 @@
+import { SimpleType } from '../internal/responseHandler';
+
 /**
  * Interface for objects that can be serialized and passed to the host
  */
@@ -22,4 +24,22 @@ export function isSerializable(arg: unknown): arg is ISerializable {
     (arg as ISerializable).serialize !== undefined &&
     typeof (arg as ISerializable).serialize === 'function'
   );
+}
+
+/**
+ * Represents an object that contains serializable properties.
+ */
+type ISerializableObject = { [key: string]: SimpleType };
+
+/**
+ * Class for serializing an object with simple properties.
+ */
+export class SerializableObject<I extends ISerializableObject> implements ISerializable {
+  public constructor(private _instance: I) {}
+
+  public serialize(): string | object {
+    return {
+      ...this._instance,
+    };
+  }
 }

--- a/packages/teams-js/test/private/externalAppCardActionsForDA.spec.ts
+++ b/packages/teams-js/test/private/externalAppCardActionsForDA.spec.ts
@@ -32,7 +32,6 @@ describe('externalAppCardActionsForDA', () => {
         height: DialogDimension.Large,
       },
     };
-    const serializedInput = [null, null];
     const testError = {
       errorCode: ExternalAppErrorCode.INTERNAL_ERROR,
       message: 'testMessage',


### PR DESCRIPTION
## Description
This pull request adds new parameters to the open action URL dialog functionality. These parameters are added as optional in order to not add any breaking change. Additionally, I added a new generic serializable object to be a bit easier to pass objects that map to single types.

### Main changes in the PR:

1. Added the `card` and `action` parameters to `actionOpenUrlDialog`
2. Added the `SerializableObject` class for easy and fast development when no special serialization is needed.

## Validation

### Validation performed:

1. Ran unit tests and test app.

### Unit Tests added:

Yes.

### End-to-end tests added:

No.

## Additional Requirements

### Change file added:
Yes
