### PR TITLE
Removed message source check but kept origin validation in nested app auth standalone bridge

### DIFF
--- a/change/@microsoft-teams-js-8a2e274f-36a6-4e8e-a1aa-c56ae77741c6.json
+++ b/change/@microsoft-teams-js-8a2e274f-36a6-4e8e-a1aa-c56ae77741c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove message source check but keep origin validation in nested app auth standalone bridge",
+  "packageName": "@microsoft/teams-js",
+  "email": "109554253+baljesingh@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-teams-js-8a2e274f-36a6-4e8e-a1aa-c56ae77741c6.json
+++ b/change/@microsoft-teams-js-8a2e274f-36a6-4e8e-a1aa-c56ae77741c6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Remove message source check but keep origin validation in nested app auth standalone bridge",
+  "comment": "Removed message source check but kept origin validation in nested app auth standalone bridge",
   "packageName": "@microsoft/teams-js",
   "email": "109554253+baljesingh@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/teams-js/src/private/nestedAppAuth/nestedAppAuthBridge.ts
+++ b/packages/teams-js/src/private/nestedAppAuth/nestedAppAuthBridge.ts
@@ -19,7 +19,7 @@ import { v4 as generateUUID } from 'uuid';
  * @internal
  * Limited to Microsoft-internal use
  */
-export const version = '1.0.0';
+export const version = '1.0.1';
 
 /**
  * Interface representing a request structure.
@@ -256,12 +256,6 @@ function processAuthBridgeMessage(evt: MessageEvent, onMessageReceived: (respons
 }
 
 function shouldProcessIncomingMessage(messageSource: Window, messageOrigin: string): boolean {
-  // Reject messages if they are not from the top window
-  if (messageSource && messageSource !== window.top) {
-    log('Should not process message because it is not coming from the top window');
-    return false;
-  }
-
   // Check if messageOrigin matches topOriginForNAA
   if (messageOrigin === topOriginForNAA) {
     try {

--- a/packages/teams-js/test/private/nestedAppAuthBridge.spec.ts
+++ b/packages/teams-js/test/private/nestedAppAuthBridge.spec.ts
@@ -147,29 +147,6 @@ describe('NestedAppAuthBridge', () => {
     expect(mockWindow.removeEventListener).not.toBeCalled();
   });
 
-  it('should ignore message if source is not top window', () => {
-    nestedAppAuthBridge.initialize(mockWindow as unknown as Window, mockOrigin);
-    const bridge = mockWindow.nestedAppAuthBridge as NestedAppAuthBridge;
-
-    const callback = jest.fn();
-    bridge.addEventListener('message', callback);
-
-    const handler = mockWindow.addEventListener.mock.calls[0][1] as (event: unknown) => void;
-
-    const fakeSource = {} as Window;
-
-    const msg = {
-      origin: mockOrigin,
-      source: fakeSource,
-      data: {
-        args: [null, JSON.stringify({ messageType: 'NestedAppAuthResponse' })],
-      },
-    };
-
-    handler(msg);
-    expect(callback).not.toBeCalled();
-  });
-
   it('should ignore message without messageType', () => {
     nestedAppAuthBridge.initialize(mockWindow as unknown as Window, mockOrigin);
     const bridge = mockWindow.nestedAppAuthBridge as NestedAppAuthBridge;


### PR DESCRIPTION
## Description

> This PR removes the message source check validation as it's causing issues in teams, but origin validation is still in place to make sure it's receiving the message from the correct origin.

### Main changes in the PR:

1. Remove source validation in shouldProcessIncomingMessage()

## Validation

### Validation performed: N/A

### Unit Tests added:

> Yes

### End-to-end tests added:

N/A

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes
