### PR TITLE
Try fallback valid domains list before CDN list

### DIFF
--- a/change/@microsoft-teams-js-2bb3cac7-5319-4348-9c43-562b8ff6f3d7.json
+++ b/change/@microsoft-teams-js-2bb3cac7-5319-4348-9c43-562b8ff6f3d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated valid domains CDN fetch logic to prevent duplicate requests.",
+  "packageName": "@microsoft/teams-js",
+  "email": "jeklouda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
       "brotli": false,
       "path": "./packages/teams-js/dist/esm/packages/teams-js/src/index.js",
       "import": "{ app, authentication, pages }",
-      "limit": "57.40 KB"
+      "limit": "57.60 KB"
     },
     {
       "brotli": false,

--- a/packages/teams-js/src/internal/validOrigins.ts
+++ b/packages/teams-js/src/internal/validOrigins.ts
@@ -22,6 +22,7 @@ async function getValidOriginsListFromCDN(shouldDisableCache: boolean = false): 
     return validOriginsCache;
   }
   if (validOriginsPromise) {
+    // Fetch has already been initiated, return the existing promise
     return validOriginsPromise;
   }
   if (!inServerSideRenderingEnvironment()) {

--- a/packages/teams-js/src/internal/validOrigins.ts
+++ b/packages/teams-js/src/internal/validOrigins.ts
@@ -165,6 +165,8 @@ function validateOriginWithValidOriginsList(messageOrigin: URL, validOriginsList
 /**
  * @internal
  * Limited to Microsoft-internal use
+ * 
+ * This function is only used for testing to reset the valid origins cache and ignore prefetched values.
  */
 export function resetValidOriginsCache(): void {
   validOriginsCache = [];

--- a/packages/teams-js/test/internal/validOrigins.spec.ts
+++ b/packages/teams-js/test/internal/validOrigins.spec.ts
@@ -293,100 +293,118 @@ describe('validOrigins', () => {
     it('validateOrigin returns true if origin is in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://teams.microsoft.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(true);
     });
     it('validateOrigin returns true if origin for subdomains in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://test.www.office.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(true);
     });
     it('validateOrigin returns false if origin is not in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://badorigin.example.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if origin is not an exact match in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://team.microsoft.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(false);
     });
     it('validateOrigin returns true if origin is valid origin supplied by user ', async () => {
       const messageOrigin = new URL('https://testorigin.example.com');
       GlobalVars.additionalValidOrigins = [messageOrigin.origin];
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(true);
     });
     it('validateOrigin returns false if origin is not supplied by user', async () => {
       const messageOrigin = new URL('https://badorigin.example.com');
       GlobalVars.additionalValidOrigins = ['https://testorigin.example.com'];
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(false);
     });
     it('validateOrigin returns true if origin for subdomains is in the user supplied list', async () => {
       const messageOrigin = new URL('https://subdomain.badorigin.example.com');
       GlobalVars.additionalValidOrigins = ['https://*.badorigin.example.com'];
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(true);
     });
     it('validateOrigin returns false if origin for subdomains is not in the user supplied list', async () => {
       const messageOrigin = new URL('https://subdomain.badorigin.example.com');
       GlobalVars.additionalValidOrigins = ['https://*.testorigin.example.com'];
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if the port number of valid origin is not in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://local.teams.live.com:4000');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if the port number of valid origin is not in the user supplied list', async () => {
       const messageOrigin = new URL('https://testorigin.example.com:4000');
       GlobalVars.additionalValidOrigins = ['https://testorigin.example.com:8080'];
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(false);
     });
     it('validateOrigin returns true if the port number of valid origin is in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://local.teams.live.com:8080');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(true);
     });
     it('validateOrigin returns true if the port number of valid origin is in the user supplied list', async () => {
       const messageOrigin = new URL('https://testorigin.example.com:8080');
       GlobalVars.additionalValidOrigins = ['https://testorigin.example.com:8080'];
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(true);
     });
     it('validateOrigin returns false if origin has extra appended', async () => {
       const messageOrigin = new URL('https://teams.microsoft.com.evil.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(false);
     });
     it("validateOrigin returns false if the protocol of origin is not 'https:'", async () => {
       /* eslint-disable-next-line @microsoft/sdl/no-insecure-url */ /* Intentionally using http here because of what it is testing */
       const messageOrigin = new URL('http://teams.microsoft.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if first end of origin is not matched valid subdomains in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://myteams.microsoft.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if first end of origin is not matched valid subdomains in the user supplied list', async () => {
       const messageOrigin = new URL('https://myteams.microsoft.com');
       const result = await validateOrigin(messageOrigin, disableCache);
       GlobalVars.additionalValidOrigins = ['https://*.teams.microsoft.com'];
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if origin for subdomains does not match in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://a.b.sharepoint.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if origin for subdomains does not match in the user supplied list', async () => {
       const messageOrigin = new URL('https://a.b.testdomain.com');
       const result = await validateOrigin(messageOrigin, disableCache);
       GlobalVars.additionalValidOrigins = ['https://*.testdomain.com'];
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(false);
     });
   });
@@ -399,6 +417,7 @@ describe('validOrigins', () => {
       app._initialize(utils.mockWindow);
       GlobalVars.isFramelessWindow = false;
       global.fetch = jest.fn(() => Promise.resolve({ status: 503, ok: false } as Response));
+      resetValidOriginsCache();
     });
 
     afterAll(() => {
@@ -414,100 +433,118 @@ describe('validOrigins', () => {
     it('validateOrigin returns true if origin is in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://teams.microsoft.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(true);
     });
     it('validateOrigin returns true if origin for subdomains in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://test.www.office.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(true);
     });
     it('validateOrigin returns false if origin is not in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://badorigin.example.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if origin is not an exact match in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://team.microsoft.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
     it('validateOrigin returns true if origin is valid origin supplied by user ', async () => {
       const messageOrigin = new URL('https://testorigin.example.com');
       GlobalVars.additionalValidOrigins = [messageOrigin.origin];
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(true);
     });
     it('validateOrigin returns false if origin is not supplied by user', async () => {
       const messageOrigin = new URL('https://badorigin.example.com');
       GlobalVars.additionalValidOrigins = ['https://testorigin.example.com'];
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
     it('validateOrigin returns true if origin for subdomains is in the user supplied list', async () => {
       const messageOrigin = new URL('https://subdomain.badorigin.example.com');
       GlobalVars.additionalValidOrigins = ['https://*.badorigin.example.com'];
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(true);
     });
     it('validateOrigin returns false if origin for subdomains is not in the user supplied list', async () => {
       const messageOrigin = new URL('https://subdomain.badorigin.example.com');
       GlobalVars.additionalValidOrigins = ['https://*.testorigin.example.com'];
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if the port number of valid origin is not in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://local.teams.live.com:4000');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if the port number of valid origin is not in the user supplied list', async () => {
       const messageOrigin = new URL('https://testorigin.example.com:4000');
       GlobalVars.additionalValidOrigins = ['https://testorigin.example.com:8080'];
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
     it('validateOrigin returns true if the port number of valid origin is in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://local.teams.live.com:8080');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(true);
     });
     it('validateOrigin returns true if the port number of valid origin is in the user supplied list', async () => {
       const messageOrigin = new URL('https://testorigin.example.com:8080');
       GlobalVars.additionalValidOrigins = ['https://testorigin.example.com:8080'];
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(0);
       expect(result).toBe(true);
     });
     it('validateOrigin returns false if origin has extra appended', async () => {
       const messageOrigin = new URL('https://teams.microsoft.com.evil.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
     it("validateOrigin returns false if the protocol of origin is not 'https:'", async () => {
       /* eslint-disable-next-line @microsoft/sdl/no-insecure-url */ /* Intentionally using http here because of what it is testing */
       const messageOrigin = new URL('http://teams.microsoft.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if first end of origin is not matched valid subdomains in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://myteams.microsoft.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if first end of origin is not matched valid subdomains in the user supplied list', async () => {
       const messageOrigin = new URL('https://myteams.microsoft.com');
       const result = await validateOrigin(messageOrigin, disableCache);
       GlobalVars.additionalValidOrigins = ['https://*.teams.microsoft.com'];
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if origin for subdomains does not match in teams pre-known allowlist', async () => {
       const messageOrigin = new URL('https://a.b.sharepoint.com');
       const result = await validateOrigin(messageOrigin, disableCache);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
     it('validateOrigin returns false if origin for subdomains does not match in the user supplied list', async () => {
       const messageOrigin = new URL('https://a.b.testdomain.com');
       const result = await validateOrigin(messageOrigin, disableCache);
       GlobalVars.additionalValidOrigins = ['https://*.testdomain.com'];
+      expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(result).toBe(false);
     });
   });

--- a/packages/teams-js/test/internal/validOrigins.spec.ts
+++ b/packages/teams-js/test/internal/validOrigins.spec.ts
@@ -1,6 +1,6 @@
 import { ORIGIN_LIST_FETCH_TIMEOUT_IN_MS } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
-import { validateOrigin } from '../../src/internal/validOrigins';
+import { resetValidOriginsCache, validateOrigin } from '../../src/internal/validOrigins';
 import * as app from '../../src/public/app/app';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';
@@ -545,6 +545,8 @@ describe('validOrigins', () => {
             } as Response);
           }),
       );
+
+      resetValidOriginsCache();
     });
 
     afterAll(() => {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This PR reduces latency for the app initialization scenario by relying on the local valid domain list before checking the list on the CDN. It also resolves an issue where teams-js was making multiple CDN fetch requests if it tried to access the valid domains list before prefetching completes.

### Main changes in the PR:

1. `validateOrigin` checks the fallback domain list before using the CDN list if there is no cached list available.
2. `getValidOriginsListFromCDN` will no longer create a new fetch request if one is already in progress.

## Validation

### Validation performed:

1. Unit tests added

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes

### End-to-end tests added:

N/A
