### PR TITLE
Break PR build on Android E2E test failures

### DIFF
--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -91,7 +91,6 @@ steps:
       targetType: inline
       script: 'chmod u+x ./gradlew && chmod u+x e2eTest.sh && ./e2eTest.sh ${{ parameters.shardNum }} ${{ parameters.shardIndex }}'
       workingDirectory: '$(Agent.BuildDirectory)/androidHost/apps/orangeandroid'
-    continueOnError: true
 
   - task: CodeQL3000Finalize@0
     condition: always()


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

I allowed the build to pass on Android test failures to get https://github.com/OfficeDev/microsoft-teams-library-js/pull/2818 checked in. This PR restores the behavior of breaking on Android test failures