### PR TITLE
Remove max url length from authenticate flow

### DIFF
--- a/change/@microsoft-teams-js-7668fe92-8f01-4492-804f-faba71615848.json
+++ b/change/@microsoft-teams-js-7668fe92-8f01-4492-804f-faba71615848.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Removed the max length validation from the `authentication.authenticate` API.",
+  "packageName": "@microsoft/teams-js",
+  "email": "jeklouda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -422,12 +422,12 @@ export function validateId(id: string, errorToThrow?: Error): void {
   }
 }
 
-export function validateUrl(url: URL, errorToThrow?: Error): void {
+export function validateUrl(url: URL, errorToThrow?: Error, enforceMaxLength: boolean = true): void {
   const urlString = url.toString().toLocaleLowerCase();
   if (hasScriptTags(urlString)) {
     throw errorToThrow || new Error('Invalid Url');
   }
-  if (urlString.length > 2048) {
+  if (enforceMaxLength && urlString.length > 2048) {
     throw errorToThrow || new Error('Url exceeds the maximum size of 2048 characters');
   }
   if (!isValidHttpsURL(url)) {

--- a/packages/teams-js/src/internal/utils.ts
+++ b/packages/teams-js/src/internal/utils.ts
@@ -422,13 +422,10 @@ export function validateId(id: string, errorToThrow?: Error): void {
   }
 }
 
-export function validateUrl(url: URL, errorToThrow?: Error, enforceMaxLength: boolean = true): void {
+export function validateUrl(url: URL, errorToThrow?: Error): void {
   const urlString = url.toString().toLocaleLowerCase();
   if (hasScriptTags(urlString)) {
     throw errorToThrow || new Error('Invalid Url');
-  }
-  if (enforceMaxLength && urlString.length > 2048) {
-    throw errorToThrow || new Error('Url exceeds the maximum size of 2048 characters');
   }
   if (!isValidHttpsURL(url)) {
     throw errorToThrow || new Error('Url should be a valid https url');

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -139,7 +139,7 @@ async function authenticateHelper(
 ): Promise<string> {
   // Convert any relative URLs into absolute URLs before sending them over to the parent window.
   const fullyQualifiedURL: URL = fullyQualifyUrlString(authenticateParameters.url);
-  validateUrl(fullyQualifiedURL);
+  validateUrl(fullyQualifiedURL, undefined, false);
 
   // Ask the parent window to open an authentication window with the parameters provided by the caller.
   return sendMessageToParentAsync<[boolean, string]>(apiVersionTag, 'authentication.authenticate', [

--- a/packages/teams-js/src/public/authentication.ts
+++ b/packages/teams-js/src/public/authentication.ts
@@ -139,7 +139,7 @@ async function authenticateHelper(
 ): Promise<string> {
   // Convert any relative URLs into absolute URLs before sending them over to the parent window.
   const fullyQualifiedURL: URL = fullyQualifyUrlString(authenticateParameters.url);
-  validateUrl(fullyQualifiedURL, undefined, false);
+  validateUrl(fullyQualifiedURL);
 
   // Ask the parent window to open an authentication window with the parameters provided by the caller.
   return sendMessageToParentAsync<[boolean, string]>(apiVersionTag, 'authentication.authenticate', [

--- a/packages/teams-js/test/internal/utils.spec.ts
+++ b/packages/teams-js/test/internal/utils.spec.ts
@@ -268,7 +268,7 @@ describe('utils', () => {
         expect(error).toEqual(new Error('Invalid Url'));
       }
     });
-    it('should throw maxlength exceed error if it contains more than 2048 chars', async () => {
+    it('should throw maxlength exceed error if enforceMaxLength is true and URL contains more than 2048 chars', async () => {
       expect.assertions(1);
       const url = 'https://example.com?param=' + 'a'.repeat(2048);
       try {
@@ -276,6 +276,11 @@ describe('utils', () => {
       } catch (error) {
         expect(error).toEqual(new Error('Url exceeds the maximum size of 2048 characters'));
       }
+    });
+    it('should not throw maxlength exceed error if enforceMaxLength is false and URL contains more than 2048 chars', async () => {
+      expect.assertions(1);
+      const url = 'https://example.com?param=' + 'a'.repeat(2048);
+      expect(() => validateUrl(new URL(url), undefined, false)).not.toThrow();
     });
     it('should throw invalid url error if it non http url', async () => {
       expect.assertions(1);

--- a/packages/teams-js/test/internal/utils.spec.ts
+++ b/packages/teams-js/test/internal/utils.spec.ts
@@ -268,20 +268,6 @@ describe('utils', () => {
         expect(error).toEqual(new Error('Invalid Url'));
       }
     });
-    it('should throw maxlength exceed error if enforceMaxLength is true and URL contains more than 2048 chars', async () => {
-      expect.assertions(1);
-      const url = 'https://example.com?param=' + 'a'.repeat(2048);
-      try {
-        validateUrl(new URL(url));
-      } catch (error) {
-        expect(error).toEqual(new Error('Url exceeds the maximum size of 2048 characters'));
-      }
-    });
-    it('should not throw maxlength exceed error if enforceMaxLength is false and URL contains more than 2048 chars', async () => {
-      expect.assertions(1);
-      const url = 'https://example.com?param=' + 'a'.repeat(2048);
-      expect(() => validateUrl(new URL(url), undefined, false)).not.toThrow();
-    });
     it('should throw invalid url error if it non http url', async () => {
       expect.assertions(1);
       // eslint-disable-next-line @microsoft/sdl/no-insecure-url


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This PR removes the max length validation from the `authentication.authenticate` and `externalAppAuthentication` flows. This will resolve the issue reported in https://github.com/MicrosoftDocs/msteams-docs/issues/13041. URLs that exceed the browser's URL size limit will be handled by the browser.

### Main changes in the PR:

1. Remove max URL length validation from the `validateUrl` util.

## Validation

### Validation performed:

1. Unit tests added

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes

### End-to-end tests added:

N/A

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes