### PR TITLE
Added checkbox input for eligibility API

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/CopilotAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/CopilotAPIs.tsx
@@ -2,7 +2,7 @@ import { copilot, sidePanelInterfaces, UUID } from '@microsoft/teams-js';
 import React, { ReactElement } from 'react';
 
 import { generateRegistrationMsg } from '../../App';
-import { ApiWithoutInput, ApiWithTextInput } from '../utils';
+import { ApiWithCheckboxInput, ApiWithoutInput, ApiWithTextInput } from '../utils';
 import { ModuleWrapper } from '../utils/ModuleWrapper';
 
 const CopilotAPIs = (): ReactElement => {
@@ -15,11 +15,12 @@ const CopilotAPIs = (): ReactElement => {
     });
 
   const GetEligibilityInfo = (): ReactElement =>
-    ApiWithoutInput({
+    ApiWithCheckboxInput({
       name: 'getEligibilityInfo',
       title: 'Get the app Eligibility Information',
-      onClick: async () => {
-        const result = await copilot.eligibility.getEligibilityInfo();
+      label: 'forceRefresh',
+      onClick: async (input) => {
+        const result = await copilot.eligibility.getEligibilityInfo(input);
         return JSON.stringify(result);
       },
     });


### PR DESCRIPTION
For better testing, the get eligibility information function adds a checkbox input so we can manipulate the argument.