### PR TITLE
Change the button text unique to enable iOS E2E tests for ExternalAppAuthForCEA APIs E2E tests

### DIFF
--- a/apps/teams-test-app/src/components/privateApis/ExternalAppAuthenticationForCEAAPIs.tsx
+++ b/apps/teams-test-app/src/components/privateApis/ExternalAppAuthenticationForCEAAPIs.tsx
@@ -25,7 +25,7 @@ const AuthenticateWithOAuthForCEA = (): React.ReactElement =>
     };
   }>({
     name: 'AuthenticateWithOAuthForCEA',
-    title: 'Authenticate With OAuth',
+    title: 'Authenticate With OAuth For CEA',
     onClick: {
       validateInput: (input) => {
         if (!input.appId) {
@@ -65,7 +65,7 @@ const AuthenticateWithSSOForCEA = (): React.ReactElement =>
     authTokenRequest: externalAppAuthenticationForCEA.AuthTokenRequestParametersForCEA;
   }>({
     name: 'authenticateWithSSOForCEA',
-    title: 'Authenticate With SSO',
+    title: 'Authenticate With SSO For CEA',
     onClick: {
       validateInput: (input) => {
         if (!input.appId) {
@@ -100,6 +100,8 @@ const AuthenticateWithSSOForCEA = (): React.ReactElement =>
       authTokenRequest: {
         claims: ['https://graph.microsoft.com'],
         silent: true,
+        authId: 'mockedId',
+        connectionName: 'mockedName',
       },
     }),
   });
@@ -117,7 +119,7 @@ const AuthenticateAndResendRequestForCEA = (): React.ReactElement =>
     originalRequestInfo: externalAppAuthentication.IActionExecuteInvokeRequest;
   }>({
     name: 'authenticateAndResendRequestForCEA',
-    title: 'Authenticate And Resend Request',
+    title: 'Authenticate And Resend Request For CEA',
     onClick: {
       validateInput: (input) => {
         if (!input.appId) {
@@ -169,7 +171,7 @@ const AuthenticateWithSSOAndResendRequestForCEA = (): React.ReactElement =>
     originalRequestInfo: externalAppAuthentication.IActionExecuteInvokeRequest;
   }>({
     name: 'authenticateWithSSOAndResendRequestForCEA',
-    title: 'Authenticate With SSO And Resend Request',
+    title: 'Authenticate With SSO And Resend Request For CEA',
     onClick: {
       validateInput: (input) => {
         if (!input.appId) {


### PR DESCRIPTION
…AuthenticateForCEA APIs

For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.
This PR covered the change that updated the button names to a unique string for ExternalAppAuthenticateForCEA APIs to enable the e2e tests in mobile platforms

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes>
<img width="702" height="241" alt="Screenshot 2025-07-22 at 12 29 43 PM" src="https://github.com/user-attachments/assets/b285b41d-d927-4a55-9219-7d4ed1182b14" />

