### PR TITLE
Add messageId to app context

### DIFF
--- a/change/@microsoft-teams-js-05700e50-9d88-4dc6-8803-d5cc7f5f8a2d.json
+++ b/change/@microsoft-teams-js-05700e50-9d88-4dc6-8803-d5cc7f5f8a2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added `messageId` to app context.",
+  "packageName": "@microsoft/teams-js",
+  "email": "jeklouda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
       "brotli": false,
       "path": "./packages/teams-js/dist/esm/packages/teams-js/src/index.js",
       "import": "{ app, authentication, pages }",
-      "limit": "57.68 KB"
+      "limit": "57.69 KB"
     },
     {
       "brotli": false,

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
       "brotli": false,
       "path": "./packages/teams-js/dist/esm/packages/teams-js/src/index.js",
       "import": "{ app, authentication, pages }",
-      "limit": "57.67 KB"
+      "limit": "57.68 KB"
     },
     {
       "brotli": false,

--- a/packages/teams-js/src/public/app/app.ts
+++ b/packages/teams-js/src/public/app/app.ts
@@ -180,6 +180,12 @@ export interface AppInfo {
   userClickTimeV2?: number;
 
   /**
+   * The ID of the message from which this task module was launched.
+   * This is only available in task modules launched from bot cards.
+   */
+  messageId?: string;
+
+  /**
    * The ID of the parent message from which this task module was launched.
    * This is only available in task modules launched from bot cards.
    */
@@ -819,6 +825,7 @@ function transformLegacyContextToAppContext(legacyContext: LegacyContext): Conte
       theme: legacyContext.theme ? legacyContext.theme : 'default',
       iconPositionVertical: legacyContext.appIconPosition,
       osLocaleInfo: legacyContext.osLocaleInfo,
+      messageId: legacyContext.messageId,
       parentMessageId: legacyContext.parentMessageId,
       userClickTime: legacyContext.userClickTime,
       userClickTimeV2: legacyContext.userClickTimeV2,

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -624,6 +624,15 @@ export interface Context {
 
   /**
    * @deprecated
+   * As of TeamsJS v2.0.0, please use {@link app.AppInfo.messageId | app.Context.app.messageId} instead
+   *
+   * The ID of the message from which this task module was launched.
+   * This is only available in task modules launched from bot cards.
+   */
+  messageId?: string;
+
+  /**
+   * @deprecated
    * As of TeamsJS v2.0.0, please use {@link app.AppInfo.parentMessageId | app.Context.app.parentMessageId} instead
    *
    * The ID of the parent message from which this task module was launched.

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -413,7 +413,7 @@ describe('Testing app capability', () => {
         message = utils.findMessageByFunc('getContext');
         expect(message).not.toBeNull();
       });
-  
+
       Object.values(FrameContexts).forEach((context) => {
         it(`app.getContext should successfully get frame context in ${context} context`, async () => {
           await utils.initializeWithContext(context);
@@ -538,6 +538,7 @@ describe('Testing app capability', () => {
             sharepoint: {},
             tenantSKU: 'someTenantSKU',
             userLicenseType: 'someUserLicenseType',
+            messageId: 'someMessageId',
             parentMessageId: 'someParentMessageId',
             ringId: 'someRingId',
             appSessionId: 'appSessionId',
@@ -570,6 +571,7 @@ describe('Testing app capability', () => {
             app: {
               iconPositionVertical: 5,
               locale: 'someLocale',
+              messageId: 'someMessageId',
               parentMessageId: 'someParentMessageId',
               sessionId: 'appSessionId',
               theme: 'someTheme',


### PR DESCRIPTION
## Description

Adds the `messageId` property to the app context for task modules launched from Teams messages. Currently, the `parentMessageId` is available, but tasks launched from reply messages do not have access to the ID of the message from which they are launched. Teams will pass this property in task modules.

### Main changes in the PR:

1. Add `messageId` to `AppInfo` interface and associated logic to convert from legacy `Context` object.

## Validation

### Validation performed:

1. Validated with context passed from test host.

### Unit Tests added:

Yes

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes
