### PR TITLE
Force install dependencies on build pipeline

### DIFF
--- a/tools/yaml-templates/build-test-publish.yml
+++ b/tools/yaml-templates/build-test-publish.yml
@@ -15,7 +15,7 @@ steps:
     displayName: 'Install repo dependencies'
     inputs:
       script: |
-        pnpm install
+        pnpm install --force
 
   - task: CmdLine@2
     displayName: 'Check that changefile was created if needed'


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Build and PR pipelines are failing on the main branch due to unresolved dependencies, but not on PR builds or branches from main with no changes. This PR adds the `--force` flag to the `pnpm install` step in the build yaml to see if we can force the main branch out of its broken state.

### Main changes in the PR:

1. Add `--force` flag to `pnpm install` step in build yaml

## Validation

### Validation performed:

1. Build passed on manual run
