### PR TITLE
Split a-d E2E tests

### DIFF
--- a/tools/yaml-templates/web-e2e-versions.yml
+++ b/tools/yaml-templates/web-e2e-versions.yml
@@ -12,7 +12,7 @@ jobs:
       AppHostingSdk: AppHostingSdk
       hostingEnvironmentType: 'standardWeb'
       teamsJsReferenceType: 'npm'
-      testPrefixPatternGroups: ['{[0-9],[A-D],[a-d]}', '{[E],[e]}', '{[F-M],[f-m]}', '{[N-Z],[n-z]}']
+      testPrefixPatternGroups: ['{[0-9],[A-B],[a-b]}', '{[C-D],[c-d]}', '{[E],[e]}', '{[F-M],[f-m]}', '{[N-Z],[n-z]}']
       versionBranch: ${{parameters.versionBranch}}
 
   - template: web-e2e-tests-job.yml@self
@@ -20,7 +20,7 @@ jobs:
       AppHostingSdk: AppHostingSdk
       hostingEnvironmentType: 'standardWeb'
       teamsJsReferenceType: 'scriptTag'
-      testPrefixPatternGroups: ['{[0-9],[A-D],[a-d]}', '{[E],[e]}', '{[F-M],[f-m]}', '{[N-Z],[n-z]}']
+      testPrefixPatternGroups: ['{[0-9],[A-B],[a-b]}', '{[C-D],[c-d]}', '{[E],[e]}', '{[F-M],[f-m]}', '{[N-Z],[n-z]}']
       versionBranch: ${{parameters.versionBranch}}
 
   - template: web-e2e-tests-job.yml@self


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

The PR pipeline is starting to fail regularly due to timeouts on the [A-D] E2E testing pipeline (this is E2E tests starting with the letters A-D. This PR further splits that suite into a [A-B] test job and a [C-D] test job to reduce the runtime of these jobs