### PR TITLE
Prerelease 2.43.0

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.42.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-kKQjKs75BOHapvR+ooLO1oHO5e6YewZT5fp0U6EgT22v+ADFCcVPHqj1cSs4iIBO"
+      src="https://res.cdn.office.net/teams-js/2.43.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-0nHNpMJRciJQlpaCyCYK4yo0UU4tusQNisqsYd0ViC1d+tHWCoicv0wyyqSyV45f"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.42.0",
+  "version": "2.43.0",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm validate-test-schema && pnpm lint && webpack",

--- a/change/@microsoft-teams-js-9425e335-8d41-4714-9bc8-4a401010fdd8.json
+++ b/change/@microsoft-teams-js-9425e335-8d41-4714-9bc8-4a401010fdd8.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Released version 2.42.0",
-  "packageName": "@microsoft/teams-js",
-  "email": "jeklouda@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-f0901ccb-dc1d-43c7-a41c-b5d78cd6c9e4.json
+++ b/change/@microsoft-teams-js-f0901ccb-dc1d-43c7-a41c-b5d78cd6c9e4.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added `shortcutRelay` capability to support host shortcuts in apps.",
-  "packageName": "@microsoft/teams-js",
-  "email": "jeklouda@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Thu, 07 Aug 2025 04:45:52 GMT and should not be manually modified.
+This log was last generated on Tue, 19 Aug 2025 15:18:35 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.43.0
+
+Tue, 19 Aug 2025 15:18:35 GMT
+
+### Minor changes
+
+- Added `shortcutRelay` capability to support host shortcuts in apps.
+- Bump eslint-plugin-recommend-no-namespaces to v0.1.0
 
 ## 2.42.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.42.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.43.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.42.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-kKQjKs75BOHapvR+ooLO1oHO5e6YewZT5fp0U6EgT22v+ADFCcVPHqj1cSs4iIBO"
+  src="https://res.cdn.office.net/teams-js/2.43.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-0nHNpMJRciJQlpaCyCYK4yo0UU4tusQNisqsYd0ViC1d+tHWCoicv0wyyqSyV45f"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.42.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.43.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.42.0",
+  "version": "2.43.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

## 2.43.0

Tue, 19 Aug 2025 15:18:35 GMT

### Minor changes

- Added `shortcutRelay` capability to support host shortcuts in apps.
- Bump eslint-plugin-recommend-no-namespaces to v0.1.0
