### PR TITLE
Disable NPM publish task on 2.43.0 release branch

### DIFF
--- a/tools/releases/prod-release.yml
+++ b/tools/releases/prod-release.yml
@@ -52,13 +52,13 @@ extends:
                 inputs:
                   targetType: 'inline'
                   script: Set-Content -Path $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed/.npmrc -Value "//registry.npmjs.org/:_authToken=$(NPM-TOKEN)"
-              - task: Npm@1
-                displayName: Publish to npm (tag latest) KV
-                inputs:
-                  command: custom
-                  workingDir: $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed
-                  verbose: false
-                  customCommand: publish --tag latest
+              # - task: Npm@1
+              #   displayName: Publish to npm (tag latest) KV
+              #   inputs:
+              #     command: custom
+              #     workingDir: $(PIPELINE.WORKSPACE)/microsoft-teams-library-js-pipeline/NPMFeed
+              #     verbose: false
+              #     customCommand: publish --tag latest
               - task: M365CdnAssetsUpload@3
                 displayName: Push teams-js to M365 1CDN (Prod)
                 inputs:


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

The CDN publishing step failed on the 2.43.0 release pipeline. This PR disables the NPM publishing step in a new branch off of the 2.43.0 release branch so that we can retry the CDN publishing step without failing on the NPM step (which will fail because we've already published 2.43.0 to NPM)