### PR TITLE
noahdarveau/ OpenFilePreview in sidePanel Frame Context

### DIFF
--- a/change/@microsoft-teams-js-e433db29-a743-4e63-8b17-cd1272e4a323.json
+++ b/change/@microsoft-teams-js-e433db29-a743-4e63-8b17-cd1272e4a323.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added `sidePanel` to `openFilePreview`'s ensureInitialized FrameContexts",
+  "packageName": "@microsoft/teams-js",
+  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/privateAPIs.ts
+++ b/packages/teams-js/src/private/privateAPIs.ts
@@ -134,7 +134,7 @@ export function registerUserSettingsChangeHandler(
  * Limited to Microsoft-internal use
  */
 export function openFilePreview(filePreviewParameters: FilePreviewParameters): void {
-  ensureInitialized(runtime, FrameContexts.content, FrameContexts.task);
+  ensureInitialized(runtime, FrameContexts.content, FrameContexts.sidePanel, FrameContexts.task);
 
   const params = [
     filePreviewParameters.entityId,

--- a/packages/teams-js/test/private/privateAPIs.spec.ts
+++ b/packages/teams-js/test/private/privateAPIs.spec.ts
@@ -686,7 +686,7 @@ describe('AppSDK-privateAPIs', () => {
   });
 
   describe('openFilePreview', () => {
-    const allowedContexts = [FrameContexts.content, FrameContexts.task];
+    const allowedContexts = [FrameContexts.content, FrameContexts.sidePanel, FrameContexts.task];
     const openFilePreviewParams = {
       entityId: 'someEntityId',
       title: 'someTitle',


### PR DESCRIPTION
Added `FrameContexts.sidePanel` to `openFilePreview`'s ensureInitialized call to allow for the use in SidePanel.