### PR TITLE
Append result if `redirectUrl` doesn't contain the result and its placeholder

### DIFF
--- a/apps/teams-test-app/src/public/auth_end.html
+++ b/apps/teams-test-app/src/public/auth_end.html
@@ -1,8 +1,8 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <h2 style="font-size: 40px;">Ending auth</h2>
-    <div id="errorMessage" style="font-size: 30px;"></div>
+    <h2 style="font-size: 40px">Ending auth</h2>
+    <div id="errorMessage" style="font-size: 30px"></div>
   </head>
   <body>
     <script>
@@ -12,15 +12,20 @@
 
       // Redirect back to Orange host
       if (method === 'deeplink') {
-        const storedRedirectUrl = sessionStorage.getItem('hostRedirectUrl')
+        const storedRedirectUrl = sessionStorage.getItem('hostRedirectUrl');
         if (storedRedirectUrl) {
-          window.location.href = storedRedirectUrl.replace('{result}',result)
+          if (storedRedirectUrl.includes('{result}')) {
+            window.location.href = storedRedirectUrl.replace('{result}', result);
+          } else {
+            const url = new URL(storedRedirectUrl);
+            url.searchParams.append('result', result);
+            window.location.href = url.toString();
+          }
         } else if (hostName === 'Orange') {
           window.location.href = `msorange://testapp.com/auth_callback?authId=${authId}&result=${result}`;
         }
       }
       document.getElementById('errorMessage').textContent = 'Unable to redirect back to the App';
     </script>
-
   </body>
 </html>


### PR DESCRIPTION
This change is checking if the redirectURL has `result` param and its placeholder `{result}`. If not, will apppend the result to the redirect url
## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).
<img width="712" height="260" alt="Screenshot 2025-09-19 at 11 32 32 AM" src="https://github.com/user-attachments/assets/eff1d2c4-67d4-4159-a607-d5c0562b0f3c" />

<No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
