### PR TITLE
Releasing 2.46.0

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.45.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-1ul+vDBl1B71YBndX5+TpWnAkYZfjzoOgjg57X9Gq3SsDAnN4OLELHWv+hoS/zjU"
+      src="https://res.cdn.office.net/teams-js/2.46.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-g9Q+4HMPYpRKmQyg6p5+Wdzlbe75oN7wP0jNLpJRkKOqZpIN9pbxYEoZtubU/eZ5"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.45.0",
+  "version": "2.46.0",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm validate-test-schema && pnpm lint && webpack",

--- a/change/@microsoft-teams-js-88216a56-3ec5-42b0-b7a5-db37b54879df.json
+++ b/change/@microsoft-teams-js-88216a56-3ec5-42b0-b7a5-db37b54879df.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added `disconnectConnector` to `{externalAppAuthentication}` capability that will disconnect the external app connector. The capability is still awaiting support in one or more host applications. To track availability of this capability across different hosts see https://aka.ms/capmatrix",
-  "packageName": "@microsoft/teams-js",
-  "email": "niharikad@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-a3a9ca4b-86f1-4286-a584-b3df08bbc3b2.json
+++ b/change/@microsoft-teams-js-a3a9ca4b-86f1-4286-a584-b3df08bbc3b2.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Merged 2.45.0 release into main",
-  "packageName": "@microsoft/teams-js",
-  "email": "109628470+noahdarveau-MSFT@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Wed, 10 Sep 2025 22:10:41 GMT and should not be manually modified.
+This log was last generated on Wed, 01 Oct 2025 22:58:28 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.46.0
+
+Wed, 01 Oct 2025 22:58:28 GMT
+
+### Minor changes
+
+- Added `disconnectConnector` to `{externalAppAuthentication}` capability that will disconnect the external app connector. The capability is still awaiting support in one or more host applications. To track availability of this capability across different hosts see https://aka.ms/capmatrix
+- Bump eslint-plugin-recommend-no-namespaces to v0.1.0
 
 ## 2.45.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.45.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.46.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.45.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-1ul+vDBl1B71YBndX5+TpWnAkYZfjzoOgjg57X9Gq3SsDAnN4OLELHWv+hoS/zjU"
+  src="https://res.cdn.office.net/teams-js/2.46.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-g9Q+4HMPYpRKmQyg6p5+Wdzlbe75oN7wP0jNLpJRkKOqZpIN9pbxYEoZtubU/eZ5"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.45.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.46.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.45.0",
+  "version": "2.46.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",


### PR DESCRIPTION
## 2.46.0

Wed, 01 Oct 2025 22:58:28 GMT

### Minor changes

- Added `disconnectConnector` to `{externalAppAuthentication}` capability that will disconnect the external app connector. The capability is still awaiting support in one or more host applications. To track availability of this capability across different hosts see https://aka.ms/capmatrix
- Bump eslint-plugin-recommend-no-namespaces to v0.1.0