### PR TITLE
Prepare to release version 2.47.1

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.47.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-IkfULjDxwgKWYEYHErhDcuw+ahOQvmrcRFwgI3sm/uu7c0HWVjyYG3qp5z5SncxD"
+      src="https://res.cdn.office.net/teams-js/2.47.1/js/MicrosoftTeams.min.js"
+      integrity="sha384-GjMCDoLGHjggMwReznovjZJkokJTvLX0ReAT43Y8d43YWFoqSVsqD/AfMjfheWVC"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.47.0",
+  "version": "2.47.1",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm validate-test-schema && pnpm lint && webpack",

--- a/change/@microsoft-teams-js-fb406c59-b6ec-4286-aab3-7455014d91b6.json
+++ b/change/@microsoft-teams-js-fb406c59-b6ec-4286-aab3-7455014d91b6.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fixed error handling in `getConfigSetting` teams full trust api.",
-  "packageName": "@microsoft/teams-js",
-  "email": "31258166+juanscr@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Wed, 12 Nov 2025 19:23:55 GMT and should not be manually modified.
+This log was last generated on Wed, 03 Dec 2025 21:10:55 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.47.1
+
+Wed, 03 Dec 2025 21:10:55 GMT
+
+### Patches
+
+- Fixed error handling in `getConfigSetting` teams full trust api.
+- Bump eslint-plugin-recommend-no-namespaces to v0.1.0
 
 ## 2.47.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.47.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.47.1/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.47.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-IkfULjDxwgKWYEYHErhDcuw+ahOQvmrcRFwgI3sm/uu7c0HWVjyYG3qp5z5SncxD"
+  src="https://res.cdn.office.net/teams-js/2.47.1/js/MicrosoftTeams.min.js"
+  integrity="sha384-GjMCDoLGHjggMwReznovjZJkokJTvLX0ReAT43Y8d43YWFoqSVsqD/AfMjfheWVC"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.47.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.47.1/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.47.0",
+  "version": "2.47.1",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5299,6 +5299,7 @@ packages:
   next@15.2.4:
     resolution: {integrity: sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

ChangeLog:

## 2.47.1

Wed, 03 Dec 2025 21:10:55 GMT

### Patches

- Fixed error handling in `getConfigSetting` teams full trust api.
- Bump eslint-plugin-recommend-no-namespaces to v0.1.0
