### PR TITLE
Version bump for 2.48.1 release

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.48.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-/Wkorl2FOOvi9PzFSf8fmiTS8SFTMOlR3mKqmOI4Rc6tra6JqJvmlssRiYqDOMjD"
+      src="https://res.cdn.office.net/teams-js/2.48.1/js/MicrosoftTeams.min.js"
+      integrity="sha384-opiKcSoAwE9QEI+cc408L9oI0NWev5vi/CLyCCX57M7GuRKrXlC4nOxJ9z6cBoXS"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.48.0",
+  "version": "2.48.1",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm validate-test-schema && pnpm lint && webpack",

--- a/change/@microsoft-teams-js-58fad0e7-f58a-433b-9684-c15f3988fe2a.json
+++ b/change/@microsoft-teams-js-58fad0e7-f58a-433b-9684-c15f3988fe2a.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Added MAC domains to valid domains for CDN",
-  "packageName": "@microsoft/teams-js",
-  "email": "niharikad@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-99b309a0-fe79-4f5b-88bb-336c5a00bfe4.json
+++ b/change/@microsoft-teams-js-99b309a0-fe79-4f5b-88bb-336c5a00bfe4.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Mark registerOnContextChangeHandler as internal API",
-  "packageName": "@microsoft/teams-js",
-  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-ce7fc29c-ccaf-4b30-bc53-104c75fb6a6f.json
+++ b/change/@microsoft-teams-js-ce7fc29c-ccaf-4b30-bc53-104c75fb6a6f.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Reverting the changes for Unauthorized FailedReason",
-  "packageName": "@microsoft/teams-js",
-  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-e8a13e3e-7384-45a3-9abc-d35119480e2a.json
+++ b/change/@microsoft-teams-js-e8a13e3e-7384-45a3-9abc-d35119480e2a.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Released TJS V2.48.0",
-  "packageName": "@microsoft/teams-js",
-  "email": "kangxuanye@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @microsoft/teams-js
 
-This log was last generated on Thu, 08 Jan 2026 23:04:26 GMT and should not be manually modified.
+<!-- This log was last generated on Wed, 04 Feb 2026 17:24:38 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 2.48.1
+
+Wed, 04 Feb 2026 17:24:38 GMT
+
+### Patches
+
+- Added MAC domains to valid domains for CDN
+- Mark registerOnContextChangeHandler as internal API
 
 ## 2.48.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.48.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.48.1/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.48.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-/Wkorl2FOOvi9PzFSf8fmiTS8SFTMOlR3mKqmOI4Rc6tra6JqJvmlssRiYqDOMjD"
+  src="https://res.cdn.office.net/teams-js/2.48.1/js/MicrosoftTeams.min.js"
+  integrity="sha384-opiKcSoAwE9QEI+cc408L9oI0NWev5vi/CLyCCX57M7GuRKrXlC4nOxJ9z6cBoXS"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.48.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.48.1/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.48.0",
+  "version": "2.48.1",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4280,15 +4280,17 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -6825,6 +6827,7 @@ packages:
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@1.0.0:
     resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}


### PR DESCRIPTION


## Description

## 2.48.1

Wed, 04 Feb 2026 17:24:38 GMT

### Patches

- Added MAC domains to valid domains for CDN
- Mark registerOnContextChangeHandler as internal API

