### PR TITLE
Cleanup release 2.49.0 (2)

### DIFF
--- a/change/@microsoft-teams-js-3ba90dd2-e28e-4a7f-acc5-b2e5615c9aba.json
+++ b/change/@microsoft-teams-js-3ba90dd2-e28e-4a7f-acc5-b2e5615c9aba.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added new params for openFilePreview SDK that will help reduce file open latency in Teams. The capability is still awaiting support in one or most host applications. To track availability of this capability across different hosts see https://aka.ms/capmatrix",
-  "packageName": "@microsoft/teams-js",
-  "email": "susriv+github@microsoft.com",
-  "dependentChangeType": "patch"
-}


### PR DESCRIPTION
The `openFilePreview` change was included in 2.49.0. Unfortunately, due to the release branch being created before this feature was integrated into main, the `release -> main` PR did not remove this changefile due to not being present in the release branch. I am manually removing it to avoid this being reported in a future release incorrectly.