### PR TITLE
Add E2E test for app performance metrics service

### DIFF
--- a/apps/teams-test-app/e2e-test-data/appPerformanceMetrics.json
+++ b/apps/teams-test-app/e2e-test-data/appPerformanceMetrics.json
@@ -20,7 +20,8 @@
         "totalFrameCommitSizeKB": 0,
         "frameMemoryMetrics": []
       },
-      "expectedTestAppValue": "##JSON_EVENT_DATA##"
+      "expectedTestAppValue": "##JSON_EVENT_DATA##",
+      "skipForCallbackBasedRuns": true
     }
   ]
 }


### PR DESCRIPTION
## Description

Enable E2E test for app performance metrics service.

### Main changes in the PR:

1. Add E2E test file.

## Validation

### Validation performed:

1. Run E2E test in test host.

### Unit Tests added:
Not necessary, adding E2E test.

### End-to-end tests added:

Yes

## Additional Requirements

### Change file added:

Nope.

### Related PRs:

https://github.com/OfficeDev/microsoft-teams-library-js/pull/2926
