### PR TITLE
Split CDN test job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,17 +124,7 @@ extends:
           - template: tools/yaml-templates/cdn-e2e-tests-job.yml@self
             parameters:
               testPrefixPatternGroups:
-                [
-                  'app(?=\.)',
-                  '{appE,appI,appS,auth}',
-                  '{[B],[b]}',
-                  '{[C-D],[c-d]}',
-                  '{[E],[e]}',
-                  '{[F-M],[f-m]}',
-                  '{[N-R],[n-r]}',
-                  '{[S],[s]}',
-                  '{[T-Z],[t-z]}',
-                ]
+                ['app(?=\.)','{appE,appI,appS,auth}']
 
       - stage: Perf_and_Android_E2E
         displayName: 'Perf & Android E2E Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -167,6 +167,7 @@ extends:
                   mergeTestResults: true
                 condition: succeededOrFailed()
 
+
           - job: E2ETestAndroidA
             displayName: 'E2E Tests - Android - Plan A'
             pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,45 +118,23 @@ extends:
               AppHostingSdk: AppHostingSdk
               versionBranch: 'Latest'
 
-          - job: E2ETestCDN
-            timeoutInMinutes: 120
-            displayName: 'E2E Tests - CDN (only runs on release builds)'
-            # This test only runs after deployment from a release branch and the new CDN version has been deployed
-            # This check will run on the PR to merge the release branch back into main
-            condition: and(
-              eq(variables['Build.Reason'], 'PullRequest'),
-              startsWith(variables['System.PullRequest.SourceBranch'], 'release/'),
-              eq(variables['System.PullRequest.TargetBranch'], 'main')
-              )
-            pool:
-              name: Azure-Pipelines-1ESPT-ExDShared
-              image: 'ubuntu-latest'
-              os: linux
-            steps:
-              - template: tools/yaml-templates/build-app-host.yml@self
-                parameters:
-                  appHostGitPath: AppHostingSdk
-
-              - task: CmdLine@2
-                displayName: 'Build Test App CDN'
-                inputs:
-                  script: |
-                    pnpm build-test-app-CDN
-                  workingDirectory: '$(ClientSdkProjectDirectory)'
-
-              - bash: 'pnpm exec ts-node tools/cli/runAppsWithE2ETests.ts --useDataFromLocal=true --reportFileName=e2e-tests-report-cdn-script-tag --envType=cdnScriptTag'
-                displayName: 'Run E2E integration tests with local script tag on latest cdn bundles'
-                condition: succeeded()
-                workingDirectory: '$(AppHostingSdkProjectDirectory)'
-                enabled: true
-
-              - task: PublishTestResults@2
-                inputs:
-                  testResultsFormat: 'JUnit'
-                  testResultsFiles: '**/e2e-tests-report*.xml'
-                  testRunTitle: 'E2E Tests - CDN'
-                  mergeTestResults: true
-                condition: succeededOrFailed()
+          # CDN E2E tests split by test name prefix pattern to avoid timeout
+          # This test only runs after deployment from a release branch and the new CDN version has been deployed
+          # This check will run on the PR to merge the release branch back into main
+          - template: tools/yaml-templates/cdn-e2e-tests-job.yml@self
+            parameters:
+              testPrefixPatternGroups:
+                [
+                  'app(?=\.)',
+                  '{appE,appI,appS,auth}',
+                  '{[B],[b]}',
+                  '{[C-D],[c-d]}',
+                  '{[E],[e]}',
+                  '{[F-M],[f-m]}',
+                  '{[N-R],[n-r]}',
+                  '{[S],[s]}',
+                  '{[T-Z],[t-z]}',
+                ]
 
       - stage: Perf_and_Android_E2E
         displayName: 'Perf & Android E2E Tests'

--- a/tools/yaml-templates/cdn-e2e-tests-job.yml
+++ b/tools/yaml-templates/cdn-e2e-tests-job.yml
@@ -29,7 +29,11 @@ jobs:
 
         timeoutInMinutes: 120
         displayName: 'E2E Tests - CDN - ${{testPrefixPattern}} (only runs on release builds)'
-        condition: succeeded()
+        condition: and(
+          eq(variables['Build.Reason'], 'PullRequest'),
+          startsWith(variables['System.PullRequest.SourceBranch'], 'release/'),
+          eq(variables['System.PullRequest.TargetBranch'], 'main')
+          )
         pool:
           name: Azure-Pipelines-1ESPT-ExDShared
           image: 'ubuntu-latest'

--- a/tools/yaml-templates/cdn-e2e-tests-job.yml
+++ b/tools/yaml-templates/cdn-e2e-tests-job.yml
@@ -29,11 +29,7 @@ jobs:
 
         timeoutInMinutes: 120
         displayName: 'E2E Tests - CDN - ${{testPrefixPattern}} (only runs on release builds)'
-        condition: and(
-          eq(variables['Build.Reason'], 'PullRequest'),
-          startsWith(variables['System.PullRequest.SourceBranch'], 'release/'),
-          eq(variables['System.PullRequest.TargetBranch'], 'main')
-          )
+        condition: succeeded()
         pool:
           name: Azure-Pipelines-1ESPT-ExDShared
           image: 'ubuntu-latest'

--- a/tools/yaml-templates/cdn-e2e-tests-job.yml
+++ b/tools/yaml-templates/cdn-e2e-tests-job.yml
@@ -1,0 +1,70 @@
+# This template handles running CDN E2E tests split by test name prefix pattern.
+# It will run one E2E job for each testPrefixPattern in the testPrefixPatternGroups parameter.
+
+parameters:
+  - name: testPrefixPatternGroups
+    type: object
+    default: ['{[A-Z],[a-z],[0-9]}']
+
+jobs:
+  - ${{each testPrefixPattern in parameters.testPrefixPatternGroups}}:
+      - job: E2ETestsCDN_${{ replace(
+          replace(
+          replace(
+          replace(
+          replace(
+          replace(
+          replace(
+          replace(
+          replace(
+          replace(
+          replace(replace(replace(testPrefixPattern, '[', 'LB'),']', 'RB'),'{', 'LC'),'}', 'RC'),',', 'COMMA'),'-', 'DASH'),
+          '*', 'STAR'),
+          '?', 'QMARK'),
+          '\', 'BS'),
+          '.', 'DOT'),
+          '(', 'LP'),
+          ')', 'RP'),
+          '=', 'EQUALS') }}
+
+        timeoutInMinutes: 120
+        displayName: 'E2E Tests - CDN - ${{testPrefixPattern}} (only runs on release builds)'
+        condition: and(
+          eq(variables['Build.Reason'], 'PullRequest'),
+          startsWith(variables['System.PullRequest.SourceBranch'], 'release/'),
+          eq(variables['System.PullRequest.TargetBranch'], 'main')
+          )
+        pool:
+          name: Azure-Pipelines-1ESPT-ExDShared
+          image: 'ubuntu-latest'
+          os: linux
+        steps:
+          - template: build-app-host.yml
+            parameters:
+              appHostGitPath: AppHostingSdk
+
+          - task: CmdLine@2
+            displayName: 'Build Test App CDN'
+            inputs:
+              script: |
+                pnpm build-test-app-CDN
+              workingDirectory: '$(ClientSdkProjectDirectory)'
+
+          - bash: >
+              pnpm exec ts-node tools/cli/runAppsWithE2ETests.ts
+              --useDataFromLocal=true
+              --testPrefixPattern "${{testPrefixPattern}}"
+              --reportFileName=e2e-tests-report-cdn-script-tag
+              --envType=cdnScriptTag
+            displayName: 'Run E2E CDN tests (${{testPrefixPattern}})'
+            condition: succeeded()
+            workingDirectory: '$(AppHostingSdkProjectDirectory)'
+            enabled: true
+
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: '**/e2e-tests-report*.xml'
+              testRunTitle: 'E2E Tests - CDN - ${{testPrefixPattern}}'
+              mergeTestResults: true
+            condition: succeededOrFailed()


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Pull requests merging release/* branches into the main branch are currently failing because they run the CDN E2E test job, which consistently times out because of the number of E2E tests. This PR splits the CDN test job to run E2E tests in parallel and runs just a few test suites (only the app* and auth capability tests). This pattern assumes that the full capability test suite is already validated by the normal PR pipeline and a select number of tests of high-usage capabilities (app* and auth) is sufficient to verify that the CDN usage is working for the new version.

### Main changes in the PR:

1. Add a new template for CDN E2E tests that takes a test prefix parameter.
2. Replace the CDN test job in the PR pipeline with the split job.

## Validation

### Validation performed:

1. Validated by running this pipeline with the latest teams-js CDN version.

### Unit Tests added:

N/A

### End-to-end tests added:

N/A

## Additional Requirements

### Change file added:

N/A