### PR TITLE
Fix typo in prod release pipeline

### DIFF
--- a/tools/releases/prod-release.yml
+++ b/tools/releases/prod-release.yml
@@ -75,7 +75,7 @@ extends:
                   verbose: false
                   customCommand: pack
               - task: EsrpRelease@10
-                displayName: Publish to npm (tag beta) - ESRP release
+                displayName: Publish to npm (tag latest) - ESRP release
                 inputs:
                   connectedservicename: '$(connectedServiceName)'
                   usemanagedidentity: true


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Fixes a typo in the display name of the NPM publish task of the prod release pipeline. The pipeline is correctly configured; this is only a change to the name of the pipeline task