### PR TITLE
Remove @beta tags from the shortcutRelay capability

### DIFF
--- a/change/@microsoft-teams-js-c957770f-cbbc-4d9f-99b7-88eddddf9ac2.json
+++ b/change/@microsoft-teams-js-c957770f-cbbc-4d9f-99b7-88eddddf9ac2.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Removed beta tags from shortcutRelay capability.",
+  "comment": "Promoted the `shortcutRelay` capability from beta to public.",
   "packageName": "@microsoft/teams-js",
   "email": "jeklouda@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-teams-js-c957770f-cbbc-4d9f-99b7-88eddddf9ac2.json
+++ b/change/@microsoft-teams-js-c957770f-cbbc-4d9f-99b7-88eddddf9ac2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Removed beta tags from shortcutRelay capability.",
+  "packageName": "@microsoft/teams-js",
+  "email": "jeklouda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/shortcutRelay.ts
+++ b/packages/teams-js/src/public/shortcutRelay.ts
@@ -1,8 +1,6 @@
 /**
  * Allows host shortcuts to function in your application by forwarding keyboard shortcuts to the host.
  *
- * This functionality is in Beta.
- * @beta
  * @module
  */
 
@@ -241,7 +239,6 @@ let isShortcutRelayCapabilityEnabled = false;
  * • Pass `undefined` to remove an existing handler.
  * • Returns the previous handler so callers can restore it if needed.
  *
- * @beta
  */
 export function setOverridableShortcutHandler(
   handler: OverridableShortcutHandler | undefined,
@@ -259,7 +256,6 @@ export function setOverridableShortcutHandler(
  * Reset the state of the shortcut relay capability.
  * This is useful for tests to ensure a clean state.
  *
- * @beta
  */
 export function resetIsShortcutRelayCapabilityEnabled(): void {
   if (!isSupported()) {
@@ -276,7 +272,6 @@ export function resetIsShortcutRelayCapabilityEnabled(): void {
 /**
  * Enable capability to support host shortcuts.
  *
- * @beta
  */
 export async function enableShortcutRelayCapability(): Promise<void> {
   if (!isSupported()) {
@@ -310,7 +305,6 @@ export async function enableShortcutRelayCapability(): Promise<void> {
  *
  * @throws Error if {@link app.initialize} has not successfully completed
  *
- * @beta
  */
 export function isSupported(): boolean {
   return ensureInitialized(runtime) && runtime.supports.shortcutRelay ? true : false;
@@ -320,6 +314,5 @@ export function isSupported(): boolean {
  * Allow apps to define zones where shortcuts should not be forwarded to the host.
  * This is useful for input fields for password where shortcuts should not trigger host actions.
  *
- * @beta
  */
 export const DISABLE_SHORTCUT_FORWARDING_ATTRIBUTE = 'data-disable-shortcuts-forwarding';


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This PR promotes the `shortcutRelay` capability from beta to full release. This API surface has been stable since it was introduced and has been validated in a production environment in Teams.

### Main changes in the PR:

1. Removed `@beta` tags from the `shortcutRelay` capability

## Validation

### Validation performed:

N/A

### Unit Tests added:

N/A

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes