### PR TITLE
Fix CVE-2026-26127: upgrade Microsoft.Bcl.Memory from 9.0.0 to 9.0.15

### DIFF
--- a/apps/blazor-test-app/Blazor-Test-App.csproj
+++ b/apps/blazor-test-app/Blazor-Test-App.csproj
@@ -25,6 +25,8 @@
     <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="3.8.0" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*" />
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.23.*" />
+    <!-- CVE-2026-26127: Pin Microsoft.Bcl.Memory to patched version (transitive dependency) -->
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.15" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Fixes **CVE-2026-26127** (.NET Denial of Service vulnerability in Microsoft.Bcl.Memory 9.0.0-9.0.13).

## Changes

- Added explicit `PackageReference` for `Microsoft.Bcl.Memory` version `9.0.15` in `apps/blazor-test-app/Blazor-Test-App.csproj` to pin the transitive dependency to a patched version.

## Testing

- `dotnet restore` completes successfully
- `dotnet build` passes with 0 errors
- `dotnet list package --include-transitive` confirms Microsoft.Bcl.Memory resolved to 9.0.15

## Related Work Item

[ADO #11293554](https://office.visualstudio.com/MetaOS/_workitems/edit/11293554)