### PR TITLE
Fix: teams-perf-test-app build failure on Windows CI

### DIFF
--- a/apps/teams-perf-test-app/package.json
+++ b/apps/teams-perf-test-app/package.json
@@ -5,10 +5,10 @@
   "description": "Teams Perf Test App utilizing Teams JavaScript client SDK to test Teams Host Perf",
   "version": "0.0.1",
   "scripts": {
-    "build": "pnpm lint && webpack",
+    "build": "pnpm lint && pnpm exec webpack",
     "clean": "rimraf ./build",
     "lint": "pnpm eslint ./src --max-warnings 0 --fix --ext .tsx",
-    "start": "webpack serve"
+    "start": "pnpm exec webpack serve"
   },
   "dependencies": {
     "react": "^17.0.1",


### PR DESCRIPTION
## Problem

The `teams-perf-test-app:build` step has been failing on Windows CI since PR #3035 (dependabot bump of `next` 15.5.14→15.5.15, merged Apr 14).

**Root cause:** The build script uses bare `webpack`, which relies on a `.cmd` shim in `node_modules/.bin/`. On Windows, this shim uses `CALL` to invoke an inner `.cmd` file inside the pnpm virtual store (`.pnpm/`). When #3035 changed `pnpm-lock.yaml`, the virtual store layout changed, causing the shim to reference a path that no longer exists:

```
teams-perf-test-app: The batch file cannot be found.
teams-perf-test-app: webpack 5.104.1 compiled successfully in 27782 ms
teams-perf-test-app:  ELIFECYCLE  Command failed with exit code 1.
```

Webpack still compiles successfully (via a fallback), but cmd.exe's errorlevel is already set to 1 from the failed shim lookup.

## Fix

Replace bare `webpack` with `pnpm exec webpack` in the build and start scripts. `pnpm exec` resolves binaries through Node.js directly, completely bypassing the `.cmd` shim mechanism.

## Affected builds
- ❌ [Build 47481708](https://office.visualstudio.com/ISS/_build/results?buildId=47481708) (Apr 14, first failure)
- ❌ [Build 48288062](https://office.visualstudio.com/ISS/_build/results?buildId=48288062) (Apr 30)
- ✅ [Build 47418061](https://office.visualstudio.com/ISS/_build/results?buildId=47418061) (Apr 13, last passing)