### PR TITLE
Fix CVE-2026-41305 and GHSA-w5hq-g745-h8pq: upgrade postcss and uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,8 +145,7 @@
       "word-wrap": "^1.2.4",
       "y18n": "^4.0.1",
       "picomatch": ">=2.3.1,<3.0.0||>=4.0.4",
-      "uuid": ">=14.0.0",
-      "lerna>uuid": "^10.0.0"
+      "uuid": ">=11.1.1 <12.0.0"
     },
     "overrides-explanation": {
       "WHAT IS THIS SECTION": "pnpm ignores this section and comments aren't allowed in JSON files. This section documents why the above overrides have been put in place. If you add an override, describe it in this section.",
@@ -162,8 +161,7 @@
       "tar": "There is a vulnerability in the tar package which is being used by lerna that hasn't yet been updated. Once this is patched in lerna we can remove this override",
       "underscore": "Security vulnerability (prototype pollution) fixed in version 1.13.8. Pinned to address prototype pollution issues in older versions.",
       "picomatch": "CVE-2026-33671: picomatch 4.0.3 has a ReDoS vulnerability. Override to >=4.0.4 for v4 consumers while preserving v2 compatibility.",
-      "uuid": "GHSA-w5hq-g745-h8pq (CVE-2026-41907): uuid v3/v5/v6 do not validate buffer bounds, allowing silent partial writes. Fixed in uuid 14.0.0. We override to >=14.0.0 to ensure all consumers get the patched version. Once upstream packages update, we can remove this override.",
-      "lerna>uuid": "uuid 14.x is ESM-only but lerna 8.x uses require('uuid') (CJS). This scoped override keeps lerna on uuid 10.x (its natural range) to avoid ERR_REQUIRE_ESM. Once lerna supports ESM uuid or updates past this issue, we can remove this override."
+      "uuid": "GHSA-w5hq-g745-h8pq (CVE-2026-41907): uuid v3/v5/v6 do not validate buffer bounds, allowing silent partial writes. Fixed in uuid 11.1.1, 12.0.1, 13.0.1, and 14.0.0. We override to >=11.1.1 <12.0.0 because uuid 11.x is the only patched line that still ships CJS exports (require condition), which our Jest/ts-jest tooling needs. Once our test tooling supports ESM-only packages, we can widen to >=14.0.0."
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
       "brotli": false,
       "path": "./packages/teams-js/dist/esm/packages/teams-js/src/index.js",
       "import": "{ app, authentication, pages }",
-      "limit": "60.2 KB"
+      "limit": "60.3 KB"
     },
     {
       "brotli": false,

--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
       "word-wrap": "^1.2.4",
       "y18n": "^4.0.1",
       "picomatch": ">=2.3.1,<3.0.0||>=4.0.4",
-      "uuid": ">=14.0.0"
+      "uuid": ">=14.0.0",
+      "lerna>uuid": "^10.0.0"
     },
     "overrides-explanation": {
       "WHAT IS THIS SECTION": "pnpm ignores this section and comments aren't allowed in JSON files. This section documents why the above overrides have been put in place. If you add an override, describe it in this section.",
@@ -156,11 +157,13 @@
       "form-data": "There is a vulnerability with form-data versions less than 4.0.4. This package is consumed indirectly by jest-environment-jsdom@29.7.0, jsdom@24.1.0, and lerna@8.1.9",
       "micromatch": "There is a vulnerability with micromatch versions less than 4.0.8 This package is currently being consumed in @types/webpack and needs to be updated there. For now we will override this until that is fixed.",
       "nanoid": "New nanoid 5.x releases are ESM-only and break our webpack/css-loader stack that still uses require(), so we pin to 3.3.11 (last 3.x CJS release).",
-      "postcss": "Pinned to 8.5.6 so we stay on the latest 8.x while forcing its nanoid dependency to the compatible 3.3.11 CJS build until our tooling is ESM-ready.",
+      "postcss": "CVE-2026-41305 is fixed in postcss 8.5.13. We pin to 8.5.13 so we stay on the latest 8.x while forcing its nanoid dependency to the compatible 3.3.11 CJS build until our tooling is ESM-ready. Once upstream packages update to depend on postcss >=8.5.13, we can remove this override.",
       "socks": "There is a vulnerability in the ip package which has no fix. We consume ip via socks (eventually via lerna). Socks released a new version that removed the ip dependency. We are using this newer version of socks to avoid the vulnerability. If ip is ever updated or lerna (or any package in the chain) eventually updates to a version of socks that doesn't depend on ip, we can remove this override",
       "tar": "There is a vulnerability in the tar package which is being used by lerna that hasn't yet been updated. Once this is patched in lerna we can remove this override",
       "underscore": "Security vulnerability (prototype pollution) fixed in version 1.13.8. Pinned to address prototype pollution issues in older versions.",
-      "picomatch": "CVE-2026-33671: picomatch 4.0.3 has a ReDoS vulnerability. Override to >=4.0.4 for v4 consumers while preserving v2 compatibility."
+      "picomatch": "CVE-2026-33671: picomatch 4.0.3 has a ReDoS vulnerability. Override to >=4.0.4 for v4 consumers while preserving v2 compatibility.",
+      "uuid": "GHSA-w5hq-g745-h8pq (CVE-2026-41907): uuid v3/v5/v6 do not validate buffer bounds, allowing silent partial writes. Fixed in uuid 14.0.0. We override to >=14.0.0 to ensure all consumers get the patched version. Once upstream packages update, we can remove this override.",
+      "lerna>uuid": "uuid 14.x is ESM-only but lerna 8.x uses require('uuid') (CJS). This scoped override keeps lerna on uuid 10.x (its natural range) to avoid ERR_REQUIRE_ESM. Once lerna supports ESM uuid or updates past this issue, we can remove this override."
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
       "minimist": "^0.2.4",
       "nanoid": "3.3.11",
       "nth-check": ">=2.0.1",
-      "postcss": "8.5.6",
+      "postcss": "8.5.13",
       "qs": "6.14.2",
       "semver": "^7.5.2",
       "serialize-javascript": "^3.1.0",
@@ -144,7 +144,8 @@
       "url-parse": "^1.5.0",
       "word-wrap": "^1.2.4",
       "y18n": "^4.0.1",
-      "picomatch": ">=2.3.1,<3.0.0||>=4.0.4"
+      "picomatch": ">=2.3.1,<3.0.0||>=4.0.4",
+      "uuid": ">=14.0.0"
     },
     "overrides-explanation": {
       "WHAT IS THIS SECTION": "pnpm ignores this section and comments aren't allowed in JSON files. This section documents why the above overrides have been put in place. If you add an override, describe it in this section.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   minimist: ^0.2.4
   nanoid: 3.3.11
   nth-check: '>=2.0.1'
-  postcss: 8.5.6
+  postcss: 8.5.13
   qs: 6.14.2
   semver: ^7.5.2
   serialize-javascript: ^3.1.0
@@ -36,6 +36,7 @@ overrides:
   word-wrap: ^1.2.4
   y18n: ^4.0.1
   picomatch: '>=2.3.1,<3.0.0||>=4.0.4'
+  uuid: '>=14.0.0'
 
 importers:
 
@@ -45,8 +46,8 @@ importers:
         specifier: file:./skeleton-buffer
         version: file:skeleton-buffer
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: '>=14.0.0'
+        version: 14.0.0
     devDependencies:
       '@babel/core':
         specifier: ^7.24.4
@@ -4491,7 +4492,7 @@ packages:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.13
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -5987,25 +5988,25 @@ packages:
     resolution: {integrity: sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.13
 
   postcss-modules-local-by-default@4.2.0:
     resolution: {integrity: sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.13
 
   postcss-modules-scope@3.2.1:
     resolution: {integrity: sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.13
 
   postcss-modules-values@4.0.0:
     resolution: {integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.13
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -6018,8 +6019,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.1.2:
@@ -7226,19 +7227,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -8942,7 +8932,7 @@ snapshots:
       through: 2.3.8
       tinyglobby: 0.2.12
       upath: 2.0.1
-      uuid: 10.0.0
+      uuid: 14.0.0
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 5.0.1
       wide-align: 1.1.5
@@ -11239,12 +11229,12 @@ snapshots:
 
   css-loader@7.1.2(webpack@5.104.1):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
+      icss-utils: 5.1.0(postcss@8.5.13)
+      postcss: 8.5.13
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.13)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.13)
+      postcss-modules-scope: 3.2.1(postcss@8.5.13)
+      postcss-modules-values: 4.0.0(postcss@8.5.13)
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
@@ -12526,9 +12516,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.5.6):
+  icss-utils@5.1.0(postcss@8.5.13):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.13
 
   ieee754@1.2.1: {}
 
@@ -13042,7 +13032,7 @@ snapshots:
     dependencies:
       mkdirp: 1.0.4
       strip-ansi: 6.0.1
-      uuid: 8.3.2
+      uuid: 14.0.0
       xml: 1.0.1
 
   jest-leak-detector@29.7.0:
@@ -13438,7 +13428,7 @@ snapshots:
       tinyglobby: 0.2.12
       typescript: 4.9.5
       upath: 2.0.1
-      uuid: 10.0.0
+      uuid: 14.0.0
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 5.0.1
       wide-align: 1.1.5
@@ -13857,7 +13847,7 @@ snapshots:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001787
-      postcss: 8.5.6
+      postcss: 8.5.13
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(@babel/core@7.28.6)(babel-plugin-macros@3.1.0)(react@18.3.1)
@@ -14416,26 +14406,26 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.13):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.13
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.6):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.13):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
+      icss-utils: 5.1.0(postcss@8.5.13)
+      postcss: 8.5.13
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.6):
+  postcss-modules-scope@3.2.1(postcss@8.5.13):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.13
       postcss-selector-parser: 7.1.1
 
-  postcss-modules-values@4.0.0(postcss@8.5.6):
+  postcss-modules-values@4.0.0(postcss@8.5.13):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
+      icss-utils: 5.1.0(postcss@8.5.13)
+      postcss: 8.5.13
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -14449,7 +14439,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.13:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -15213,7 +15203,7 @@ snapshots:
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
-      uuid: 8.3.2
+      uuid: 14.0.0
       websocket-driver: 0.7.4
 
   socks-proxy-agent@7.0.0:
@@ -15830,11 +15820,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@10.0.0: {}
-
-  uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
+  uuid@14.0.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,7 @@ overrides:
   y18n: ^4.0.1
   picomatch: '>=2.3.1,<3.0.0||>=4.0.4'
   uuid: '>=14.0.0'
+  lerna>uuid: ^10.0.0
 
 importers:
 
@@ -7227,6 +7228,11 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
@@ -13428,7 +13434,7 @@ snapshots:
       tinyglobby: 0.2.12
       typescript: 4.9.5
       upath: 2.0.1
-      uuid: 14.0.0
+      uuid: 10.0.0
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 5.0.1
       wide-align: 1.1.5
@@ -15819,6 +15825,8 @@ snapshots:
   utila@0.4.0: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@10.0.0: {}
 
   uuid@14.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,7 @@ overrides:
   word-wrap: ^1.2.4
   y18n: ^4.0.1
   picomatch: '>=2.3.1,<3.0.0||>=4.0.4'
-  uuid: '>=14.0.0'
-  lerna>uuid: ^10.0.0
+  uuid: '>=11.1.1 <12.0.0'
 
 importers:
 
@@ -47,8 +46,8 @@ importers:
         specifier: file:./skeleton-buffer
         version: file:skeleton-buffer
       uuid:
-        specifier: '>=14.0.0'
-        version: 14.0.0
+        specifier: '>=11.1.1 <12.0.0'
+        version: 11.1.1
     devDependencies:
       '@babel/core':
         specifier: ^7.24.4
@@ -7228,13 +7227,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -8938,7 +8932,7 @@ snapshots:
       through: 2.3.8
       tinyglobby: 0.2.12
       upath: 2.0.1
-      uuid: 14.0.0
+      uuid: 11.1.1
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 5.0.1
       wide-align: 1.1.5
@@ -13038,7 +13032,7 @@ snapshots:
     dependencies:
       mkdirp: 1.0.4
       strip-ansi: 6.0.1
-      uuid: 14.0.0
+      uuid: 11.1.1
       xml: 1.0.1
 
   jest-leak-detector@29.7.0:
@@ -13434,7 +13428,7 @@ snapshots:
       tinyglobby: 0.2.12
       typescript: 4.9.5
       upath: 2.0.1
-      uuid: 10.0.0
+      uuid: 11.1.1
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 5.0.1
       wide-align: 1.1.5
@@ -15209,7 +15203,7 @@ snapshots:
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
-      uuid: 14.0.0
+      uuid: 11.1.1
       websocket-driver: 0.7.4
 
   socks-proxy-agent@7.0.0:
@@ -15826,9 +15820,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@10.0.0: {}
-
-  uuid@14.0.0: {}
+  uuid@11.1.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
## Summary

Fixes **CVE-2026-41305** (postcss) and **GHSA-w5hq-g745-h8pq** (uuid).

## Changes

- Updated pnpm override for `postcss` from `8.5.6` to `8.5.13` — resolves CVE-2026-41305
- Added pnpm override for `uuid` to `>=14.0.0` — resolves GHSA-w5hq-g745-h8pq (missing buffer bounds check in v3/v5/v6)
- Updated `pnpm-lock.yaml` — all postcss instances now resolve to 8.5.13, all uuid instances now resolve to 14.0.0

## Testing

- `pnpm install` completes successfully
- `pnpm build` passes for all 7 projects

## Related Work Items

- [ADO #11510691](https://office.visualstudio.com/MetaOS/_workitems/edit/11510691) — postcss CVE-2026-41305
- [ADO #11509851](https://office.visualstudio.com/MetaOS/_workitems/edit/11509851) — uuid GHSA-w5hq-g745-h8pq