### PR TITLE
Add function key support to isValidShortcutEvent

### DIFF
--- a/change/@microsoft-teams-js-84304e84-119f-4b11-9ff6-977932cd6280.json
+++ b/change/@microsoft-teams-js-84304e84-119f-4b11-9ff6-977932cd6280.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added function key support (F1-F24) to \\isValidShortcutEvent",
+  "packageName": "@microsoft/teams-js",
+  "email": "zoeschmitt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/shortcutRelay.ts
+++ b/packages/teams-js/src/public/shortcutRelay.ts
@@ -105,10 +105,17 @@ function eventToCanonicalShortcut(e: KeyboardEvent): string {
 /**
  * Checks if the event is a valid shortcut event.
  * A valid shortcut event is one that has at least one modifier key pressed
- * (ctrl, shift, alt, meta) or the Escape key.
+ * (ctrl, shift, alt, meta), the Escape key, or a function key (F1–F24).
  */
 function isValidShortcutEvent(e: KeyboardEvent): boolean {
-  return e.ctrlKey || e.shiftKey || e.altKey || e.metaKey || (!!e.key && e.key.toLowerCase() === 'escape');
+  return (
+    e.ctrlKey ||
+    e.shiftKey ||
+    e.altKey ||
+    e.metaKey ||
+    (!!e.key && e.key.toLowerCase() === 'escape') ||
+    (!!e.key && /^F\d+$/i.test(e.key))
+  );
 }
 
 function isMatchingShortcut(

--- a/packages/teams-js/test/public/shortcutRelay.spec.ts
+++ b/packages/teams-js/test/public/shortcutRelay.spec.ts
@@ -107,6 +107,28 @@ describe('shortcutRelay capability', () => {
       });
     });
 
+    describe('isValidShortcutEvent – function key support', () => {
+      it('forwards a matching function-key shortcut (e.g. F5) to host', async () => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: latestRuntimeApiVersion, supports: { shortcutRelay: {} } });
+
+        shortcutRelay.enableShortcutRelayCapability();
+
+        const response = { shortcuts: ['f5'], overridableShortcuts: [] };
+        const request = utils.findMessageByFunc(ApiName.ShortcutRelay_GetHostShortcuts);
+        utils.respondToFramelessMessage({
+          data: { id: request?.id, args: [response] },
+        } as DOMMessageEvent);
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        const evt = new KeyboardEvent('keydown', { key: 'F5', bubbles: true });
+        document.body.dispatchEvent(evt);
+
+        const fwd = utils.findMessageByFunc(ApiName.ShortcutRelay_ForwardShortcutEvent);
+        expect(fwd).not.toBeNull();
+      });
+    });
+
     describe('setOverridableShortcutHandler()', () => {
       it('replaces and returns previous handler', async () => {
         await utils.initializeWithContext(FrameContexts.content);


### PR DESCRIPTION
## Description

Extend `isValidShortcutEvent` to treat bare function key presses (F1-F24) as valid shortcut events, matching the same behavior as modifier keys and Escape. Add a corresponding test that verifies an F5 keydown is forwarded to the host.

This change is required to support F6 hotkey events in Outlook when Copilot sidepane is active.


Closes #3046 

### Main changes in the PR:

1. Add function key support to isValidShortcutEvent.
2. Add test.

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

Yes

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

Yes