### PR TITLE
fix: properly await async origin validation in processAuthBridgeMessage

### DIFF
--- a/change/@microsoft-teams-js-891d1892-3abb-4cdb-a9a6-db19bbbaa486.json
+++ b/change/@microsoft-teams-js-891d1892-3abb-4cdb-a9a6-db19bbbaa486.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix async origin validation in processAuthBridgeMessage to properly await the result of verifyIncomingMessageOrigin before processing messages",
+  "packageName": "@microsoft/teams-js",
+  "email": "aeun@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
       "brotli": false,
       "path": "./packages/teams-js/dist/esm/packages/teams-js/src/index.js",
       "import": "{ app, authentication, pages }",
-      "limit": "60.3 KB"
+      "limit": "60.4 KB"
     },
     {
       "brotli": false,

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -554,8 +554,8 @@ async function processIncomingMessage(evt: DOMMessageEvent): Promise<void> {
   const messageSource = evt.source || (evt.originalEvent && evt.originalEvent.source);
   const messageOrigin = evt.origin || (evt.originalEvent && evt.originalEvent.origin);
 
-  return shouldProcessIncomingMessage(messageSource, messageOrigin).then((result) => {
-    if (!result) {
+  return verifyIncomingMessageOrigin(messageSource, messageOrigin).then((isOriginValid) => {
+    if (!isOriginValid) {
       processIncomingMessageLogger(
         'Message being ignored by app because it is either coming from the current window or a different window with an invalid origin, message: %o, source: %o, origin: %o',
         evt,
@@ -630,51 +630,62 @@ function processAuthBridgeMessage(evt: MessageEvent, onMessageReceived: (respons
     return;
   }
 
-  if (!shouldProcessIncomingMessage(messageSource, messageOrigin)) {
-    logger(
-      'Message being ignored by app because it is either coming from the current window or a different window with an invalid origin',
-    );
-    return;
-  }
+  verifyIncomingMessageOrigin(messageSource, messageOrigin).then((isOriginValid) => {
+    if (!isOriginValid) {
+      logger(
+        'Message being ignored by app because it is either coming from the current window or a different window with an invalid origin',
+      );
+      return;
+    }
 
-  /**
-   * In most cases, top level window and the parent window will be same.
-   * If they're not, perform the necessary updates for the top level window.
-   *
-   * Top window logic to flush messages is kept independent so that we don't affect
-   * any of the code for the existing communication channel.
-   */
-  if (!Communication.topWindow || Communication.topWindow.closed || messageSource === Communication.topWindow) {
-    Communication.topWindow = messageSource;
-    Communication.topOrigin = messageOrigin;
-  }
+    /**
+     * In most cases, top level window and the parent window will be same.
+     * If they're not, perform the necessary updates for the top level window.
+     *
+     * Top window logic to flush messages is kept independent so that we don't affect
+     * any of the code for the existing communication channel.
+     */
+    if (!Communication.topWindow || Communication.topWindow.closed || messageSource === Communication.topWindow) {
+      Communication.topWindow = messageSource;
+      Communication.topOrigin = messageOrigin;
+    }
 
-  // Clean up pointers to closed parent
-  if (Communication.topWindow && Communication.topWindow.closed) {
-    Communication.topWindow = null;
-    Communication.topOrigin = null;
-  }
+    // Clean up pointers to closed parent
+    if (Communication.topWindow && Communication.topWindow.closed) {
+      Communication.topWindow = null;
+      Communication.topOrigin = null;
+    }
 
-  flushMessageQueue(Communication.topWindow, Communication.topOrigin, CommunicationPrivate.topMessageQueue, 'top');
+    flushMessageQueue(Communication.topWindow, Communication.topOrigin, CommunicationPrivate.topMessageQueue, 'top');
 
-  // Return the response to the registered callback
-  onMessageReceived(message);
+    // Return the response to the registered callback
+    onMessageReceived(message);
+  }).catch((err) => {
+    // Sanity check; this should not execute
+    logger('Unexpected error verifying message origin: %o', err);
+  });
 }
 
-const shouldProcessIncomingMessageLogger = communicationLogger.extend('shouldProcessIncomingMessage');
+const verifyIncomingMessageOriginLogger = communicationLogger.extend('verifyIncomingMessageOrigin');
 
 /**
  * @hidden
- * Validates the message source and origin, if it should be processed
+ * Verifies that an incoming message originates from a different window and that its origin
+ * is either in the pre-known allowlist or was supplied by the app developer during initialization.
+ *
+ * @param messageSource - The window that sent the message.
+ * @param messageOrigin - The origin of the message.
+ *
+ * @returns A promise that resolves to `true` if the origin is valid and the message is safe to process, `false` otherwise.
  *
  * @internal
  * Limited to Microsoft-internal use
  */
-async function shouldProcessIncomingMessage(messageSource: Window, messageOrigin: string): Promise<boolean> {
+async function verifyIncomingMessageOrigin(messageSource: Window, messageOrigin: string): Promise<boolean> {
   // Process if message source is a different window and if origin is either in
   // Teams' pre-known whitelist or supplied as valid origin by user during initialization
   if (Communication.currentWindow && messageSource === Communication.currentWindow) {
-    shouldProcessIncomingMessageLogger('Should not process message because it is coming from the current window');
+    verifyIncomingMessageOriginLogger('Should not process message because it is coming from the current window');
     return false;
   } else if (
     Communication.currentWindow &&
@@ -688,13 +699,13 @@ async function shouldProcessIncomingMessage(messageSource: Window, messageOrigin
     try {
       messageOriginURL = new URL(messageOrigin);
     } catch (_) {
-      shouldProcessIncomingMessageLogger('Message has an invalid origin of %s', messageOrigin);
+      verifyIncomingMessageOriginLogger('Message has an invalid origin of %s', messageOrigin);
       return false;
     }
 
     const isOriginValid = await validateOrigin(messageOriginURL);
     if (!isOriginValid) {
-      shouldProcessIncomingMessageLogger('Message has an invalid origin of %s', messageOrigin);
+      verifyIncomingMessageOriginLogger('Message has an invalid origin of %s', messageOrigin);
     }
     return isOriginValid;
   }

--- a/packages/teams-js/src/internal/communication.ts
+++ b/packages/teams-js/src/internal/communication.ts
@@ -630,40 +630,42 @@ function processAuthBridgeMessage(evt: MessageEvent, onMessageReceived: (respons
     return;
   }
 
-  verifyIncomingMessageOrigin(messageSource, messageOrigin).then((isOriginValid) => {
-    if (!isOriginValid) {
-      logger(
-        'Message being ignored by app because it is either coming from the current window or a different window with an invalid origin',
-      );
-      return;
-    }
+  verifyIncomingMessageOrigin(messageSource, messageOrigin)
+    .then((isOriginValid) => {
+      if (!isOriginValid) {
+        logger(
+          'Message being ignored by app because it is either coming from the current window or a different window with an invalid origin',
+        );
+        return;
+      }
 
-    /**
-     * In most cases, top level window and the parent window will be same.
-     * If they're not, perform the necessary updates for the top level window.
-     *
-     * Top window logic to flush messages is kept independent so that we don't affect
-     * any of the code for the existing communication channel.
-     */
-    if (!Communication.topWindow || Communication.topWindow.closed || messageSource === Communication.topWindow) {
-      Communication.topWindow = messageSource;
-      Communication.topOrigin = messageOrigin;
-    }
+      /**
+       * In most cases, top level window and the parent window will be same.
+       * If they're not, perform the necessary updates for the top level window.
+       *
+       * Top window logic to flush messages is kept independent so that we don't affect
+       * any of the code for the existing communication channel.
+       */
+      if (!Communication.topWindow || Communication.topWindow.closed || messageSource === Communication.topWindow) {
+        Communication.topWindow = messageSource;
+        Communication.topOrigin = messageOrigin;
+      }
 
-    // Clean up pointers to closed parent
-    if (Communication.topWindow && Communication.topWindow.closed) {
-      Communication.topWindow = null;
-      Communication.topOrigin = null;
-    }
+      // Clean up pointers to closed parent
+      if (Communication.topWindow && Communication.topWindow.closed) {
+        Communication.topWindow = null;
+        Communication.topOrigin = null;
+      }
 
-    flushMessageQueue(Communication.topWindow, Communication.topOrigin, CommunicationPrivate.topMessageQueue, 'top');
+      flushMessageQueue(Communication.topWindow, Communication.topOrigin, CommunicationPrivate.topMessageQueue, 'top');
 
-    // Return the response to the registered callback
-    onMessageReceived(message);
-  }).catch((err) => {
-    // Sanity check; this should not execute
-    logger('Unexpected error verifying message origin: %o', err);
-  });
+      // Return the response to the registered callback
+      onMessageReceived(message);
+    })
+    .catch((err) => {
+      // Sanity check; this should not execute
+      logger('Unexpected error verifying message origin: %o', err);
+    });
 }
 
 const verifyIncomingMessageOriginLogger = communicationLogger.extend('verifyIncomingMessageOrigin');

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -5,7 +5,6 @@ import { MessageRequest } from '../../src/internal/messageObjects';
 import { NestedAppAuthMessageEventNames, NestedAppAuthRequest } from '../../src/internal/nestedAppAuthUtils';
 import { ResponseHandler } from '../../src/internal/responseHandler';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../src/internal/telemetry';
-import * as validOrigins from '../../src/internal/validOrigins';
 import { ErrorCode, FrameContexts, SdkError } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import { UUID } from '../../src/public/uuidObject';
@@ -1959,26 +1958,16 @@ describe('Testing communication', () => {
       });
     });
 
-    describe('origin validation in processAuthBridgeMessage', () => {
-      let validateOriginSpy: jest.SpyInstance;
-
-      beforeEach(() => {
-        validateOriginSpy = jest.spyOn(validOrigins, 'validateOrigin');
-      });
-
-      afterEach(() => {
-        validateOriginSpy.mockRestore();
-      });
-
-      test('should not call onMessageReceived when the message origin is invalid', async () => {
+    describe('verifyIncomingMessageOrigin', () => {
+      test('should not call onMessageReceived when the message comes from the same window', async () => {
         const onMessageReceivedCb = jest.fn();
 
         utils.mockWindow.parent = utils.mockWindow.top;
         await setupNAABridge();
         communication.Communication.currentWindow.nestedAppAuthBridge.addEventListener('message', onMessageReceivedCb);
 
-        // Mock validateOrigin to reject the origin after the bridge is set up
-        validateOriginSpy.mockResolvedValue(false);
+        // Set parent to currentWindow so the message appears to come from the same window
+        utils.mockWindow.parent = communication.Communication.currentWindow;
 
         utils.respondToMessage(
           {
@@ -1990,19 +1979,26 @@ describe('Testing communication', () => {
           validResponseMessage,
         );
 
-        // Wait for the async origin validation promise to resolve
         await new Promise(process.nextTick);
 
         expect(onMessageReceivedCb).not.toBeCalled();
       });
 
-      test('should call onMessageReceived when the message origin is valid', async () => {
+      test('should not call onMessageReceived when the message origin is not in valid origins', async () => {
         const onMessageReceivedCb = jest.fn();
-        validateOriginSpy.mockResolvedValue(true);
 
         utils.mockWindow.parent = utils.mockWindow.top;
         await setupNAABridge();
         communication.Communication.currentWindow.nestedAppAuthBridge.addEventListener('message', onMessageReceivedCb);
+
+        // Use an invalid origin and stub the CDN fetch so that validateOrigin resolves to false
+        // (validateOrigin itself is not under test here)
+        const savedOrigin = utils.validOrigin;
+        const savedFetch = global.fetch;
+        utils.validOrigin = 'https://invalid.example.com';
+        global.fetch = jest.fn(() =>
+          Promise.resolve({ ok: true, json: () => Promise.resolve({ validOrigins: [] }) } as unknown as Response),
+        );
 
         utils.respondToMessage(
           {
@@ -2014,10 +2010,13 @@ describe('Testing communication', () => {
           validResponseMessage,
         );
 
-        // Wait for the async origin validation promise to resolve
+        await new Promise(process.nextTick);
         await new Promise(process.nextTick);
 
-        expect(onMessageReceivedCb).toBeCalledWith(validResponseMessage);
+        expect(onMessageReceivedCb).not.toBeCalled();
+
+        utils.validOrigin = savedOrigin;
+        global.fetch = savedFetch;
       });
     });
   });

--- a/packages/teams-js/test/internal/communication.spec.ts
+++ b/packages/teams-js/test/internal/communication.spec.ts
@@ -5,6 +5,7 @@ import { MessageRequest } from '../../src/internal/messageObjects';
 import { NestedAppAuthMessageEventNames, NestedAppAuthRequest } from '../../src/internal/nestedAppAuthUtils';
 import { ResponseHandler } from '../../src/internal/responseHandler';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../src/internal/telemetry';
+import * as validOrigins from '../../src/internal/validOrigins';
 import { ErrorCode, FrameContexts, SdkError } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import { UUID } from '../../src/public/uuidObject';
@@ -1912,6 +1913,9 @@ describe('Testing communication', () => {
           validResponseMessage,
         );
 
+        // Wait for the async origin validation promise to resolve
+        await new Promise(process.nextTick);
+
         expect(onMessageReceivedCb).toBeCalledWith(validResponseMessage);
       });
 
@@ -1952,6 +1956,68 @@ describe('Testing communication', () => {
         );
 
         expect(onMessageReceivedCb).not.toBeCalled();
+      });
+    });
+
+    describe('origin validation in processAuthBridgeMessage', () => {
+      let validateOriginSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        validateOriginSpy = jest.spyOn(validOrigins, 'validateOrigin');
+      });
+
+      afterEach(() => {
+        validateOriginSpy.mockRestore();
+      });
+
+      test('should not call onMessageReceived when the message origin is invalid', async () => {
+        const onMessageReceivedCb = jest.fn();
+
+        utils.mockWindow.parent = utils.mockWindow.top;
+        await setupNAABridge();
+        communication.Communication.currentWindow.nestedAppAuthBridge.addEventListener('message', onMessageReceivedCb);
+
+        // Mock validateOrigin to reject the origin after the bridge is set up
+        validateOriginSpy.mockResolvedValue(false);
+
+        utils.respondToMessage(
+          {
+            id: 0,
+            data: validMessage,
+            func: 'nestedAppAuth.execute',
+          },
+          false,
+          validResponseMessage,
+        );
+
+        // Wait for the async origin validation promise to resolve
+        await new Promise(process.nextTick);
+
+        expect(onMessageReceivedCb).not.toBeCalled();
+      });
+
+      test('should call onMessageReceived when the message origin is valid', async () => {
+        const onMessageReceivedCb = jest.fn();
+        validateOriginSpy.mockResolvedValue(true);
+
+        utils.mockWindow.parent = utils.mockWindow.top;
+        await setupNAABridge();
+        communication.Communication.currentWindow.nestedAppAuthBridge.addEventListener('message', onMessageReceivedCb);
+
+        utils.respondToMessage(
+          {
+            id: 0,
+            data: validMessage,
+            func: 'nestedAppAuth.execute',
+          },
+          false,
+          validResponseMessage,
+        );
+
+        // Wait for the async origin validation promise to resolve
+        await new Promise(process.nextTick);
+
+        expect(onMessageReceivedCb).toBeCalledWith(validResponseMessage);
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixed a bug where `processAuthBridgeMessage` was synchronously checking the return value of an async origin validation function. Since the function returns a `Promise<boolean>`, the check was evaluating the truthiness of the Promise object (always truthy), causing the origin validation guard to never block messages.

## Changes

- Renamed `shouldProcessIncomingMessage` → `verifyIncomingMessageOrigin` to better reflect async behavior and avoid confusion with a sync function of the same name in `nestedAppAuthBridge.ts`
- Fixed `processAuthBridgeMessage` to properly resolve the promise via `.then()` before checking the boolean result
- Added `.catch()` handler for unhandled rejection safety
- Updated JSDoc documentation
- Added regression tests covering both valid and invalid origin scenarios
- Fixed pre-existing test that implicitly relied on the synchronous (buggy) behavior
- I had to bump the bundle size limit a bit (just enough to contain this change) since this is an unavoidable change that has to exist in communication.ts.