### PR TITLE
Enable Playwright E2E tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,17 +3,6 @@ variables:
   - name: products
     value: 6eff390d-80c0-4456-81b6-6abafa71e768
 
-# The legacy Cypress E2E stages are disabled (see "Temporarily disable all
-# e2e tests in pipeline YAML", #3064). The Playwright E2E suite is opt-in
-# while it is being validated: set `runPlaywrightE2E` to true (from the
-# pipeline UI "Run pipeline" -> Variables, or by editing the default below)
-# to run it.
-parameters:
-  - name: runPlaywrightE2E
-    displayName: 'Run Playwright E2E tests'
-    type: boolean
-    default: false
-
 trigger:
   branches:
     include:
@@ -252,14 +241,11 @@ extends:
       #     #   ...
 
       # Playwright E2E tests. The legacy Cypress E2E stages above are disabled
-      # (#3064); this stage is the Playwright replacement and is gated on the
-      # `runPlaywrightE2E` parameter (default false) while it is validated.
-      - ${{ if eq(parameters.runPlaywrightE2E, true) }}:
-          - stage: Latest_E2E_Playwright
-            displayName: 'Latest E2E Tests (Playwright)'
-            dependsOn: Build
-            jobs:
-              - template: tools/yaml-templates/web-e2e-playwright-tests-job.yml@self
-                parameters:
-                  AppHostingSdk: AppHostingSdk
-                  versionBranch: 'Latest'
+      - stage: Latest_E2E_Playwright
+        displayName: 'Latest E2E Tests (Playwright)'
+        dependsOn: Build
+        jobs:
+          - template: tools/yaml-templates/web-e2e-playwright-tests-job.yml@self
+            parameters:
+              AppHostingSdk: AppHostingSdk
+              versionBranch: 'Latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,17 @@ variables:
   - name: products
     value: 6eff390d-80c0-4456-81b6-6abafa71e768
 
+# The legacy Cypress E2E stages are disabled (see "Temporarily disable all
+# e2e tests in pipeline YAML", #3064). The Playwright E2E suite is opt-in
+# while it is being validated: set `runPlaywrightE2E` to true (from the
+# pipeline UI "Run pipeline" -> Variables, or by editing the default below)
+# to run it.
+parameters:
+  - name: runPlaywrightE2E
+    displayName: 'Run Playwright E2E tests'
+    type: boolean
+    default: false
+
 trigger:
   branches:
     include:
@@ -239,3 +250,16 @@ extends:
       #     # - job: E2ETestIOS2
       #     #   displayName: 'E2E Tests - IOS - Plan B'
       #     #   ...
+
+      # Playwright E2E tests. The legacy Cypress E2E stages above are disabled
+      # (#3064); this stage is the Playwright replacement and is gated on the
+      # `runPlaywrightE2E` parameter (default false) while it is validated.
+      - ${{ if eq(parameters.runPlaywrightE2E, true) }}:
+          - stage: Latest_E2E_Playwright
+            displayName: 'Latest E2E Tests (Playwright)'
+            dependsOn: Build
+            jobs:
+              - template: tools/yaml-templates/web-e2e-playwright-tests-job.yml@self
+                parameters:
+                  AppHostingSdk: AppHostingSdk
+                  versionBranch: 'Latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -248,4 +248,4 @@ extends:
           - template: tools/yaml-templates/web-e2e-playwright-tests-job.yml@self
             parameters:
               AppHostingSdk: AppHostingSdk
-              versionBranch: 'Latest'
+              versionBranch: 'latest'

--- a/tools/yaml-templates/build-app-host.yml
+++ b/tools/yaml-templates/build-app-host.yml
@@ -40,10 +40,6 @@ steps:
       pnpm config set store-dir $(Pipeline.Workspace)/.pnpm-store
     displayName: 'Setup pnpm'
 
-  # The Cypress e2e suite is disabled in favor of the Playwright suite, so the
-  # Cypress binary is never needed, and its download host (download.cypress.io)
-  # is blocked on the build agents. We therefore skip the Cypress binary
-  # download entirely via CYPRESS_INSTALL_BINARY=0 and no longer cache it.
   - task: npmAuthenticate@0
     inputs:
       workingFile: '$(AppHostingSdkProjectDirectory)/.npmrc'
@@ -55,7 +51,7 @@ steps:
       rm -rf $(pnpm store path)
       sed -i '/"preinstall":/d' package.json
       pnpm install --frozen-lockfile
-    displayName: Install app hosting dependencies (skip Cypress binary download)
+    displayName: Install app hosting dependencies
     workingDirectory: '$(AppHostingSdkProjectDirectory)'
     env:
       CYPRESS_INSTALL_BINARY: '0'
@@ -78,7 +74,7 @@ steps:
       pnpm build-force-blazor
     displayName: 'Build client sdk'
     workingDirectory: '$(ClientSdkProjectDirectory)'
-    
+
   - task: CmdLine@2
     displayName: 'Configure host machine'
     inputs:

--- a/tools/yaml-templates/build-app-host.yml
+++ b/tools/yaml-templates/build-app-host.yml
@@ -40,38 +40,25 @@ steps:
       pnpm config set store-dir $(Pipeline.Workspace)/.pnpm-store
     displayName: 'Setup pnpm'
 
-  # Cypress needs to run a post_install script, when `node_modules` are cached, therefore the cypress binary file
-  # should be cached, as cypress doesn't supports running post_install script after node_modules are cached.
-  # The below task caches the Cypress binary.
-  - task: Cache@2
-    inputs:
-      key: 'cy_v1 | "$(Agent.OS)" | $(AppHostingSdkProjectDirectory)/pnpm-lock.yaml'
-      path: /home/cloudtest/.cache/Cypress
-      cacheHitVar: CYPRESS_CACHE_RESTORED
-    displayName: 'Cache Cypress binary'
-
+  # The Cypress e2e suite is disabled in favor of the Playwright suite, so the
+  # Cypress binary is never needed, and its download host (download.cypress.io)
+  # is blocked on the build agents. We therefore skip the Cypress binary
+  # download entirely via CYPRESS_INSTALL_BINARY=0 and no longer cache it.
   - task: npmAuthenticate@0
     inputs:
       workingFile: '$(AppHostingSdkProjectDirectory)/.npmrc'
 
-  # Below script task checks if Cypress cache is hit or not.
-  # If Cypress cache is found skip cypress install.
-  - script: |
-      CYPRESS_INSTALL_BINARY=0
-      sed -i '/"preinstall":/d' package.json
-      pnpm install --frozen-lockfile
-    displayName: Install app hosting dependencies (skip Cypress install)
-    workingDirectory: '$(AppHostingSdkProjectDirectory)'
-    condition: eq(variables.CYPRESS_CACHE_RESTORED, 'true')
-
-  # If Cypress cache is not found include cypress install.
+  # Install dependencies, skipping Cypress's postinstall binary download.
+  # CYPRESS_INSTALL_BINARY is set via the step env (not a bare shell assignment)
+  # so that it is exported to the pnpm child process.
   - script: |
       rm -rf $(pnpm store path)
       sed -i '/"preinstall":/d' package.json
       pnpm install --frozen-lockfile
-    displayName: Install app hosting dependencies (include Cypress install)
+    displayName: Install app hosting dependencies (skip Cypress binary download)
     workingDirectory: '$(AppHostingSdkProjectDirectory)'
-    condition: eq(variables.CYPRESS_CACHE_RESTORED, 'false')
+    env:
+      CYPRESS_INSTALL_BINARY: '0'
 
   - task: CodeQL3000Init@0
     inputs:

--- a/tools/yaml-templates/web-e2e-playwright-tests-job.yml
+++ b/tools/yaml-templates/web-e2e-playwright-tests-job.yml
@@ -1,7 +1,7 @@
-# This template runs the Playwright E2E suite from the metaos-hub-sdk repo
-# against the locally-built teams-js bundle. It mirrors the existing Cypress
-# `web-e2e-tests-job.yml` template but uses Playwright's native sharding
-# (--shardIndex / --shardTotal) instead of test-prefix patterns.
+# This template runs the Playwright E2E suite against the locally-built
+# teams-js bundle. It mirrors the existing Cypress `web-e2e-tests-job.yml`
+# template but uses Playwright's native sharding (--shardIndex / --shardTotal)
+# instead of test-prefix patterns.
 #
 # Each invocation produces one parallel job per element of the `shards`
 # parameter (default [1, 2, 3] = three shards).
@@ -45,16 +45,11 @@ jobs:
             parameters:
               appHostGitPath: ${{ parameters.AppHostingSdk }}
 
-          # Build the local teams-js test app so the Playwright suite picks
-          # up the PR's teams-js changes (matches Cypress flow for the
-          # npm/local case).
           - script: |
               pnpm --filter teams-test-app build
             displayName: 'Build teamsjs test app'
             workingDirectory: '$(ClientSdkProjectDirectory)'
 
-          # SSR setup must run on every shard since Playwright sharding is
-          # not predicate-based; any shard may include an SSR test.
           - script: |
               sudo apt-get install -y libnss3-tools
               curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"

--- a/tools/yaml-templates/web-e2e-playwright-tests-job.yml
+++ b/tools/yaml-templates/web-e2e-playwright-tests-job.yml
@@ -3,7 +3,8 @@
 # `web-e2e-tests-job.yml` template but uses Playwright's native sharding
 # (--shardIndex / --shardTotal) instead of test-prefix patterns.
 #
-# Each invocation produces `shardTotal` parallel jobs.
+# Each invocation produces one parallel job per element of the `shards`
+# parameter (default [1, 2, 3] = three shards).
 #
 # Setup parity notes vs the Cypress template:
 #   * mkcert / SSR cert / SSR app build are done unconditionally for every
@@ -22,15 +23,19 @@ parameters:
     type: string
     default: 'Latest'
 
-  - name: shardTotal
-    type: number
-    default: 3
+  # The `shards` array is the single source of truth for sharding: it both
+  # controls how many parallel jobs are generated (one per element) and, via
+  # length(), the --shardTotal passed to Playwright. To change the shard count,
+  # edit this list only — e.g. [1, 2, 3, 4] for four shards.
+  - name: shards
+    type: object
+    default: [1, 2, 3]
 
 jobs:
-  - ${{ each shardIndex in split('1,2,3', ',') }}:
+  - ${{ each shardIndex in parameters.shards }}:
       - job: E2EPlaywrightWeb_${{ parameters.versionBranch }}_shard_${{ shardIndex }}
         timeoutInMinutes: 120
-        displayName: 'Playwright E2E - Web ${{ parameters.versionBranch }} - shard ${{ shardIndex }}/${{ parameters.shardTotal }}'
+        displayName: 'Playwright E2E - Web ${{ parameters.versionBranch }} - shard ${{ shardIndex }}/${{ length(parameters.shards) }}'
         pool:
           name: Azure-Pipelines-1ESPT-ExDShared
           image: 'ubuntu-latest'
@@ -87,8 +92,8 @@ jobs:
                 --targetClientSdkCheckpoint "${{ parameters.versionBranch }}" \
                 --reportFileName "e2e-playwright-report-shard-${{ shardIndex }}" \
                 --shardIndex ${{ shardIndex }} \
-                --shardTotal ${{ parameters.shardTotal }}
-            displayName: 'Run Playwright E2E tests (shard ${{ shardIndex }}/${{ parameters.shardTotal }})'
+                --shardTotal ${{ length(parameters.shards) }}
+            displayName: 'Run Playwright E2E tests (shard ${{ shardIndex }}/${{ length(parameters.shards) }})'
             condition: succeeded()
             workingDirectory: '$(AppHostingSdkProjectDirectory)'
             env:
@@ -98,6 +103,6 @@ jobs:
             inputs:
               testResultsFormat: 'JUnit'
               testResultsFiles: '**/e2e-playwright-report*.xml'
-              testRunTitle: 'Playwright E2E - Web ${{ parameters.versionBranch }} - shard ${{ shardIndex }}/${{ parameters.shardTotal }}'
+              testRunTitle: 'Playwright E2E - Web ${{ parameters.versionBranch }} - shard ${{ shardIndex }}/${{ length(parameters.shards) }}'
               mergeTestResults: true
             condition: succeededOrFailed()

--- a/tools/yaml-templates/web-e2e-playwright-tests-job.yml
+++ b/tools/yaml-templates/web-e2e-playwright-tests-job.yml
@@ -1,0 +1,103 @@
+# This template runs the Playwright E2E suite from the metaos-hub-sdk repo
+# against the locally-built teams-js bundle. It mirrors the existing Cypress
+# `web-e2e-tests-job.yml` template but uses Playwright's native sharding
+# (--shardIndex / --shardTotal) instead of test-prefix patterns.
+#
+# Each invocation produces `shardTotal` parallel jobs.
+#
+# Setup parity notes vs the Cypress template:
+#   * mkcert / SSR cert / SSR app build are done unconditionally for every
+#     shard (Playwright distributes tests across shards randomly, so any
+#     shard could run an SSR test).
+#   * `npx playwright install --with-deps chromium` installs the Playwright
+#     browser; this isn't needed for Cypress.
+#   * dotnet HTTPS dev cert is initialized for the Blazor test app.
+
+parameters:
+  - name: AppHostingSdk
+    default: none
+    type: string
+
+  - name: versionBranch
+    type: string
+    default: 'Latest'
+
+  - name: shardTotal
+    type: number
+    default: 3
+
+jobs:
+  - ${{ each shardIndex in split('1,2,3', ',') }}:
+      - job: E2EPlaywrightWeb_${{ parameters.versionBranch }}_shard_${{ shardIndex }}
+        timeoutInMinutes: 120
+        displayName: 'Playwright E2E - Web ${{ parameters.versionBranch }} - shard ${{ shardIndex }}/${{ parameters.shardTotal }}'
+        pool:
+          name: Azure-Pipelines-1ESPT-ExDShared
+          image: 'ubuntu-latest'
+          os: linux
+        steps:
+          - template: build-app-host.yml
+            parameters:
+              appHostGitPath: ${{ parameters.AppHostingSdk }}
+
+          # Build the local teams-js test app so the Playwright suite picks
+          # up the PR's teams-js changes (matches Cypress flow for the
+          # npm/local case).
+          - script: |
+              pnpm --filter teams-test-app build
+            displayName: 'Build teamsjs test app'
+            workingDirectory: '$(ClientSdkProjectDirectory)'
+
+          # SSR setup must run on every shard since Playwright sharding is
+          # not predicate-based; any shard may include an SSR test.
+          - script: |
+              sudo apt-get install -y libnss3-tools
+              curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
+              chmod +x mkcert-v*-linux-amd64
+              sudo mv mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+            displayName: 'Install mkcert (for SSR test app cert)'
+
+          - script: |
+              pnpm setup-ssr-app-cert
+            displayName: 'Setup SSR app certificates'
+            workingDirectory: '$(ClientSdkProjectDirectory)'
+
+          - script: |
+              pnpm --filter ssr-test-app build
+            displayName: 'Build teamsjs SSR test app'
+            workingDirectory: '$(ClientSdkProjectDirectory)'
+
+          # Initialize the .NET HTTPS dev cert so the Blazor test app can
+          # serve over https://127.0.0.1:44302.
+          - script: |
+              dotnet dev-certs https --check || dotnet dev-certs https
+            displayName: 'Ensure .NET HTTPS dev certificate for Blazor'
+
+          - script: |
+              npx playwright install --with-deps chromium
+            displayName: 'Install Playwright browsers'
+            workingDirectory: '$(AppHostingSdkProjectDirectory)'
+
+          # runPlaywrightE2ETests.ts handles starting servers (test app,
+          # Blazor, Orange, SSR), running the suite for the requested
+          # shard, and tearing down on completion.
+          - bash: |
+              pnpm exec ts-node tools/cli/runPlaywrightE2ETests.ts \
+                --useDataFromLocal=true \
+                --targetClientSdkCheckpoint "${{ parameters.versionBranch }}" \
+                --reportFileName "e2e-playwright-report-shard-${{ shardIndex }}" \
+                --shardIndex ${{ shardIndex }} \
+                --shardTotal ${{ parameters.shardTotal }}
+            displayName: 'Run Playwright E2E tests (shard ${{ shardIndex }}/${{ parameters.shardTotal }})'
+            condition: succeeded()
+            workingDirectory: '$(AppHostingSdkProjectDirectory)'
+            env:
+              CI: 'true'
+
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: '**/e2e-playwright-report*.xml'
+              testRunTitle: 'Playwright E2E - Web ${{ parameters.versionBranch }} - shard ${{ shardIndex }}/${{ parameters.shardTotal }}'
+              mergeTestResults: true
+            condition: succeededOrFailed()


### PR DESCRIPTION
## Description

Cypress is currently blocked on the PR pipeline due to its requiring downloading the Cypress binary from an external endpoint. We've begun the process of converting our Cypress tests to Playwright tests on the app host repo, and can now enable those tests here to unblock teams-js PR validation
.
This PR enables Playwright E2E tests on the microsoft-teams-library-js pipeline. The Cypress tests are gradually being converted to Playwright tests on the app host repo, so at this point these tests will only run against the latest app host version.

### Main changes in the PR:

1. Add job to PR pipeline to run the Playwright E2E tests.
2. Add env variable to the build-app-host job to avoid Cypress install.

## Validation

### Validation performed:

1. PR run contains Playwright tests and passes.

### Unit Tests added:

No, N/A

### End-to-end tests added:

Playwright suite added

## Additional Requirements

### Change file added:

No

### Next/remaining steps:

E2E will be incrementally ported on the app host sdk. We may have to adjust shard settings on teams-js pipeline, but other than that there shouldn't be anything else required here.
Back compat tests and full migration to CFS dependency resolution will be added in separate PRs.