### PR TITLE
Fix CVE-2026-44503: pin Microsoft.Graph.Core to 3.2.6 (Kiota.Abstractions 1.22.1)

### DIFF
--- a/apps/blazor-test-app/Blazor-Test-App.csproj
+++ b/apps/blazor-test-app/Blazor-Test-App.csproj
@@ -27,6 +27,8 @@
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.23.*" />
     <!-- CVE-2026-26127: Pin Microsoft.Bcl.Memory to patched version (transitive dependency) -->
     <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.15" />
+    <!-- CVE-2026-44503: Pin Microsoft.Graph.Core to patched version (transitive via Microsoft.Graph); 3.2.6 brings Microsoft.Kiota.Abstractions >= 1.22.1 -->
+    <PackageReference Include="Microsoft.Graph.Core" Version="3.2.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

This PR remediates **CVE-2026-44503** in `Microsoft.Kiota.Abstractions` (flagged at 1.17.1) in the Blazor test app.

### Main changes in the PR:

1. Add a `Microsoft.Graph.Core` `3.2.6` `PackageReference` pin in `apps/blazor-test-app/Blazor-Test-App.csproj` (with a CVE comment), upgrading transitive Kiota packages from 1.17.1 → 1.22.1.

## Validation

### Validation performed:

1. Ran `dotnet restore` on `Blazor-Test-App.csproj` — restored successfully.
2. Inspected `obj/project.assets.json`: `Microsoft.Graph.Core` resolves to **3.2.6** and the full Kiota family (Abstractions, Authentication.Azure, Http.HttpClientLibrary, Serialization.Form/Json/Multipart/Text) resolves to **1.22.1**, with **zero** remaining 1.17.1 references.

### Unit Tests added:

No — this is a transitive dependency version pin in a test app to resolve a Component Governance CVE. There is no product code change to unit test; correctness is validated by NuGet restore resolution.

### End-to-end tests added:

No — dependency-only change, no functional/behavioral change.


