### PR TITLE
Deprecate clipboard capability APIs

### DIFF
--- a/change/@microsoft-teams-js-5ab00d2f-b245-413d-869b-69e34f99aeba.json
+++ b/change/@microsoft-teams-js-5ab00d2f-b245-413d-869b-69e34f99aeba.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Deprecated the `clipboard` capability (`clipboard.write`, `clipboard.read`, `clipboard.isSupported`) and its `ClipboardParams` and `ClipboardSupportedMimeType` types. These APIs may stop working at any time without notice: support for this capability in Teams and other host apps may be removed entirely and independently of a TeamsJS major release, so continued functionality is not guaranteed. The intended long-term replacement is the browser's standardized Clipboard API (`navigator.clipboard`); note that using it directly within Teams hosts is not yet fully supported and depends on native device permission work still being enabled.",
+  "packageName": "@microsoft/teams-js",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/clipboard.ts
+++ b/packages/teams-js/src/public/clipboard.ts
@@ -1,6 +1,16 @@
 /**
  * Interact with the system clipboard
  *
+ * @deprecated
+ * As of TeamsJS v2.54.0, the clipboard capability is deprecated. These APIs may stop working at
+ * any time without notice: support for this capability in Teams and other host apps may be removed
+ * entirely and independently of a TeamsJS major release, so continued functionality is not
+ * guaranteed. The intended long-term replacement is the standardized Clipboard API provided by the
+ * browser ({@link https://developer.mozilla.org/docs/Web/API/Clipboard_API | Clipboard API}, `navigator.clipboard`).
+ * Note that using the browser-native Clipboard API directly within Teams hosts is not yet fully
+ * supported; it depends on native device permission handling that is still being enabled as a
+ * separate effort.
+ *
  * @beta
  * @module
  */
@@ -21,6 +31,17 @@ const clipboardTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 
 /**
  * Function to copy data to clipboard.
+ *
+ * @deprecated
+ * As of TeamsJS v2.54.0, the clipboard capability is deprecated. These APIs may stop working at
+ * any time without notice: support for this capability in Teams and other host apps may be removed
+ * entirely and independently of a TeamsJS major release, so continued functionality is not
+ * guaranteed. The intended long-term replacement is the standardized Clipboard API provided by the
+ * browser ({@link https://developer.mozilla.org/docs/Web/API/Clipboard_API | Clipboard API}, `navigator.clipboard`).
+ * Note that using the browser-native Clipboard API directly within Teams hosts is not yet fully
+ * supported; it depends on native device permission handling that is still being enabled as a
+ * separate effort.
+ *
  * @remarks
  * Note: clipboard.write only supports Text, HTML, PNG, and JPEG data format.
  *       MIME type for Text -> `text/plain`, HTML -> `text/html`, PNG/JPEG -> `image/(png | jpeg)`
@@ -63,6 +84,16 @@ export async function write(blob: Blob): Promise<void> {
 /**
  * Function to read data from clipboard.
  *
+ * @deprecated
+ * As of TeamsJS v2.54.0, the clipboard capability is deprecated. These APIs may stop working at
+ * any time without notice: support for this capability in Teams and other host apps may be removed
+ * entirely and independently of a TeamsJS major release, so continued functionality is not
+ * guaranteed. The intended long-term replacement is the standardized Clipboard API provided by the
+ * browser ({@link https://developer.mozilla.org/docs/Web/API/Clipboard_API | Clipboard API}, `navigator.clipboard`).
+ * Note that using the browser-native Clipboard API directly within Teams hosts is not yet fully
+ * supported; it depends on native device permission handling that is still being enabled as a
+ * separate effort.
+ *
  * @returns A promise blob which resolves to the data read from the clipboard or
  *          rejects stating the reason for failure.
  *          Note: Returned blob type will contain one of the MIME type `image/png`, `text/plain` or `text/html`.
@@ -95,6 +126,16 @@ export async function read(): Promise<Blob> {
  * @returns boolean to represent whether the clipboard capability is supported
  *
  * @throws Error if {@linkcode app.initialize} has not successfully completed
+ *
+ * @deprecated
+ * As of TeamsJS v2.54.0, the clipboard capability is deprecated. These APIs may stop working at
+ * any time without notice: support for this capability in Teams and other host apps may be removed
+ * entirely and independently of a TeamsJS major release, so continued functionality is not
+ * guaranteed. The intended long-term replacement is the standardized Clipboard API provided by the
+ * browser ({@link https://developer.mozilla.org/docs/Web/API/Clipboard_API | Clipboard API}, `navigator.clipboard`).
+ * Note that using the browser-native Clipboard API directly within Teams hosts is not yet fully
+ * supported; it depends on native device permission handling that is still being enabled as a
+ * separate effort.
  *
  * @beta
  */

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -1384,7 +1384,17 @@ export enum EduType {
 }
 
 /**
- * Currently supported Mime type
+ * Currently supported MIME types
+ *
+ * @deprecated
+ * As of TeamsJS v2.54.0, the clipboard capability is deprecated. These APIs may stop working at
+ * any time without notice: support for this capability in Teams and other host apps may be removed
+ * entirely and independently of a TeamsJS major release, so continued functionality is not
+ * guaranteed. The intended long-term replacement is the standardized Clipboard API provided by the
+ * browser ({@link https://developer.mozilla.org/docs/Web/API/Clipboard_API | Clipboard API}, `navigator.clipboard`).
+ * Note that using the browser-native Clipboard API directly within Teams hosts is not yet fully
+ * supported; it depends on native device permission handling that is still being enabled as a
+ * separate effort.
  */
 export enum ClipboardSupportedMimeType {
   TextPlain = 'text/plain',
@@ -1395,9 +1405,19 @@ export enum ClipboardSupportedMimeType {
 
 /**
  * Clipboard write parameters
+ *
+ * @deprecated
+ * As of TeamsJS v2.54.0, the clipboard capability is deprecated. These APIs may stop working at
+ * any time without notice: support for this capability in Teams and other host apps may be removed
+ * entirely and independently of a TeamsJS major release, so continued functionality is not
+ * guaranteed. The intended long-term replacement is the standardized Clipboard API provided by the
+ * browser ({@link https://developer.mozilla.org/docs/Web/API/Clipboard_API | Clipboard API}, `navigator.clipboard`).
+ * Note that using the browser-native Clipboard API directly within Teams hosts is not yet fully
+ * supported; it depends on native device permission handling that is still being enabled as a
+ * separate effort.
  */
 export interface ClipboardParams {
-  /** Mime Type of data to be copied to Clipboard */
+  /** MIME type of data to be copied to Clipboard */
   mimeType: ClipboardSupportedMimeType;
   /** Blob content in Base64 string format */
   content: string;


### PR DESCRIPTION
## Summary

Deprecates the **`clipboard`** capability in TeamsJS. This is a **documentation-only** deprecation — no runtime behavior, wire calls, or telemetry are changed. The APIs continue to function today; they are simply marked `@deprecated` to discourage new adoption and signal that they should not be relied upon going forward.

## Motivation

We need apps to know these APIs **may stop working at any time without notice** — support for the clipboard capability in Teams and other host apps may be removed entirely and independently of a TeamsJS major release, so continued functionality is **not guaranteed**.

The **intended long-term replacement** is the browser's standardized Clipboard API (`navigator.clipboard`). **Important:** using the browser-native Clipboard API directly within Teams hosts is **not yet fully supported** — it depends on native device permission handling that is still being enabled as a separate, longer-term effort. We are deprecating the capability first to signal the direction; the notice makes the readiness caveat explicit so apps are not misled into thinking `navigator.clipboard` is a drop-in replacement today.

## Changes

- **`packages/teams-js/src/public/clipboard.ts`** — added `@deprecated` tags to the module doc comment and to `write()`, `read()`, and `isSupported()`.
- **`packages/teams-js/src/public/interfaces.ts`** — added `@deprecated` tags to `ClipboardParams` and `ClipboardSupportedMimeType` (and fixed "Mime" → "MIME" casing in the surrounding docs).
- **`change/`** — beachball changefile (`minor` bump) describing the deprecation.

The `@deprecated` notice reads:

> As of TeamsJS v2.54.0, the clipboard capability is deprecated. These APIs may stop working at any time without notice: support for this capability in Teams and other host apps may be removed entirely and independently of a TeamsJS major release, so continued functionality is not guaranteed. The intended long-term replacement is the standardized Clipboard API provided by the browser (`navigator.clipboard`). Note that using the browser-native Clipboard API directly within Teams hosts is not yet fully supported; it depends on native device permission handling that is still being enabled as a separate effort.

## What is NOT changed

- No functions removed or signatures changed — fully backward compatible.
- No telemetry or wire message changes.
- The `teams-test-app` Clipboard component continues to work unchanged.

## Validation

- ✅ `pnpm --filter @microsoft/teams-js build`
- ✅ 316 clipboard unit tests pass
- ✅ ESLint + Prettier clean on changed files
- ✅ `beachball check` passes

## Follow-ups (tracked separately)

- Eventual full removal of the clipboard capability.
- Investigation into native device permission handling so apps can request clipboard consent and use `navigator.clipboard` directly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
