### PR TITLE
Add M365CalendarMeetNow to EventActionSource enum

### DIFF
--- a/change/@microsoft-teams-js-3b3bfc88-8bb4-41a4-b3f2-893ff39a085a.json
+++ b/change/@microsoft-teams-js-3b3bfc88-8bb4-41a4-b3f2-893ff39a085a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added `M365CalendarMeetNow` to the `EventActionSource` enum",
+  "packageName": "@microsoft/teams-js",
+  "email": "idudas@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/public/meeting/meeting.ts
+++ b/packages/teams-js/src/public/meeting/meeting.ts
@@ -1117,6 +1117,10 @@ export enum EventActionSource {
    */
   M365CalendarFormJoinTeamsMeetingButton = 'm365_calendar_form_join_teams_meeting_button',
   /**
+   * Source is the M365 calendar Meet Now start action.
+   */
+  M365CalendarMeetNow = 'm365_calendar_meet_now',
+  /**
    * Other sources.
    */
   Other = 'other',


### PR DESCRIPTION
Adds `EventActionSource.M365CalendarMeetNow = 'm365_calendar_meet_now'` so Teams-side code can reference the enum member instead of a raw string literal.

This is a type-correctness-only follow-up — **no behavioral change**. The OWA M365/Monarch calendar "Meet Now -> Start" action already sends `source: "m365_calendar_meet_now"` to `meeting.joinMeeting`, teams-js forwards the source as-is, and the Teams host already maps the literal string to `isAdhoc: true` -> `create_meetup` logging. This change simply completes the enum.

The string value `m365_calendar_meet_now` is the locked cross-repo contract (OWA sends it, Teams host matches it) and is byte-for-byte unchanged.

Context: Teams bug 4507219, OWA PR #248961.

Fixes #3076

A beachball change file (minor) is included.

_Supersedes #3075 (previously opened as a cross-fork PR; reopened directly against upstream now that I have write access)._
