### PR TITLE
[Clipboard-Read P0] Add ClipboardRead device permission + telemetry + runtime flag

### DIFF
--- a/change/@microsoft-teams-js-clipboard-read-device-permission-p0.json
+++ b/change/@microsoft-teams-js-clipboard-read-device-permission-p0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add `DevicePermission.ClipboardRead` and clipboard permission telemetry/runtime foundations for the updated clipboard-read architecture (P0, additive; no behavior change)",
+  "packageName": "@microsoft/teams-js",
+  "email": "leahxia@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/internal/telemetry.ts
+++ b/packages/teams-js/src/internal/telemetry.ts
@@ -105,6 +105,8 @@ export const enum ApiName {
   Chat_OpenGroupChat = 'chat.openGroupChat',
   Clipboard_Read = 'clipboard.read',
   Clipboard_Write = 'clipboard.write',
+  Clipboard_HasPermission = 'clipboard.hasPermission',
+  Clipboard_RequestPermission = 'clipboard.requestPermission',
   Conversations_CloseConversation = 'conversations.closeConversation',
   Conversations_GetChatMember = 'conversations.getChatMember',
   Conversations_OpenConversation = 'conversations.openConversation',

--- a/packages/teams-js/src/public/interfaces.ts
+++ b/packages/teams-js/src/public/interfaces.ts
@@ -1161,6 +1161,7 @@ export enum ErrorCode {
 export enum DevicePermission {
   GeoLocation = 'geolocation',
   Media = 'media',
+  ClipboardRead = 'clipboard-read',
 }
 
 /** @hidden */

--- a/packages/teams-js/src/public/runtime.ts
+++ b/packages/teams-js/src/public/runtime.ts
@@ -235,7 +235,15 @@ interface IRuntimeV4 extends IBaseRuntime {
     readonly calendar?: {};
     readonly call?: {};
     readonly chat?: {};
-    readonly clipboard?: {};
+    readonly clipboard?: {
+      /**
+       * When present, the host supports reading the clipboard natively in the app
+       * frame (via `navigator.clipboard`) gated by the `clipboard-read` device
+       * permission, instead of the legacy host-proxied `clipboard.readFromClipboard`
+       * path. Absent on older hosts, which fall back to the proxied path.
+       */
+      readonly native?: {};
+    };
     readonly conversations?: {};
     readonly copilot?: {
       readonly customTelemetry?: {};


### PR DESCRIPTION
## Summary

**P0** of the *Updated architecture for clipboard read using device permissions* effort. This is the **additive, no-behavior-change** foundation that lets a later change move `clipboard.read()` onto the browser-native [Clipboard API](https://developer.mozilla.org/docs/Web/API/Clipboard_API) (`navigator.clipboard.read`) gated by a device-permission consent flow, replacing the deprecated host-proxied `clipboard.readFromClipboard` path.

- **Feature:** [ADO 11070811 – Updated architecture for clipboard read using device permissions](https://office.visualstudio.com/MetaOS/_workitems/edit/11070811)
- **Task:** [ADO 12061800 – Clipboard-Read P0](https://dev.azure.com/office/MetaOS/_workitems/edit/12061800)
- **Epic (context):** [ADO 10815146 – Better device permissions for all MetaOS Apps](https://office.visualstudio.com/MetaOS/_workitems/edit/10815146)
- **Companion PR (host side):** `@metaos/hub-sdk` adds the matching `DevicePermission.ClipboardRead` value.

## Why

Today `clipboard.read()` is proxied: the app asks the host to read the OS clipboard and marshals a `Blob` back over the postMessage bridge. The capability was marked `@deprecated` (v2.54.0). The standards-based replacement is for the app to call `navigator.clipboard.read()` **itself** — but that requires (1) a `clipboard-read` device permission + consent, and (2) the host delegating `clipboard-read` via the iframe `allow` Permissions-Policy. This PR lays the guest-SDK groundwork for that; the actual `read()` rework is **P2**.

## Changes (all additive)

| File | Change |
|---|---|
| `public/interfaces.ts` | Add `DevicePermission.ClipboardRead = 'clipboard-read'`. The value deliberately matches the browser Permissions-Policy feature token so the host can emit it verbatim into the iframe `allow` attribute. |
| `internal/telemetry.ts` | Add `Clipboard_HasPermission` and `Clipboard_RequestPermission` `ApiName` entries, following the existing `*_HasPermission` / `*_RequestPermission` convention. |
| `public/runtime.ts` | Add an optional `clipboard.native` capability marker on the v4 runtime. When present, the host supports the native app-frame clipboard-read path; when absent (older hosts), consumers fall back to the legacy proxied path. |

## Not in this PR (scoped out / later phases)

- **P2** – `clipboard.hasPermission()` / `requestPermission()` and the native `read()` implementation with proxy fallback (teams-js).
- **P1** – host allow-list entry, consent gating, and IndexedDB migration (hub-sdk).
- No change to `clipboard.write()` or any existing permission. `clipboard-write` behavior is untouched.
- LNA and the broader permission-model unification are **out of scope** for this feature (separate epic work).

## Compatibility

Purely additive: a new enum member, two telemetry names, and an optional runtime sub-flag. Nothing branches on these yet, so there is no behavior change and no impact on existing hosts or apps. Old hosts simply won't advertise `clipboard.native`.

## Validation

- `tsc --noEmit` passes.
- `eslint` passes (0 warnings) on the changed files.
- Beachball changefile included (`minor`).

## Reviewer notes

- ⚠️ **Open question (blocks P1, not this PR):** on **Teams Desktop (Electron) and mobile**, does clipboard-read flow through the iframe Permissions-Policy or through native OS/Electron permission handling? If native, P1/P2 need a native branch behind the same API. The `clipboard.native` marker is intentionally generic to accommodate either.
- The `ClipboardRead` naming/value is chosen to stay forward-compatible with any future unified device-permission enum, to avoid a later rename.
