### PR TITLE
Updating teams-js to version 2.54.0

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.53.1/js/MicrosoftTeams.min.js"
-      integrity="sha384-u/ADAeV1WhPQrTvoCmXcIhzguvD7vpAOyMxZFTIk4lTwgZAKtRKT1SFqOWTyQJ/s"
+      src="https://res.cdn.office.net/teams-js/2.54.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-PIuQ2V7hlz4b1x3G1mPCYYZiWTjxzRTL6bf547xR9ARsAeNv2DAzti86LQnFCwlo"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.53.1",
+  "version": "2.54.0",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm validate-test-schema && pnpm lint && webpack",

--- a/change/@microsoft-teams-js-3b3bfc88-8bb4-41a4-b3f2-893ff39a085a.json
+++ b/change/@microsoft-teams-js-3b3bfc88-8bb4-41a4-b3f2-893ff39a085a.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added `M365CalendarMeetNow` to the `EventActionSource` enum",
-  "packageName": "@microsoft/teams-js",
-  "email": "idudas@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-5ab00d2f-b245-413d-869b-69e34f99aeba.json
+++ b/change/@microsoft-teams-js-5ab00d2f-b245-413d-869b-69e34f99aeba.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Deprecated the `clipboard` capability (`clipboard.write`, `clipboard.read`, `clipboard.isSupported`) and its `ClipboardParams` and `ClipboardSupportedMimeType` types. These APIs may stop working at any time without notice: support for this capability in Teams and other host apps may be removed entirely and independently of a TeamsJS major release, so continued functionality is not guaranteed. The intended long-term replacement is the browser's standardized Clipboard API (`navigator.clipboard`); note that using it directly within Teams hosts is not yet fully supported and depends on native device permission work still being enabled.",
-  "packageName": "@microsoft/teams-js",
-  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-6b7b983a-9553-43d0-90e9-f265ad5ab840.json
+++ b/change/@microsoft-teams-js-6b7b983a-9553-43d0-90e9-f265ad5ab840.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Update version number to 2.53.1 after release",
-  "packageName": "@microsoft/teams-js",
-  "email": "aeun@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-teams-js-e7c0b12b-b04f-4889-8666-0308f962df9d.json
+++ b/change/@microsoft-teams-js-e7c0b12b-b04f-4889-8666-0308f962df9d.json
@@ -1,7 +1,0 @@
-{
-  "comment": "Added `mouseRelay` capability that will forward mouse back/forward (X1/X2) buttons from app iframes to the host for Teams history navigation.",
-  "type": "minor",
-  "packageName": "@microsoft/teams-js",
-  "email": "yuanboxue@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,18 @@
 # Change Log - @microsoft/teams-js
 
-<!-- This log was last generated on Wed, 17 Jun 2026 17:10:04 GMT and should not be manually modified. -->
+<!-- This log was last generated on Wed, 15 Jul 2026 20:17:53 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 2.54.0
+
+Wed, 15 Jul 2026 20:17:53 GMT
+
+### Minor changes
+
+- Added `mouseRelay` capability that will forward mouse back/forward (X1/X2) buttons from app iframes to the host for Teams history navigation.
+- Deprecated the `clipboard` capability (`clipboard.write`, `clipboard.read`, `clipboard.isSupported`) and its `ClipboardParams` and `ClipboardSupportedMimeType` types. These APIs may stop working at any time without notice: support for this capability in Teams and other host apps may be removed entirely and independently of a TeamsJS major release, so continued functionality is not guaranteed. The intended long-term replacement is the browser's standardized Clipboard API (`navigator.clipboard`); note that using it directly within Teams hosts is not yet fully supported and depends on native device permission work still being enabled.
+- Added `M365CalendarMeetNow` to the `EventActionSource` enum
 
 ## 2.53.1
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.53.1/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.54.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.53.1/js/MicrosoftTeams.min.js"
-  integrity="sha384-u/ADAeV1WhPQrTvoCmXcIhzguvD7vpAOyMxZFTIk4lTwgZAKtRKT1SFqOWTyQJ/s"
+  src="https://res.cdn.office.net/teams-js/2.54.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-PIuQ2V7hlz4b1x3G1mPCYYZiWTjxzRTL6bf547xR9ARsAeNv2DAzti86LQnFCwlo"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.53.1/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.54.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.53.1",
+  "version": "2.54.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",


### PR DESCRIPTION
## 2.54.0

Wed, 15 Jul 2026 20:17:53 GMT

### Minor changes

- Added `mouseRelay` capability that will forward mouse back/forward (X1/X2) buttons from app iframes to the host for Teams history navigation.
- Deprecated the `clipboard` capability (`clipboard.write`, `clipboard.read`, `clipboard.isSupported`) and its `ClipboardParams` and `ClipboardSupportedMimeType` types. These APIs may stop working at any time without notice: support for this capability in Teams and other host apps may be removed entirely and independently of a TeamsJS major release, so continued functionality is not guaranteed. The intended long-term replacement is the browser's standardized Clipboard API (`navigator.clipboard`); note that using it directly within Teams hosts is not yet fully supported and depends on native device permission work still being enabled.
- Added `M365CalendarMeetNow` to the `EventActionSource` enum