### PR TITLE
Add shared changelog extractor and fix integrity regex

### DIFF
--- a/tools/cli/extract-changelog-section.js
+++ b/tools/cli/extract-changelog-section.js
@@ -1,0 +1,45 @@
+/* eslint-disable */
+
+const fs = require('fs');
+const path = require('path');
+
+const CHANGELOG_PATH = path.resolve(__dirname, '../../packages/teams-js/CHANGELOG.md');
+
+/**
+ * Returns the changelog body for a specific version (the content between the
+ * `## <version>` header and the next `## ` header). If no version is provided,
+ * the full changelog is returned.
+ *
+ * @param {string} [version] semver string, e.g. "2.53.1"
+ * @param {string} [changelogPath] override path to CHANGELOG.md (used in tests)
+ * @returns {string} the trimmed changelog section, or the full changelog
+ */
+function extractChangelogSection(version, changelogPath = CHANGELOG_PATH) {
+  if (!fs.existsSync(changelogPath)) {
+    throw new Error(`Changelog was not found at ${changelogPath}`);
+  }
+  const fullChangelog = fs.readFileSync(changelogPath, 'utf8');
+  if (!version) {
+    return fullChangelog;
+  }
+  // Split on level-2 headers, keeping the headers as delimiters so the array
+  // alternates between header and body entries.
+  const parts = fullChangelog.split(/(^## .*$)/m);
+  const index = parts.findIndex((part) => part.trim() === `## ${version}`);
+  if (index === -1) {
+    throw new Error(`Matching version ${version} in changelog was not found`);
+  }
+  return parts[index + 1] ? parts[index + 1].trim() : '';
+}
+
+module.exports = { extractChangelogSection, CHANGELOG_PATH };
+
+if (require.main === module) {
+  const version = process.argv[2];
+  try {
+    process.stdout.write(extractChangelogSection(version));
+  } catch (e) {
+    console.error(e.message || e);
+    process.exit(1);
+  }
+}

--- a/tools/cli/preRelease.js
+++ b/tools/cli/preRelease.js
@@ -58,7 +58,7 @@ const updateVersionAndIntegrity = async (absolutePath, version, integrityHash) =
   }
   const readme = fs.readFileSync(absolutePath, 'utf8');
   const result = readme
-    .replace(/integrity=\".*?\"/, `integrity="${integrityHash}"`)
+    .replace(/integrity=".*?"/g, `integrity="${integrityHash}"`)
     .replace(
       /res\.cdn\.office.net\/teams-js\/.*\/js\/MicrosoftTeams\.min\.js/g,
       `res.cdn.office.net/teams-js/${version}/js/MicrosoftTeams.min.js`,

--- a/tools/cli/readChangelog.js
+++ b/tools/cli/readChangelog.js
@@ -1,33 +1,12 @@
 /* eslint-disable */
 
-const fs = require('fs');
-const path = require('path');
-
-const readChangeLog = version => {
-  const relativePathToChangelog = '../../packages/teams-js/CHANGELOG.md';
-  const absolutePathToChangelog = path.resolve(__dirname, relativePathToChangelog);
-  if (!fs.existsSync(absolutePathToChangelog)) {
-    throw `ERROR: ${absolutePathToChangelog} was not found.`;
-  }
-  const fullChangelog = fs.readFileSync(absolutePathToChangelog, 'utf8');
-  if (!version) {
-    return fullChangelog;
-  } else {
-    const result = fullChangelog.split(/(## .*\d)/);
-    const index = result.findIndex(substr => substr.startsWith(`## ${version}`));
-    if (index !== -1) {
-      const log = result[index + 1];
-      return log;
-    }
-    throw new Error('Matching version in changelog was not found');
-  }
-};
+const { extractChangelogSection } = require('./extract-changelog-section');
 
 (async () => {
   const args = process.argv.slice(2);
   const version = args[0];
   try {
-    const section = readChangeLog(version);
+    const section = extractChangelogSection(version);
     console.log(section);
   } catch (e) {
     console.log('Something went wrong!');


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

This is the first of four stacked PRs that streamline the TeamsJS release pipeline by automating the current manual release checklist and GitHub Release creation. This foundational PR contains no workflow/behavior changes — it extracts shared logic and fixes two latent bugs, so the later PRs (validation library, validate workflow, orchestrate workflow) can build on it.

Main changes in the PR:

1. Add tools/cli/extract-changelog-section.js - a shared, importable module that returns the changelog body for a given version. It matches the ## <version> header exactly, fixing a latent bug in the previous  startsWith -based logic where requesting 2.53.1 could match the 2.53.10 section (and vice-versa). Reused by the validation scripts and workflows introduced in later PRs.
2. Refactor tools/cli/readChangelog.js to delegate to the new shared extractor (behavior-preserving; keeps the existing  prerelease.yml  workflow working).
3. Fix the integrity-replacement regex in tools/cli/preRelease.js - add the global ( /g ) flag to /integrity=".*?"/ so every integrity="..." attribute in a file is updated during a release, not just the first. Previously a file with more than one integrity attribute would ship a stale SRI hash on all but the first.

Validation

Validation performed:

1. Ran the extractor against the real changelog:  node tools/cli/extract-changelog-section.js 2.53.1 returns the correct, isolated section.
2. Verified the prefix-collision fix:  2.53.1 and 2.53.10 each return only their own section.
3. Confirmed the preRelease.js regex now replaces all integrity occurrences (covered by tests in PR 2).

Unit Tests added:

No — the unit tests that cover this module (extract-changelog-section , including the prefix-collision and missing-version cases) live in stacked PR 2, which registers tools/cli as a workspace package and adds the Jest harness. Splitting them out keeps this PR to a minimal, low-risk refactor. The tests fully exercise the code introduced here.

End-to-end tests added:

No — no runtime/product behavior changes; these are release-tooling scripts.

Additional Requirements

Change file added:

No — changes are limited to repo release tooling under tools/cli/ and produce no @microsoft/teams-js package changes, so no beachball change file is required.

Related PRs:

Part of a stacked series:

• PR 1 (this) — shared changelog extractor + bug fixes
• PR 2 — validation scripts + Jest tests
• PR 3 —  release-validate.yml  workflow
• PR 4 —  release-orchestrate.yml  (auto pre-release)

Next/remaining steps:

• PR 2: release integrity + SRI validation library, with fixture-based unit tests
• PR 3: PR validation workflow (back required status checks on release/* )
• PR 4: automate GitHub pre-release creation on release-PR merge