### PR TITLE
Add helper function getImmediateParentOrigin

### DIFF
--- a/change/@microsoft-teams-js-b33af9f5-2e13-435b-b9d3-e7673174140e.json
+++ b/change/@microsoft-teams-js-b33af9f5-2e13-435b-b9d3-e7673174140e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add getImmediateParentOrigin helper function",
+  "packageName": "@microsoft/teams-js",
+  "email": "77021369+jimchou-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
       "brotli": false,
       "path": "./packages/teams-js/dist/esm/packages/teams-js/src/index.js",
       "import": "{ app, authentication, pages }",
-      "limit": "60.7 KB"
+      "limit": "60.8 KB"
     },
     {
       "brotli": false,

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
       "brotli": false,
       "path": "./packages/teams-js/dist/esm/packages/teams-js/src/index.js",
       "import": "{ app, authentication, pages }",
-      "limit": "60.4 KB"
+      "limit": "60.7 KB"
     },
     {
       "brotli": false,

--- a/packages/teams-js/src/public/app/app.ts
+++ b/packages/teams-js/src/public/app/app.ts
@@ -693,6 +693,52 @@ export function initialize(validMessageOrigins?: string[]): Promise<void> {
 }
 
 /**
+ * Returns the immediate parent origin when this app is running inside an iframe.
+ *
+ * @remarks
+ * This helper is useful for scenarios where the app must explicitly trust the hosting parent origin during
+ * {@link initialize} by passing `[origin]` as `validMessageOrigins`.
+ *
+ * If no parent origin can be determined, this function returns `null`.
+ *
+ * @example
+ * ```typescript
+ * import { app } from '@microsoft/teams-js';
+ *
+ * const parentOrigin = app.getImmediateParentOrigin();
+ * await app.initialize(parentOrigin ? [parentOrigin] : undefined);
+ * ```
+ *
+ * @returns The immediate parent origin, or `null` when unavailable.
+ */
+export function getImmediateParentOrigin(): string | null {
+  if (inServerSideRenderingEnvironment()) {
+    return null;
+  }
+
+  const currentWindow = Communication.currentWindow ?? window;
+  if (currentWindow.parent === currentWindow) {
+    return null;
+  }
+
+  const ancestorOrigins = (currentWindow.location as Location & { ancestorOrigins?: DOMStringList }).ancestorOrigins;
+  if (ancestorOrigins && ancestorOrigins.length > 0 && ancestorOrigins[0]) {
+    return ancestorOrigins[0];
+  }
+
+  const referrer = currentWindow.document?.referrer;
+  if (!referrer) {
+    return null;
+  }
+
+  try {
+    return new URL(referrer).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * @hidden
  * Undocumented function used to set a mock window for unit tests
  *

--- a/packages/teams-js/src/public/app/app.ts
+++ b/packages/teams-js/src/public/app/app.ts
@@ -733,7 +733,15 @@ export function getImmediateParentOrigin(): string | null {
   }
 
   try {
-    return new URL(referrer).origin;
+    const referrerOrigin = new URL(referrer).origin;
+
+    // `document.referrer` can point to this iframe's prior URL after in-frame redirects.
+    // Returning self-origin as the parent would be incorrect; treat this as unavailable.
+    if (referrerOrigin === currentWindow.location.origin) {
+      return null;
+    }
+
+    return referrerOrigin;
   } catch {
     return null;
   }

--- a/packages/teams-js/src/public/app/app.ts
+++ b/packages/teams-js/src/public/app/app.ts
@@ -722,8 +722,9 @@ export function getImmediateParentOrigin(): string | null {
   }
 
   const ancestorOrigins = (currentWindow.location as Location & { ancestorOrigins?: DOMStringList }).ancestorOrigins;
-  if (ancestorOrigins && ancestorOrigins.length > 0 && ancestorOrigins[0]) {
-    return ancestorOrigins[0];
+  const immediateAncestorOrigin = ancestorOrigins?.item(0);
+  if (immediateAncestorOrigin) {
+    return immediateAncestorOrigin;
   }
 
   const referrer = currentWindow.document?.referrer;

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -120,8 +120,6 @@ describe('Testing app capability', () => {
         const mockWindow = utils.mockWindow as any;
         mockWindow.parent = utils.parentWindow;
         mockWindow.location.ancestorOrigins = {
-          0: 'https://widget-renderer.usercontent.microsoft',
-          1: 'https://ignored-ancestor.example.com',
           length: 2,
           item: (index: number) =>
             index === 0

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -106,6 +106,57 @@ describe('Testing app capability', () => {
       });
     });
 
+    describe('Testing app.getImmediateParentOrigin function', () => {
+      it('returns null when app is not running in an iframe', () => {
+        const mockWindow = utils.mockWindow as any;
+        mockWindow.parent = mockWindow;
+
+        const result = app.getImmediateParentOrigin();
+
+        expect(result).toBeNull();
+      });
+
+      it('returns immediate parent origin from location.ancestorOrigins when available', () => {
+        const mockWindow = utils.mockWindow as any;
+        mockWindow.parent = utils.parentWindow;
+        mockWindow.location.ancestorOrigins = {
+          0: 'https://widget-renderer.usercontent.microsoft',
+          1: 'https://ignored-ancestor.example.com',
+          length: 2,
+        };
+
+        const result = app.getImmediateParentOrigin();
+
+        expect(result).toBe('https://widget-renderer.usercontent.microsoft');
+      });
+
+      it('returns origin derived from document.referrer when ancestorOrigins is unavailable', () => {
+        const mockWindow = utils.mockWindow as any;
+        mockWindow.parent = utils.parentWindow;
+        mockWindow.location.ancestorOrigins = undefined;
+        mockWindow.document = {
+          referrer: 'https://widget-renderer.usercontent.microsoft/embed/page?foo=bar',
+        };
+
+        const result = app.getImmediateParentOrigin();
+
+        expect(result).toBe('https://widget-renderer.usercontent.microsoft');
+      });
+
+      it('returns null when ancestorOrigins is unavailable and document.referrer is invalid', () => {
+        const mockWindow = utils.mockWindow as any;
+        mockWindow.parent = utils.parentWindow;
+        mockWindow.location.ancestorOrigins = undefined;
+        mockWindow.document = {
+          referrer: 'not-a-valid-url',
+        };
+
+        const result = app.getImmediateParentOrigin();
+
+        expect(result).toBeNull();
+      });
+    });
+
     describe('Testing app.initialize function', () => {
       it('app.initialize message contains all necessary data', () => {
         app.initialize();

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -147,6 +147,20 @@ describe('Testing app capability', () => {
         expect(result).toBe('https://widget-renderer.usercontent.microsoft');
       });
 
+      it('returns null when referrer origin matches app origin', () => {
+        const mockWindow = utils.mockWindow as any;
+        mockWindow.parent = utils.parentWindow;
+        mockWindow.location.origin = 'https://my-app.example.com';
+        mockWindow.location.ancestorOrigins = undefined;
+        mockWindow.document = {
+          referrer: 'https://my-app.example.com/redirected/inside/iframe',
+        };
+
+        const result = app.getImmediateParentOrigin();
+
+        expect(result).toBeNull();
+      });
+
       it('returns null when ancestorOrigins is unavailable and document.referrer is invalid', () => {
         const mockWindow = utils.mockWindow as any;
         mockWindow.parent = utils.parentWindow;

--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -123,6 +123,12 @@ describe('Testing app capability', () => {
           0: 'https://widget-renderer.usercontent.microsoft',
           1: 'https://ignored-ancestor.example.com',
           length: 2,
+          item: (index: number) =>
+            index === 0
+              ? 'https://widget-renderer.usercontent.microsoft'
+              : index === 1
+                ? 'https://ignored-ancestor.example.com'
+                : null,
         };
 
         const result = app.getImmediateParentOrigin();


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description
- Add helper function getImmediateParentOrigin to be used by widget app

example usage:
 ```typescript
 import { app } from '@microsoft/teams-js';
 
 const parentOrigin = app.getImmediateParentOrigin();
 await app.initialize(parentOrigin ? [parentOrigin] : undefined);
```

### Main changes in the PR:

1. Add getImmediateParentOrigin helper functio

## Validation

### Validation performed:

1. Unit test

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

Yes

### End-to-end tests added:

No

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

Yes

