### PR TITLE
Add missing @hidden tags to private teams-js APIs

### DIFF
--- a/change/@microsoft-teams-js-ef59d850-6913-4469-99b0-0463c4f0436a.json
+++ b/change/@microsoft-teams-js-ef59d850-6913-4469-99b0-0463c4f0436a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add missing @hidden tags to private teams-js APIs to prevent them from leaking into public docs",
+  "packageName": "@microsoft/teams-js",
+  "email": "joshlai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/conversations.ts
+++ b/packages/teams-js/src/private/conversations.ts
@@ -26,6 +26,12 @@ import { ChatMembersInformation } from './interfaces';
  */
 const conversationsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
 
+/**
+ * @hidden
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export interface OpenConversationRequest {
   /**
    * @hidden
@@ -242,6 +248,7 @@ export function getChatMembers(): Promise<ChatMembersInformation> {
 }
 
 /**
+ * @hidden
  * Checks if the conversations capability is supported by the host
  * @returns boolean to represent whether conversations capability is supported
  *

--- a/packages/teams-js/src/private/copilot/sidePanel.ts
+++ b/packages/teams-js/src/private/copilot/sidePanel.ts
@@ -108,7 +108,12 @@ export async function preCheckUserConsent(request?: UserConsentRequest): Promise
   );
 }
 
-/** Register user action content select handler function type */
+/**
+ * @hidden
+ * Register user action content select handler function type
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export type userActionHandlerType = (selectedContent: Content) => void;
 /**
  * @hidden

--- a/packages/teams-js/src/private/copilot/sidePanelInterfaces.ts
+++ b/packages/teams-js/src/private/copilot/sidePanelInterfaces.ts
@@ -65,7 +65,12 @@ export interface DraftEmailContent extends BaseEmailContent {
   composeType?: 'new' | 'reply' | 'replyAll' | 'forward'; // Type of compose action
 }
 
-// Union type for usage elsewhere
+/**
+ * @hidden
+ * Union type for usage elsewhere
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export type EmailContent = ServerEmailContent | DraftEmailContent;
 
 /**

--- a/packages/teams-js/src/private/externalAppAuthentication.ts
+++ b/packages/teams-js/src/private/externalAppAuthentication.ts
@@ -323,6 +323,12 @@ export type ComposeResultTypes = 'auth' | 'config' | 'message' | 'result' | 'sil
 /*********** END RESPONSE TYPE ************/
 
 /*********** BEGIN ERROR TYPE ***********/
+/**
+ * @hidden
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export interface InvokeError {
   errorCode: InvokeErrorCode;
   message?: string;
@@ -668,6 +674,12 @@ export interface ConnectorParameters {
   windowParameters?: OauthWindowProperties;
 }
 
+/**
+ * @hidden
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export class SerializableConnectorParameters implements ISerializable {
   public constructor(private param: ConnectorParameters) {}
 

--- a/packages/teams-js/src/private/hostEntity/hostEntity.ts
+++ b/packages/teams-js/src/private/hostEntity/hostEntity.ts
@@ -12,6 +12,11 @@ import { ensureInitialized } from '../../internal/internalAPIs';
 import { runtime } from '../../public/runtime';
 import * as tab from './tab';
 
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export enum AppTypes {
   edu = 'EDU',
   /**
@@ -32,14 +37,20 @@ interface TeamsEntityId {
 }
 
 /**
+ * @hidden
  * Id of message in which channel meeting is created
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface TeamsChannelMeetingEntityIds extends TeamsEntityId {
   parentMessageId: string;
 }
 
 /**
+ * @hidden
  * Id of the host entity
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export type HostEntityIds = TeamsEntityId | TeamsChannelMeetingEntityIds;
 

--- a/packages/teams-js/src/private/hostEntity/tab.ts
+++ b/packages/teams-js/src/private/hostEntity/tab.ts
@@ -69,7 +69,7 @@ class SerializableHostEntityId implements ISerializable {
 
 /**
  * @hidden
- * Represents information about a tab instance associated with a host entity like chat, channel or meeting. Cab be a configurable tab or static tab.
+ * Represents information about a tab instance associated with a host entity like chat, channel or meeting. Can be a configurable tab or static tab.
  * @internal
  * Limited to Microsoft-internal use
  */

--- a/packages/teams-js/src/private/hostEntity/tab.ts
+++ b/packages/teams-js/src/private/hostEntity/tab.ts
@@ -24,14 +24,20 @@ import { AppTypes, HostEntityIds, isSupported as isHostEntitySupported } from '.
 const hostEntityTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 
 /**
+ * @hidden
  * Represents information about a static tab instance
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface StaticTabInstance extends TabInstance {
   tabType: 'StaticTab';
 }
 
 /**
+ * @hidden
  * Represents information about a configurable tab instance
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface ConfigurableTabInstance extends TabInstance {
   tabType: 'ConfigurableTab';
@@ -62,7 +68,10 @@ class SerializableHostEntityId implements ISerializable {
 }
 
 /**
+ * @hidden
  * Represents information about a tab instance associated with a host entity like chat, channel or meeting. Cab be a configurable tab or static tab.
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export type HostEntityTabInstance = StaticTabInstance | ConfigurableTabInstance;
 
@@ -83,7 +92,10 @@ class SerializableHostEntityTabInstance implements ISerializable {
 }
 
 /**
+ * @hidden
  * Represents all tabs associated with a host entity like chat, channel or meeting
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface HostEntityTabInstances {
   allTabs: HostEntityTabInstance[];

--- a/packages/teams-js/src/private/otherAppStateChange.ts
+++ b/packages/teams-js/src/private/otherAppStateChange.ts
@@ -138,6 +138,7 @@ export function notifyInstallCompleted(appId: AppId): Promise<void> {
 }
 
 /**
+ * @hidden
  * Checks if the otherAppStateChange capability is supported by the host
  * @returns boolean to represent whether the otherAppStateChange capability is supported
  *

--- a/packages/teams-js/src/private/privateAPIs.ts
+++ b/packages/teams-js/src/private/privateAPIs.ts
@@ -10,6 +10,8 @@ import { FrameContexts } from '../public/constants';
 import { runtime } from '../public/runtime';
 import { FilePreviewParameters, UserSettingTypes } from './interfaces';
 
+const privateAPIsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
+
 /**
  * @hidden
  * Upload a custom App manifest directly to both team and personal scopes.
@@ -17,11 +19,7 @@ import { FilePreviewParameters, UserSettingTypes } from './interfaces';
  *
  * @internal
  * Limited to Microsoft-internal use
- *
- * v1 APIs telemetry file: All of APIs in this capability file should send out API version v1 ONLY
  */
-const privateAPIsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
-
 export function uploadCustomApp(manifestBlob: Blob, onComplete?: (status: boolean, reason?: string) => void): void {
   ensureInitialized(runtime);
 

--- a/packages/teams-js/src/private/store.ts
+++ b/packages/teams-js/src/private/store.ts
@@ -191,6 +191,7 @@ export async function openSpecificStore(params: OpenSpecificStoreParams): Promis
 }
 
 /**
+ * @hidden
  * Checks if the store capability is supported by the host
  * @returns boolean to represent whether the store capability is supported
  *

--- a/packages/teams-js/src/private/teams/teams.ts
+++ b/packages/teams-js/src/private/teams/teams.ts
@@ -20,6 +20,11 @@ import * as fullTrust from './fullTrust/fullTrust';
  */
 const teamsTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_1;
 
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export enum ChannelType {
   Regular = 0,
   Private = 1,

--- a/packages/teams-js/src/private/videoEffectsEx.ts
+++ b/packages/teams-js/src/private/videoEffectsEx.ts
@@ -28,6 +28,11 @@ import * as videoEffects from '../public/videoEffects';
  */
 const videoEffectsExTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
 
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export const frameProcessingTimeoutInMs = 2000;
 
 const videoPerformanceMonitor = inServerSideRenderingEnvironment()

--- a/packages/teams-js/src/private/widgetHosting/widgetContext.ts
+++ b/packages/teams-js/src/private/widgetHosting/widgetContext.ts
@@ -1,13 +1,35 @@
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
 import { RenderingSurfaces } from '../../public';
 
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export interface ISecurityPolicy {
   connectDomains?: string[];
   resourceDomains?: string[];
   isTrusted?: boolean;
 }
 
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export type Theme = 'light' | 'dark';
 
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export type SafeAreaInsets = {
   top: number;
   bottom: number;
@@ -15,12 +37,27 @@ export type SafeAreaInsets = {
   right: number;
 };
 
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export type SafeArea = {
   insets: SafeAreaInsets;
 };
 
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export type DeviceType = 'mobile' | 'tablet' | 'desktop' | 'unknown';
 
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export type UserAgent = {
   device: { type: DeviceType };
   capabilities: {
@@ -30,7 +67,10 @@ export type UserAgent = {
 };
 
 /**
+ * @hidden
  * Options for requesting a modal dialog
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface IModalOptions {
   /** Unique identifier for the modal */
@@ -46,26 +86,52 @@ export interface IModalOptions {
 }
 
 /**
+ * @hidden
  * Response from requesting a modal dialog
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface IModalResponse {
   /** A DOM element representing the modal's root */
   modalElement: HTMLElement;
 }
 
-/** Declare generic JSON - serializable structure */
+/**
+ * @hidden
+ * Declare generic JSON - serializable structure
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export interface JSONObject {
   [key: string]: JSONValue;
 }
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export interface JSONArray extends Array<JSONValue> {}
 
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export type JSONValue = string | number | boolean | null | JSONObject | JSONArray;
 
-/** Display mode */
+/**
+ * @hidden
+ * Display mode
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export type DisplayMode = 'pip' | 'inline' | 'fullscreen';
 
 /**
+ * @hidden
  * MCP-compatible tool input structure following OpenAI MCP server specification
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface IToolInput {
   /** The name of the tool to call */
@@ -75,7 +141,10 @@ export interface IToolInput {
 }
 
 /**
+ * @hidden
  * MCP-compatible tool output structure matching exact MCP schema
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface IToolOutput {
   /** Whether the tool call resulted in an error */
@@ -107,7 +176,10 @@ export interface IToolOutput {
 }
 
 /**
+ * @hidden
  * Widget context similar to IWidgetHost structure - simplified for widget rendering
+ * @internal
+ * Limited to Microsoft-internal use
  */
 export interface IWidgetContext {
   /** Unique identifier for the widget instance */

--- a/packages/teams-js/src/private/widgetHosting/widgetHosting.ts
+++ b/packages/teams-js/src/private/widgetHosting/widgetHosting.ts
@@ -33,6 +33,12 @@ export function isSupported(): boolean {
   return ensureInitialized(runtime) && !!runtime.supports.widgetHosting;
 }
 
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ * @beta
+ */
 export async function callTool(widgetId: string, input: IToolInput): Promise<IToolOutput> {
   ensureInitializeCalled();
   widgetHostingLogger('Calling tool with widgetId and input: ', { widgetId, input });
@@ -172,7 +178,12 @@ export function openExternal(widgetId: string, payload: { href: string }): void 
   );
 }
 
-/** Modal close handler function type */
+/**
+ * @hidden
+ * Modal close handler function type
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export type ModalCloseHandlerType = (modalId: string) => void;
 
 /**


### PR DESCRIPTION
Fixes several exported functions, interfaces, types, and enums in packages/teams-js/src/private that were missing @hidden TSDoc tags, causing them to leak into the generated public API docs.
