### PR TITLE
Prepare release 2.55.0

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.54.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-PIuQ2V7hlz4b1x3G1mPCYYZiWTjxzRTL6bf547xR9ARsAeNv2DAzti86LQnFCwlo"
+      src="https://res.cdn.office.net/teams-js/2.55.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-qOOENVJGWr7UF7wvgyycjvq3sZen4SEYQwZMKqpquvV/PNMtSJb3VGZ/sAIKsZDw"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.54.0",
+  "version": "2.55.0",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm validate-test-schema && pnpm lint && webpack",

--- a/change/@microsoft-teams-js-b33af9f5-2e13-435b-b9d3-e7673174140e.json
+++ b/change/@microsoft-teams-js-b33af9f5-2e13-435b-b9d3-e7673174140e.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Add getImmediateParentOrigin helper function",
-  "packageName": "@microsoft/teams-js",
-  "email": "77021369+jimchou-dev@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-ef59d850-6913-4469-99b0-0463c4f0436a.json
+++ b/change/@microsoft-teams-js-ef59d850-6913-4469-99b0-0463c4f0436a.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Add missing @hidden tags to private teams-js APIs to prevent them from leaking into public docs",
-  "packageName": "@microsoft/teams-js",
-  "email": "joshlai@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Change Log - @microsoft/teams-js
 
-<!-- This log was last generated on Wed, 15 Jul 2026 20:17:53 GMT and should not be manually modified. -->
+<!-- This log was last generated on Wed, 05 Aug 2026 18:17:09 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 2.55.0
+
+Wed, 05 Aug 2026 18:17:09 GMT
+
+### Minor changes
+
+- Add getImmediateParentOrigin helper function
+
+### Patches
+
+- Add missing @hidden tags to private teams-js APIs to prevent them from leaking into public docs
 
 ## 2.54.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.54.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.55.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.54.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-PIuQ2V7hlz4b1x3G1mPCYYZiWTjxzRTL6bf547xR9ARsAeNv2DAzti86LQnFCwlo"
+  src="https://res.cdn.office.net/teams-js/2.55.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-qOOENVJGWr7UF7wvgyycjvq3sZen4SEYQwZMKqpquvV/PNMtSJb3VGZ/sAIKsZDw"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.54.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.55.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.54.0",
+  "version": "2.55.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",


### PR DESCRIPTION
## 2.55.0

Wed, 05 Aug 2026 18:17:09 GMT

### Minor changes

- Add getImmediateParentOrigin helper function

### Patches

- Add missing @hidden tags to private teams-js APIs to prevent them from leaking into public docs