### PR TITLE
Cleanup release 2.55.0

### DIFF
--- a/apps/teams-test-app/index_cdn.html
+++ b/apps/teams-test-app/index_cdn.html
@@ -15,8 +15,8 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script
-      src="https://res.cdn.office.net/teams-js/2.54.0/js/MicrosoftTeams.min.js"
-      integrity="sha384-PIuQ2V7hlz4b1x3G1mPCYYZiWTjxzRTL6bf547xR9ARsAeNv2DAzti86LQnFCwlo"
+      src="https://res.cdn.office.net/teams-js/2.55.0/js/MicrosoftTeams.min.js"
+      integrity="sha384-qOOENVJGWr7UF7wvgyycjvq3sZen4SEYQwZMKqpquvV/PNMtSJb3VGZ/sAIKsZDw"
       crossorigin="anonymous"
     ></script>
     <div id="root"></div>

--- a/apps/teams-test-app/package.json
+++ b/apps/teams-test-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "description": "Teams Test App utilizing Teams JavaScript client SDK to test Hosts",
-  "version": "2.54.0",
+  "version": "2.55.0",
   "scripts": {
     "build": "pnpm build:bundle",
     "build:bundle": "pnpm validate-test-schema && pnpm lint && webpack",

--- a/change/@microsoft-teams-js-b33af9f5-2e13-435b-b9d3-e7673174140e.json
+++ b/change/@microsoft-teams-js-b33af9f5-2e13-435b-b9d3-e7673174140e.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Add getImmediateParentOrigin helper function",
-  "packageName": "@microsoft/teams-js",
-  "email": "77021369+jimchou-dev@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-teams-js-ef509d25-29b9-41c0-9bc5-eb70e9d18f5e.json
+++ b/change/@microsoft-teams-js-ef509d25-29b9-41c0-9bc5-eb70e9d18f5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Released 2.55.0",
+  "packageName": "@microsoft/teams-js",
+  "email": "liuella@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-teams-js-ef59d850-6913-4469-99b0-0463c4f0436a.json
+++ b/change/@microsoft-teams-js-ef59d850-6913-4469-99b0-0463c4f0436a.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Add missing @hidden tags to private teams-js APIs to prevent them from leaking into public docs",
-  "packageName": "@microsoft/teams-js",
-  "email": "joshlai@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/teams-js/CHANGELOG.md
+++ b/packages/teams-js/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Change Log - @microsoft/teams-js
 
-<!-- This log was last generated on Wed, 15 Jul 2026 20:17:53 GMT and should not be manually modified. -->
+<!-- This log was last generated on Wed, 05 Aug 2026 18:17:09 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 2.55.0
+
+Wed, 05 Aug 2026 18:17:09 GMT
+
+### Minor changes
+
+- Add getImmediateParentOrigin helper function
+
+### Patches
+
+- Add missing @hidden tags to private teams-js APIs to prevent them from leaking into public docs
 
 ## 2.54.0
 

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -24,7 +24,7 @@ To install the stable [version](https://learn.microsoft.com/javascript/api/overv
 
 ### Production
 
-You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.54.0/js/MicrosoftTeams.min.js) or point your package manager at them.
+You can reference these files directly [from here](https://res.cdn.office.net/teams-js/2.55.0/js/MicrosoftTeams.min.js) or point your package manager at them.
 
 ## Usage
 
@@ -45,13 +45,13 @@ Reference the library inside of your `.html` page using:
 ```html
 <!-- Microsoft Teams JavaScript API (via CDN) -->
 <script
-  src="https://res.cdn.office.net/teams-js/2.54.0/js/MicrosoftTeams.min.js"
-  integrity="sha384-PIuQ2V7hlz4b1x3G1mPCYYZiWTjxzRTL6bf547xR9ARsAeNv2DAzti86LQnFCwlo"
+  src="https://res.cdn.office.net/teams-js/2.55.0/js/MicrosoftTeams.min.js"
+  integrity="sha384-qOOENVJGWr7UF7wvgyycjvq3sZen4SEYQwZMKqpquvV/PNMtSJb3VGZ/sAIKsZDw"
   crossorigin="anonymous"
 ></script>
 
 <!-- Microsoft Teams JavaScript API (via npm) -->
-<script src="node_modules/@microsoft/teams-js@2.54.0/dist/MicrosoftTeams.min.js"></script>
+<script src="node_modules/@microsoft/teams-js@2.55.0/dist/MicrosoftTeams.min.js"></script>
 
 <!-- Microsoft Teams JavaScript API (via local) -->
 <script src="MicrosoftTeams.min.js"></script>

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/teams-js",
   "author": "Microsoft Teams",
-  "version": "2.54.0",
+  "version": "2.55.0",
   "description": "Microsoft Client SDK for building app for Microsoft hosts",
   "repository": {
     "directory": "packages/teams-js",


### PR DESCRIPTION
## Description

Merges the `release/2.55.0` branch back into `main` after the 2.55.0 release, following the release cleanup process.

Because a direct `release/2.55.0` -> `main` merge cannot be used here, this uses the proxy cleanup branch `liuella/cleanup_release_2.55.0` created off `release/2.55.0` with `main` merged in.

### Main changes in the PR:

1. Bring the 2.55.0 release commit (version bump, changelog, README/test-app CDN references) into `main`.
2. Add a `none` change file with the comment `Released 2.55.0` to satisfy the beachball change file requirement for this proxy branch PR.

## Validation

### Validation performed:

1. Confirmed `main` had not diverged from `release/2.55.0` (release is one commit ahead).
2. Ran `pnpm beachball check` — passes with the `Released 2.55.0` change file committed.

### Unit Tests added:

No. This PR only merges the released version metadata back into `main` and adds a release change file.

### End-to-end tests added:

No.

## Additional Requirements

### Change file added:

Yes. A `none` change file with the comment `Released 2.55.0`.