### PR TITLE
Scope the SSR failureSuccess POST counter to the app session

### DIFF
--- a/apps/ssr-test-app/pages/failureSuccessTest.tsx
+++ b/apps/ssr-test-app/pages/failureSuccessTest.tsx
@@ -36,8 +36,8 @@ export interface FailureSuccessTestPageProps {
 // one, which is the sequence this counter exists to track.
 const postRequestCountBySession = new Map<string, number>();
 
-// This server outlives many test runs, so the map is bounded. Entries are only a
-// small integer each, and the oldest session is always the least interesting.
+// This server outlives many test runs, so the map is bounded, evicting the least
+// recently used session. Entries are one small integer each.
 const maxTrackedSessions = 100;
 
 // Used when the session id cannot be read. Falls back to the previous shared
@@ -57,14 +57,26 @@ function getSessionKey(postBody: string): string {
 
 function nextPostCountForSession(sessionKey: string): number {
   const currentCount = postRequestCountBySession.get(sessionKey) ?? 0;
+
+  // Delete before setting so the key moves to the end of the iteration order.
+  // Map#set does not reorder an existing key, so without this an active session
+  // that happened to be inserted first would stay the "oldest" forever and be
+  // evicted while still in use.
+  postRequestCountBySession.delete(sessionKey);
   postRequestCountBySession.set(sessionKey, currentCount + 1);
 
-  if (postRequestCountBySession.size > maxTrackedSessions) {
-    // Map preserves insertion order, so the first key is the oldest session.
-    const oldestSessionKey = postRequestCountBySession.keys().next().value;
-    if (oldestSessionKey !== undefined && oldestSessionKey !== sessionKey) {
-      postRequestCountBySession.delete(oldestSessionKey);
+  // Evict until the bound holds rather than once per call. A single conditional
+  // delete cannot recover if the map is ever more than one entry over, and the
+  // loop also makes the intent explicit.
+  while (postRequestCountBySession.size > maxTrackedSessions) {
+    const leastRecentlyUsedKey = postRequestCountBySession.keys().next().value;
+    // The key just written is now last, so it can only be first when it is the
+    // only entry -- which cannot exceed the bound. Guard anyway: deleting the
+    // current key would discard the count this request depends on.
+    if (leastRecentlyUsedKey === undefined || leastRecentlyUsedKey === sessionKey) {
+      break;
     }
+    postRequestCountBySession.delete(leastRecentlyUsedKey);
   }
 
   return currentCount;

--- a/apps/ssr-test-app/pages/failureSuccessTest.tsx
+++ b/apps/ssr-test-app/pages/failureSuccessTest.tsx
@@ -18,8 +18,57 @@ export interface FailureSuccessTestPageProps {
 // Add ?withMessage=true to the URL to include a message in notifyFailure
 // Second POST request will trigger notifySuccess
 
-// Track the number of POST requests received
-let postRequestCount = 0;
+// Track POST requests per app session rather than per server process.
+//
+// A single module-level counter is shared by every request this page ever
+// serves, and four tab definitions point at this same page (plain, customInit,
+// withMessage, and both), so tests observe each other's state. Because the count
+// resets on every second request, the behaviour is parity-dependent: an even
+// count yields notifyFailure, an odd one yields notifySuccess. Any extra POST --
+// a Cypress retry, a host-initiated reload, a refresh -- flips that parity, and
+// the next test then sees notifySuccess where it asserts notifyFailure. It
+// passes again on the following attempt, which is what makes it look flaky
+// rather than broken.
+//
+// The app session id is the correct scope. The host regenerates it when the app,
+// entity or frame context changes, so a page load or tab switch starts a fresh
+// count, while the notifyFailure -> reload -> notifySuccess cycle keeps the same
+// one, which is the sequence this counter exists to track.
+const postRequestCountBySession = new Map<string, number>();
+
+// This server outlives many test runs, so the map is bounded. Entries are only a
+// small integer each, and the oldest session is always the least interesting.
+const maxTrackedSessions = 100;
+
+// Used when the session id cannot be read. Falls back to the previous shared
+// behaviour rather than failing the request, so a body shape change degrades to
+// today's semantics instead of breaking the page.
+const fallbackSessionKey = 'unknown-session';
+
+function getSessionKey(postBody: string): string {
+  try {
+    const parsedBody = JSON.parse(postBody);
+    const sessionId = parsedBody?.hostContext?.appSessionId;
+    return typeof sessionId === 'string' && sessionId.length > 0 ? sessionId : fallbackSessionKey;
+  } catch {
+    return fallbackSessionKey;
+  }
+}
+
+function nextPostCountForSession(sessionKey: string): number {
+  const currentCount = postRequestCountBySession.get(sessionKey) ?? 0;
+  postRequestCountBySession.set(sessionKey, currentCount + 1);
+
+  if (postRequestCountBySession.size > maxTrackedSessions) {
+    // Map preserves insertion order, so the first key is the oldest session.
+    const oldestSessionKey = postRequestCountBySession.keys().next().value;
+    if (oldestSessionKey !== undefined && oldestSessionKey !== sessionKey) {
+      postRequestCountBySession.delete(oldestSessionKey);
+    }
+  }
+
+  return currentCount;
+}
 
 export default function FailureSuccessTestPage(props: FailureSuccessTestPageProps): ReactElement {
   const [teamsContext, setTeamsContext] = useState({});
@@ -81,14 +130,10 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res, query }
   const withMessage = query.withMessage === 'true';
 
   if (req.method === 'POST') {
-    const currentCount = postRequestCount;
-    postRequestCount++;
     const postBody = await parseBody(req);
-
-    // Reset counter after the second request
-    if (postRequestCount >= 2) {
-      postRequestCount = 0;
-    }
+    // Read the body first: the session key comes out of it, and the count has to
+    // be scoped to that session rather than to this server process.
+    const currentCount = nextPostCountForSession(getSessionKey(postBody));
 
     return {
       props: {


### PR DESCRIPTION
The counter that decides whether this page calls notifyFailure or notifySuccess was a single module-level variable, so it was shared by every request the page ever served. Four tab definitions in the hub's app catalog point at this same page (plain, customInit, withMessage, and both), and the count reset on every second request, which made the behaviour parity-dependent: an even count yields notifyFailure, an odd one yields notifySuccess.

That only holds together while requests arrive in exact pairs. Any extra POST -- a Cypress retry, a host-initiated reload, a refresh -- flips the parity, and the next test then receives notifySuccess where it asserts notifyFailure. The following attempt flips it back and passes, which is what makes this present as flakiness rather than as a broken test.

Key the count by the app session id from the POST body instead. That is the correct scope: the host regenerates the session id when the app, entity or frame context changes, so a page load or tab switch starts a fresh count, while the notifyFailure -> reload -> notifySuccess cycle keeps the same one, which is precisely the sequence this counter exists to track.

Verified against the hub: orange-web derives the session id from a uuid per page load and regenerates it in an effect keyed on appName, entityId and frameContext, none of which change during the reload cycle.

The map is bounded, since this server outlives many test runs, and a missing or unreadable session id falls back to a shared key so a body-shape change degrades to the previous behaviour rather than breaking the page.

Covered by 14 assertions over the logic: the normal failure-then-success cycle, isolation between sessions, the interrupted-then-retried case that produced the flake, interleaved sessions, malformed and missing session ids, and the map bound.

For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

> Summarize the changes, including the goals and reasons for this change. Be sure to call out any technical or behavior changes that reviewers should be aware of.

> If this Pull Request should close/resolve any issues when merged, use [the special syntax for that](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

1. <Step 1>
2. <Step 2>

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
