### PR TITLE
[CI] Pipeline security isolation CFS issue for npm view teamsjs

### DIFF
--- a/tools/yaml-templates/build-test-publish.yml
+++ b/tools/yaml-templates/build-test-publish.yml
@@ -57,6 +57,13 @@ steps:
     inputs:
       script: 'node prepBetaRelease.cjs'
       workingDirectory: '$(System.DefaultWorkingDirectory)\packages\teams-js'
+    env:
+      # prepBetaRelease.cjs runs `npm view @microsoft/teams-js` from packages/teams-js,
+      # which has no .npmrc. npm does not walk up to the repo-root .npmrc, so it would
+      # fall back to registry.npmjs.org (a CFSClean network-isolation violation). Point
+      # npm at the root .npmrc (which npmAuthenticate populated with the CFS feed URL and
+      # its auth token) so the version lookup resolves through the CFS-backed ADO feed.
+      NPM_CONFIG_USERCONFIG: '$(Build.SourcesDirectory)\.npmrc'
 
   # Generate nuget.config for the Blazor test app so dotnet restore uses the
   # CFS-backed ADO feed instead of api.nuget.org (CFSClean compliance).


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

### Problem

The  node prepBetaRelease.cjs  step in the "Build Test Publish" job produced a single CFSClean network-isolation violation:

Domain: registry.npmjs.org  |  Process: node.exe  |  Task: CmdLine

This step runs on main CI builds ( Build.SourceBranch == refs/heads/main ,  Build.Reason != PullRequest ), so it affects both the release pipeline ( build-release.yml ) and the PR-definition pipeline ( azure-pipelines.yml ) whenever they run against  main . Both pipelines share the same  tools/yaml-templates/build-test-publish.yml  template.

### Root cause

 prepBetaRelease.cjs  calls  npm view @microsoft/teams-js version --tag beta  to find the current beta version. The step runs with  workingDirectory: packages/teams-js , which has no  .npmrc .  npm view  resolves its registry from CWD  ./.npmrc  → user/global config → built-in default, and npm does not walk up to the repo-root  .npmrc  where the CFS-backed ADO feed is configured. With nothing overriding it,  npm view  falls through to the built-in default  https://registry.npmjs.org/ .

(The neighboring  pnpm beachball bump  runs from repo root — where the CFS  .npmrc  lives — and is git/fs-only, so it doesn't leak. The CWD difference is why only  npm view  violates.)

### Fix

Point npm at the repo-root  .npmrc  for that step by setting  NPM_CONFIG_USERCONFIG  on the  node prepBetaRelease.cjs  task:

env:
  NPM_CONFIG_USERCONFIG: '$(Build.SourcesDirectory)\.npmrc'

The root  .npmrc  is already populated earlier in the template by the "Configure CFS-compliant npm registry" step ( registry=<CFS feed>  +  always-auth=true ) and  npmAuthenticate@0  (auth token), so  npm view  now resolves through the CFS-backed ADO feed instead of  registry.npmjs.org .

### Scope / impact

• One-line-of-config change in the shared  build-test-publish.yml  template; fixes the violation in every pipeline that consumes it.
• No behavioral change to beta-release logic — only the registry endpoint used by the version lookup.

### Main changes in the PR:

1. <Change 1>
2. <Change 2>

## Validation

### Validation performed:

• Confirmed  npm view  is the only registry-hitting call in  prepBetaRelease.cjs ;  beachball bump  is local-only.
• Expect zero  registry.npmjs.org  violations in the "Build Test Publish" step on the next main CI run.

### Unit Tests added:

> Unit tests are required for all changes. If no unit tests were added as part of this change, please explain why they aren't necessary.

<Yes/No>

### End-to-end tests added:

<Yes/No>

## Additional Requirements

### Change file added:

> Ensure the change file meets the [formatting requirements](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md#change-log-using-beachball).

<Yes/No>

### Related PRs:

> Remove this section if n/a

### Next/remaining steps:

> List the next or remaining steps in implementing the overall feature in subsequent PRs (or is the feature 100% complete after this?).

> Remove this section if n/a

- [ ] Item 1
- [ ] Item 2

### Screenshots:

> Remove this section if n/a

| Before     | After      |
| ---------- | ---------- |
| < image1 > | < image2 > |
