### PR TITLE
Add fixture-driven capability contract tests (calendar + chat)

### DIFF
--- a/packages/teams-js/test/contract/loadFixtureCase.ts
+++ b/packages/teams-js/test/contract/loadFixtureCase.ts
@@ -1,0 +1,43 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface FixtureCase<TInputValue = unknown> {
+  title: string;
+  inputValue: TInputValue;
+  expectedAlertValue: string;
+}
+
+interface FixtureCaseRecord {
+  title?: string;
+  inputValue?: unknown;
+  expectedAlertValue?: string;
+}
+
+interface FixtureFeatureRecord {
+  testCases?: FixtureCaseRecord[];
+}
+
+interface FixtureRecord {
+  testCases?: FixtureCaseRecord[];
+  featureTests?: FixtureFeatureRecord[];
+}
+
+export function loadFixtureCase<TInputValue = unknown>(family: string, title: string): FixtureCase<TInputValue> {
+  const fixturePath = path.resolve(__dirname, '../../../../apps/teams-test-app/e2e-test-data', `${family}.json`);
+  const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8')) as FixtureRecord;
+  const testCases = [
+    ...(fixture.testCases ?? []),
+    ...(fixture.featureTests ?? []).flatMap((featureTest) => featureTest.testCases ?? []),
+  ];
+  const fixtureCase = testCases.find((testCase) => testCase.title === title);
+
+  if (!fixtureCase) {
+    throw new Error(`Fixture case "${title}" not found in ${fixturePath}`);
+  }
+
+  return {
+    title: fixtureCase.title ?? title,
+    inputValue: fixtureCase.inputValue as TInputValue,
+    expectedAlertValue: fixtureCase.expectedAlertValue ?? '',
+  };
+}

--- a/packages/teams-js/test/contract/loadFixtureCase.ts
+++ b/packages/teams-js/test/contract/loadFixtureCase.ts
@@ -10,8 +10,18 @@ export interface FixtureCase<TInputValue = unknown, TExpectedWirePayload = unkno
 
 interface FixtureCaseRecord {
   title?: string;
+  version?: string;
   inputValue?: unknown;
   expectedAlertValue?: string;
+}
+
+export interface LoadFixtureCaseOptions {
+  /**
+   * Disambiguates when multiple fixture cases share the same title (several families,
+   * e.g. chat, have duplicate titles differing only by `version`). Must match the case's
+   * `version` string exactly.
+   */
+  version?: string;
 }
 
 interface FixtureFeatureRecord {
@@ -45,6 +55,7 @@ function parseExpectedWirePayload(expectedAlertValue: string): unknown | undefin
 export function loadFixtureCase<TInputValue = unknown, TExpectedWirePayload = unknown>(
   family: string,
   title: string,
+  options: LoadFixtureCaseOptions = {},
 ): FixtureCase<TInputValue, TExpectedWirePayload> {
   const fixturePath = path.resolve(__dirname, '../../../../apps/teams-test-app/e2e-test-data', `${family}.json`);
   const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8')) as FixtureRecord;
@@ -52,12 +63,26 @@ export function loadFixtureCase<TInputValue = unknown, TExpectedWirePayload = un
     ...(fixture.testCases ?? []),
     ...(fixture.featureTests ?? []).flatMap((featureTest) => featureTest.testCases ?? []),
   ];
-  const fixtureCase = testCases.find((testCase) => testCase.title === title);
 
-  if (!fixtureCase) {
-    throw new Error(`Fixture case "${title}" not found in ${fixturePath}`);
+  let matches = testCases.filter((testCase) => testCase.title === title);
+  if (options.version !== undefined) {
+    matches = matches.filter((testCase) => testCase.version === options.version);
   }
 
+  if (matches.length === 0) {
+    const versionHint = options.version !== undefined ? ` (version "${options.version}")` : '';
+    throw new Error(`Fixture case "${title}"${versionHint} not found in ${fixturePath}`);
+  }
+
+  if (matches.length > 1) {
+    const versions = matches.map((testCase) => testCase.version ?? '(no version)').join(', ');
+    throw new Error(
+      `Fixture case "${title}" is ambiguous in ${fixturePath}: ${matches.length} cases match ` +
+        `(versions: ${versions}). Pass options.version to disambiguate.`,
+    );
+  }
+
+  const fixtureCase = matches[0];
   const expectedAlertValue = fixtureCase.expectedAlertValue ?? '';
 
   return {

--- a/packages/teams-js/test/contract/loadFixtureCase.ts
+++ b/packages/teams-js/test/contract/loadFixtureCase.ts
@@ -1,10 +1,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-export interface FixtureCase<TInputValue = unknown> {
+export interface FixtureCase<TInputValue = unknown, TExpectedWirePayload = unknown> {
   title: string;
   inputValue: TInputValue;
   expectedAlertValue: string;
+  expectedWirePayload?: TExpectedWirePayload;
 }
 
 interface FixtureCaseRecord {
@@ -22,7 +23,29 @@ interface FixtureRecord {
   featureTests?: FixtureFeatureRecord[];
 }
 
-export function loadFixtureCase<TInputValue = unknown>(family: string, title: string): FixtureCase<TInputValue> {
+function parseExpectedWirePayload(expectedAlertValue: string): unknown | undefined {
+  const calledWithMarker = ' called with ';
+  const calledWithIndex = expectedAlertValue.indexOf(calledWithMarker);
+  if (calledWithIndex === -1) {
+    return undefined;
+  }
+
+  const payload = expectedAlertValue.slice(calledWithIndex + calledWithMarker.length).trim();
+  if (!payload.startsWith('{') && !payload.startsWith('[')) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return undefined;
+  }
+}
+
+export function loadFixtureCase<TInputValue = unknown, TExpectedWirePayload = unknown>(
+  family: string,
+  title: string,
+): FixtureCase<TInputValue, TExpectedWirePayload> {
   const fixturePath = path.resolve(__dirname, '../../../../apps/teams-test-app/e2e-test-data', `${family}.json`);
   const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8')) as FixtureRecord;
   const testCases = [
@@ -35,9 +58,12 @@ export function loadFixtureCase<TInputValue = unknown>(family: string, title: st
     throw new Error(`Fixture case "${title}" not found in ${fixturePath}`);
   }
 
+  const expectedAlertValue = fixtureCase.expectedAlertValue ?? '';
+
   return {
     title: fixtureCase.title ?? title,
     inputValue: fixtureCase.inputValue as TInputValue,
-    expectedAlertValue: fixtureCase.expectedAlertValue ?? '',
+    expectedAlertValue,
+    expectedWirePayload: parseExpectedWirePayload(expectedAlertValue) as TExpectedWirePayload | undefined,
   };
 }

--- a/packages/teams-js/test/public/calendar.contract.spec.ts
+++ b/packages/teams-js/test/public/calendar.contract.spec.ts
@@ -1,0 +1,42 @@
+import { FrameContexts } from '../../src/public';
+import * as app from '../../src/public/app/app';
+import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
+import * as calendar from '../../src/public/calendar';
+import { loadFixtureCase } from '../contract/loadFixtureCase';
+import { Utils } from '../utils';
+
+describe('calendar contract', () => {
+  let utils: Utils;
+
+  beforeEach(() => {
+    utils = new Utils();
+  });
+
+  afterEach(() => {
+    if (app._uninitialize) {
+      utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
+      app._uninitialize();
+    }
+  });
+
+  it('emits the fixture-defined openCalendarItem wire message', async () => {
+    await utils.initializeWithContext(FrameContexts.content);
+    utils.setRuntimeConfig({ apiVersion: 1, supports: { calendar: {} } });
+    const fixtureCase = loadFixtureCase<calendar.OpenCalendarItemParams>(
+      'calendar',
+      'openCalendarItem API Call - Success',
+    );
+
+    const openCalendarItemPromise = calendar.openCalendarItem(fixtureCase.inputValue);
+    const message = utils.findMessageByFunc('calendar.openCalendarItem');
+
+    expect(message).not.toBeNull();
+    if (!message) {
+      throw new Error('calendar.openCalendarItem message not found');
+    }
+    expect(message.args).toEqual([fixtureCase.inputValue]);
+
+    await utils.respondToMessage(message, true);
+    await expect(openCalendarItemPromise).resolves.toBeUndefined();
+  });
+});

--- a/packages/teams-js/test/public/chat.contract.spec.ts
+++ b/packages/teams-js/test/public/chat.contract.spec.ts
@@ -1,0 +1,50 @@
+import { FrameContexts } from '../../src/public';
+import * as app from '../../src/public/app/app';
+import * as chat from '../../src/public/chat';
+import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
+import { loadFixtureCase } from '../contract/loadFixtureCase';
+import { Utils } from '../utils';
+
+interface OpenChatWirePayload {
+  members: string[];
+  message?: string;
+  topic?: string;
+}
+
+describe('chat contract', () => {
+  let utils: Utils;
+
+  beforeEach(() => {
+    utils = new Utils();
+  });
+
+  afterEach(() => {
+    if (app._uninitialize) {
+      utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
+      app._uninitialize();
+    }
+  });
+
+  it('emits the fixture-defined openGroupChat wire message', async () => {
+    await utils.initializeWithContext(FrameContexts.content);
+    utils.setRuntimeConfig({ apiVersion: 1, isLegacyTeams: false, supports: { chat: {} } });
+    const fixtureCase = loadFixtureCase<chat.OpenGroupChatRequest, OpenChatWirePayload>(
+      'chat',
+      'openGroupChat API Call - Success',
+    );
+
+    expect(fixtureCase.expectedWirePayload).toBeDefined();
+
+    const openGroupChatPromise = chat.openGroupChat(fixtureCase.inputValue);
+    const message = utils.findMessageByFunc('chat.openChat');
+
+    expect(message).not.toBeNull();
+    if (!message) {
+      throw new Error('chat.openChat message not found');
+    }
+    expect(message.args).toEqual([fixtureCase.expectedWirePayload]);
+
+    await utils.respondToMessage(message, true);
+    await expect(openGroupChatPromise).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
This is the teams-js half of moving our shared capability tests from the browser E2E suite into fast Jest contract tests. Nothing is removed from E2E here — these are additive producer tests.

Each test drives a real teams-js API and checks the wire message it emits, with the expected values read from the shared capability fixtures (so a contract change fails the test). Two families to start:
- calendar.openCalendarItem
- chat.openGroupChat — the interesting case, since teams-js transforms the input ({users}) into a different wire shape ({members}), so it validates we assert the emitted wire, not the raw input.

These pair with the Hub SDK provider tests that read the same fixtures, so neither repo can change the wire shape without a failing test on one side.

Paired Hub SDK PR: #5593136

Test-only — no src changes.
