### PR TITLE
chore: align lingering pnpm version references to 9.15.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following guide references steps to build the entire project including Teams
 
 Please look through our [Contributing Guide](CONTRIBUTING.md) for important details on how to submit a pull request and contribute to this repository.
 
-NOTE: Make sure `pnpm@9.0.6` or greater is installed as a global tool, by running `npm install -g pnpm@9.0.6`.
+NOTE: Make sure `pnpm@9.15.9` or greater is installed as a global tool, by running `npm install -g pnpm@9.15.9`.
 
 TIP: whenever building or testing the Teams client library, you can run `pnpm build` or `pnpm test` from the `packages/teams-js` directory.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": "Microsoft Teams",
   "engines": {
-    "pnpm": ">=9.0.6",
+    "pnpm": ">=9.15.9",
     "node": ">=18.0.0"
   },
   "scripts": {


### PR DESCRIPTION
## Description

Aligns the last lingering `pnpm@9.0.6` references with the version the repo actually uses everywhere else, `9.15.9`.

The pipelines already install `pnpm@9.15.9`:

- `.github/workflows/prerelease.yml`
- `tools/yaml-templates/build-test-publish.yml`
- `tools/yaml-templates/build-app-host.yml`
- `tools/yaml-templates/android-test.yml`
- `tools/yaml-templates/ios-test.yml`

But two places were still pointing at the old version:

| File | Before | After |
| --- | --- | --- |
| `README.md` | ``npm install -g pnpm@9.0.6`` | ``npm install -g pnpm@9.15.9`` |
| `package.json` (`engines`) | `"pnpm": ">=9.0.6"` | `"pnpm": ">=9.15.9"` |

## Validation

Docs/metadata only - no source or dependency changes. `pnpm-lock.yaml` is untouched. No change file needed since the root package is `private`.