### PR TITLE
test: cover uncovered branches in appHelpers.ts (SSR, init timeout, notifySuccess not-initialized)

### DIFF
--- a/packages/teams-js/test/public/app.spec.ts
+++ b/packages/teams-js/test/public/app.spec.ts
@@ -2,6 +2,7 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import { ensureInitialized } from '../../src/internal/internalAPIs';
+import * as internalUtils from '../../src/internal/utils';
 import { AppId, dialog, menus, pages } from '../../src/public';
 import * as app from '../../src/public/app/app';
 import {
@@ -48,6 +49,8 @@ function isM365ContentType(actionItem: unknown): actionItem is M365ContentAction
 
 describe('Testing app capability', () => {
   const mockErrorMessage = 'Something went wrong...';
+  /** Mirrors the (non-exported) initializationTimeoutInMs constant in src/internal/appHelpers.ts */
+  const initializationTimeoutInMs = 60000;
   const loadContext: LoadContext = {
     entityId: 'testEntityId',
     contentUrl: 'https://localhost:4000',
@@ -515,6 +518,59 @@ describe('Testing app capability', () => {
         await utils.respondToMessage(initMessage!!, FrameContexts.content);
         expect(initPromise).resolves.toBeFalsy();
       });
+
+      describe('Testing app.initialize in a server-side rendering environment', () => {
+        afterEach(() => {
+          jest.restoreAllMocks();
+        });
+
+        it('app.initialize should resolve without initializing anything when there is no window object', async () => {
+          const inServerSideRenderingEnvironmentSpy = jest
+            .spyOn(internalUtils, 'inServerSideRenderingEnvironment')
+            .mockReturnValue(true);
+
+          await expect(app.initialize()).resolves.toBeUndefined();
+
+          expect(inServerSideRenderingEnvironmentSpy).toHaveBeenCalled();
+          expect(utils.messages.length).toBe(0);
+          expect(app.isInitialized()).toBe(false);
+          expect(GlobalVars.initializeCalled).toBe(false);
+          expect(GlobalVars.initializePromise).toBeUndefined();
+        });
+      });
+
+      describe('Testing app.initialize timeout behavior', () => {
+        beforeEach(() => {
+          jest.useFakeTimers();
+        });
+
+        afterEach(() => {
+          jest.useRealTimers();
+        });
+
+        it('app.initialize should reject if the host never responds within the initialization timeout', async () => {
+          const initPromise = app.initialize();
+
+          // The host is intentionally never responded to, so only the timeout can settle the promise.
+          expect(utils.findMessageByFunc('initialize')).not.toBeNull();
+
+          jest.advanceTimersByTime(initializationTimeoutInMs);
+
+          await expect(initPromise).rejects.toThrowError(new Error('SDK initialization timed out.'));
+        });
+
+        it('app.initialize should not reject with a timeout if the host responds before the timeout elapses', async () => {
+          const initPromise = app.initialize();
+
+          const initMessage = utils.findMessageByFunc('initialize');
+          await utils.respondToMessage(initMessage!!, FrameContexts.content);
+          await expect(initPromise).resolves.toBeUndefined();
+
+          jest.advanceTimersByTime(initializationTimeoutInMs);
+
+          await expect(initPromise).resolves.toBeUndefined();
+        });
+      });
     });
 
     describe('Testing app.getContext function', () => {
@@ -833,8 +889,26 @@ describe('Testing app capability', () => {
     });
 
     describe('Testing app.notifySuccess function', () => {
-      it('app.notifySuccess should not allow calls before initialization', () => {
-        expect(app.notifySuccess).rejects.toThrowError(new Error(errorLibraryNotInitialized));
+      it('app.notifySuccess should not allow calls before initialization', async () => {
+        expect(GlobalVars.initializeCompleted).toBe(false);
+        expect(GlobalVars.initializePromise).toBeUndefined();
+
+        await expect(app.notifySuccess()).rejects.toThrowError(new Error(errorLibraryNotInitialized));
+      });
+
+      it('app.notifySuccess should not allow calls after uninitialization', async () => {
+        const initPromise = app.initialize();
+        const initMessage = utils.findMessageByFunc('initialize');
+        await utils.respondToMessage(initMessage!!, FrameContexts.content);
+        await initPromise;
+
+        utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
+        app._uninitialize();
+
+        expect(GlobalVars.initializeCompleted).toBe(false);
+        expect(GlobalVars.initializePromise).toBeUndefined();
+
+        await expect(app.notifySuccess()).rejects.toThrowError(new Error(errorLibraryNotInitialized));
       });
 
       it('app.notifySuccess should allow calls after initialization called, but before it finished', async () => {
@@ -1831,8 +1905,11 @@ describe('Testing app capability', () => {
     });
 
     describe('Testing app.notifySuccess function', () => {
-      it('app.notifySuccess should not allow calls before initialization', () => {
-        expect(app.notifySuccess).rejects.toThrowError(new Error(errorLibraryNotInitialized));
+      it('app.notifySuccess should not allow calls before initialization', async () => {
+        expect(GlobalVars.initializeCompleted).toBe(false);
+        expect(GlobalVars.initializePromise).toBeUndefined();
+
+        await expect(app.notifySuccess()).rejects.toThrowError(new Error(errorLibraryNotInitialized));
       });
 
       it('app.notifySuccess should allow calls after initialization called, but before it finished', async () => {


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Test-only change. Three branches in `packages/teams-js/src/internal/appHelpers.ts` were never exercised by the test suite. Most of the module is already covered indirectly and thoroughly through `app.initialize` / `app.notifySuccess` in `test/public/app.spec.ts`, so these tests were added there rather than in a new internal spec.

The gaps were:

- The server-side rendering early return in `appInitializeHelper` (the `inServerSideRenderingEnvironment()` `else` branch). Lines 64–68 were completely uncovered.
- The 60s `runWithTimeout` rejection with `'SDK initialization timed out.'`. That string did not appear anywhere under `test/`.
- `notifySuccessHelper` throwing `errorLibraryNotInitialized` when neither `GlobalVars.initializeCompleted` nor `GlobalVars.initializePromise` is set.

While covering the third case I found that the existing `app.notifySuccess should not allow calls before initialization` tests (in both the framed and frameless suites) were **floating promise assertions** — `expect(app.notifySuccess).rejects.toThrowError(...)` was never `await`ed, so those tests could never actually fail. Those are now `await`ed.

No production code was changed.

### Main changes in the PR:

1. Added `Testing app.initialize in a server-side rendering environment` — stubs `inServerSideRenderingEnvironment()` via `jest.spyOn` and asserts `app.initialize()` resolves, sends zero messages, and leaves `GlobalVars.initializeCalled` / `GlobalVars.initializePromise` untouched.
2. Added `Testing app.initialize timeout behavior` — with fake timers, the host is intentionally never responded to and the clock is advanced 60s, asserting rejection with `'SDK initialization timed out.'`. A companion negative test confirms no spurious timeout rejection when the host responds first.
3. Added `app.notifySuccess should not allow calls after uninitialization` and tightened the two pre-existing `should not allow calls before initialization` tests to `await` their rejection assertions and to explicitly assert the `GlobalVars` preconditions the branch depends on.

## Validation

### Validation performed:

1. `npx jest test/public/app.spec.ts` — 322/322 pass.
2. `npx jest` (full `packages/teams-js` suite) — 9239 pass. The only failure is the pre-existing `test/internal/umdExportParity.spec.ts`, which requires `pnpm build-webpack` to have been run first and is unrelated to this change.
3. Coverage of `src/internal/appHelpers.ts` measured before and after with `npx jest test/public/app.spec.ts --coverage --collectCoverageFrom='src/internal/appHelpers.ts'`:

   | | % Stmts | % Branch | % Funcs | % Lines | Uncovered lines |
   | --- | --- | --- | --- | --- | --- |
   | Before | 93.75 | 90 | 94.11 | 93.68 | 64-68, 225, 237-238 |
   | After | 96.87 | 92.5 | 94.11 | 96.84 | 225, 237-238 |

   The remaining uncovered lines are out of scope: line 225 is the defensive `GlobalVars.initializePromise is unexpectedly undefined` log that should be unreachable, and 237-238 (`registerOnContextChangeHandlerHelper`) is covered by other specs.
4. `npx eslint test/public/app.spec.ts`, `npx prettier --check`, and `npx tsc --noEmit` are all clean.

### Unit Tests added:

Yes — this PR is entirely unit tests.

### End-to-end tests added:

No — this is a test-only change to existing unit test coverage; no runtime behavior changed.

## Additional Requirements

### Change file added:

No — not required. `beachball.config.js` lists `**/test/**` in `ignorePatterns`, and this PR touches only `packages/teams-js/test/public/app.spec.ts`.
