### PR TITLE
docs: fix typos in thirdPartyCloudStorage FileResult TSDoc

### DIFF
--- a/change/@microsoft-teams-js-76a7c2f8-6fa1-4100-9480-dd5f0102f05a.json
+++ b/change/@microsoft-teams-js-76a7c2f8-6fa1-4100-9480-dd5f0102f05a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated documentation for `thirdPartyCloudStorage` capability.",
+  "packageName": "@microsoft/teams-js",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/public/thirdPartyCloudStorage.ts
+++ b/packages/teams-js/src/public/thirdPartyCloudStorage.ts
@@ -102,15 +102,15 @@ export interface FileResult {
    */
   error?: SdkError;
   /**
-   * File chunk which will be assemebled and converted into a blob
+   * File chunk which will be assembled and converted into a blob
    */
   fileChunk: FileChunk;
   /**
-   * File index of the file for which chunk data is getting recieved
+   * File index of the file for which chunk data is getting received
    */
   fileIndex: number;
   /**
-   * File type/MIME type which is getting recieved
+   * File type/MIME type which is getting received
    */
   fileType: string;
   /**


### PR DESCRIPTION
## Description

Fixes three spelling mistakes in the TSDoc comments on the exported `FileResult` interface in `packages/teams-js/src/public/thirdPartyCloudStorage.ts`. Because these are doc comments on exported interface members, they surface in the generated API documentation.

| Line | Before | After |
| --- | --- | --- |
| 105 | `File chunk which will be assemebled and converted into a blob` | `... assembled ...` |
| 109 | `File index of the file for which chunk data is getting recieved` | `... received` |
| 113 | `File type/MIME type which is getting recieved` | `... received` |

## Scope

Comment-only change confined to a single file. No runtime behavior, type signatures, or public API surface are affected. A `patch` beachball change file is included.

## Validation

- No remaining instances of `recieved` / `assemebled` in `thirdPartyCloudStorage.ts`
- No generated API report (`*.api.md`) contains these strings, so no report regeneration is required
