### PR TITLE
Cover handleDialogMessage and the dialog.submit content-context warning

### DIFF
--- a/packages/teams-js/test/public/dialog.spec.ts
+++ b/packages/teams-js/test/public/dialog.spec.ts
@@ -1,4 +1,5 @@
 import { errorLibraryNotInitialized } from '../../src/internal/constants';
+import { handleDialogMessage, storedMessages } from '../../src/internal/dialogHelpers';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { doesHandlerExist } from '../../src/internal/handlers';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
@@ -1967,6 +1968,107 @@ describe('Dialog', () => {
           });
         });
       });
+    });
+  });
+
+  describe('handleDialogMessage', () => {
+    let utils: Utils = new Utils();
+
+    beforeEach(() => {
+      utils = new Utils();
+      utils.messages = [];
+      storedMessages.length = 0;
+    });
+
+    afterEach(() => {
+      app._uninitialize();
+      storedMessages.length = 0;
+    });
+
+    it('should do nothing when GlobalVars.frameContext is not set', async () => {
+      await utils.initializeWithContext(FrameContexts.task);
+      GlobalVars.frameContext = undefined;
+
+      handleDialogMessage('someMessage');
+
+      expect(storedMessages).toEqual([]);
+      expect(doesHandlerExist('messageForChild')).toBeTruthy();
+    });
+
+    it('should store messages when in the task frame context', async () => {
+      await utils.initializeWithContext(FrameContexts.task);
+
+      await utils.sendMessage('messageForChild', 'firstMessage');
+      await utils.sendMessage('messageForChild', 'secondMessage');
+
+      expect(storedMessages).toEqual(['firstMessage', 'secondMessage']);
+      expect(doesHandlerExist('messageForChild')).toBeTruthy();
+    });
+
+    it('should remove the messageForChild handler when not in the task frame context', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      expect(doesHandlerExist('messageForChild')).toBeTruthy();
+
+      await utils.sendMessage('messageForChild', 'someMessage');
+
+      expect(storedMessages).toEqual([]);
+      expect(doesHandlerExist('messageForChild')).toBeFalsy();
+    });
+
+    it('should replay stored messages to the listener registered through registerOnMessageFromParent', async () => {
+      await utils.initializeWithContext(FrameContexts.task);
+      utils.setRuntimeConfig({
+        apiVersion: latestRuntimeApiVersion,
+        supports: { dialog: { url: { parentCommunication: {} } } },
+      });
+
+      await utils.sendMessage('messageForChild', 'firstMessage');
+      await utils.sendMessage('messageForChild', 'secondMessage');
+
+      const receivedMessages: string[] = [];
+      dialog.url.parentCommunication.registerOnMessageFromParent((message) => receivedMessages.push(message));
+
+      expect(receivedMessages).toEqual(['firstMessage', 'secondMessage']);
+      expect(storedMessages).toEqual([]);
+    });
+  });
+
+  describe('dialog.url.submit frame context warning', () => {
+    let utils: Utils = new Utils();
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      utils = new Utils();
+      utils.messages = [];
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+      app._uninitialize();
+    });
+
+    it('should warn when submit is called from the content frame context', async () => {
+      await utils.initializeWithContext(FrameContexts.content);
+      warnSpy.mockClear();
+
+      dialog.url.submit('someResult');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('dialog.submit should not be called from FrameContext.content.'),
+      );
+      expect(utils.findMessageByFunc('tasks.completeTask')).not.toBeNull();
+    });
+
+    it('should not warn when submit is called from the task frame context', async () => {
+      await utils.initializeWithContext(FrameContexts.task);
+      warnSpy.mockClear();
+
+      dialog.url.submit('someResult');
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(utils.findMessageByFunc('tasks.completeTask')).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
`handleDialogMessage` and its `storedMessages` array in `src/internal/dialogHelpers.ts` had **zero coverage anywhere** in the repo. The sibling helpers in that file (`updateResizeHelper`, `urlSubmitHelper`) are already exercised indirectly through `dialog.spec.ts`, but nothing ever invoked `handleDialogMessage`.

Separately, the `console.warn(dialogSubmitWarning)` branch in `urlSubmitHelper` — hit when `dialog.submit` is called from `FrameContexts.content` — was untested. No test in the repo asserted on `console.warn` at all.

## Changes

All in `test/public/dialog.spec.ts` (test-only, no source changes).

**`handleDialogMessage`** — covers all three branches:
- the early return when `GlobalVars.frameContext` is unset
- the `storedMessages.push` when in `FrameContexts.task`
- the `removeHandler('messageForChild')` branch otherwise

The task/non-task branches are driven through the *real* handler registered by `dialog.initialize()` (via `utils.sendMessage('messageForChild', ...)`) rather than by calling the export directly, so the registration wiring is covered too. A fourth test asserts the stored messages are replayed in original order to the listener passed to `dialog.url.parentCommunication.registerOnMessageFromParent`, which exercises the `reverse()`/`pop()` drain in `parentCommunication.ts`.

**`dialog.url.submit` warning** — adds the repo's first `console.warn` assertions, covering both the warning branch in `FrameContexts.content` and its absence in `FrameContexts.task`, while still asserting `tasks.completeTask` is sent in both cases.

## Validation

- `jest test/public/dialog.spec.ts` — 379 passed (6 new)
- `tsc --noEmit`, `eslint`, `prettier --check` — clean
- `beachball check` — no change file needed (`**/test/**` is in `ignorePatterns`)
- Mutation-checked: each of the four target branches was individually neutered in `dialogHelpers.ts` and the corresponding test(s) failed, confirming the assertions are real rather than incidentally passing.