### PR TITLE
Add tests for validateSafeStringInstance

### DIFF
--- a/packages/teams-js/test/internal/idValidation.spec.ts
+++ b/packages/teams-js/test/internal/idValidation.spec.ts
@@ -5,9 +5,11 @@ import {
   minimumValidAppIdLength,
   validateAppIdInstance,
   validateSafeContent,
+  validateSafeStringInstance,
   validateStringLength,
 } from '../../src/internal/idValidation';
 import { AppId } from '../../src/public/appId';
+import { ValidatedSafeString } from '../../src/public/validatedSafeString';
 
 describe('doesStringContainNonPrintableCharacters', () => {
   test('should return true for strings with only non-printable characters', () => {
@@ -99,5 +101,26 @@ describe('validateAppIdInstance', () => {
   test('should not throw error when appId is an instance of AppId', () => {
     const appIdInstance = new AppId('app-id-that-does-not-throw');
     expect(() => validateAppIdInstance(appIdInstance)).not.toThrow();
+  });
+});
+
+describe('validateSafeStringInstance', () => {
+  test('should throw error when the string is an object but not instance of ValidatedSafeString', () => {
+    expect(() => validateSafeStringInstance({ Object: 'object' } as unknown as ValidatedSafeString)).toThrowError(
+      'The string ([object Object]) is invalid; it is not an instance of ValidatedSafeString class.',
+    );
+  });
+
+  test('should throw error when the string is an instance of an object other than ValidatedSafeString', () => {
+    class NotValidatedSafeString {}
+    const notValidatedSafeStringInstance = new NotValidatedSafeString();
+    expect(() =>
+      validateSafeStringInstance(notValidatedSafeStringInstance as unknown as ValidatedSafeString),
+    ).toThrowError('The string ([object Object]) is invalid; it is not an instance of ValidatedSafeString class.');
+  });
+
+  test('should not throw error when the string is an instance of ValidatedSafeString', () => {
+    const validatedSafeStringInstance = new ValidatedSafeString('string-that-does-not-throw');
+    expect(() => validateSafeStringInstance(validatedSafeStringInstance)).not.toThrow();
   });
 });

--- a/packages/teams-js/test/internal/idValidation.spec.ts
+++ b/packages/teams-js/test/internal/idValidation.spec.ts
@@ -120,7 +120,9 @@ describe('validateSafeStringInstance', () => {
   });
 
   test('should not throw error when the string is an instance of ValidatedSafeString', () => {
-    const validatedSafeStringInstance = new ValidatedSafeString('string-that-does-not-throw');
+    // Reuses a string already asserted as valid by the validateSafeContent tests above, so this test
+    // stays focused on the instanceof check rather than on the constructor's content validation.
+    const validatedSafeStringInstance = new ValidatedSafeString('8e6523aa-97f9-49ad-8614-75cae22f6597');
     expect(() => validateSafeStringInstance(validatedSafeStringInstance)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Description

`validateSafeStringInstance` in `src/internal/idValidation.ts` was the only uncovered export in that file. Its exact sibling `validateAppIdInstance` is already tested; this adds the equivalent coverage for the `ValidatedSafeString` variant.

As a side effect this is also the first test coverage anywhere under `test/` for the `ValidatedSafeString` class itself (its constructor now runs in a test).

## Changes

- New `validateSafeStringInstance` describe block mirroring the existing `validateAppIdInstance` one, with three cases:
  - a plain object cast to `ValidatedSafeString` → throws
  - an instance of an unrelated class → throws
  - a real `ValidatedSafeString` instance → does not throw
- Asserts on the exact message (`The string (...) is invalid; it is not an instance of ValidatedSafeString class.`) so the wording stays pinned.

## Validation

- `jest test/internal/idValidation.spec.ts` → 19/19 passing
- prettier and eslint clean on the changed file

No production code changed. No beachball change file: `**/test/**` is in `ignorePatterns`.