### PR TITLE
Cover the tryPolyfillWithNestedAppAuthBridge guards, including the nested-iframe check

### DIFF
--- a/packages/teams-js/test/internal/nestedAppAuthUtils.spec.ts
+++ b/packages/teams-js/test/internal/nestedAppAuthUtils.spec.ts
@@ -1,0 +1,143 @@
+import { GlobalVars } from '../../src/internal/globalVars';
+import {
+  NestedAppAuthMessageEventNames,
+  NestedAuthExtendedWindow,
+  tryPolyfillWithNestedAppAuthBridge,
+} from '../../src/internal/nestedAppAuthUtils';
+
+/**
+ * These tests cover the early-return guards in tryPolyfillWithNestedAppAuthBridge directly.
+ * The happy path is exercised indirectly through communication.spec.ts, but the guards -
+ * in particular the nested iframe check, which prevents bridge injection into a non-top-most
+ * app - are only reachable by calling the function with a purpose-built window.
+ */
+describe('nestedAppAuthUtils', () => {
+  describe('tryPolyfillWithNestedAppAuthBridge', () => {
+    const supportedSDKVersion = JSON.stringify({ supports: { nestedAppAuth: {} } });
+
+    let handlers: {
+      onMessage: jest.Mock;
+      sendPostMessage: jest.Mock;
+    };
+
+    /**
+     * Builds a minimal window-like object. By default it is top-most (parent === top === itself),
+     * which is what the polyfill requires.
+     */
+    function createMockWindow(): NestedAuthExtendedWindow {
+      const mockWindow = {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      } as unknown as NestedAuthExtendedWindow;
+
+      (mockWindow as unknown as { parent: unknown }).parent = mockWindow;
+      (mockWindow as unknown as { top: unknown }).top = mockWindow;
+
+      return mockWindow;
+    }
+
+    beforeEach(() => {
+      GlobalVars.isFramelessWindow = false;
+      handlers = {
+        onMessage: jest.fn(),
+        sendPostMessage: jest.fn(),
+      };
+    });
+
+    afterEach(() => {
+      GlobalVars.isFramelessWindow = false;
+      jest.clearAllMocks();
+    });
+
+    it('should polyfill the bridge on a top-most window in a host that supports nested app auth', () => {
+      const mockWindow = createMockWindow();
+
+      tryPolyfillWithNestedAppAuthBridge(supportedSDKVersion, mockWindow, handlers);
+
+      expect(mockWindow.nestedAppAuthBridge).toBeDefined();
+      expect(typeof mockWindow.nestedAppAuthBridge.addEventListener).toBe('function');
+      expect(typeof mockWindow.nestedAppAuthBridge.postMessage).toBe('function');
+      expect(typeof mockWindow.nestedAppAuthBridge.removeEventListener).toBe('function');
+    });
+
+    it('should not polyfill the bridge when the current window is frameless', () => {
+      GlobalVars.isFramelessWindow = true;
+      const mockWindow = createMockWindow();
+
+      tryPolyfillWithNestedAppAuthBridge(supportedSDKVersion, mockWindow, handlers);
+
+      expect(mockWindow.nestedAppAuthBridge).toBeUndefined();
+    });
+
+    it('should not throw when the window does not exist', () => {
+      expect(() => tryPolyfillWithNestedAppAuthBridge(supportedSDKVersion, null, handlers)).not.toThrow();
+    });
+
+    it('should not polyfill the bridge when running in a nested iframe', () => {
+      const mockWindow = createMockWindow();
+      // A nested iframe has a parent that is not the top-most window.
+      (mockWindow as unknown as { parent: unknown }).parent = { name: 'middleFrame' };
+
+      tryPolyfillWithNestedAppAuthBridge(supportedSDKVersion, mockWindow, handlers);
+
+      expect(mockWindow.nestedAppAuthBridge).toBeUndefined();
+    });
+
+    it('should polyfill the bridge when the window is an iframe directly under the top window', () => {
+      const mockWindow = createMockWindow();
+      const topWindow = { name: 'topWindow' };
+      // A single-level iframe still reports parent === top, so injection is allowed.
+      (mockWindow as unknown as { parent: unknown }).parent = topWindow;
+      (mockWindow as unknown as { top: unknown }).top = topWindow;
+
+      tryPolyfillWithNestedAppAuthBridge(supportedSDKVersion, mockWindow, handlers);
+
+      expect(mockWindow.nestedAppAuthBridge).toBeDefined();
+    });
+
+    it('should not polyfill the bridge when the supported SDK version is not valid JSON', () => {
+      const mockWindow = createMockWindow();
+
+      tryPolyfillWithNestedAppAuthBridge('not valid json', mockWindow, handlers);
+
+      expect(mockWindow.nestedAppAuthBridge).toBeUndefined();
+    });
+
+    it('should not polyfill the bridge when the host does not report a supports object', () => {
+      const mockWindow = createMockWindow();
+
+      tryPolyfillWithNestedAppAuthBridge(JSON.stringify({}), mockWindow, handlers);
+
+      expect(mockWindow.nestedAppAuthBridge).toBeUndefined();
+    });
+
+    it('should not polyfill the bridge when the host does not support nested app auth', () => {
+      const mockWindow = createMockWindow();
+
+      tryPolyfillWithNestedAppAuthBridge(JSON.stringify({ supports: { appEntity: {} } }), mockWindow, handlers);
+
+      expect(mockWindow.nestedAppAuthBridge).toBeUndefined();
+    });
+
+    it('should leave an existing bridge untouched instead of polyfilling over it', () => {
+      const mockWindow = createMockWindow();
+      const existingBridge = {
+        addEventListener: jest.fn(),
+        postMessage: jest.fn(),
+        removeEventListener: jest.fn(),
+      };
+      mockWindow.nestedAppAuthBridge = existingBridge;
+
+      tryPolyfillWithNestedAppAuthBridge(supportedSDKVersion, mockWindow, handlers);
+
+      expect(mockWindow.nestedAppAuthBridge).toBe(existingBridge);
+
+      // The pre-existing bridge is still the one wired up, so its handlers are used.
+      mockWindow.nestedAppAuthBridge.postMessage(
+        JSON.stringify({ messageType: NestedAppAuthMessageEventNames.Request }),
+      );
+      expect(existingBridge.postMessage).toHaveBeenCalled();
+      expect(handlers.sendPostMessage).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

`tryPolyfillWithNestedAppAuthBridge` (`src/internal/nestedAppAuthUtils.ts`) has five early-return guards and no spec of its own. This PR adds `test/internal/nestedAppAuthUtils.spec.ts` to cover them directly.

Being precise about what was and wasn't already covered:

- **Already covered indirectly** via `test/internal/communication.spec.ts` — the happy path (bridge gets created and wired up) and the frameless-window guard.
- **Not covered anywhere under `test/`** — and the reason for this PR:
  - the **nested-iframe guard** (`window.parent !== window.top`, line 135), a security-relevant check that stops default NAA bridge injection when the app is not the top-most frame;
  - the **"bridge already exists, skip polyfill"** branch;
  - the **`JSON.parse` failure** path (malformed `clientSupportedSDKVersion`);
  - the **missing `supports.nestedAppAuth`** path.

None of those branches were reachable from the existing tests, because `communication.spec.ts` always drives the function through a top-most mock window with a well-formed capability payload.

## Changes

Adds 9 tests against a purpose-built minimal window:

| Test | Guard |
| --- | --- |
| polyfills on a top-most window when the host supports NAA | happy path |
| frameless window → no bridge | `GlobalVars.isFramelessWindow` |
| `null` window → does not throw | `!window` |
| **nested iframe → no bridge** | `window.parent !== window.top` |
| single-level iframe (`parent === top`) → bridge created | boundary of the same guard |
| invalid JSON version string → no bridge | `JSON.parse` catch |
| no `supports` object → no bridge | `!parsedClientSupportedSDKVersion.supports?.nestedAppAuth` |
| `supports` without `nestedAppAuth` → no bridge | same |
| existing bridge is left untouched | `extendedWindow.nestedAppAuthBridge` |

The nested-iframe case also pins the boundary: an iframe directly under the top window still reports `parent === top`, so injection is allowed there — only genuinely nested frames are blocked.

## Validation

- `jest test/internal/nestedAppAuthUtils.spec.ts` — 9/9 passing.
- Mutation check: deleting the `window.parent !== window.top` guard from the source makes the nested-iframe test fail, and only that test — confirming it actually pins the behavior rather than passing vacuously.
- `eslint --max-warnings 0` and `prettier --check` clean.
- No change file needed: `beachball.config.js` ignores `**/test/**`.

Test-only change; no production code or public API is touched.
