### PR TITLE
docs: name the geoLocation replacements for the deprecated location interfaces

### DIFF
--- a/change/@microsoft-teams-js-07267fa4-29f3-4b62-baa6-56c8a553509e.json
+++ b/change/@microsoft-teams-js-07267fa4-29f3-4b62-baa6-56c8a553509e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Point the `location.LocationProps` and `location.Location` deprecation notices at their concrete `geoLocation` replacements.",
+  "packageName": "@microsoft/teams-js",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -27,8 +27,8 @@ export type showLocationCallbackFunctionType = (error: SdkError, status: boolean
 /**
  * @deprecated
  * As of 2.1.0, this interface is no longer needed. Instead of setting `allowChooseLocation`, call one of the following functions:
- * - {@link geoLocation.getCurrentLocation geoLocation.getCurrentLocation(): Promise\<Location\>} to get the current location.
- * - {@link geoLocation.map.chooseLocation geoLocation.map.chooseLocation(): Promise\<Location\>} to choose location on map.
+ * - {@link geoLocation.getCurrentLocation geoLocation.getCurrentLocation(): Promise\<geoLocation.Location\>} to get the current location.
+ * - {@link geoLocation.map.chooseLocation geoLocation.map.chooseLocation(): Promise\<geoLocation.Location\>} to choose location on map.
  *
  * Data Structure to set the location properties in getLocation call.
  */
@@ -52,7 +52,7 @@ export interface LocationProps {
  * @deprecated
  * As of 2.1.0, please use {@link geoLocation.Location} instead.
  *
- * Data struture to represent the location information
+ * Data structure to represent the location information
  */
 export interface Location {
   /**
@@ -76,8 +76,8 @@ export interface Location {
 /**
  * @deprecated
  * As of 2.1.0, please use one of the following functions:
- * - {@link geoLocation.getCurrentLocation geoLocation.getCurrentLocation(): Promise\<Location\>} to get the current location.
- * - {@link geoLocation.map.chooseLocation geoLocation.map.chooseLocation(): Promise\<Location\>} to choose location on map.
+ * - {@link geoLocation.getCurrentLocation geoLocation.getCurrentLocation(): Promise\<geoLocation.Location\>} to get the current location.
+ * - {@link geoLocation.map.chooseLocation geoLocation.map.chooseLocation(): Promise\<geoLocation.Location\>} to choose location on map.
  *
  * Fetches user location
  * @param props {@link LocationProps} - Specifying how the location request is handled
@@ -109,7 +109,7 @@ export function getLocation(props: LocationProps, callback: getLocationCallbackF
 
 /**
  * @deprecated
- * As of 2.1.0, please use {@link geoLocation.map.showLocation geoLocation.map.showLocation(location: Location): Promise\<void\>} instead.
+ * As of 2.1.0, please use {@link geoLocation.map.showLocation geoLocation.map.showLocation(location: geoLocation.Location): Promise\<void\>} instead.
  *
  * Shows the location on map corresponding to the given coordinates
  *

--- a/packages/teams-js/src/public/location.ts
+++ b/packages/teams-js/src/public/location.ts
@@ -26,6 +26,10 @@ export type showLocationCallbackFunctionType = (error: SdkError, status: boolean
 
 /**
  * @deprecated
+ * As of 2.1.0, this interface is no longer needed. Instead of setting `allowChooseLocation`, call one of the following functions:
+ * - {@link geoLocation.getCurrentLocation geoLocation.getCurrentLocation(): Promise\<Location\>} to get the current location.
+ * - {@link geoLocation.map.chooseLocation geoLocation.map.chooseLocation(): Promise\<Location\>} to choose location on map.
+ *
  * Data Structure to set the location properties in getLocation call.
  */
 export interface LocationProps {
@@ -46,6 +50,8 @@ export interface LocationProps {
 
 /**
  * @deprecated
+ * As of 2.1.0, please use {@link geoLocation.Location} instead.
+ *
  * Data struture to represent the location information
  */
 export interface Location {


### PR DESCRIPTION
## Description

Every function in `packages/teams-js/src/public/location.ts` already points at its `geoLocation` replacement with a `{@link}` — `getLocation`, `showLocation`, and `isSupported` all do. The two exported interfaces in the same file did not: `LocationProps` and `Location` carried a bare `@deprecated` plus a one-line description, so in the generated API docs there was nothing to click through to.

Both now name their concrete replacements:

- **`Location`** maps directly onto `geoLocation.Location`, so it links there.
- **`LocationProps`** has no single successor type. Its `allowChooseLocation` flag is what used to select between behaviors that are now separate functions, so it points at both `geoLocation.getCurrentLocation()` and `geoLocation.map.chooseLocation()` — the same wording already used on `getLocation` a few lines below.

Docs-only change; no runtime behavior, signatures, or exports are affected.

## Validation

- `pnpm docs:validate` (typedoc) passes with 0 errors and 0 warnings, confirming both `{@link}` targets resolve.
- `pnpm lint` clean on the changed file.
- `jest` suite passes (the only failure, `umdExportParity.spec.ts`, is a pre-existing local failure that requires `pnpm build-webpack` first).
- Beachball change file included (`patch`, `dependentChangeType: none`).