### PR TITLE
test: cover isNullOrUndefined and prefetchOriginsFromCDN

### DIFF
--- a/packages/teams-js/test/internal/typeCheckUtilities.spec.ts
+++ b/packages/teams-js/test/internal/typeCheckUtilities.spec.ts
@@ -1,0 +1,46 @@
+import { isNullOrUndefined } from '../../src/internal/typeCheckUtilities';
+
+describe('isNullOrUndefined', () => {
+  it('should return true for null', () => {
+    expect(isNullOrUndefined(null)).toBe(true);
+  });
+
+  it('should return true for undefined', () => {
+    expect(isNullOrUndefined(undefined)).toBe(true);
+  });
+
+  it('should return true when no argument is passed', () => {
+    expect(isNullOrUndefined()).toBe(true);
+  });
+
+  // The callers of this function (for example handlers.ts and appHelpers.ts) rely on it being a
+  // nullish check rather than a falsy check, so that falsy-but-defined values are still treated as
+  // real values. Simplifying the implementation to `!value` would silently break those callers.
+  it.each([
+    ['zero', 0],
+    ['negative zero', -0],
+    ['empty string', ''],
+    ['false', false],
+    ['NaN', NaN],
+    ['zero bigint', BigInt(0)],
+  ])('should return false for the falsy value %s', (_name, value) => {
+    expect(isNullOrUndefined(value)).toBe(false);
+  });
+
+  it.each([
+    ['a non-empty string', 'value'],
+    ['a non-zero number', 42],
+    ['true', true],
+    ['an empty object', {}],
+    ['an empty array', []],
+    ['a function', (): void => {}],
+    ['a symbol', Symbol('symbol')],
+  ])('should return false for the truthy value %s', (_name, value) => {
+    expect(isNullOrUndefined(value)).toBe(false);
+  });
+
+  it('should return false for a handler function, so that handler registration is not skipped', () => {
+    const handler = (): void => {};
+    expect(isNullOrUndefined(handler)).toBe(false);
+  });
+});

--- a/packages/teams-js/test/internal/validOrigins.spec.ts
+++ b/packages/teams-js/test/internal/validOrigins.spec.ts
@@ -1,6 +1,6 @@
 import { ORIGIN_LIST_FETCH_TIMEOUT_IN_MS } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
-import { resetValidOriginsCache, validateOrigin } from '../../src/internal/validOrigins';
+import { prefetchOriginsFromCDN, resetValidOriginsCache, validateOrigin } from '../../src/internal/validOrigins';
 import * as app from '../../src/public/app/app';
 import { _minRuntimeConfigToUninitialize } from '../../src/public/runtime';
 import { Utils } from '../utils';
@@ -724,6 +724,108 @@ describe('validOrigins', () => {
       const result = await validateOrigin(messageOrigin, disableCache);
       expect(abortSpy).toBeCalledTimes(1);
       expect(result).toBe(false);
+    });
+  });
+
+  describe('testing prefetchOriginsFromCDN', () => {
+    let utils: Utils = new Utils();
+    beforeEach(() => {
+      // Set a mock window for testing
+      utils = new Utils();
+      utils.mockWindow.parent = undefined;
+      app._initialize(utils.mockWindow);
+      GlobalVars.isFramelessWindow = false;
+      resetValidOriginsCache();
+    });
+
+    afterAll(() => {
+      GlobalVars.isFramelessWindow = false;
+    });
+    afterEach(() => {
+      // Reset the object since it's a singleton
+      if (app._uninitialize) {
+        utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
+        app._uninitialize();
+      }
+    });
+
+    it('prefetchOriginsFromCDN warms the cache so later validations use the CDN list without fetching again', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          json: async () => {
+            return { validOrigins: ['prefetched.example.com'] };
+          },
+        } as Response),
+      );
+
+      await prefetchOriginsFromCDN();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      // This origin is only known because of the prefetch, and it is served from the cache
+      const messageOrigin = new URL('https://prefetched.example.com');
+      const result = await validateOrigin(messageOrigin);
+      expect(result).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('prefetchOriginsFromCDN only initiates a single fetch call when called repeatedly', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          json: async () => {
+            return { validOrigins: ['prefetched.example.com'] };
+          },
+        } as Response),
+      );
+
+      await prefetchOriginsFromCDN();
+      await prefetchOriginsFromCDN();
+      await prefetchOriginsFromCDN();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('prefetchOriginsFromCDN resolves and falls back to the hardcoded list when the fetch call fails', async () => {
+      global.fetch = jest.fn(() => Promise.resolve({ status: 503, ok: false } as Response));
+
+      await expect(prefetchOriginsFromCDN()).resolves.toBeUndefined();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      const fallbackOrigin = new URL('https://teams.microsoft.com');
+      expect(await validateOrigin(fallbackOrigin)).toBe(true);
+
+      const unknownOrigin = new URL('https://badorigin.example.com');
+      expect(await validateOrigin(unknownOrigin)).toBe(false);
+    });
+
+    it('prefetchOriginsFromCDN resolves and falls back to the hardcoded list when the fetch call rejects', async () => {
+      global.fetch = jest.fn(() => Promise.reject(new Error('Network failure')));
+
+      await expect(prefetchOriginsFromCDN()).resolves.toBeUndefined();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      const fallbackOrigin = new URL('https://teams.microsoft.com');
+      expect(await validateOrigin(fallbackOrigin)).toBe(true);
+    });
+
+    it('prefetchOriginsFromCDN resolves and falls back to the hardcoded list when the CDN returns an invalid list', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          json: async () => {
+            return { badExample: 'badLink' };
+          },
+        } as Response),
+      );
+
+      await expect(prefetchOriginsFromCDN()).resolves.toBeUndefined();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      const fallbackOrigin = new URL('https://teams.microsoft.com');
+      expect(await validateOrigin(fallbackOrigin)).toBe(true);
     });
   });
 });

--- a/packages/teams-js/test/internal/validOrigins.spec.ts
+++ b/packages/teams-js/test/internal/validOrigins.spec.ts
@@ -729,6 +729,8 @@ describe('validOrigins', () => {
 
   describe('testing prefetchOriginsFromCDN', () => {
     let utils: Utils = new Utils();
+    // The baseline fetch mock installed by test/setupTest.ts, captured before any test overwrites it
+    const originalFetch = global.fetch;
     beforeEach(() => {
       // Set a mock window for testing
       utils = new Utils();
@@ -747,6 +749,9 @@ describe('validOrigins', () => {
         utils.setRuntimeConfig(_minRuntimeConfigToUninitialize);
         app._uninitialize();
       }
+      // Restore the shared state these tests mutate so nothing leaks into other suites
+      global.fetch = originalFetch;
+      resetValidOriginsCache();
     });
 
     it('prefetchOriginsFromCDN warms the cache so later validations use the CDN list without fetching again', async () => {
@@ -770,7 +775,31 @@ describe('validOrigins', () => {
       expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
-    it('prefetchOriginsFromCDN only initiates a single fetch call when called repeatedly', async () => {
+    it('prefetchOriginsFromCDN only initiates a single fetch call when concurrent callers race the in-flight request', async () => {
+      let resolveFetch: (response: Response) => void = () => {};
+      global.fetch = jest.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+
+      // All three callers start before the first fetch settles, so they must share the in-flight promise
+      const prefetches = Promise.all([prefetchOriginsFromCDN(), prefetchOriginsFromCDN(), prefetchOriginsFromCDN()]);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      resolveFetch({
+        status: 200,
+        ok: true,
+        json: async () => {
+          return { validOrigins: ['prefetched.example.com'] };
+        },
+      } as Response);
+      await prefetches;
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('prefetchOriginsFromCDN only initiates a single fetch call when called again after the first one resolves', async () => {
       global.fetch = jest.fn(() =>
         Promise.resolve({
           status: 200,


### PR DESCRIPTION
## Description

Adds unit tests for two internal exports that had no direct test coverage.

**`isNullOrUndefined` (`src/internal/typeCheckUtilities.ts`)** had no spec at all. The new `test/internal/typeCheckUtilities.spec.ts` locks in that it is a *nullish* check and not a *falsy* check: `0`, `-0`, `''`, `false`, `NaN` and `0n` all return `false`, while `null`, `undefined` and a missing argument return `true`.

That distinction matters because `handlers.ts`, `appHelpers.ts`, `teamsAPIs.ts`, `media.ts` and the `pages` modules all use it in the `!isNullOrUndefined(handler) && ...` pattern to decide whether to register a handler. A well-meaning "simplify to `!value`" refactor would silently break handler registration, and nothing would have failed.

**`prefetchOriginsFromCDN` (`src/internal/validOrigins.ts`)** is a distinct entry point (also called from `pages.ts` and at module load) that warms the valid-origins cache ahead of the first `validateOrigin` call. Although this file is heavily tested through `validateOrigin`, neither `prefetchOriginsFromCDN` nor `getValidOriginsListFromCDN` was referenced by name in any test. The new `describe` block in the existing `test/internal/validOrigins.spec.ts` asserts that:

- the prefetch populates the cache, so a later validation of a CDN-only origin succeeds without a second `fetch`;
- repeated calls initiate only one `fetch` (the in-flight promise is reused);
- a non-ok response, a rejected `fetch`, and a malformed CDN payload each degrade gracefully to the hardcoded fallback list and resolve rather than rejecting — i.e. a CDN outage cannot fail `app.initialize`.

No production code is changed.

## Validation

- `pnpm test` for the two affected suites passes (113 tests).
- Both suites were verified to be real regression guards by mutating the implementations: replacing `isNullOrUndefined` with `!value` and making `prefetchOriginsFromCDN` a no-op each cause failures (11 failing tests across both suites); the sources were then restored.
- `eslint`, `prettier --check` and `tsc --noEmit` are clean.
- `beachball check` reports "No change files are needed" (test files are in `ignorePatterns`).
