### PR TITLE
docs: fix broken @example block in search.registerHandlers

### DIFF
--- a/change/@microsoft-teams-js-7a7c8ccb-76ca-4dcf-917c-fa7aaa249656.json
+++ b/change/@microsoft-teams-js-7a7c8ccb-76ca-4dcf-917c-fa7aaa249656.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated documentation for `search` capability.",
+  "packageName": "@microsoft/teams-js",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/public/search.ts
+++ b/packages/teams-js/src/public/search.ts
@@ -45,46 +45,46 @@ export interface SearchQuery {
 export type SearchQueryHandler = (query: SearchQuery) => void;
 
 /**
-   * Allows the caller to register for various events fired by the host search experience.
-   * Calling this function indicates that your application intends to plug into the host's search box and handle search events,
-   * when the user is actively using your page/tab.
-   * 
-   * The host may visually update its search box, e.g. with the name or icon of your application.
-   * 
-   * Your application should *not* re-render inside of these callbacks, there may be a large number
-   * of onChangeHandler calls if the user is typing rapidly in the search box.
-   *
-   * @param onClosedHandler - This handler will be called when the user exits or cancels their search.
-   * Should be used to return your application to its most recent, non-search state. The value of {@link SearchQuery.searchTerm} 
-   * will be whatever the last query was before ending search. 
-   * 
-   * @param onExecuteHandler - The handler will be called when the user executes their 
-   * search (by pressing Enter for example). Should be used to display the full list of search results. 
-   * The value of {@link SearchQuery.searchTerm} is the complete query the user entered in the search box.
-   *
-   * @param onChangeHandler - This optional handler will be called when the user first starts using the
-   * host's search box and as the user types their query. Can be used to put your application into a 
-   * word-wheeling state or to display suggestions as the user is typing. 
-   * 
-   * This handler will be called with an empty {@link SearchQuery.searchTerm} when search is beginning, and subsequently,
-   * with the current contents of the search box.
-   * @example
-   * ``` ts
-   * search.registerHandlers(
-      query => {
-        console.log('Update your application to handle the search experience being closed. Last query: ${query.searchTerm}');
-      },
-      query => {
-        console.log(`Update your application to handle an executed search result: ${query.searchTerm}`);
-      },
-      query => {
-        console.log(`Update your application with the changed search query: ${query.searchTerm}`);
-      },
-     );
-   * ```
-   *
-   * @beta
-   */
+ * Allows the caller to register for various events fired by the host search experience.
+ * Calling this function indicates that your application intends to plug into the host's search box and handle search events,
+ * when the user is actively using your page/tab.
+ *
+ * The host may visually update its search box, e.g. with the name or icon of your application.
+ *
+ * Your application should *not* re-render inside of these callbacks, there may be a large number
+ * of onChangeHandler calls if the user is typing rapidly in the search box.
+ *
+ * @param onClosedHandler - This handler will be called when the user exits or cancels their search.
+ * Should be used to return your application to its most recent, non-search state. The value of {@link SearchQuery.searchTerm}
+ * will be whatever the last query was before ending search.
+ *
+ * @param onExecuteHandler - The handler will be called when the user executes their
+ * search (by pressing Enter for example). Should be used to display the full list of search results.
+ * The value of {@link SearchQuery.searchTerm} is the complete query the user entered in the search box.
+ *
+ * @param onChangeHandler - This optional handler will be called when the user first starts using the
+ * host's search box and as the user types their query. Can be used to put your application into a
+ * word-wheeling state or to display suggestions as the user is typing.
+ *
+ * This handler will be called with an empty {@link SearchQuery.searchTerm} when search is beginning, and subsequently,
+ * with the current contents of the search box.
+ * @example
+ * ``` ts
+ * search.registerHandlers(
+ *   query => {
+ *     console.log(`Update your application to handle the search experience being closed. Last query: ${query.searchTerm}`);
+ *   },
+ *   query => {
+ *     console.log(`Update your application to handle an executed search result: ${query.searchTerm}`);
+ *   },
+ *   query => {
+ *     console.log(`Update your application with the changed search query: ${query.searchTerm}`);
+ *   },
+ * );
+ * ```
+ *
+ * @beta
+ */
 export function registerHandlers(
   onClosedHandler: SearchQueryHandler,
   onExecuteHandler: SearchQueryHandler,


### PR DESCRIPTION
## Description

Two small doc bugs in the `search.registerHandlers` TSDoc `@example`:

1. **Wrong quote type.** The `onClosedHandler` line used single quotes around a string containing `${query.searchTerm}`, so the published example prints the placeholder verbatim instead of interpolating it. The other two handlers in the same example already use backticks.

2. **Malformed comment block.** The lines inside the fenced code block were missing their leading `*` continuation markers, which breaks the fenced code block in the generated API docs.

Adding the missing `*` markers means Prettier now treats the whole JSDoc block as a normal comment and normalizes its indentation (it was indented 3 spaces instead of 1), which accounts for the rest of the diff.

Comment-only change — no runtime behavior is affected.

## Validation

- `tsc --noEmit` on `packages/teams-js` passes
- `eslint` and `prettier --check` are clean on the modified file
- Beachball change file included (`patch`, documentation comment)
