### PR TITLE
test: cover createEffectParameterChangeCallback in internal/videoEffectsUtils

### DIFF
--- a/packages/teams-js/test/internal/videoEffectsUtils.spec.ts
+++ b/packages/teams-js/test/internal/videoEffectsUtils.spec.ts
@@ -28,15 +28,19 @@ function flushPromises(): Promise<void> {
 describe('videoEffectsUtils', () => {
   describe('createEffectParameterChangeCallback', () => {
     let sendMessageToParentSpy: jest.SpyInstance;
+    let reportApplyingVideoEffect: jest.Mock;
+    let reportVideoEffectChanged: jest.Mock;
     let videoPerformanceMonitor: VideoPerformanceMonitor;
 
     beforeEach(() => {
       sendMessageToParentSpy = jest
         .spyOn(communicationModule, 'sendMessageToParent')
         .mockImplementation(() => undefined);
+      reportApplyingVideoEffect = jest.fn();
+      reportVideoEffectChanged = jest.fn();
       videoPerformanceMonitor = {
-        reportApplyingVideoEffect: jest.fn(),
-        reportVideoEffectChanged: jest.fn(),
+        reportApplyingVideoEffect,
+        reportVideoEffectChanged,
       } as unknown as VideoPerformanceMonitor;
     });
 
@@ -49,9 +53,12 @@ describe('videoEffectsUtils', () => {
 
       createEffectParameterChangeCallback(effectCallback, videoPerformanceMonitor)('effectId', 'effectParam');
 
-      expect(videoPerformanceMonitor.reportApplyingVideoEffect).toHaveBeenCalledWith('effectId', 'effectParam');
+      expect(reportApplyingVideoEffect).toHaveBeenCalledWith('effectId', 'effectParam');
       expect(effectCallback).toHaveBeenCalledWith('effectId', 'effectParam');
-      expect(videoPerformanceMonitor.reportVideoEffectChanged).not.toHaveBeenCalled();
+      expect(reportApplyingVideoEffect.mock.invocationCallOrder[0]).toBeLessThan(
+        effectCallback.mock.invocationCallOrder[0],
+      );
+      expect(reportVideoEffectChanged).not.toHaveBeenCalled();
       expect(sendMessageToParentSpy).not.toHaveBeenCalled();
     });
 
@@ -61,7 +68,7 @@ describe('videoEffectsUtils', () => {
       createEffectParameterChangeCallback(effectCallback, videoPerformanceMonitor)('effectId', 'effectParam');
       await flushPromises();
 
-      expect(videoPerformanceMonitor.reportVideoEffectChanged).toHaveBeenCalledWith('effectId', 'effectParam');
+      expect(reportVideoEffectChanged).toHaveBeenCalledWith('effectId', 'effectParam');
       expect(sendMessageToParentSpy).toHaveBeenCalledWith(effectChangedApiVersionTag, 'video.videoEffectReadiness', [
         true,
         'effectId',
@@ -76,7 +83,7 @@ describe('videoEffectsUtils', () => {
       createEffectParameterChangeCallback(effectCallback, videoPerformanceMonitor)('effectId', 'effectParam');
       await flushPromises();
 
-      expect(videoPerformanceMonitor.reportVideoEffectChanged).not.toHaveBeenCalled();
+      expect(reportVideoEffectChanged).not.toHaveBeenCalled();
       expect(sendMessageToParentSpy).toHaveBeenCalledWith(effectFailureApiVersionTag, 'video.videoEffectReadiness', [
         false,
         'effectId',
@@ -105,8 +112,8 @@ describe('videoEffectsUtils', () => {
       createEffectParameterChangeCallback(effectCallback, videoPerformanceMonitor)(undefined);
       await flushPromises();
 
-      expect(videoPerformanceMonitor.reportApplyingVideoEffect).toHaveBeenCalledWith('', undefined);
-      expect(videoPerformanceMonitor.reportVideoEffectChanged).toHaveBeenCalledWith('', undefined);
+      expect(reportApplyingVideoEffect).toHaveBeenCalledWith('', undefined);
+      expect(reportVideoEffectChanged).toHaveBeenCalledWith('', undefined);
       expect(effectCallback).toHaveBeenCalledWith(undefined, undefined);
       expect(sendMessageToParentSpy).toHaveBeenCalledWith(effectChangedApiVersionTag, 'video.videoEffectReadiness', [
         true,

--- a/packages/teams-js/test/internal/videoEffectsUtils.spec.ts
+++ b/packages/teams-js/test/internal/videoEffectsUtils.spec.ts
@@ -1,0 +1,147 @@
+import * as communicationModule from '../../src/internal/communication';
+import { ApiName, ApiVersionNumber, getApiVersionTag } from '../../src/internal/telemetry';
+import { createEffectParameterChangeCallback } from '../../src/internal/videoEffectsUtils';
+import { VideoPerformanceMonitor } from '../../src/internal/videoPerformanceMonitor';
+import { EffectFailureReason } from '../../src/public/videoEffects';
+
+/**
+ * v2 APIs telemetry file: All of APIs in this capability file should send out API version v2 ONLY
+ */
+const videoEffectsUtilTelemetryVersionNumber: ApiVersionNumber = ApiVersionNumber.V_2;
+
+const effectChangedApiVersionTag = getApiVersionTag(
+  videoEffectsUtilTelemetryVersionNumber,
+  ApiName.VideoEffectsUtils_ReportVideoEffectChanged,
+);
+const effectFailureApiVersionTag = getApiVersionTag(
+  videoEffectsUtilTelemetryVersionNumber,
+  ApiName.VideoEffectsUtils_EffectFailure,
+);
+
+/**
+ * Lets the promise chain inside the callback settle before assertions run.
+ */
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('videoEffectsUtils', () => {
+  describe('createEffectParameterChangeCallback', () => {
+    let sendMessageToParentSpy: jest.SpyInstance;
+    let videoPerformanceMonitor: VideoPerformanceMonitor;
+
+    beforeEach(() => {
+      sendMessageToParentSpy = jest
+        .spyOn(communicationModule, 'sendMessageToParent')
+        .mockImplementation(() => undefined);
+      videoPerformanceMonitor = {
+        reportApplyingVideoEffect: jest.fn(),
+        reportVideoEffectChanged: jest.fn(),
+      } as unknown as VideoPerformanceMonitor;
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should report the effect as applying before invoking the callback', () => {
+      const effectCallback = jest.fn().mockReturnValue(new Promise(() => {}));
+
+      createEffectParameterChangeCallback(effectCallback, videoPerformanceMonitor)('effectId', 'effectParam');
+
+      expect(videoPerformanceMonitor.reportApplyingVideoEffect).toHaveBeenCalledWith('effectId', 'effectParam');
+      expect(effectCallback).toHaveBeenCalledWith('effectId', 'effectParam');
+      expect(videoPerformanceMonitor.reportVideoEffectChanged).not.toHaveBeenCalled();
+      expect(sendMessageToParentSpy).not.toHaveBeenCalled();
+    });
+
+    it('should report success to the host and the performance monitor when the callback resolves', async () => {
+      const effectCallback = jest.fn().mockResolvedValue(undefined);
+
+      createEffectParameterChangeCallback(effectCallback, videoPerformanceMonitor)('effectId', 'effectParam');
+      await flushPromises();
+
+      expect(videoPerformanceMonitor.reportVideoEffectChanged).toHaveBeenCalledWith('effectId', 'effectParam');
+      expect(sendMessageToParentSpy).toHaveBeenCalledWith(effectChangedApiVersionTag, 'video.videoEffectReadiness', [
+        true,
+        'effectId',
+        undefined,
+        'effectParam',
+      ]);
+    });
+
+    it('should pass a known failure reason through when the callback rejects', async () => {
+      const effectCallback = jest.fn().mockRejectedValue(EffectFailureReason.InvalidEffectId);
+
+      createEffectParameterChangeCallback(effectCallback, videoPerformanceMonitor)('effectId', 'effectParam');
+      await flushPromises();
+
+      expect(videoPerformanceMonitor.reportVideoEffectChanged).not.toHaveBeenCalled();
+      expect(sendMessageToParentSpy).toHaveBeenCalledWith(effectFailureApiVersionTag, 'video.videoEffectReadiness', [
+        false,
+        'effectId',
+        EffectFailureReason.InvalidEffectId,
+        'effectParam',
+      ]);
+    });
+
+    it('should fall back to InitializationFailure when the rejection reason is not a known failure reason', async () => {
+      const effectCallback = jest.fn().mockRejectedValue('SomethingElseWentWrong');
+
+      createEffectParameterChangeCallback(effectCallback, videoPerformanceMonitor)('effectId', 'effectParam');
+      await flushPromises();
+
+      expect(sendMessageToParentSpy).toHaveBeenCalledWith(effectFailureApiVersionTag, 'video.videoEffectReadiness', [
+        false,
+        'effectId',
+        EffectFailureReason.InitializationFailure,
+        'effectParam',
+      ]);
+    });
+
+    it('should report an empty effect id to the performance monitor but keep it undefined for the host', async () => {
+      const effectCallback = jest.fn().mockResolvedValue(undefined);
+
+      createEffectParameterChangeCallback(effectCallback, videoPerformanceMonitor)(undefined);
+      await flushPromises();
+
+      expect(videoPerformanceMonitor.reportApplyingVideoEffect).toHaveBeenCalledWith('', undefined);
+      expect(videoPerformanceMonitor.reportVideoEffectChanged).toHaveBeenCalledWith('', undefined);
+      expect(effectCallback).toHaveBeenCalledWith(undefined, undefined);
+      expect(sendMessageToParentSpy).toHaveBeenCalledWith(effectChangedApiVersionTag, 'video.videoEffectReadiness', [
+        true,
+        undefined,
+        undefined,
+        undefined,
+      ]);
+    });
+
+    it('should still notify the host when no performance monitor is provided', async () => {
+      const effectCallback = jest.fn().mockResolvedValue(undefined);
+
+      createEffectParameterChangeCallback(effectCallback)('effectId', 'effectParam');
+      await flushPromises();
+
+      expect(sendMessageToParentSpy).toHaveBeenCalledWith(effectChangedApiVersionTag, 'video.videoEffectReadiness', [
+        true,
+        'effectId',
+        undefined,
+        'effectParam',
+      ]);
+    });
+
+    it('should still notify the host of a failure when no performance monitor is provided', async () => {
+      const effectCallback = jest.fn().mockRejectedValue(EffectFailureReason.InitializationFailure);
+
+      createEffectParameterChangeCallback(effectCallback)('effectId', 'effectParam');
+      await flushPromises();
+
+      expect(sendMessageToParentSpy).toHaveBeenCalledWith(effectFailureApiVersionTag, 'video.videoEffectReadiness', [
+        false,
+        'effectId',
+        EffectFailureReason.InitializationFailure,
+        'effectParam',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
### Description

`src/internal/videoEffectsUtils.ts` has no spec file at all, so none of its three exports are directly tested. `createEffectParameterChangeCallback` is the one that needs no media plumbing to exercise: it is a plain factory that reports to the performance monitor, invokes the app's effect callback, and then notifies the host over `video.videoEffectReadiness`.

The new `test/internal/videoEffectsUtils.spec.ts` locks down:

- **The synchronous part** — `reportApplyingVideoEffect` fires and the app callback is invoked before the promise settles, with nothing sent to the host yet.
- **The resolve path** — `reportVideoEffectChanged` plus a readiness message of `[true, effectId, undefined, effectParam]` tagged with `VideoEffectsUtils_ReportVideoEffectChanged`.
- **The reject path** — a known `EffectFailureReason` is forwarded as-is, while an unrecognised reason falls back to `InitializationFailure`, tagged with `VideoEffectsUtils_EffectFailure` and with no "effect changed" report.
- **The `effectId || ''` fallback** — an undefined effect id is reported to the performance monitor as an empty string but is still sent to the host as `undefined`.
- **Both settle paths with no `VideoPerformanceMonitor`**, which is what guards the `?.` calls.

`processMediaStream` and `processMediaStreamWithMetadata` need insertable-streams and `MediaStreamTrack` mocks and are already exercised indirectly through `registerForVideoFrame`; they are left for a follow-up.

### Validation

Test-only change; no production code touched and no API surface change, so no beachball change file (same as #3129).

- `npx jest test/internal/videoEffectsUtils.spec.ts` — 7 passed
- `npx jest test/internal test/private/videoEffectsEx.spec.ts test/public/videoEffects.spec.ts` — 851 passed; the only failure is the pre-existing `umdExportParity.spec.ts`, which requires `pnpm build-webpack` to have been run first
- `eslint --max-warnings 0` and `prettier --check` clean on the new file
