### PR TITLE
Fix .NET SDK selection for Component Governance

### DIFF
--- a/apps/blazor-test-app/global.json
+++ b/apps/blazor-test-app/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": ">=10.0.300"
+    "version": "10.0.400",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
   }
 }

--- a/tools/yaml-templates/android-test.yml
+++ b/tools/yaml-templates/android-test.yml
@@ -73,6 +73,10 @@ steps:
       EOF
     displayName: 'Generate Blazor nuget.config (CFS feed only)'
 
+  - template: install-dotnet-sdk.yml
+    parameters:
+      workingDirectory: '$(ClientSdkProjectDirectory)/apps/blazor-test-app'
+
   - task: NuGetAuthenticate@1
 
   - task: DotNetCoreCLI@2

--- a/tools/yaml-templates/build-app-host.yml
+++ b/tools/yaml-templates/build-app-host.yml
@@ -111,6 +111,10 @@ steps:
       EOF
     displayName: 'Generate Blazor nuget.config (CFS feed only)'
 
+  - template: install-dotnet-sdk.yml
+    parameters:
+      workingDirectory: '$(ClientSdkProjectDirectory)/apps/blazor-test-app'
+
   - task: NuGetAuthenticate@1
 
   - task: DotNetCoreCLI@2

--- a/tools/yaml-templates/build-test-publish.yml
+++ b/tools/yaml-templates/build-test-publish.yml
@@ -86,6 +86,10 @@ steps:
         Write-Host "Generated $configPath"
         Get-Content $configPath
 
+  - template: install-dotnet-sdk.yml
+    parameters:
+      workingDirectory: '$(Build.SourcesDirectory)/apps/blazor-test-app'
+
   - task: NuGetAuthenticate@1
 
   # Clean stale Blazor build artifacts to ensure no cached static web assets

--- a/tools/yaml-templates/install-dotnet-sdk.yml
+++ b/tools/yaml-templates/install-dotnet-sdk.yml
@@ -1,0 +1,11 @@
+parameters:
+  - name: 'workingDirectory'
+    type: string
+
+steps:
+  - task: UseDotNet@2
+    displayName: 'Install .NET SDK from global.json'
+    inputs:
+      packageType: 'sdk'
+      useGlobalJson: true
+      workingDirectory: '${{ parameters.workingDirectory }}'

--- a/tools/yaml-templates/ios-test.yml
+++ b/tools/yaml-templates/ios-test.yml
@@ -84,6 +84,10 @@ steps:
       EOF
     displayName: 'Generate Blazor nuget.config (CFS feed only)'
 
+  - template: install-dotnet-sdk.yml
+    parameters:
+      workingDirectory: '$(ClientSdkProjectDirectory)/apps/blazor-test-app'
+
   - task: NuGetAuthenticate@1
 
   - task: DotNetCoreCLI@2


### PR DESCRIPTION
## Summary

Fixes the persistent **DOTNET-Security-10.0** Component Governance detection.

The previous `global.json` values used unsupported range syntax such as `">=10.0.300"`. The .NET CLI ignores that value and falls back to an installed SDK, which allowed vulnerable SDK `10.0.101` to remain selected after PR #2985 merged.

## Changes

- Pin the SDK to the valid, current security release `10.0.400`
- Roll forward to later stable .NET 10 feature bands
- Explicitly disallow prerelease SDK selection

## Validation

- Confirmed the previous range value is ignored and falls back to the locally installed SDK
- Confirmed the corrected `global.json` is parsed and requests SDK `10.0.400` instead of falling back
- Confirmed `10.0.400` is the August 2026 .NET 10 security SDK in Microsoft release metadata

## Related

- [ADO bug #11165134](https://office.visualstudio.com/ISS/_workitems/edit/11165134)
- [CG alert #12334987](https://office.visualstudio.com/ISS/_componentGovernance/188427/alert/12334987?typeId=11726721)
- Follow-up to #2985