### PR TITLE
Release pipeline (2/4): release-integrity + SRI validation library and tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/teams-js
 
+  tools/cli: {}
+
 packages:
 
   '@asamuzakjp/css-color@3.2.0':

--- a/tools/cli/jest.config.js
+++ b/tools/cli/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/test/**/*.spec.js'],
+  clearMocks: true,
+};

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "teams-js-cli-tools",
+  "version": "0.0.0",
+  "private": true,
+  "description": "TeamsJS release/CI helper scripts and their unit tests",
+  "license": "MIT",
+  "author": "Microsoft Teams",
+  "scripts": {
+    "test": "jest"
+  }
+}

--- a/tools/cli/test/extract-changelog-section.spec.js
+++ b/tools/cli/test/extract-changelog-section.spec.js
@@ -1,0 +1,87 @@
+/* eslint-disable */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { extractChangelogSection } = require('../extract-changelog-section');
+
+function writeChangelog(content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamsjs-changelog-'));
+  const file = path.join(dir, 'CHANGELOG.md');
+  fs.writeFileSync(file, content);
+  return { file, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+const SAMPLE = [
+  '# Change Log - @microsoft/teams-js',
+  '',
+  '<!-- Start content -->',
+  '',
+  '## 2.53.10',
+  '',
+  'Fri, 01 Jan 2027 00:00:00 GMT',
+  '',
+  '### Patches',
+  '',
+  '- MARKER_TEN',
+  '',
+  '## 2.53.1',
+  '',
+  'Wed, 17 Jun 2026 17:10:04 GMT',
+  '',
+  '### Patches',
+  '',
+  '- MARKER_ONE',
+  '',
+  '## 2.53.0',
+  '',
+  'Wed, 06 May 2026 19:04:08 GMT',
+  '',
+  '### Minor changes',
+  '',
+  '- MARKER_ZERO',
+  '',
+].join('\n');
+
+describe('extractChangelogSection', () => {
+  let ctx;
+  afterEach(() => ctx && ctx.cleanup());
+
+  it('returns only the requested version section', () => {
+    ctx = writeChangelog(SAMPLE);
+    const section = extractChangelogSection('2.53.1', ctx.file);
+    expect(section).toContain('- MARKER_ONE');
+    expect(section).not.toContain('- MARKER_ZERO');
+    expect(section).not.toContain('- MARKER_TEN');
+  });
+
+  it('does not confuse a prefix version with a longer one (2.53.1 vs 2.53.10)', () => {
+    ctx = writeChangelog(SAMPLE);
+    const s1 = extractChangelogSection('2.53.1', ctx.file);
+    const s10 = extractChangelogSection('2.53.10', ctx.file);
+    expect(s1).toContain('- MARKER_ONE');
+    expect(s1).not.toContain('- MARKER_TEN');
+    expect(s10).toContain('- MARKER_TEN');
+    expect(s10).not.toContain('- MARKER_ONE');
+  });
+
+  it('returns the full changelog when no version is provided', () => {
+    ctx = writeChangelog(SAMPLE);
+    const full = extractChangelogSection(undefined, ctx.file);
+    expect(full).toContain('- MARKER_TEN');
+    expect(full).toContain('- MARKER_ONE');
+    expect(full).toContain('- MARKER_ZERO');
+  });
+
+  it('throws when the version is not present', () => {
+    ctx = writeChangelog(SAMPLE);
+    expect(() => extractChangelogSection('9.9.9', ctx.file)).toThrow(/9\.9\.9/);
+  });
+
+  it('throws when the changelog file does not exist', () => {
+    expect(() => extractChangelogSection('2.53.1', path.join(os.tmpdir(), 'does-not-exist-changelog.md'))).toThrow(
+      /was not found/,
+    );
+  });
+});

--- a/tools/cli/test/fixtures.js
+++ b/tools/cli/test/fixtures.js
@@ -1,0 +1,98 @@
+/* eslint-disable */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+/**
+ * Creates a temporary directory populated with a valid, self-consistent set of
+ * release files for the given version. Individual files can be overridden to
+ * simulate specific failure modes. Returns { dir, paths, integrity, cleanup }.
+ */
+function createReleaseFixture(version = '2.53.1', overrides = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'teamsjs-release-'));
+  const integrity = overrides.integrity || 'sha384-TESTINTEGRITYHASHVALUE0000000000000000000000000000000000000000000';
+
+  const paths = {
+    teamsJsPackageJson: path.join(dir, 'teams-js.package.json'),
+    testAppPackageJson: path.join(dir, 'test-app.package.json'),
+    readme: path.join(dir, 'README.md'),
+    testAppHtml: path.join(dir, 'index_cdn.html'),
+    changelog: path.join(dir, 'CHANGELOG.md'),
+    changeDir: path.join(dir, 'change'),
+    manifest: path.join(dir, 'MicrosoftTeams-manifest.json'),
+  };
+
+  const teamsJsVersion = overrides.teamsJsVersion || version;
+  const testAppVersion = overrides.testAppVersion || version;
+  const readmeVersion = overrides.readmeVersion || version;
+  const htmlVersion = overrides.htmlVersion || version;
+  const readmeIntegrity = overrides.readmeIntegrity || integrity;
+  const htmlIntegrity = overrides.htmlIntegrity || integrity;
+
+  fs.writeFileSync(paths.teamsJsPackageJson, JSON.stringify({ name: '@microsoft/teams-js', version: teamsJsVersion }));
+  fs.writeFileSync(paths.testAppPackageJson, JSON.stringify({ name: 'teams-test-app', version: testAppVersion }));
+
+  const readme =
+    overrides.readme ||
+    [
+      `You can reference these files directly [from here](https://res.cdn.office.net/teams-js/${readmeVersion}/js/MicrosoftTeams.min.js) or point your package manager at them.`,
+      `<script`,
+      `  src="https://res.cdn.office.net/teams-js/${readmeVersion}/js/MicrosoftTeams.min.js"`,
+      `  integrity="${readmeIntegrity}"`,
+      `  crossorigin="anonymous"></script>`,
+      `<script src="node_modules/@microsoft/teams-js@${readmeVersion}/dist/MicrosoftTeams.min.js"></script>`,
+    ].join('\n');
+  fs.writeFileSync(paths.readme, readme);
+
+  const html =
+    overrides.html ||
+    [
+      `<script`,
+      `  src="https://res.cdn.office.net/teams-js/${htmlVersion}/js/MicrosoftTeams.min.js"`,
+      `  integrity="${htmlIntegrity}"`,
+      `  crossorigin="anonymous"></script>`,
+    ].join('\n');
+  fs.writeFileSync(paths.testAppHtml, html);
+
+  const changelog =
+    overrides.changelog ||
+    [
+      '# Change Log - @microsoft/teams-js',
+      '',
+      '<!-- Start content -->',
+      '',
+      `## ${version}`,
+      '',
+      'Wed, 17 Jun 2026 17:10:04 GMT',
+      '',
+      '### Patches',
+      '',
+      '- Fixed a thing',
+      '',
+      '## 2.53.0',
+      '',
+      'Wed, 06 May 2026 19:04:08 GMT',
+      '',
+      '### Patches',
+      '',
+      '- An earlier fix',
+      '',
+    ].join('\n');
+  fs.writeFileSync(paths.changelog, changelog);
+
+  fs.mkdirSync(paths.changeDir);
+  if (overrides.changeFiles) {
+    overrides.changeFiles.forEach((name, i) => fs.writeFileSync(path.join(paths.changeDir, name), JSON.stringify({ i })));
+  }
+
+  fs.writeFileSync(
+    paths.manifest,
+    JSON.stringify({ 'MicrosoftTeams.min.js': { integrity: overrides.manifestIntegrity || integrity } }),
+  );
+
+  const cleanup = () => fs.rmSync(dir, { recursive: true, force: true });
+  return { dir, paths, integrity, cleanup };
+}
+
+module.exports = { createReleaseFixture };

--- a/tools/cli/test/validate-release-integrity.spec.js
+++ b/tools/cli/test/validate-release-integrity.spec.js
@@ -1,0 +1,89 @@
+/* eslint-disable */
+
+const { validate } = require('../validate-release-integrity');
+const { createReleaseFixture } = require('./fixtures');
+
+describe('validate-release-integrity', () => {
+  let fx;
+  afterEach(() => fx && fx.cleanup());
+
+  const run = (version, overrides, options) => {
+    fx = createReleaseFixture(version, overrides);
+    return validate(version, { ...(options || {}), paths: fx.paths });
+  };
+
+  it('passes for a fully consistent release', () => {
+    expect(run('2.53.1')).toEqual([]);
+  });
+
+  it('fails when teams-js package.json version is stale', () => {
+    const failures = run('2.53.1', { teamsJsVersion: '2.53.0' });
+    expect(failures).toEqual(expect.arrayContaining([expect.stringContaining('packages/teams-js/package.json')]));
+  });
+
+  it('fails when the test app package.json version is stale', () => {
+    const failures = run('2.53.1', { testAppVersion: '2.53.0' });
+    expect(failures).toEqual(expect.arrayContaining([expect.stringContaining('apps/teams-test-app/package.json')]));
+  });
+
+  it('fails when beachball change files are still present', () => {
+    const failures = run('2.53.1', { changeFiles: ['@microsoft-teams-js-abc.json'] });
+    expect(failures).toEqual(expect.arrayContaining([expect.stringContaining('Unconsumed beachball change files')]));
+  });
+
+  it('fails when the changelog has no section for the version', () => {
+    fx = createReleaseFixture('2.53.2', { changelog: '# Change Log\n\n## 2.53.0\n\n- old\n' });
+    const failures = validate('2.53.2', { paths: fx.paths });
+    expect(failures).toEqual(expect.arrayContaining([expect.stringContaining('Changelog')]));
+  });
+
+  it('fails when README CDN URL points at the wrong version', () => {
+    const failures = run('2.53.1', { readmeVersion: '2.53.0' });
+    expect(failures).toEqual(expect.arrayContaining([expect.stringContaining('README.md CDN URL')]));
+  });
+
+  it('fails when the test app HTML CDN URL points at the wrong version', () => {
+    const failures = run('2.53.1', { htmlVersion: '2.53.0' });
+    expect(failures).toEqual(
+      expect.arrayContaining([expect.stringContaining('index_cdn.html CDN URL')]),
+    );
+  });
+
+  it('rejects a non-clean semver version', () => {
+    const failures = run('2.53.1-beta.0');
+    expect(failures).toEqual(expect.arrayContaining([expect.stringContaining('not a clean release semver')]));
+  });
+
+  it('rejects a major version bump', () => {
+    // Previous version in the fixture changelog is 2.53.0; bumping to 3.x is a major bump.
+    fx = createReleaseFixture('3.0.0', {
+      changelog: '# Change Log\n\n## 3.0.0\n\n- new\n\n## 2.53.0\n\n- old\n',
+    });
+    const failures = validate('3.0.0', { paths: fx.paths });
+    expect(failures).toEqual(expect.arrayContaining([expect.stringContaining('Major version bump detected')]));
+  });
+
+  it('passes PR-body check when the body contains the changelog section', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const { extractChangelogSection } = require('../extract-changelog-section');
+    fx = createReleaseFixture('2.53.1');
+    const section = extractChangelogSection('2.53.1', fx.paths.changelog);
+    const bodyFile = path.join(fx.dir, 'pr-body.md');
+    fs.writeFileSync(bodyFile, `Release 2.53.1\n\n${section}\n`);
+    const failures = validate('2.53.1', { paths: fx.paths, prBodyFile: bodyFile });
+    expect(failures.filter((f) => f.includes('PR body'))).toEqual([]);
+  });
+
+  it('fails PR-body check when the body omits the changelog section', () => {
+    const fs = require('fs');
+    const path = require('path');
+    fx = createReleaseFixture('2.53.1');
+    const bodyFile = path.join(fx.dir, 'pr-body.md');
+    fs.writeFileSync(bodyFile, 'Totally unrelated PR description');
+    const failures = validate('2.53.1', { paths: fx.paths, prBodyFile: bodyFile });
+    expect(failures).toEqual(
+      expect.arrayContaining([expect.stringContaining('PR body does not contain the changelog section')]),
+    );
+  });
+});

--- a/tools/cli/test/verify-sri.spec.js
+++ b/tools/cli/test/verify-sri.spec.js
@@ -1,0 +1,43 @@
+/* eslint-disable */
+
+const { verifySri, getManifestIntegrity, getIntegrityAttributes } = require('../verify-sri');
+const { createReleaseFixture } = require('./fixtures');
+
+describe('verify-sri', () => {
+  let fx;
+  afterEach(() => fx && fx.cleanup());
+
+  it('passes when README and HTML integrity match the manifest', () => {
+    fx = createReleaseFixture('2.53.1');
+    expect(verifySri(fx.paths)).toEqual([]);
+  });
+
+  it('fails when the README integrity is stale', () => {
+    fx = createReleaseFixture('2.53.1', { readmeIntegrity: 'sha384-STALE0000000000000000000000000000000000000000000000000000000000000' });
+    const failures = verifySri(fx.paths);
+    expect(failures).toEqual(expect.arrayContaining([expect.stringContaining('Integrity mismatch')]));
+    expect(failures.some((f) => f.includes('README.md'))).toBe(true);
+  });
+
+  it('fails when the test app HTML integrity is stale', () => {
+    fx = createReleaseFixture('2.53.1', { htmlIntegrity: 'sha384-STALE0000000000000000000000000000000000000000000000000000000000000' });
+    const failures = verifySri(fx.paths);
+    expect(failures.some((f) => f.includes('index_cdn.html'))).toBe(true);
+  });
+
+  it('reads the integrity hash from the manifest', () => {
+    fx = createReleaseFixture('2.53.1');
+    expect(getManifestIntegrity(fx.paths.manifest)).toBe(fx.integrity);
+  });
+
+  it('throws a helpful error when the manifest is missing', () => {
+    expect(() => getManifestIntegrity('/nope/MicrosoftTeams-manifest.json')).toThrow(/Run 'pnpm build' first/);
+  });
+
+  it('extracts every integrity attribute in a file', () => {
+    fx = createReleaseFixture('2.53.1');
+    const attrs = getIntegrityAttributes(fx.paths.readme);
+    expect(attrs.length).toBeGreaterThanOrEqual(1);
+    attrs.forEach((a) => expect(a).toBe(fx.integrity));
+  });
+});

--- a/tools/cli/validate-release-integrity.js
+++ b/tools/cli/validate-release-integrity.js
@@ -1,0 +1,168 @@
+/* eslint-disable */
+
+const fs = require('fs');
+const path = require('path');
+
+const { extractChangelogSection } = require('./extract-changelog-section');
+
+const DEFAULT_PATHS = {
+  teamsJsPackageJson: path.resolve(__dirname, '../../packages/teams-js/package.json'),
+  testAppPackageJson: path.resolve(__dirname, '../../apps/teams-test-app/package.json'),
+  readme: path.resolve(__dirname, '../../packages/teams-js/README.md'),
+  testAppHtml: path.resolve(__dirname, '../../apps/teams-test-app/index_cdn.html'),
+  changeDir: path.resolve(__dirname, '../../change'),
+  changelog: undefined, // undefined => extract-changelog-section default
+};
+
+const CDN_URL_REGEX = /res\.cdn\.office\.net\/teams-js\/([^/]+)\/js\/MicrosoftTeams\.min\.js/g;
+const NODE_MODULES_REGEX = /node_modules\/@microsoft\/teams-js@([^/]+)\/dist\/MicrosoftTeams\.min\.js/g;
+const SEMVER_REGEX = /^\d+\.\d+\.\d+$/;
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        args[key] = next;
+        i++;
+      } else {
+        args[key] = true;
+      }
+    }
+  }
+  return args;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+/**
+ * Asserts that every occurrence of `regex` in `content` captures `expected` as
+ * its version. Pushes a failure message per stale/missing occurrence.
+ */
+function checkAllVersionsMatch(content, regex, expectedVersion, label, failures) {
+  const matches = [...content.matchAll(regex)];
+  if (matches.length === 0) {
+    failures.push(`${label}: no reference found (expected version ${expectedVersion})`);
+    return;
+  }
+  matches.forEach((match) => {
+    if (match[1] !== expectedVersion) {
+      failures.push(`${label}: found version "${match[1]}", expected "${expectedVersion}"`);
+    }
+  });
+}
+
+function getPreviousChangelogVersion(currentVersion, changelogPath) {
+  const full = extractChangelogSection(undefined, changelogPath);
+  const headers = [...full.matchAll(/^## (\d+\.\d+\.\d+)$/gm)].map((m) => m[1]);
+  return headers.find((v) => v !== currentVersion);
+}
+
+function validate(version, options = {}) {
+  const failures = [];
+  const paths = { ...DEFAULT_PATHS, ...(options.paths || {}) };
+
+  // Check 9 (format): version must be a clean release semver (no prerelease/build metadata).
+  if (!SEMVER_REGEX.test(version)) {
+    failures.push(`Version "${version}" is not a clean release semver (expected MAJOR.MINOR.PATCH)`);
+  }
+
+  // Check 1: teams-js package.json version.
+  const teamsJsVersion = readJson(paths.teamsJsPackageJson).version;
+  if (teamsJsVersion !== version) {
+    failures.push(`packages/teams-js/package.json version is "${teamsJsVersion}", expected "${version}"`);
+  }
+
+  // Check 2: test app package.json version.
+  const testAppVersion = readJson(paths.testAppPackageJson).version;
+  if (testAppVersion !== version) {
+    failures.push(`apps/teams-test-app/package.json version is "${testAppVersion}", expected "${version}"`);
+  }
+
+  // Check 3: beachball change files have been consumed by the bump.
+  if (fs.existsSync(paths.changeDir)) {
+    const remaining = fs.readdirSync(paths.changeDir).filter((f) => f.endsWith('.json'));
+    if (remaining.length > 0) {
+      failures.push(
+        `Unconsumed beachball change files remain in change/ (expected none on a release branch): ${remaining.join(', ')}`,
+      );
+    }
+  }
+
+  // Check 4: changelog section exists and is non-empty.
+  let changelogSection = '';
+  try {
+    changelogSection = extractChangelogSection(version, paths.changelog);
+    if (!changelogSection.trim()) {
+      failures.push(`Changelog section for ${version} is empty`);
+    }
+  } catch (e) {
+    failures.push(`Changelog: ${e.message || e}`);
+  }
+
+  // Check 5: README references the version in both the CDN URL and the @version path.
+  const readme = fs.readFileSync(paths.readme, 'utf8');
+  checkAllVersionsMatch(readme, CDN_URL_REGEX, version, 'README.md CDN URL', failures);
+  checkAllVersionsMatch(readme, NODE_MODULES_REGEX, version, 'README.md @microsoft/teams-js@version', failures);
+
+  // Check 6: test app CDN HTML references the version in the CDN URL.
+  const testAppHtml = fs.readFileSync(paths.testAppHtml, 'utf8');
+  checkAllVersionsMatch(testAppHtml, CDN_URL_REGEX, version, 'apps/teams-test-app/index_cdn.html CDN URL', failures);
+
+  // Check (no major / no prerelease bump): major version must not change vs. the previous release.
+  if (SEMVER_REGEX.test(version)) {
+    const previous = getPreviousChangelogVersion(version, paths.changelog);
+    if (previous) {
+      const currentMajor = version.split('.')[0];
+      const previousMajor = previous.split('.')[0];
+      if (currentMajor !== previousMajor) {
+        failures.push(
+          `Major version bump detected (${previous} -> ${version}); only patch/minor releases are allowed`,
+        );
+      }
+    }
+  }
+
+  // Optional check 4b: PR body matches the extracted changelog section.
+  if (options.prBodyFile) {
+    if (!fs.existsSync(options.prBodyFile)) {
+      failures.push(`PR body file was not found at ${options.prBodyFile}`);
+    } else if (changelogSection.trim()) {
+      const prBody = fs.readFileSync(options.prBodyFile, 'utf8');
+      const normalize = (s) => s.replace(/\r\n/g, '\n').trim();
+      if (!normalize(prBody).includes(normalize(changelogSection))) {
+        failures.push('PR body does not contain the changelog section for this version');
+      }
+    }
+  }
+
+  return failures;
+}
+
+module.exports = { validate, DEFAULT_PATHS };
+
+if (require.main === module) {
+  const args = parseArgs(process.argv.slice(2));
+  let version = args.version;
+  if (!version || version === true) {
+    version = readJson(DEFAULT_PATHS.teamsJsPackageJson).version;
+    console.log(`No --version provided; using packages/teams-js/package.json version "${version}"`);
+  }
+  try {
+    const failures = validate(version, { prBodyFile: typeof args['pr-body-file'] === 'string' ? args['pr-body-file'] : undefined });
+    if (failures.length > 0) {
+      console.error(`Release integrity validation FAILED for version ${version}:`);
+      failures.forEach((f) => console.error(`  - ${f}`));
+      process.exit(1);
+    }
+    console.log(`Release integrity validation passed for version ${version}.`);
+  } catch (e) {
+    console.error(e.message || e);
+    process.exit(1);
+  }
+}

--- a/tools/cli/verify-sri.js
+++ b/tools/cli/verify-sri.js
@@ -1,0 +1,89 @@
+/* eslint-disable */
+
+const fs = require('fs');
+const path = require('path');
+
+const MANIFEST_PATH = path.resolve(__dirname, '../../packages/teams-js/dist/umd/MicrosoftTeams-manifest.json');
+const README_PATH = path.resolve(__dirname, '../../packages/teams-js/README.md');
+const TEST_APP_HTML_PATH = path.resolve(__dirname, '../../apps/teams-test-app/index_cdn.html');
+
+const INTEGRITY_REGEX = /integrity="([^"]+)"/g;
+
+/**
+ * Reads the integrity (SRI) hash of MicrosoftTeams.min.js from the built UMD
+ * manifest. Requires the package to have been built first (`pnpm build`).
+ *
+ * @param {string} [manifestPath] override path (used in tests)
+ * @returns {string} the integrity hash, e.g. "sha384-..."
+ */
+function getManifestIntegrity(manifestPath = MANIFEST_PATH) {
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`Manifest was not found at ${manifestPath}. Run 'pnpm build' first.`);
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const entry = manifest['MicrosoftTeams.min.js'];
+  const integrity = entry && entry.integrity;
+  if (!integrity) {
+    throw new Error('MicrosoftTeams.min.js integrity hash value was not found in the manifest');
+  }
+  return integrity;
+}
+
+/**
+ * Returns all integrity="..." attribute values found in a file.
+ *
+ * @param {string} filePath
+ * @returns {string[]}
+ */
+function getIntegrityAttributes(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`File was not found at ${filePath}`);
+  }
+  const content = fs.readFileSync(filePath, 'utf8');
+  return [...content.matchAll(INTEGRITY_REGEX)].map((match) => match[1]);
+}
+
+/**
+ * Verifies that every checked-in integrity attribute (in the README and the
+ * CDN test app) matches the freshly-built manifest integrity hash.
+ *
+ * @param {object} [paths] optional path overrides { manifest, readme, testAppHtml }
+ * @returns {string[]} list of human-readable failure messages (empty = success)
+ */
+function verifySri(paths = {}) {
+  const manifestPath = paths.manifest || MANIFEST_PATH;
+  const filesToCheck = [paths.readme || README_PATH, paths.testAppHtml || TEST_APP_HTML_PATH];
+  const failures = [];
+  const expected = getManifestIntegrity(manifestPath);
+
+  for (const filePath of filesToCheck) {
+    const attributes = getIntegrityAttributes(filePath);
+    if (attributes.length === 0) {
+      failures.push(`No integrity attribute found in ${filePath}`);
+      continue;
+    }
+    attributes.forEach((value) => {
+      if (value !== expected) {
+        failures.push(`Integrity mismatch in ${filePath}: found "${value}", expected "${expected}"`);
+      }
+    });
+  }
+  return failures;
+}
+
+module.exports = { verifySri, getManifestIntegrity, getIntegrityAttributes };
+
+if (require.main === module) {
+  try {
+    const failures = verifySri();
+    if (failures.length > 0) {
+      console.error('SRI verification FAILED:');
+      failures.forEach((f) => console.error(`  - ${f}`));
+      process.exit(1);
+    }
+    console.log('SRI verification passed: all integrity hashes match the built manifest.');
+  } catch (e) {
+    console.error(e.message || e);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Description

Part 2 of the release-pipeline streamlining stack. This PR adds the reusable **release-integrity and SRI validation library** (plus its unit tests) that later workflow PRs consume. No workflow is wired up here yet — this PR is pure, independently testable library code so it can be reviewed on its own.

It builds on #3090 (shared changelog extractor). Stacked on top of `pr1-changelog-util`.

### Main changes in the PR:

1. Add `tools/cli/validate-release-integrity.js` — validates that a release PR is internally consistent: `package.json` version matches the requested version, CHANGELOG has a matching section, README/test-app CDN references are updated, change files are consumed, and the version is valid semver. Paths are injectable via a `paths` option (`validate(version, { paths })`) so the logic is unit-testable and reusable from CI.
2. Add `tools/cli/verify-sri.js` — cross-checks the built manifest's integrity hash against the README and `index_cdn.html` SRI attributes. Exposes `verifySri(paths)`, `getManifestIntegrity()`, and `getIntegrityAttributes()`.
3. Register `tools/cli` as a private workspace package (`teams-js-cli-tools`) with a `jest` test script, and add `jest.config.js`.
4. Add 22 Jest tests (`tools/cli/test/*.spec.js`) plus a `createReleaseFixture()` helper that builds a temporary release tree with overridable fields.

## Validation

### Validation performed:

1. `pnpm --filter teams-js-cli-tools test` → **22/22 passing**.
2. Confirmed `lerna run test` discovers the new `teams-js-cli-tools` package so the suite runs in CI.
3. Verified `pnpm install --frozen-lockfile` passes with the single added importer entry.

### Unit Tests added:

Yes — 22 tests covering the changelog extractor, integrity validator (version/changelog/README/test-app/change-file/semver cases), and SRI verifier.

### End-to-end tests added:

No — this is CI-side tooling with no runtime/host surface; unit tests fully cover it.

## Additional Requirements

### Change file added:

No — `tools/cli` is a private, unpublished workspace package (release/CI tooling only), so it does not participate in beachball versioning.

### Related PRs:

- Depends on #3090 (`pr1-changelog-util`) — must merge first.
- Followed by the `release-validate.yml` workflow PR (stacked on this branch) which consumes these validators.

### Next/remaining steps:

- [ ] `release-validate.yml` workflow PR (wires these validators into PR CI on `release/*`)
- [ ] `release-orchestrate.yml` PR (automated GitHub pre-release creation)
