### PR TITLE
Release pipeline (3/4): automated release PR validation workflow

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -1,0 +1,55 @@
+name: Validate Release PR
+
+# Runs on pull requests targeting a release/* branch (the PR opened by the
+# release bootstrap workflow). Encodes the former manual reviewer checklist as
+# required status checks: version consistency, changelog/PR-body consistency,
+# README + test app CDN references, and SRI integrity correctness.
+on:
+  pull_request:
+    branches:
+      - 'release/*'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version: '18.x'
+
+      - uses: pnpm/action-setup@v3
+        name: Install pnpm
+        with:
+          version: 9.0.6
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Derive release version from base branch
+        id: version
+        run: echo "version=${GITHUB_BASE_REF#release/}" >> "$GITHUB_OUTPUT"
+
+      - name: Write PR body to file
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printf '%s' "$PR_BODY" > pr-body.md
+
+      - name: Validate release integrity
+        run: node tools/cli/validate-release-integrity.js --version ${{ steps.version.outputs.version }} --pr-body-file pr-body.md
+
+      - name: Build TeamsJS
+        run: pnpm build
+
+      - name: Verify CDN integrity hashes (SRI)
+        run: node tools/cli/verify-sri.js
+
+      - name: Run unit tests
+        run: pnpm test


### PR DESCRIPTION
## Description

Part 3 of the release-pipeline streamlining stack. This PR wires the validation library from the previous PR into an automated **release PR validation workflow**. When a PR targets `release/*`, GitHub Actions now runs the integrity and SRI checks automatically, replacing the manual reviewer checklist (confirm consumed change files, updated changelog, bumped package versions, updated README/test-app references, matching integrity hashes).

Stacked on top of `pr2-validation-lib`.

### Main changes in the PR:

1. Add `.github/workflows/release-validate.yml` — triggers on `pull_request` targeting `release/*`. It installs dependencies, builds, then runs `validate-release-integrity.js` and `verify-sri.js` against the PR, reporting a required status check.

## Validation

### Validation performed:

1. Workflow YAML validated locally; step commands match the `teams-js-cli-tools` scripts introduced in the base PR.
2. Confirmed the referenced validator entry points and their CLI invocation match the exports added in `pr2-validation-lib`.

### Unit Tests added:

No — this PR only adds a workflow definition. The logic it invokes is fully unit-tested in the base PR (`pr2-validation-lib`, 22 tests). Workflow wiring is verified by CI execution on the release PR itself.

### End-to-end tests added:

No — the workflow is itself the end-to-end validation gate for release PRs.

## Additional Requirements

### Change file added:

No — CI workflow only; no published-package changes, so beachball does not apply.

### Related PRs:

- Depends on `pr2-validation-lib` (the validation library) — must merge first.
- Part of the same stack as #3090.

### Next/remaining steps:

- [ ] `release-orchestrate.yml` PR (automated GitHub pre-release creation on release-PR merge)
