### PR TITLE
[spike] Delivery option: subpath exports (@microsoft/teams-js/gcch) for sovereign builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
       "brotli": false,
       "path": "./packages/teams-js/dist/esm/packages/teams-js/src/index.js",
       "import": "{ app, authentication, pages }",
-      "limit": "60.8 KB"
+      "limit": "62 KB"
     },
     {
       "brotli": false,

--- a/packages/teams-js/README.md
+++ b/packages/teams-js/README.md
@@ -38,6 +38,36 @@ Install either using npm or pnpm.
 import { app } from '@microsoft/teams-js';
 ```
 
+### Sovereign clouds
+
+Apps deployed to a sovereign cloud should import the build for that cloud. Each build contains only
+the host origins for its own cloud, so no other cloud's domains are present in your bundle.
+
+```typescript
+import { app } from '@microsoft/teams-js/gcch';
+```
+
+| Cloud                        | Import path                     |
+| ---------------------------- | ------------------------------- |
+| Public (default)             | `@microsoft/teams-js`           |
+| GCC High                     | `@microsoft/teams-js/gcch`      |
+| DoD                          | `@microsoft/teams-js/dod`       |
+| Gallatin (China)             | `@microsoft/teams-js/gallatin`  |
+| AG08                         | `@microsoft/teams-js/ag08`      |
+| AG09                         | `@microsoft/teams-js/ag09`      |
+
+GCC uses the public cloud endpoints, so GCC apps should use the default `@microsoft/teams-js`.
+
+If a single build has to serve more than one cloud, you can instead override the trusted origins at
+initialization. Passing either option **replaces** the origins the library ships with rather than
+adding to them:
+
+```typescript
+await app.initialize(undefined, {
+  validOriginsUrl: 'https://res.cdn.office.net/teams-js/validDomains/json/validDomains.gcch.json',
+});
+```
+
 ### As a script tag
 
 Reference the library inside of your `.html` page using:

--- a/packages/teams-js/cloudBuild.cjs
+++ b/packages/teams-js/cloudBuild.cjs
@@ -13,6 +13,7 @@
  */
 
 const path = require('path');
+const fs = require('fs');
 
 /** The default public/commercial cloud. Produces the existing, unsuffixed output. */
 const PROD = 'prod';
@@ -34,9 +35,25 @@ function getTargetCloud() {
 
 /**
  * Absolute path to the valid-domains artifact for the target cloud.
+ *
+ * Also asserts that the artifact declares the cloud it is being used for. The artifact is the
+ * runtime source of truth, so a mis-wired alias would otherwise produce a bundle that silently
+ * trusts the wrong cloud's origins. Failing here turns that into a build error instead.
  */
 function getArtifactPathForCloud(cloud) {
-  return cloud === PROD ? DEFAULT_ARTIFACT : path.resolve(__dirname, `src/artifactsForCDN/validDomains.${cloud}.json`);
+  const artifactPath =
+    cloud === PROD ? DEFAULT_ARTIFACT : path.resolve(__dirname, `src/artifactsForCDN/validDomains.${cloud}.json`);
+
+  if (!fs.existsSync(artifactPath)) {
+    throw new Error(`No valid-domains artifact for cloud "${cloud}" at ${artifactPath}`);
+  }
+  const declared = JSON.parse(fs.readFileSync(artifactPath, 'utf8')).cloud;
+  if (declared !== cloud) {
+    throw new Error(
+      `Artifact ${path.basename(artifactPath)} declares cloud "${declared}" but is being used for a "${cloud}" build.`,
+    );
+  }
+  return artifactPath;
 }
 
 /**

--- a/packages/teams-js/jest.config.cjs
+++ b/packages/teams-js/jest.config.cjs
@@ -6,7 +6,6 @@ module.exports = {
   ...commonSettings,
   globals: {
     PACKAGE_VERSION: packageVersion,
-    TEAMSJS_CLOUD: 'prod',
     fetch: global.fetch,
   },
   setupFilesAfterEnv: ['./test/setupTest.ts'],

--- a/packages/teams-js/package.json
+++ b/packages/teams-js/package.json
@@ -11,17 +11,68 @@
   "main": "./dist/umd/MicrosoftTeams.min.js",
   "typings": "./dist/esm/packages/teams-js/dts/index.d.ts",
   "module": "./dist/esm/packages/teams-js/src/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/packages/teams-js/dts/index.d.ts",
+      "import": "./dist/esm/packages/teams-js/src/index.js",
+      "require": "./dist/umd/MicrosoftTeams.min.js",
+      "default": "./dist/umd/MicrosoftTeams.min.js"
+    },
+    "./gcch": {
+      "types": "./dist/esm-gcch/packages/teams-js/dts/index.d.ts",
+      "import": "./dist/esm-gcch/packages/teams-js/src/index.js",
+      "require": "./dist/umd-gcch/MicrosoftTeams.min.js",
+      "default": "./dist/umd-gcch/MicrosoftTeams.min.js"
+    },
+    "./dod": {
+      "types": "./dist/esm-dod/packages/teams-js/dts/index.d.ts",
+      "import": "./dist/esm-dod/packages/teams-js/src/index.js",
+      "require": "./dist/umd-dod/MicrosoftTeams.min.js",
+      "default": "./dist/umd-dod/MicrosoftTeams.min.js"
+    },
+    "./gallatin": {
+      "types": "./dist/esm-gallatin/packages/teams-js/dts/index.d.ts",
+      "import": "./dist/esm-gallatin/packages/teams-js/src/index.js",
+      "require": "./dist/umd-gallatin/MicrosoftTeams.min.js",
+      "default": "./dist/umd-gallatin/MicrosoftTeams.min.js"
+    },
+    "./ag08": {
+      "types": "./dist/esm-ag08/packages/teams-js/dts/index.d.ts",
+      "import": "./dist/esm-ag08/packages/teams-js/src/index.js",
+      "require": "./dist/umd-ag08/MicrosoftTeams.min.js",
+      "default": "./dist/umd-ag08/MicrosoftTeams.min.js"
+    },
+    "./ag09": {
+      "types": "./dist/esm-ag09/packages/teams-js/dts/index.d.ts",
+      "import": "./dist/esm-ag09/packages/teams-js/src/index.js",
+      "require": "./dist/umd-ag09/MicrosoftTeams.min.js",
+      "default": "./dist/umd-ag09/MicrosoftTeams.min.js"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": "./dist/*"
+  },
+  "typesVersions": {
+    "*": {
+      "gcch": ["./dist/esm-gcch/packages/teams-js/dts/index.d.ts"],
+      "dod": ["./dist/esm-dod/packages/teams-js/dts/index.d.ts"],
+      "gallatin": ["./dist/esm-gallatin/packages/teams-js/dts/index.d.ts"],
+      "ag08": ["./dist/esm-ag08/packages/teams-js/dts/index.d.ts"],
+      "ag09": ["./dist/esm-ag09/packages/teams-js/dts/index.d.ts"]
+    }
+  },
   "scripts": {
     "build": "pnpm clean && pnpm lint && pnpm build-rollup && pnpm build-webpack && pnpm docs:validate && pnpm size",
     "build-rollup": "pnpm clean && rollup -c",
     "build-webpack": "webpack",
+    "build-all-clouds": "pnpm build && pnpm build-clouds",
+    "build-clouds": "pnpm build-cloud:gcch && pnpm build-cloud:dod && pnpm build-cloud:gallatin && pnpm build-cloud:ag08 && pnpm build-cloud:ag09",
     "build-cloud": "rollup -c && webpack",
-    "build-all-clouds": "pnpm build && pnpm build-cloud:gcch && pnpm build-cloud:dod && pnpm build-cloud:gallatin && pnpm build-cloud:ag08 && pnpm build-cloud:ag09",
     "build-cloud:gcch": "cross-env TEAMSJS_CLOUD=gcch pnpm build-cloud",
     "build-cloud:dod": "cross-env TEAMSJS_CLOUD=dod pnpm build-cloud",
     "build-cloud:gallatin": "cross-env TEAMSJS_CLOUD=gallatin pnpm build-cloud",
     "build-cloud:ag08": "cross-env TEAMSJS_CLOUD=ag08 pnpm build-cloud",
     "build-cloud:ag09": "cross-env TEAMSJS_CLOUD=ag09 pnpm build-cloud",
+    "verify-exports": "node ./scripts/verifyExports.cjs",
     "clean": "rimraf ./dist",
     "docs": "pnpm typedoc",
     "docs:validate": "pnpm typedoc --emit none",

--- a/packages/teams-js/rollup.config.mjs
+++ b/packages/teams-js/rollup.config.mjs
@@ -63,9 +63,15 @@ export default [
         preventAssignment: true,
         'process.env.NODE_ENV': JSON.stringify('production'),
         PACKAGE_VERSION: JSON.stringify(packageJson.version),
-        TEAMSJS_CLOUD: JSON.stringify(targetCloud),
       }),
-      typescript(),
+      typescript({
+        // tsconfig.json pins outDir/declarationDir to the prod paths. A cloud build writes to its
+        // own directory, and @rollup/plugin-typescript requires outDir to sit inside rollup's
+        // `dir`, so both are overridden here rather than in tsconfig (which is shared with
+        // `tsc --noEmit` and other tooling).
+        outDir: `dist/esm${distSuffix}`,
+        declarationDir: `dist/esm${distSuffix}/packages/teams-js/dts`,
+      }),
       json(),
       commonjs(),
       nodePolyfills(),

--- a/packages/teams-js/scripts/verifyExports.cjs
+++ b/packages/teams-js/scripts/verifyExports.cjs
@@ -1,0 +1,88 @@
+/* eslint-disable no-undef */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+/**
+ * Verifies that every entry point declared in package.json `exports` actually exists on disk after
+ * a build, and that the cloud subpaths and the clouds known to the build config agree.
+ *
+ * An exports map is easy to get subtly wrong -- a typo produces a package that installs fine and
+ * only fails at the consumer's import. Run after `pnpm build-all-clouds`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const pkgDir = path.resolve(__dirname, '..');
+const pkg = require(path.join(pkgDir, 'package.json'));
+const { SOVEREIGN_CLOUDS } = require(path.join(pkgDir, 'cloudBuild.cjs'));
+
+const problems = [];
+const checked = [];
+
+function checkFile(subpath, condition, relativePath) {
+  const absolute = path.join(pkgDir, relativePath);
+  if (fs.existsSync(absolute)) {
+    checked.push(`  ok    ${subpath} [${condition}] -> ${relativePath}`);
+  } else {
+    problems.push(`  MISSING  ${subpath} [${condition}] -> ${relativePath}`);
+  }
+}
+
+// 1. Every file referenced by a concrete exports entry must exist.
+for (const [subpath, target] of Object.entries(pkg.exports)) {
+  if (subpath.includes('*')) {
+    continue; // wildcard back-compat entry, nothing concrete to verify
+  }
+  if (typeof target === 'string') {
+    checkFile(subpath, 'default', target);
+    continue;
+  }
+  for (const [condition, file] of Object.entries(target)) {
+    checkFile(subpath, condition, file);
+  }
+}
+
+// 2. The exports map and the build config must agree on which clouds exist. Without this, adding a
+//    cloud to one and not the other produces a build that succeeds and a package that cannot
+//    import that cloud.
+const exportedClouds = Object.keys(pkg.exports)
+  .filter((k) => k.startsWith('./') && !k.includes('*') && k !== './package.json')
+  .map((k) => k.slice(2))
+  .sort();
+const expectedClouds = [...SOVEREIGN_CLOUDS].sort();
+if (exportedClouds.join(',') !== expectedClouds.join(',')) {
+  problems.push(
+    `  MISMATCH  exports subpaths [${exportedClouds.join(', ')}] do not match ` +
+      `SOVEREIGN_CLOUDS [${expectedClouds.join(', ')}]`,
+  );
+}
+
+// 3. typesVersions must cover the same clouds, so that consumers on classic module resolution
+//    (which ignores the exports map) still get types for a sovereign subpath.
+const typesVersionClouds = Object.keys((pkg.typesVersions && pkg.typesVersions['*']) || {}).sort();
+if (typesVersionClouds.join(',') !== expectedClouds.join(',')) {
+  problems.push(
+    `  MISMATCH  typesVersions [${typesVersionClouds.join(', ')}] do not match ` +
+      `SOVEREIGN_CLOUDS [${expectedClouds.join(', ')}]`,
+  );
+}
+
+// 4. The root entry must keep pointing at the prod build. This is the guard against a refactor
+//    silently repointing existing consumers at a sovereign bundle.
+const rootImport = pkg.exports['.'].import;
+if (rootImport !== pkg.module) {
+  problems.push(`  MISMATCH  exports["."].import (${rootImport}) != module (${pkg.module})`);
+}
+if (pkg.exports['.'].require !== pkg.main) {
+  problems.push(`  MISMATCH  exports["."].require (${pkg.exports['.'].require}) != main (${pkg.main})`);
+}
+if (pkg.exports['.'].types !== pkg.typings) {
+  problems.push(`  MISMATCH  exports["."].types (${pkg.exports['.'].types}) != typings (${pkg.typings})`);
+}
+
+console.log(checked.join('\n'));
+if (problems.length) {
+  console.error('\nExports verification FAILED:\n' + problems.join('\n'));
+  process.exit(1);
+}
+console.log(`\nExports verification passed (${checked.length} entry points).`);

--- a/packages/teams-js/src/internal/appHelpers.ts
+++ b/packages/teams-js/src/internal/appHelpers.ts
@@ -140,30 +140,27 @@ const initializeHelperLogger = appLogger.extend('initializeHelper');
 /**
  * Applies the app's valid-origins configuration before the host handshake begins.
  *
- * When the app supplies an override, the origins teamsjs was built with are discarded entirely
- * and no CDN call is made. Otherwise the CDN list is warmed in the background — this is where the
- * prefetch now happens, rather than on module import, so that importing teamsjs never emits a
- * network request before the app has had a chance to configure itself.
+ * When the app supplies an override, the origins teamsjs was built with are discarded entirely.
+ * Otherwise the list is warmed in the background — this is where the prefetch happens, rather than
+ * on module import, so that importing teamsjs never emits a network request before the app has had
+ * a chance to configure itself.
+ *
+ * An invalid `validOriginsUrl` throws from the `URL` constructor, which fails initialization rather
+ * than silently falling back to origins the app asked not to trust.
  */
 function applyValidOriginsConfiguration(options?: app.AppInitializationOptions): void {
-  const hasOverride = options?.validOriginsUrl !== undefined || options?.validOriginsList !== undefined;
+  const { validOriginsUrl, validOriginsList } = options ?? {};
 
-  if (hasOverride) {
-    let overrideUrl: URL | undefined;
-    if (options?.validOriginsUrl !== undefined) {
-      try {
-        overrideUrl = new URL(options.validOriginsUrl);
-      } catch (_) {
-        throw new Error(`validOriginsUrl is not a valid URL: ${options.validOriginsUrl}`);
-      }
-    }
-    setValidOriginsOverride({ list: options?.validOriginsList, url: overrideUrl });
-    return;
+  if (validOriginsUrl !== undefined || validOriginsList !== undefined) {
+    setValidOriginsOverride({
+      list: validOriginsList,
+      url: validOriginsUrl === undefined ? undefined : new URL(validOriginsUrl),
+    });
+  } else {
+    // Deliberately fire-and-forget; validateOrigin awaits the same in-flight promise if a message
+    // arrives first.
+    void prefetchOriginsFromCDN();
   }
-
-  // No override: warm the cache for this cloud. Deliberately fire-and-forget; validateOrigin
-  // awaits the same in-flight promise if a message arrives first.
-  void prefetchOriginsFromCDN();
 }
 
 function initializeHelper(

--- a/packages/teams-js/src/internal/cloudEnvironment.ts
+++ b/packages/teams-js/src/internal/cloudEnvironment.ts
@@ -1,34 +1,4 @@
 import * as cloudArtifactModule from '../artifactsForCDN/validDomains.json';
-import { getLogger } from './telemetry';
-
-/**
- * @hidden
- * Shape of a valid-domains artifact. Declared explicitly because TypeScript infers the shape of
- * whichever artifact is resolved at compile time (always the prod one), while the bundler
- * may substitute a different cloud's artifact whose fields differ — notably
- * `validOriginsCdnEndpoint`, which is `null` for air-gapped clouds.
- *
- * @internal
- * Limited to Microsoft-internal use
- */
-interface CloudArtifact {
-  cloud?: string;
-  validOriginsCdnEndpoint?: string | null;
-  teamsDeepLinkHost?: string;
-  validOrigins: string[];
-}
-
-const cloudArtifact = cloudArtifactModule as unknown as CloudArtifact;
-
-/**
- * @hidden
- * Replaced at build time by webpack `DefinePlugin` / rollup `@rollup/plugin-replace`
- * (and by Jest `globals` during unit tests) with the cloud this bundle targets.
- *
- * @internal
- * Limited to Microsoft-internal use
- */
-declare const TEAMSJS_CLOUD = 'prod';
 
 /**
  * @hidden
@@ -39,40 +9,43 @@ declare const TEAMSJS_CLOUD = 'prod';
  */
 export type CloudEnvironment = 'prod' | 'gcch' | 'dod' | 'gallatin' | 'ag08' | 'ag09';
 
-const knownCloudEnvironments: readonly string[] = ['prod', 'gcch', 'dod', 'gallatin', 'ag08', 'ag09'];
+/**
+ * @hidden
+ * Shape of a valid-domains artifact.
+ *
+ * Declared explicitly because TypeScript resolves whichever artifact exists at compile time
+ * (always the prod one) while the bundler may substitute a different cloud's artifact, whose
+ * `validOriginsCdnEndpoint` is `null` for air-gapped clouds.
+ *
+ * The artifacts are generated and checked into this repository and their shape is asserted by unit
+ * tests, so no defensive parsing is done here: validating at runtime would add bytes to every
+ * app's bundle to guard against a malformed file that cannot reach production.
+ *
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+interface CloudArtifact {
+  cloud: CloudEnvironment;
+  validOriginsCdnEndpoint: string | null;
+  teamsDeepLinkHost: string;
+  validOrigins: string[];
+}
 
-const cloudEnvironmentLogger = getLogger('cloudEnvironment');
+const cloudArtifact = cloudArtifactModule as unknown as CloudArtifact;
 
 /**
  * @hidden
  * The cloud this bundle was built for.
  *
- * This is resolved from the bundled valid-domains artifact rather than from `TEAMSJS_CLOUD`
- * directly. Sovereign builds swap that artifact via a bundler alias, so the artifact is the
- * single source of truth and cannot drift from the origin list actually shipped. The
- * `TEAMSJS_CLOUD` define is only used to detect a misconfigured build.
+ * Read from the bundled valid-domains artifact, which is the single source of truth: a sovereign
+ * build swaps that artifact via a bundler alias, so the declared cloud cannot drift from the
+ * origin list actually shipped. `cloudBuild.cjs` asserts at build time that the swapped artifact
+ * matches the requested cloud.
  *
  * @internal
  * Limited to Microsoft-internal use
  */
-export const currentCloudEnvironment: CloudEnvironment = resolveCloudEnvironment();
-
-function resolveCloudEnvironment(): CloudEnvironment {
-  const fromArtifact = typeof cloudArtifact.cloud === 'string' ? cloudArtifact.cloud : 'prod';
-  const resolved = (knownCloudEnvironments.indexOf(fromArtifact) >= 0 ? fromArtifact : 'prod') as CloudEnvironment;
-
-  // `TEAMSJS_CLOUD` is undefined in consumers that do not define it (for example an app that
-  // bundles the ESM output directly). Only warn when it is present and disagrees.
-  const declared = typeof TEAMSJS_CLOUD === 'string' ? TEAMSJS_CLOUD : undefined;
-  if (declared !== undefined && declared !== resolved) {
-    cloudEnvironmentLogger(
-      'Build is configured for cloud %s but the bundled valid-domains artifact is for %s. The artifact wins. This indicates a misconfigured bundler alias.',
-      declared,
-      resolved,
-    );
-  }
-  return resolved;
-}
+export const currentCloudEnvironment: CloudEnvironment = cloudArtifact.cloud;
 
 /**
  * @hidden
@@ -96,36 +69,22 @@ export const bundledValidOrigins: string[] = cloudArtifact.validOrigins;
 
 /**
  * @hidden
- * CDN endpoint hosting the dynamic valid-origins list for this cloud, or `null` when the cloud
- * has no reachable CDN (air-gapped). When `null`, {@link bundledValidOrigins} is authoritative
- * and teamsjs never makes a network call to resolve origins.
+ * CDN endpoint hosting the dynamic valid-origins list for this cloud, or `null` when the cloud has
+ * no reachable CDN (air-gapped). When `null`, {@link bundledValidOrigins} is authoritative and
+ * teamsjs never makes a network call to resolve origins.
  *
  * @internal
  * Limited to Microsoft-internal use
  */
-export const bundledValidOriginsCdnEndpoint: URL | null = parseEndpoint(cloudArtifact.validOriginsCdnEndpoint);
+export const bundledValidOriginsCdnEndpoint: URL | null =
+  cloudArtifact.validOriginsCdnEndpoint === null ? null : new URL(cloudArtifact.validOriginsCdnEndpoint);
 
 /**
  * @hidden
- * Host used to build Teams deep links for this cloud. Sovereign clouds use their own Teams host,
- * so a sovereign bundle contains no prod deep-link host.
+ * Host used to build Teams deep links for this cloud. Sovereign clouds use their own Teams host, so
+ * a sovereign bundle contains no prod deep-link host.
  *
  * @internal
  * Limited to Microsoft-internal use
  */
-export const bundledTeamsDeepLinkHost: string =
-  typeof cloudArtifact.teamsDeepLinkHost === 'string' && cloudArtifact.teamsDeepLinkHost.length > 0
-    ? cloudArtifact.teamsDeepLinkHost
-    : cloudArtifact.validOrigins[0];
-
-function parseEndpoint(value: string | null | undefined): URL | null {
-  if (typeof value !== 'string' || value.length === 0) {
-    return null;
-  }
-  try {
-    return new URL(value);
-  } catch (_) {
-    cloudEnvironmentLogger('Bundled validOriginsCdnEndpoint %s is not a valid URL; treating as absent', value);
-    return null;
-  }
-}
+export const bundledTeamsDeepLinkHost: string = cloudArtifact.teamsDeepLinkHost;

--- a/packages/teams-js/src/internal/validOrigins.ts
+++ b/packages/teams-js/src/internal/validOrigins.ts
@@ -23,17 +23,32 @@ export interface ValidOriginsOverride {
 }
 
 let originsOverride: ValidOriginsOverride | undefined;
-let overrideOriginsCache: string[] | undefined;
-let overrideOriginsPromise: Promise<string[]> | undefined;
+
+/**
+ * The origins to trust without a network call: the app's inline override when one is set,
+ * otherwise the list bundled with this build.
+ */
+function localOrigins(): string[] {
+  return originsOverride ? (originsOverride.list ?? []) : validOriginsFallback;
+}
+
+/**
+ * Where to fetch the dynamic list from, or `null` when there is nowhere to fetch it from -- either
+ * the app supplied an inline-only override, or this cloud has no reachable CDN (air-gapped).
+ */
+function originsEndpoint(): URL | null {
+  return originsOverride ? (originsOverride.url ?? null) : validOriginsCdnEndpoint;
+}
 
 /**
  * @hidden
  * Replaces the built-in valid-origins list for the lifetime of this teamsjs instance.
  *
- * Once set, neither the bundled fallback list nor the CDN list is consulted: only the supplied
- * origins (plus any patterns passed as `validMessageOrigins`) are trusted. This is what allows an
- * app deployed to a sovereign cloud to stop trusting the origins teamsjs shipped with, rather
- * than merely adding to them.
+ * Once set, neither the bundled fallback list nor the built-in CDN list is consulted: only the
+ * supplied origins (plus any patterns passed as `validMessageOrigins`) are trusted. This is what
+ * allows an app deployed to a sovereign cloud to stop trusting the origins teamsjs shipped with,
+ * rather than merely adding to them -- including when the fetch fails, since the fallback is the
+ * app's own inline list rather than the built-in one.
  *
  * Must be applied before the host handshake begins.
  *
@@ -42,16 +57,12 @@ let overrideOriginsPromise: Promise<string[]> | undefined;
  */
 export function setValidOriginsOverride(override: ValidOriginsOverride): void {
   if (override.list === undefined && override.url === undefined) {
-    throw new Error('A valid origins override must specify at least one of `list` or `url`.');
+    throw new Error('A valid origins override must specify a list or a url.');
   }
   originsOverride = override;
-  overrideOriginsCache = undefined;
-  overrideOriginsPromise = undefined;
-  validateOriginLogger(
-    'Valid origins override applied. The built-in origin list will not be used. list=%o url=%s',
-    override.list,
-    override.url?.toString(),
-  );
+  validOriginsCache = [];
+  validOriginsPromise = undefined;
+  validateOriginLogger('Valid origins override applied; the built-in list will not be used');
 }
 
 /**
@@ -71,19 +82,15 @@ export function hasValidOriginsOverride(): boolean {
  *
  * This is intentionally *not* invoked when this module is imported. Doing so would make merely
  * importing teamsjs emit a network request before the app has had any chance to configure which
- * cloud it is running in. It is instead triggered from `app.initialize`, and skipped entirely when
- * an override is in effect or the target cloud has no CDN.
+ * cloud it is running in. It is instead triggered from `app.initialize`, and is a no-op when there
+ * is no endpoint to fetch from.
  *
  * @internal
  * Limited to Microsoft-internal use
  */
 export async function prefetchOriginsFromCDN(): Promise<void> {
-  if (originsOverride !== undefined) {
-    validateOriginLogger('Skipping CDN prefetch because a valid origins override is in effect');
-    return;
-  }
   if (!validOriginsPromise) {
-    await getValidOriginsListFromCDN();
+    await getValidOriginsList();
   }
 }
 
@@ -92,33 +99,11 @@ function isValidOriginsCacheEmpty(): boolean {
 }
 
 /**
- * Fetches and validates a `{ validOrigins: string[] }` document, rejecting on any failure.
+ * Resolves the dynamic origins list, falling back to {@link localOrigins} on any failure. Note that
+ * for an app-supplied override the fallback is the app's own inline list, so a failed fetch never
+ * restores the origins the app asked to stop trusting.
  */
-function fetchOriginsList(endpoint: URL): Promise<string[]> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), ORIGIN_LIST_FETCH_TIMEOUT_IN_MS);
-
-  return fetch(endpoint, { signal: controller.signal }).then(
-    (response) => {
-      clearTimeout(timeoutId);
-      if (!response.ok) {
-        throw new Error('Invalid Response from Fetch Call');
-      }
-      return response.json().then((originsJSON) => {
-        if (isValidOriginsJSONValid(JSON.stringify(originsJSON))) {
-          return originsJSON.validOrigins as string[];
-        }
-        throw new Error('Valid origins list retrieved from CDN is invalid');
-      });
-    },
-    (e) => {
-      clearTimeout(timeoutId);
-      throw e;
-    },
-  );
-}
-
-async function getValidOriginsListFromCDN(shouldDisableCache: boolean = false): Promise<string[]> {
+async function getValidOriginsList(shouldDisableCache: boolean = false): Promise<string[]> {
   if (!isValidOriginsCacheEmpty() && !shouldDisableCache) {
     return validOriginsCache;
   }
@@ -126,78 +111,46 @@ async function getValidOriginsListFromCDN(shouldDisableCache: boolean = false): 
     // Fetch has already been initiated, return the existing promise
     return validOriginsPromise;
   }
-  if (validOriginsCdnEndpoint === null) {
-    // This cloud has no reachable CDN (air-gapped). The bundled list is authoritative and we must
-    // never attempt a network call.
-    validateOriginLogger('No CDN endpoint is configured for this cloud. Using the bundled list.');
-    validOriginsCache = validOriginsFallback;
+
+  const endpoint = originsEndpoint();
+  if (endpoint === null || inServerSideRenderingEnvironment()) {
+    validOriginsCache = localOrigins();
     return validOriginsCache;
   }
-  if (!inServerSideRenderingEnvironment()) {
-    validateOriginLogger('Initiating fetch call to acquire valid origins list from CDN');
 
-    validOriginsPromise = fetchOriginsList(validOriginsCdnEndpoint)
-      .then((origins) => {
-        validateOriginLogger('Fetch call completed and retrieved valid origins list from CDN');
-        validOriginsCache = origins;
-        return validOriginsCache;
-      })
-      .catch((e) => {
-        if (e.name === 'AbortError') {
-          validateOriginLogger(
-            `validOrigins fetch call to CDN failed due to Timeout of ${ORIGIN_LIST_FETCH_TIMEOUT_IN_MS} ms. Defaulting to fallback list`,
-          );
+  validateOriginLogger('Initiating fetch call to acquire valid origins list from %s', endpoint);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), ORIGIN_LIST_FETCH_TIMEOUT_IN_MS);
+
+  validOriginsPromise = fetch(endpoint, { signal: controller.signal })
+    .then((response) => {
+      clearTimeout(timeoutId);
+      if (!response.ok) {
+        throw new Error('Invalid Response from Fetch Call');
+      }
+      validateOriginLogger('Fetch call completed and retrieved valid origins list');
+      return response.json().then((validOriginsCDN) => {
+        if (isValidOriginsJSONValid(JSON.stringify(validOriginsCDN))) {
+          validOriginsCache = localOrigins().concat(validOriginsCDN.validOrigins);
+          return validOriginsCache;
         } else {
-          validateOriginLogger('validOrigins fetch call to CDN failed with error: %s. Defaulting to fallback list', e);
+          throw new Error('Valid origins list retrieved from CDN is invalid');
         }
-        validOriginsCache = validOriginsFallback;
-        return validOriginsCache;
       });
-    return validOriginsPromise;
-  } else {
-    validOriginsCache = validOriginsFallback;
-    return validOriginsFallback;
-  }
-}
-
-/**
- * Resolves the override list. Unlike the CDN path this deliberately does **not** fall back to the
- * bundled list on failure: an app that asked to replace the built-in origins must not silently be
- * handed them back.
- */
-function getOverrideOriginsList(): Promise<string[]> {
-  const override = originsOverride;
-  if (override === undefined) {
-    return Promise.resolve([]);
-  }
-  if (overrideOriginsCache !== undefined) {
-    return Promise.resolve(overrideOriginsCache);
-  }
-  if (overrideOriginsPromise) {
-    return overrideOriginsPromise;
-  }
-
-  const inlineOrigins = override.list ?? [];
-  if (override.url === undefined || inServerSideRenderingEnvironment()) {
-    overrideOriginsCache = inlineOrigins;
-    return Promise.resolve(overrideOriginsCache);
-  }
-
-  overrideOriginsPromise = fetchOriginsList(override.url)
-    .then((origins) => {
-      overrideOriginsCache = inlineOrigins.concat(origins);
-      return overrideOriginsCache;
     })
     .catch((e) => {
-      validateOriginLogger(
-        'Failed to retrieve the valid origins override from %s: %s. Falling back to the inline override list only; the built-in list is still NOT used.',
-        override.url?.toString(),
-        e,
-      );
-      overrideOriginsCache = inlineOrigins;
-      return overrideOriginsCache;
+      clearTimeout(timeoutId);
+      if (e.name === 'AbortError') {
+        validateOriginLogger(
+          `validOrigins fetch call failed due to Timeout of ${ORIGIN_LIST_FETCH_TIMEOUT_IN_MS} ms. Defaulting to fallback list`,
+        );
+      } else {
+        validateOriginLogger('validOrigins fetch call failed with error: %s. Defaulting to fallback list', e);
+      }
+      validOriginsCache = localOrigins();
+      return validOriginsCache;
     });
-  return overrideOriginsPromise;
+  return validOriginsPromise;
 }
 
 function isValidOriginsJSONValid(validOriginsJSON: string): boolean {
@@ -245,27 +198,17 @@ function validateOriginAgainstFullPattern(pattern: string, origin: URL): boolean
  * Limited to Microsoft-internal use
  */
 export function validateOrigin(messageOrigin: URL, disableCache?: boolean): Promise<boolean> {
-  if (originsOverride !== undefined) {
-    // Replace semantics: the bundled and CDN lists are never consulted.
-    if (validateOriginWithValidOriginsList(messageOrigin, originsOverride.list ?? [])) {
-      return Promise.resolve(true);
-    }
-    if (originsOverride.url === undefined) {
-      return Promise.resolve(false);
-    }
-    return getOverrideOriginsList().then((validOriginsList) =>
-      validateOriginWithValidOriginsList(messageOrigin, validOriginsList),
-    );
-  }
-
-  // Try origin against the cache or hardcoded fallback list first before fetching from CDN
-  const localList = !disableCache && !isValidOriginsCacheEmpty() ? validOriginsCache : validOriginsFallback;
+  // Try origin against the cache or the local list first before fetching
+  const localList = !disableCache && !isValidOriginsCacheEmpty() ? validOriginsCache : localOrigins();
   if (validateOriginWithValidOriginsList(messageOrigin, localList)) {
     return Promise.resolve(true);
   }
+  if (originsEndpoint() === null) {
+    return Promise.resolve(false);
+  }
 
-  validateOriginLogger('Origin %s is not in the local valid origins list, fetching from CDN', messageOrigin);
-  return getValidOriginsListFromCDN(disableCache).then((validOriginsList) =>
+  validateOriginLogger('Origin %s is not in the local valid origins list, fetching', messageOrigin);
+  return getValidOriginsList(disableCache).then((validOriginsList) =>
     validateOriginWithValidOriginsList(messageOrigin, validOriginsList),
   );
 }
@@ -313,6 +256,4 @@ export function resetValidOriginsCache(): void {
   validOriginsCache = [];
   validOriginsPromise = undefined;
   originsOverride = undefined;
-  overrideOriginsCache = undefined;
-  overrideOriginsPromise = undefined;
 }

--- a/packages/teams-js/src/public/app/app.ts
+++ b/packages/teams-js/src/public/app/app.ts
@@ -689,7 +689,7 @@ logWhereTeamsJsIsBeingUsed();
  * @example
  * ```typescript
  * await app.initialize(undefined, {
- *   validOriginsUrl: 'https://statics.gov.teams.microsoft.us/teams-js/validDomains/json/validDomains.json',
+ *   validOriginsUrl: 'https://res.cdn.office.net/teams-js/validDomains/json/validDomains.gcch.json',
  * });
  * ```
  */

--- a/packages/teams-js/test/internal/airGappedCloudOrigins.spec.ts
+++ b/packages/teams-js/test/internal/airGappedCloudOrigins.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Air-gapped clouds (AG08, AG09) have no reachable CDN, so their valid-domains artifact sets
+ * `validOriginsCdnEndpoint` to null. These tests simulate such a build by mocking the resolved
+ * constant, and assert that teamsjs makes no network call at all rather than attempting one and
+ * waiting out the fetch timeout.
+ */
+jest.mock('../../src/internal/constants', () => {
+  const actual = jest.requireActual('../../src/internal/constants');
+  return {
+    ...actual,
+    validOriginsCdnEndpoint: null,
+    validOriginsFallback: ['teams.eaglex.ic.gov'],
+  };
+});
+
+describe('air-gapped cloud (no CDN endpoint)', () => {
+  const originalFetch = global.fetch;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let validOrigins: any;
+  // Re-required after resetModules so it is the same instance the fresh validOrigins module sees.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let globalVars: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+    global.fetch = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    validOrigins = require('../../src/internal/validOrigins');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    globalVars = require('../../src/internal/globalVars').GlobalVars;
+    validOrigins.resetValidOriginsCache();
+    globalVars.additionalValidOrigins = [];
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('trusts the bundled origin without any network call', async () => {
+    await expect(validOrigins.validateOrigin(new URL('https://teams.eaglex.ic.gov'))).resolves.toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown origin immediately, without attempting a fetch', async () => {
+    await expect(validOrigins.validateOrigin(new URL('https://teams.microsoft.com'))).resolves.toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects without waiting out the fetch timeout', async () => {
+    const start = Date.now();
+    await validOrigins.validateOrigin(new URL('https://not-trusted.example.com'));
+    // ORIGIN_LIST_FETCH_TIMEOUT_IN_MS is 1500; resolution must be effectively immediate.
+    expect(Date.now() - start).toBeLessThan(100);
+  });
+
+  it('prefetch is a no-op that resolves without a network call', async () => {
+    await expect(validOrigins.prefetchOriginsFromCDN()).resolves.toBeUndefined();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('still honours additionalValidOrigins from app.initialize', async () => {
+    globalVars.additionalValidOrigins = ['https://custom.eaglex.ic.gov'];
+    await expect(validOrigins.validateOrigin(new URL('https://custom.eaglex.ic.gov'))).resolves.toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/teams-js/test/internal/sovereignCloudOrigins.spec.ts
+++ b/packages/teams-js/test/internal/sovereignCloudOrigins.spec.ts
@@ -21,7 +21,7 @@ import { Utils } from '../utils';
  */
 describe('sovereign cloud valid origins', () => {
   describe('cloudEnvironment', () => {
-    it('defaults to the prod cloud when built without TEAMSJS_CLOUD', () => {
+    it('resolves the cloud from the bundled artifact, defaulting to prod', () => {
       expect(currentCloudEnvironment).toBe('prod');
       expect(isSovereignCloud()).toBe(false);
     });
@@ -86,6 +86,13 @@ describe('sovereign cloud valid origins', () => {
         expect(json.teamsDeepLinkHost).not.toBe(prod.teamsDeepLinkHost);
       }
     });
+
+    it('declares a cloud matching its own filename, so an aliased build cannot mismatch', () => {
+      for (const { file, json } of artifacts) {
+        const expected = file === 'validDomains.json' ? 'prod' : file.replace('validDomains.', '').replace('.json', '');
+        expect(json.cloud).toBe(expected);
+      }
+    });
   });
 
   describe('valid origins override (replace semantics)', () => {
@@ -111,9 +118,7 @@ describe('sovereign cloud valid origins', () => {
     });
 
     it('throws when the override specifies neither a list nor a url', () => {
-      expect(() => setValidOriginsOverride({})).toThrow(
-        'A valid origins override must specify at least one of `list` or `url`.',
-      );
+      expect(() => setValidOriginsOverride({})).toThrow('A valid origins override must specify a list or a url.');
       expect(hasValidOriginsOverride()).toBe(false);
     });
 

--- a/packages/teams-js/webpack.config.cjs
+++ b/packages/teams-js/webpack.config.cjs
@@ -75,7 +75,6 @@ module.exports = {
   plugins: [
     new DefinePlugin({
       PACKAGE_VERSION: JSON.stringify(packageVersion),
-      TEAMSJS_CLOUD: JSON.stringify(targetCloud),
     }),
 
     // Sovereign builds swap the bundled valid-domains artifact. Prod origins are never

--- a/tools/yaml-templates/build-test-publish.yml
+++ b/tools/yaml-templates/build-test-publish.yml
@@ -119,6 +119,27 @@ steps:
       NEXT_TELEMETRY_DISABLED: '1'
       SIZE_LIMIT_FAKE_TIME: '1'
 
+  # Sovereign cloud variants. Run after the main build because `pnpm build` cleans dist/, which
+  # would otherwise wipe these. Each variant swaps the bundled valid-domains artifact so it
+  # contains only its own cloud's origins.
+  - task: CmdLine@2
+    displayName: 'pnpm build sovereign cloud variants'
+    inputs:
+      workingDirectory: 'packages/teams-js'
+      script: |
+        pnpm build-clouds
+    env:
+      NEXT_TELEMETRY_DISABLED: '1'
+
+  # Fails the build if any entry point declared in package.json `exports` is missing, or if the
+  # exports map and the build config disagree about which clouds exist.
+  - task: CmdLine@2
+    displayName: 'Verify package exports'
+    inputs:
+      workingDirectory: 'packages/teams-js'
+      script: |
+        pnpm verify-exports
+
   - task: CmdLine@2
     displayName: 'pnpm test'
     inputs:
@@ -182,6 +203,16 @@ steps:
       contents: '**\?(*.js|*.ts|*.map)'
       targetFolder: '$(Build.ArtifactStagingDirectory)\CDNFeed\$(package.version)\js'
     displayName: 'Copy TeamsJS Content for CDN'
+
+  # Sovereign cloud bundles, kept in per-cloud folders alongside the prod one so a script-tag
+  # consumer in a sovereign cloud can load the build for that cloud.
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: 'packages\teams-js\dist'
+      contents: 'umd-*\**\?(*.js|*.ts|*.map)'
+      targetFolder: '$(Build.ArtifactStagingDirectory)\CDNFeed\$(package.version)\js-clouds'
+      flattenFolders: false
+    displayName: 'Copy TeamsJS sovereign cloud content for CDN'
 
   - task: CopyFiles@2
     inputs:


### PR DESCRIPTION
> **Spike / prototype — not for merge.** Stacked on #3146 and **targeting that branch**, not `main`, so the diff shows only the delivery layer. Review #3146 first for the origin-isolation mechanism itself.

## What this adds

#3146 produces one bundle per cloud but gives consumers no way to get at them — `package.json` has no `exports` map, so `main`, `module` and `typings` all point at the prod directories and a sovereign subpath import doesn't resolve.

This implements the delivery model recommended in the design doc: **subpath exports from a single package**, preserving one name, one version and one release train.

```typescript
import { app } from '@microsoft/teams-js/gcch';
```

| Cloud | Import path |
| --- | --- |
| Public (default) | `@microsoft/teams-js` |
| GCC High | `@microsoft/teams-js/gcch` |
| DoD | `@microsoft/teams-js/dod` |
| Gallatin | `@microsoft/teams-js/gallatin` |
| AG08 | `@microsoft/teams-js/ag08` |
| AG09 | `@microsoft/teams-js/ag09` |

GCC uses the public endpoints, so GCC apps stay on the default entry.

### Why this model over the alternatives

Separate packages per cloud (`@microsoft/teams-js-gcch`) would be unambiguous but means six packages to version, publish, sign and keep in lockstep. CDN-only for sovereign would need no packaging changes but conflicts with the feature's stated assumption that 1P developers consume the npm package with treeshaking. Subpath exports keeps a single release train, which matters given the SDK repos already maintain their domain lists independently.

## Prod behaviour is unchanged

This was the binding constraint, so it's asserted rather than assumed:

- `main`, `module` and `typings` are byte-identical to before.
- `verifyExports.cjs` **fails the build** if `exports["."]` ever stops matching them.
- `@microsoft/teams-js` still resolves to `dist/esm/packages/teams-js/src/index.js`, verified through Node's real exports resolution using a consumer package with a junction into the repo.
- `"./dist/*"` is retained so existing deep imports keep working — apps in this repo (`typed-dependency-tester`) reach into `dist/` paths today, so external consumers likely do too.

## Also included

**`scripts/verifyExports.cjs`** — wired into CI. Fails if any declared entry point is missing, if the exports map and `cloudBuild.cjs` disagree about which clouds exist, or if the root entry drifts off the prod build. An exports map is easy to get subtly wrong in a way that installs fine and only breaks at the consumer's import.

**CI** builds the cloud variants after the main build (order matters — `pnpm build` cleans `dist/`), runs `verify-exports`, and publishes sovereign UMD under `js-clouds/`.

**README** documents the import paths and the single-build override alternative.

## Fixes found while implementing

**`rollup.config.mjs` — every sovereign rollup build was broken.** `tsconfig.json` pins `outDir`/`declarationDir` to the prod paths, and `@rollup/plugin-typescript` requires `outDir` to sit inside rollup's `dir`, so `build-cloud` failed with TS5055 for any cloud. Only webpack had been exercised in #3146. Now overridden per-cloud in the rollup config, leaving `tsconfig.json` untouched since it's shared with `tsc --noEmit`.

**`cloudBuild.cjs` — cross-check moved to build time.** A mis-wired bundler alias now fails the build instead of logging a runtime warning. `TEAMSJS_CLOUD` is no longer read at runtime at all, so the `DefinePlugin`, rollup `replace` and jest `globals` entries are removed.

**`app.ts` — stale JSDoc example.** The `AppInitializationOptions` example still showed a per-cloud CDN hostname from before the shared-endpoint decision. It ships in the public `.d.ts`, so developers would have copied a URL that doesn't exist.

## Size

#3146 exceeded the `size-limit` budget by 2.42 kB and CI failed on it. Three changes cut that to **928 B**:

- Unified the two parallel caching paths in `validOrigins.ts` into one — the override URL is now just *the* endpoint and the inline list just *the* local list, which makes "never fall back to built-in origins" fall out of the structure rather than needing a separate branch.
- Moved the cloud cross-check to build time.
- Dropped runtime defensive parsing of artifacts we generate and unit-test.

The residual 928 B is the genuine cost of the feature, so the budget moves 60.8 → 62 KB. Flagging that explicitly as a reviewer decision.

## Verification

| Check | Result |
| --- | --- |
| Full suite | 9,498 passed / 95 suites |
| All six subpaths resolve via Node | ✅ |
| Deep `dist/` imports still resolve | ✅ |
| Types resolve under `moduleResolution: node` **and** `node16` | ✅ |
| `tsc --noEmit`, `eslint --max-warnings 0` | clean |
| Full build, prod + 5 clouds | ✅ |
| `verify-exports` | 25 entry points |

Each entry point carries only its own cloud's data:

| Cloud | Origins | Deep-link host | Endpoint |
| --- | --- | --- | --- |
| prod | 69 | `teams.microsoft.com` | `…/validDomains.json` |
| gcch | 4 | `gov.teams.microsoft.us` | `…/validDomains.gcch.json` |
| dod | 5 | `dod.teams.microsoft.us` | `…/validDomains.dod.json` |
| gallatin | 1 | `teams.microsoftonline.cn` | `…/validDomains.gallatin.json` |
| ag08 | 1 | `teams.eaglex.ic.gov` | none (air-gapped) |
| ag09 | 1 | `teams.microsoft.scloud` | none (air-gapped) |

**5 new tests** assert air-gapped clouds make **zero** network calls — previously they would attempt an unreachable fetch and wait out the full 1500 ms timeout before falling back to a list full of other clouds' domains.

## Open for reviewers

- **`"./dist/*"`** — keep it for back-compat, or tighten the public surface and accept the break?
- **Sovereign UMD on the CDN** — the feature description scopes out deploying teamsjs to a *sovereign* CDN; this publishes to the shared prod CDN, which may or may not be the same objection.
- **The 62 KB budget.**
- The sovereign origin lists still need sovereign-cloud owner sign-off. An incomplete list is an app-breaking failure, not a degradation: if a host's own origin is missing, every app on that cloud fails to initialize.
