### PR TITLE
Add tests for validateUuidInstance and fix its wrong TSDoc

### DIFF
--- a/change/@microsoft-teams-js-4662ca81-af8e-4201-983a-0403756de5a1.json
+++ b/change/@microsoft-teams-js-4662ca81-af8e-4201-983a-0403756de5a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Correct the TSDoc on `validateUuidInstance`, which incorrectly described it as checking whether an id is an instance of `ValidatedSafeString` rather than `UUID`.",
+  "packageName": "@microsoft/teams-js",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/public/uuidObject.ts
+++ b/packages/teams-js/src/public/uuidObject.ts
@@ -39,8 +39,8 @@ export class UUID implements ISerializable {
 
 /**
  * @hidden
- * Checks if the incoming id is an instance of ValidatedSafeString
- * @param id An object to check if it's an instance of ValidatedSafeString
+ * Checks if the incoming id is an instance of UUID
+ * @param id An object to check if it's an instance of UUID
  * @throws Error with a message describing the violation
  * @internal
  * Limited to Microsoft-internal use

--- a/packages/teams-js/test/public/uuidObject.spec.ts
+++ b/packages/teams-js/test/public/uuidObject.spec.ts
@@ -1,0 +1,22 @@
+import { UUID, validateUuidInstance } from '../../src/public/uuidObject';
+
+describe('validateUuidInstance', () => {
+  test('should throw error when id is an object but not an instance of UUID', () => {
+    expect(() => validateUuidInstance({ Object: 'object' } as unknown as UUID)).toThrowError(
+      'Potential id ({"Object":"object"}) is invalid; it is not an instance of UUID class.',
+    );
+  });
+
+  test('should throw error when id is an instance of a class other than UUID', () => {
+    class NotUuid {}
+    const notUuidInstance = new NotUuid();
+    expect(() => validateUuidInstance(notUuidInstance as unknown as UUID)).toThrowError(
+      'Potential id ({}) is invalid; it is not an instance of UUID class.',
+    );
+  });
+
+  test('should not throw error when id is an instance of UUID', () => {
+    const uuidInstance = new UUID('8e6523aa-97f9-49ad-8614-75cae22f6597');
+    expect(() => validateUuidInstance(uuidInstance)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Description

`validateUuidInstance` in `src/public/uuidObject.ts` was an uncovered export, and while adding tests for it I found a real docs bug sitting right above it.

**The docs bug.** The TSDoc on `validateUuidInstance` is copy-pasted from `validateSafeStringInstance`. Both the summary and the `@param` say the function "Checks if the incoming id is an instance of ValidatedSafeString", when it actually checks `UUID` — the body throws `"...it is not an instance of UUID class."` So the generated docs describe the wrong type entirely, which is worse than a typo: someone reading the docs is told the wrong contract. Corrected both lines to say `UUID`.

**The tests.** This is the third sibling of a well-established pattern — `validateAppIdInstance` is already covered in `test/internal/idValidation.spec.ts`, and `validateSafeStringInstance` was covered recently. The table is a known quantity, so the new `test/public/uuidObject.spec.ts` mirrors it:

- a plain object throws,
- an instance of some other class throws,
- a real `UUID` does not throw.

The two throwing cases also pin the exact error message, matching how the `validateAppIdInstance` tests are written. Note the messages differ slightly from the AppId ones: `validateUuidInstance` uses `JSON.stringify(id)` rather than string interpolation, so a plain object serializes as `{"Object":"object"}` instead of `[object Object]`.

## Validation

- `jest test/public/uuidObject.spec.ts` — 3 passing.
- Ran the neighbouring suites (`idValidation`, `serializable`, `externalAppCardActionsForDA`, the one production caller of `validateUuidInstance`) — 46 passing.
- `tsc --noEmit`, `eslint`, `prettier --check`, `beachball check`, and `docs:validate` (typedoc) all clean.

Change file is `patch` and covers only the doc correction; the new spec is test-only.
