### PR TITLE
test: cover search.registerHandlers and search.unregisterHandlers

### DIFF
--- a/packages/teams-js/test/public/search.spec.ts
+++ b/packages/teams-js/test/public/search.spec.ts
@@ -2,11 +2,17 @@ import { errorLibraryNotInitialized } from '../../src/internal/constants';
 import { GlobalVars } from '../../src/internal/globalVars';
 import { DOMMessageEvent } from '../../src/internal/interfaces';
 import * as app from '../../src/public/app/app';
-import { FrameContexts } from '../../src/public/constants';
+import { errorNotSupportedOnPlatform, FrameContexts } from '../../src/public/constants';
 import * as search from '../../src/public/search';
 import { Utils } from '../utils';
 
 const dataError = 'Something went wrong...';
+
+const emptyHandler = (): void => {};
+
+const closedQuery: search.SearchQuery = { searchTerm: 'closed term', timestamp: 100 };
+const executedQuery: search.SearchQuery = { searchTerm: 'executed term', timestamp: 200 };
+const changedQuery: search.SearchQuery = { searchTerm: 'changed term', timestamp: 300 };
 
 describe('Search', () => {
   describe('Framed', () => {
@@ -111,6 +117,147 @@ describe('Search', () => {
           utils.respondToMessage(closeSearchMessage, data.success);
           await expect(promise).resolves.not.toThrow();
         }
+      });
+    });
+
+    describe('registerHandlers', () => {
+      it('FRAMED: should not allow calls before initialization', () => {
+        expect(() => search.registerHandlers(emptyHandler, emptyHandler)).toThrowError(
+          new Error(errorLibraryNotInitialized),
+        );
+      });
+
+      const allowedContexts = [FrameContexts.content];
+      Object.values(FrameContexts).forEach((frameContext) => {
+        if (allowedContexts.includes(frameContext)) {
+          return;
+        }
+        it(`FRAMED: should not allow calls from ${frameContext} context`, async () => {
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 1, supports: { search: {} } });
+
+          expect(() => search.registerHandlers(emptyHandler, emptyHandler)).toThrowError(
+            new Error(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${frameContext}".`,
+            ),
+          );
+        });
+      });
+
+      it('FRAMED: should throw if the runtime does not support search', async () => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+
+        expect.assertions(1);
+        try {
+          search.registerHandlers(emptyHandler, emptyHandler);
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
+
+      it('FRAMED: should register and dispatch all three handlers', async () => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: { search: {} } });
+
+        const onClosed = jest.fn();
+        const onExecute = jest.fn();
+        const onChange = jest.fn();
+        search.registerHandlers(onClosed, onExecute, onChange);
+
+        const registeredHandlerNames = utils.messages
+          .filter((message) => message.func === 'registerHandler')
+          .map((message) => message.args && message.args[0]);
+        expect(registeredHandlerNames).toEqual(['search.queryClose', 'search.queryExecute', 'search.queryChange']);
+
+        await utils.sendMessage('search.queryClose', closedQuery);
+        await utils.sendMessage('search.queryExecute', executedQuery);
+        await utils.sendMessage('search.queryChange', changedQuery);
+
+        expect(onClosed).toHaveBeenCalledWith(closedQuery);
+        expect(onExecute).toHaveBeenCalledWith(executedQuery);
+        expect(onChange).toHaveBeenCalledWith(changedQuery);
+      });
+
+      it('FRAMED: should not register the change handler when it is not provided', async () => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: { search: {} } });
+
+        const onClosed = jest.fn();
+        const onExecute = jest.fn();
+        search.registerHandlers(onClosed, onExecute);
+
+        const registeredHandlerNames = utils.messages
+          .filter((message) => message.func === 'registerHandler')
+          .map((message) => message.args && message.args[0]);
+        expect(registeredHandlerNames).toEqual(['search.queryClose', 'search.queryExecute']);
+
+        await utils.sendMessage('search.queryChange', changedQuery);
+        expect(onClosed).not.toHaveBeenCalled();
+        expect(onExecute).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('unregisterHandlers', () => {
+      it('FRAMED: should not allow calls before initialization', () => {
+        expect(() => search.unregisterHandlers()).toThrowError(new Error(errorLibraryNotInitialized));
+      });
+
+      const allowedContexts = [FrameContexts.content];
+      Object.values(FrameContexts).forEach((frameContext) => {
+        if (allowedContexts.includes(frameContext)) {
+          return;
+        }
+        it(`FRAMED: should not allow calls from ${frameContext} context`, async () => {
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 1, supports: { search: {} } });
+
+          expect(() => search.unregisterHandlers()).toThrowError(
+            new Error(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${frameContext}".`,
+            ),
+          );
+        });
+      });
+
+      it('FRAMED: should throw if the runtime does not support search', async () => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+
+        expect.assertions(1);
+        try {
+          search.unregisterHandlers();
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
+
+      it('FRAMED: should send the unregister message and remove every handler', async () => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: { search: {} } });
+
+        const onClosed = jest.fn();
+        const onExecute = jest.fn();
+        const onChange = jest.fn();
+        search.registerHandlers(onClosed, onExecute, onChange);
+
+        search.unregisterHandlers();
+
+        const unregisterMessage = utils.findMessageByFunc('search.unregister');
+        expect(unregisterMessage).not.toBeNull();
+        expect(unregisterMessage?.args?.length).toEqual(0);
+
+        await utils.sendMessage('search.queryClose', closedQuery);
+        await utils.sendMessage('search.queryExecute', executedQuery);
+        await utils.sendMessage('search.queryChange', changedQuery);
+
+        expect(onClosed).not.toHaveBeenCalled();
+        expect(onExecute).not.toHaveBeenCalled();
+        expect(onChange).not.toHaveBeenCalled();
       });
     });
   });
@@ -230,6 +377,161 @@ describe('Search', () => {
           },
         } as DOMMessageEvent);
         await expect(promise).resolves.not.toThrow();
+      });
+    });
+
+    describe('registerHandlers', () => {
+      it('FRAMELESS: should not allow calls before initialization', () => {
+        expect(() => search.registerHandlers(emptyHandler, emptyHandler)).toThrowError(
+          new Error(errorLibraryNotInitialized),
+        );
+      });
+
+      const allowedContexts = [FrameContexts.content];
+      Object.values(FrameContexts).forEach((frameContext) => {
+        if (allowedContexts.includes(frameContext)) {
+          return;
+        }
+        it(`FRAMELESS: should not allow calls from ${frameContext} context`, async () => {
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 1, supports: { search: {} } });
+
+          expect(() => search.registerHandlers(emptyHandler, emptyHandler)).toThrowError(
+            new Error(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${frameContext}".`,
+            ),
+          );
+        });
+      });
+
+      it('FRAMELESS: should throw if the runtime does not support search', async () => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+
+        expect.assertions(1);
+        try {
+          search.registerHandlers(emptyHandler, emptyHandler);
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
+
+      it('FRAMELESS: should register and dispatch all three handlers', async () => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: { search: {} } });
+
+        const onClosed = jest.fn();
+        const onExecute = jest.fn();
+        const onChange = jest.fn();
+        search.registerHandlers(onClosed, onExecute, onChange);
+
+        const registeredHandlerNames = utils.messages
+          .filter((message) => message.func === 'registerHandler')
+          .map((message) => message.args && message.args[0]);
+        expect(registeredHandlerNames).toEqual(['search.queryClose', 'search.queryExecute', 'search.queryChange']);
+
+        utils.respondToFramelessMessage({
+          data: { func: 'search.queryClose', args: [closedQuery] },
+        } as DOMMessageEvent);
+        utils.respondToFramelessMessage({
+          data: { func: 'search.queryExecute', args: [executedQuery] },
+        } as DOMMessageEvent);
+        utils.respondToFramelessMessage({
+          data: { func: 'search.queryChange', args: [changedQuery] },
+        } as DOMMessageEvent);
+
+        expect(onClosed).toHaveBeenCalledWith(closedQuery);
+        expect(onExecute).toHaveBeenCalledWith(executedQuery);
+        expect(onChange).toHaveBeenCalledWith(changedQuery);
+      });
+
+      it('FRAMELESS: should not register the change handler when it is not provided', async () => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: { search: {} } });
+
+        const onClosed = jest.fn();
+        const onExecute = jest.fn();
+        search.registerHandlers(onClosed, onExecute);
+
+        const registeredHandlerNames = utils.messages
+          .filter((message) => message.func === 'registerHandler')
+          .map((message) => message.args && message.args[0]);
+        expect(registeredHandlerNames).toEqual(['search.queryClose', 'search.queryExecute']);
+
+        utils.respondToFramelessMessage({
+          data: { func: 'search.queryChange', args: [changedQuery] },
+        } as DOMMessageEvent);
+        expect(onClosed).not.toHaveBeenCalled();
+        expect(onExecute).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('unregisterHandlers', () => {
+      it('FRAMELESS: should not allow calls before initialization', () => {
+        expect(() => search.unregisterHandlers()).toThrowError(new Error(errorLibraryNotInitialized));
+      });
+
+      const allowedContexts = [FrameContexts.content];
+      Object.values(FrameContexts).forEach((frameContext) => {
+        if (allowedContexts.includes(frameContext)) {
+          return;
+        }
+        it(`FRAMELESS: should not allow calls from ${frameContext} context`, async () => {
+          await utils.initializeWithContext(frameContext);
+          utils.setRuntimeConfig({ apiVersion: 1, supports: { search: {} } });
+
+          expect(() => search.unregisterHandlers()).toThrowError(
+            new Error(
+              `This call is only allowed in following contexts: ${JSON.stringify(
+                allowedContexts,
+              )}. Current context: "${frameContext}".`,
+            ),
+          );
+        });
+      });
+
+      it('FRAMELESS: should throw if the runtime does not support search', async () => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: {} });
+
+        expect.assertions(1);
+        try {
+          search.unregisterHandlers();
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
+
+      it('FRAMELESS: should send the unregister message and remove every handler', async () => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: 1, supports: { search: {} } });
+
+        const onClosed = jest.fn();
+        const onExecute = jest.fn();
+        const onChange = jest.fn();
+        search.registerHandlers(onClosed, onExecute, onChange);
+
+        search.unregisterHandlers();
+
+        const unregisterMessage = utils.findMessageByFunc('search.unregister');
+        expect(unregisterMessage).not.toBeNull();
+        expect(unregisterMessage?.args?.length).toEqual(0);
+
+        utils.respondToFramelessMessage({
+          data: { func: 'search.queryClose', args: [closedQuery] },
+        } as DOMMessageEvent);
+        utils.respondToFramelessMessage({
+          data: { func: 'search.queryExecute', args: [executedQuery] },
+        } as DOMMessageEvent);
+        utils.respondToFramelessMessage({
+          data: { func: 'search.queryChange', args: [changedQuery] },
+        } as DOMMessageEvent);
+
+        expect(onClosed).not.toHaveBeenCalled();
+        expect(onExecute).not.toHaveBeenCalled();
+        expect(onChange).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
## Description

`test/public/search.spec.ts` was 236 lines but covered only `closeSearch` (framed and frameless). The two primary APIs of the capability — `registerHandlers` and `unregisterHandlers` — had **no tests at all**.

This adds framed and frameless suites for both, following the existing structure of the file.

### What is covered

- **`ensureInitialized(FrameContexts.content)` guards** — calling either API before `app.initialize` throws `errorLibraryNotInitialized`, and calling from any frame context other than `content` throws the "only allowed in following contexts" error.
- **`errorNotSupportedOnPlatform`** — both APIs throw when the runtime does not declare `search` support.
- **`registerHandlers` registers all three handlers** — `search.queryClose`, `search.queryExecute` and `search.queryChange`, in that order, and each registered handler is invoked with the `SearchQuery` the host dispatches.
- **`onChangeHandler` is optional** — when omitted, only the two required handlers are registered and a `search.queryChange` message from the host reaches nothing.
- **`unregisterHandlers` cleans up** — sends the `search.unregister` message with no args and removes all three handlers, so subsequent host dispatches invoke none of them.

### Result

`src/public/search.ts` goes from partial coverage to **100% statements, branches, functions and lines**.

```
-----------|---------|----------|---------|---------|
File       | % Stmts | % Branch | % Funcs | % Lines |
-----------|---------|----------|---------|---------|
 search.ts |     100 |      100 |     100 |     100 |
-----------|---------|----------|---------|---------|
Test Suites: 1 passed, 1 total
Tests:       68 passed, 68 total
```

### Notes

- Test-only change; no product code is touched, so no beachball change file is required (`**/test/**` is in `ignorePatterns`).
- The broken `@example` template literal in `search.registerHandlers` that I flagged earlier was already fixed separately in #3132, so this PR is tests only.