### PR TITLE
test: cover the shortcutRelay reset contract

### DIFF
--- a/packages/teams-js/test/public/shortcutRelay.spec.ts
+++ b/packages/teams-js/test/public/shortcutRelay.spec.ts
@@ -141,5 +141,124 @@ describe('shortcutRelay capability', () => {
         expect(prev).toBe(noop);
       });
     });
+
+    describe('resetIsShortcutRelayCapabilityEnabled()', () => {
+      let addEventListenerSpy: jest.SpyInstance;
+      let removeEventListenerSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        addEventListenerSpy = jest.spyOn(document, 'addEventListener');
+        removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+      });
+
+      afterEach(() => {
+        addEventListenerSpy.mockRestore();
+        removeEventListenerSpy.mockRestore();
+      });
+
+      const keydownListenersAdded = (): number =>
+        addEventListenerSpy.mock.calls.filter(([type]) => type === 'keydown').length;
+      const keydownListenersRemoved = (): number =>
+        removeEventListenerSpy.mock.calls.filter(([type]) => type === 'keydown').length;
+
+      /**
+       * The capability keeps module-level state that survives between tests in this file, so
+       * normalize it before asserting on listener bookkeeping.
+       */
+      const initializeSupportedAndReset = async (): Promise<void> => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: latestRuntimeApiVersion, supports: { shortcutRelay: {} } });
+        shortcutRelay.resetIsShortcutRelayCapabilityEnabled();
+        addEventListenerSpy.mockClear();
+        removeEventListenerSpy.mockClear();
+      };
+
+      const enableAndRespond = async (shortcuts: string[], overridableShortcuts: string[] = []): Promise<void> => {
+        utils.messages = [];
+        const enablePromise = shortcutRelay.enableShortcutRelayCapability();
+        const request = utils.findMessageByFunc(ApiName.ShortcutRelay_GetHostShortcuts);
+        expect(request).not.toBeNull();
+        utils.respondToFramelessMessage({
+          data: { id: request?.id, args: [{ shortcuts, overridableShortcuts }] },
+        } as DOMMessageEvent);
+        await enablePromise;
+      };
+
+      const dispatchCtrlS = (): void => {
+        document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true }));
+      };
+
+      it('should throw before initialization', () => {
+        utils.uninitializeRuntimeConfig();
+        expect(() => shortcutRelay.resetIsShortcutRelayCapabilityEnabled()).toThrowError(
+          new Error(errorLibraryNotInitialized),
+        );
+      });
+
+      it('should throw when capability not supported in runtime', async () => {
+        await utils.initializeWithContext(FrameContexts.content);
+        utils.setRuntimeConfig({ apiVersion: latestRuntimeApiVersion, supports: {} });
+
+        expect.assertions(1);
+        try {
+          shortcutRelay.resetIsShortcutRelayCapabilityEnabled();
+        } catch (e) {
+          expect(e).toEqual(errorNotSupportedOnPlatform);
+        }
+      });
+
+      it('stops forwarding shortcuts that were previously registered by the host', async () => {
+        await initializeSupportedAndReset();
+        await enableAndRespond(['ctrl+s']);
+
+        utils.messages = [];
+        dispatchCtrlS();
+        expect(utils.findMessageByFunc(ApiName.ShortcutRelay_ForwardShortcutEvent)).not.toBeNull();
+
+        shortcutRelay.resetIsShortcutRelayCapabilityEnabled();
+
+        utils.messages = [];
+        dispatchCtrlS();
+        expect(utils.findMessageByFunc(ApiName.ShortcutRelay_ForwardShortcutEvent)).toBeNull();
+      });
+
+      it('drops the overridable shortcut handler', async () => {
+        await initializeSupportedAndReset();
+        const handler = jest.fn(() => true);
+        expect(shortcutRelay.setOverridableShortcutHandler(handler)).toBeUndefined();
+
+        shortcutRelay.resetIsShortcutRelayCapabilityEnabled();
+
+        expect(shortcutRelay.setOverridableShortcutHandler(undefined)).toBeUndefined();
+      });
+
+      it('does not add a second keydown listener when the capability is enabled twice', async () => {
+        await initializeSupportedAndReset();
+        await enableAndRespond(['ctrl+s']);
+        await enableAndRespond(['ctrl+s']);
+
+        expect(keydownListenersAdded()).toBe(1);
+        expect(keydownListenersRemoved()).toBe(0);
+      });
+
+      it('leaves exactly one keydown listener attached after an enable -> reset -> enable cycle', async () => {
+        await initializeSupportedAndReset();
+
+        await enableAndRespond(['ctrl+s']);
+        expect(keydownListenersAdded()).toBe(1);
+        expect(keydownListenersRemoved()).toBe(0);
+
+        shortcutRelay.resetIsShortcutRelayCapabilityEnabled();
+        expect(keydownListenersRemoved()).toBe(1);
+
+        await enableAndRespond(['ctrl+s']);
+        expect(keydownListenersAdded()).toBe(2);
+        expect(keydownListenersAdded() - keydownListenersRemoved()).toBe(1);
+
+        utils.messages = [];
+        dispatchCtrlS();
+        expect(utils.messages.filter((m) => m.func === ApiName.ShortcutRelay_ForwardShortcutEvent)).toHaveLength(1);
+      });
+    });
   });
 });

--- a/packages/teams-js/test/public/shortcutRelay.spec.ts
+++ b/packages/teams-js/test/public/shortcutRelay.spec.ts
@@ -152,6 +152,13 @@ describe('shortcutRelay capability', () => {
       });
 
       afterEach(() => {
+        // Tests here enable the capability, which keeps module-level state and a document keydown
+        // listener alive past the test. Tear it down so later tests never start from a dirty state.
+        // Tests that intentionally leave the runtime uninitialized or unsupported have nothing to
+        // reset, and calling reset in those states would throw.
+        if (GlobalVars.initializeCompleted && shortcutRelay.isSupported()) {
+          shortcutRelay.resetIsShortcutRelayCapabilityEnabled();
+        }
         addEventListenerSpy.mockRestore();
         removeEventListenerSpy.mockRestore();
       });


### PR DESCRIPTION
`resetIsShortcutRelayCapabilityEnabled` (`src/public/shortcutRelay.ts:267`) had no test coverage despite doing real teardown: it throws when the capability is unsupported, clears the enabled flag, empties `hostShortcuts` and `overridableShortcuts`, drops the overridable-shortcut handler, and removes the global `keydown` listener.

The assertion worth having is the add/remove symmetry. `enableShortcutRelayCapability` only attaches the document listener when `isShortcutRelayCapabilityEnabled` is false (line 298) and `reset` detaches it (line 276) — the two halves live ~25 lines apart, so an `enable -> reset -> enable` cycle must end with exactly one listener attached, not two. There is no leak today; this keeps it that way.

## Tests added (`test/public/shortcutRelay.spec.ts`)

- throws `errorLibraryNotInitialized` before `app.initialize`
- throws `errorNotSupportedOnPlatform` when the runtime does not support the capability
- a shortcut the host previously registered stops being forwarded after reset
- the overridable-shortcut handler is dropped (observed through `setOverridableShortcutHandler` returning `undefined` as the previous handler)
- enabling twice without a reset attaches the listener only once
- **enable -> reset -> enable leaves a net of exactly one `keydown` listener**, and a matching keydown afterwards forwards exactly one message

The capability keeps module-level state that survives between tests in this file, so the new block normalizes that state before asserting on listener bookkeeping.

## Validation

`pnpm jest test/public/shortcutRelay.spec.ts` — 15/15 pass. Verified the new tests are load-bearing by mutating the source:

- deleting the `document.removeEventListener` line fails the symmetry test
- deleting the state-clearing lines fails the handler-drop test

Test-only change, no change file (consistent with #3148 / #3144).