### PR TITLE
Hide private modules from reference docs

### DIFF
--- a/change/@microsoft-teams-js-42d66f52-6ea0-4c89-aa48-4b6434660320.json
+++ b/change/@microsoft-teams-js-42d66f52-6ea0-4c89-aa48-4b6434660320.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hide private module namespace shells from generated public reference documentation",
+  "packageName": "@microsoft/teams-js",
+  "email": "jeklouda@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/teams-js/src/private/copilot/copilot.ts
+++ b/packages/teams-js/src/private/copilot/copilot.ts
@@ -1,6 +1,23 @@
+/**
+ * @beta
+ * @hidden
+ * Copilot capabilities for Microsoft-internal apps.
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
 import * as customTelemetry from './customTelemetry';
 import * as eligibility from './eligibility';
 import * as sidePanel from './sidePanel';
 import * as view from './view';
 
-export { customTelemetry, eligibility, sidePanel, view };
+export { customTelemetry, eligibility, sidePanel };
+
+/**
+ * @beta
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
+export { view };

--- a/packages/teams-js/src/private/copilot/sidePanelInterfaces.ts
+++ b/packages/teams-js/src/private/copilot/sidePanelInterfaces.ts
@@ -1,4 +1,13 @@
 /**
+ * @beta
+ * @hidden
+ * Interfaces for Microsoft-internal Copilot side panel capabilities.
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
+/**
  * @hidden
  *
  * Interface for content data

--- a/packages/teams-js/src/private/copilot/view.ts
+++ b/packages/teams-js/src/private/copilot/view.ts
@@ -1,3 +1,12 @@
+/**
+ * @beta
+ * @hidden
+ * Copilot view capabilities for Microsoft-internal apps.
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
 import { callFunctionInHostAndHandleResponse } from '../../internal/communication';
 import { ensureInitialized } from '../../internal/internalAPIs';
 import { ResponseHandler } from '../../internal/responseHandler';

--- a/packages/teams-js/src/private/index.ts
+++ b/packages/teams-js/src/private/index.ts
@@ -1,3 +1,8 @@
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export * as logs from './logs';
 export {
   ChatMembersInformation,
@@ -23,10 +28,25 @@ export * as conversations from './conversations';
 //It is necessary to export ConversationResponse and OpenConversationRequest from conversations.ts individually as well
 //to keep the named exports so as to not break the existing consumers directly referencing the named exports.
 export { ConversationResponse, OpenConversationRequest } from './conversations';
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export * as copilot from './copilot/copilot';
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export * as sidePanelInterfaces from './copilot/sidePanelInterfaces';
 export * as externalAppAuthentication from './externalAppAuthentication';
 export { ConnectorParameters, UserAuthenticationState } from './externalAppAuthentication';
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export * as externalAppAuthenticationForCEA from './externalAppAuthenticationForCEA';
 export * as externalAppCardActions from './externalAppCardActions';
 export * as externalAppCardActionsForCEA from './externalAppCardActionsForCEA';
@@ -35,15 +55,30 @@ export * as externalAppCommands from './externalAppCommands';
 export * as files from './files';
 export * as meetingRoom from './meetingRoom';
 export * as messageChannels from './messageChannels/messageChannels';
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export * as nestedAppAuthBridge from './nestedAppAuth/nestedAppAuthBridge';
 export * as notifications from './notifications';
 export * as otherAppStateChange from './otherAppStateChange';
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export * as plugins from './plugins';
 export * as remoteCamera from './remoteCamera';
 export * as appEntity from './appEntity';
 export * as teams from './teams/teams';
 export * as videoEffectsEx from './videoEffectsEx';
 export * as hostEntity from './hostEntity/hostEntity';
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export * as store from './store';
 export * as widgetHosting from './widgetHosting/widgetHosting';
 export {

--- a/packages/teams-js/src/private/index.ts
+++ b/packages/teams-js/src/private/index.ts
@@ -3,6 +3,11 @@
  * @internal
  * Limited to Microsoft-internal use
  */
+/**
+ * @hidden
+ * @internal
+ * Limited to Microsoft-internal use
+ */
 export * as logs from './logs';
 export {
   ChatMembersInformation,

--- a/packages/teams-js/src/private/nestedAppAuth/nestedAppAuthBridge.ts
+++ b/packages/teams-js/src/private/nestedAppAuth/nestedAppAuthBridge.ts
@@ -1,3 +1,12 @@
+/**
+ * @beta
+ * @hidden
+ * Nested app authentication bridge for Microsoft-internal apps.
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
 import { v4 as generateUUID } from 'uuid';
 
 /**

--- a/packages/teams-js/src/private/plugins.ts
+++ b/packages/teams-js/src/private/plugins.ts
@@ -1,3 +1,12 @@
+/**
+ * @beta
+ * @hidden
+ * Plugin messaging capabilities for Microsoft-internal apps.
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
 import { callFunctionInHost } from '../internal/communication';
 import { registerHandlerHelper } from '../internal/handlers';
 import { ensureInitialized } from '../internal/internalAPIs';

--- a/packages/teams-js/src/private/store.ts
+++ b/packages/teams-js/src/private/store.ts
@@ -1,3 +1,12 @@
+/**
+ * @beta
+ * @hidden
+ * Namespace to open the app store.
+ * @internal
+ * Limited to Microsoft-internal use
+ * @module
+ */
+
 import { callFunctionInHost } from '../internal/communication';
 import { ensureInitialized } from '../internal/internalAPIs';
 import { ApiName, ApiVersionNumber, getApiVersionTag } from '../internal/telemetry';
@@ -5,15 +14,6 @@ import { DialogSize } from '../public';
 import { AppId } from '../public/appId';
 import { errorNotSupportedOnPlatform, FrameContexts } from '../public/constants';
 import { runtime } from '../public/runtime';
-
-/**
- * @beta
- * @hidden
- * @module
- * Namespace to open app store
- * @internal
- * Limited to Microsoft-internal use
- */
 
 /**
  * @beta


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/OfficeDev/microsoft-teams-library-js/blob/main/CONTRIBUTING.md).

## Description

Eight private namespace exports currently produce empty pages in the published teams-js reference documentation. This change hides those namespace symbols at the export boundary and adds effective module-level metadata so downstream documentation generators do not retain empty module shells.

### Main changes in the PR:

1. Add `@hidden` and `@internal` metadata to the affected namespace exports: `copilot`, `copilot.view`, `externalAppAuthenticationForCEA`, `logs`, `nestedAppAuthBridge`, `plugins`, `sidePanelInterfaces`, and `store`.
2. Add missing module documentation blocks and move the `store` module block before imports so the metadata is associated with the module.

## Validation

### Validation performed:

1. Ran targeted ESLint checks for all changed TypeScript files.
2. Ran the teams-js TypeScript compiler with `--noEmit` and `docs:validate`.
3. Emitted declarations and confirmed the hiding metadata is preserved on the namespace aliases.

### Unit Tests added:

No. This change only updates documentation metadata and does not change runtime behavior.

### End-to-end tests added:

No. This change does not affect runtime behavior or user-facing flows.

## Additional Requirements

### Change file added:

Yes.

### Related PRs:

N/A

### Next/remaining steps:

The source change is complete. Existing generated empty pages may require the reference documentation publishing pipeline to prune stale YAML artifacts on its next refresh.

### Screenshots:

N/A