### PR TITLE
fix: guard isActionExecuteResponse against null host responses

### DIFF
--- a/change/@microsoft-teams-js-09b033b8-a4a2-4c9b-b5ce-eec5a23d3222.json
+++ b/change/@microsoft-teams-js-09b033b8-a4a2-4c9b-b5ce-eec5a23d3222.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix `isActionExecuteResponse` so a `null` or non-object response from the host returns `false` instead of throwing a `TypeError`, allowing the intended `INTERNAL_ERROR` to surface.",
+  "packageName": "@microsoft/teams-js",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/teams-js/src/private/externalAppAuthentication.ts
+++ b/packages/teams-js/src/private/externalAppAuthentication.ts
@@ -158,6 +158,10 @@ export class SerializableActionExecuteInvokeRequest implements ISerializable {
  * @param response The object to check whether it is of IActionExecuteResponse type
  */
 export function isActionExecuteResponse(response: unknown): response is IActionExecuteResponse {
+  if (typeof response !== 'object' || response === null) {
+    return false;
+  }
+
   const actionResponse = response as IActionExecuteResponse;
 
   return (

--- a/packages/teams-js/test/private/externalAppAuthentication.spec.ts
+++ b/packages/teams-js/test/private/externalAppAuthentication.spec.ts
@@ -1472,4 +1472,39 @@ describe('externalAppAuthentication', () => {
       return expect(externalAppAuthentication.isSupported()).toEqual(false);
     });
   });
+
+  describe('isActionExecuteResponse', () => {
+    const validResponse = {
+      responseType: externalAppAuthentication.InvokeResponseType.ActionExecuteInvokeResponse,
+      value: {},
+      statusCode: 200,
+      type: 'type',
+    };
+
+    it('should return true for a valid IActionExecuteResponse', () => {
+      expect(externalAppAuthentication.isActionExecuteResponse(validResponse)).toEqual(true);
+    });
+
+    it('should return false without throwing for null and undefined responses', () => {
+      expect(externalAppAuthentication.isActionExecuteResponse(null)).toEqual(false);
+      expect(externalAppAuthentication.isActionExecuteResponse(undefined)).toEqual(false);
+    });
+
+    it('should return false for non-object responses', () => {
+      expect(externalAppAuthentication.isActionExecuteResponse('response')).toEqual(false);
+      expect(externalAppAuthentication.isActionExecuteResponse(1)).toEqual(false);
+      expect(externalAppAuthentication.isActionExecuteResponse(true)).toEqual(false);
+    });
+
+    it('should return false when a required property is missing', () => {
+      expect(externalAppAuthentication.isActionExecuteResponse({ ...validResponse, responseType: undefined })).toEqual(
+        false,
+      );
+      expect(externalAppAuthentication.isActionExecuteResponse({ ...validResponse, value: undefined })).toEqual(false);
+      expect(externalAppAuthentication.isActionExecuteResponse({ ...validResponse, statusCode: undefined })).toEqual(
+        false,
+      );
+      expect(externalAppAuthentication.isActionExecuteResponse({ ...validResponse, type: undefined })).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
## Description

`isActionExecuteResponse` (`src/private/externalAppAuthentication.ts`) casts its `unknown` argument to `IActionExecuteResponse` and immediately reads `.responseType` with no null guard:

```ts
const actionResponse = response as IActionExecuteResponse;
return actionResponse.responseType === ... // throws on null
```

This is reachable: `communication.ts` calls `responseHandler.validate(response)` on the raw host response, and `isSdkError(null)` returns `false` safely (optional chaining), so a `null` response falls straight through to `ActionExecuteResponseHandler.validate` → `isActionExecuteResponse(null)` → `TypeError: Cannot read properties of null (reading 'responseType')`, instead of the intended `INTERNAL_ERROR` / `Invalid response from host`.

Both sibling type guards already do this correctly:
- `isInvokeError` (same file) starts with `typeof err !== 'object' || err === null`
- `copilot/sidePanel.isResponseAReportableError` does the same

This PR adds the identical guard so a `null`/non-object response returns `false` and the error path produces the intended `InvokeError` instead of an unexpected `TypeError`.

## Validation

- Added regression tests in `test/private/externalAppAuthentication.spec.ts` covering `null`, `undefined`, non-object values, a valid response, and each missing required property. The `null`/`undefined` case throws on `main` and passes with this fix.
- `jest test/private/externalAppAuthentication.spec.ts` — 161 passed
- eslint + prettier clean, `tsc --noEmit` clean
- No public API surface change (signature and behavior for valid inputs unchanged)